### PR TITLE
Implement faction-based cost reduction locations

### DIFF
--- a/server/game/cards/locations.js
+++ b/server/game/cards/locations.js
@@ -35,11 +35,11 @@ locations['01040'] = {
     }
 };
 
-// 01059 - Dragonstone Port
-class DragonstonePort {
-    constructor(player, card) {
+class FactionCostReduction {
+    constructor(player, card, factionCode) {
         this.player = player;
         this.card = card;
+        this.factionCode = factionCode;
 
         this.cardClick = this.cardClick.bind(this);
         this.beforeCardPlayed = this.beforeCardPlayed.bind(this);
@@ -74,7 +74,7 @@ class DragonstonePort {
             return;
         }
 
-        if(this.active && !this.abilityUsed && card.faction_code === 'baratheon' && card.cost > 0) {
+        if(this.active && !this.abilityUsed && card.faction_code === this.factionCode && card.cost > 0) {
             card.cost -= 1;
             this.abilityUsed = true;
             this.cost = card.cost;
@@ -96,192 +96,38 @@ class DragonstonePort {
         this.active = false;
     }
 }
-locations['01059'] = {
-    register: function(game, player, card) {
 
-        var implementation = new DragonstonePort(player, card);
+function factionCostReductionLocation(factionCode) {
+    return {
+        register: function(game, player, card) {
 
-        game.playerCards[player.id + card.uuid] = implementation;
+            var implementation = new FactionCostReduction(player, card, factionCode);
 
-        game.on('cardClicked', implementation.cardClick);
-        game.on('beforeCardPlayed', implementation.beforeCardPlayed);
-        game.on('afterCardPlayed', implementation.afterCardPlayed);
-        game.on('cardsStanding', implementation.cardsStanding);
-    },
-    unregister: function(game, player, card) {
-        var implementation = game.playerCards[player.id + card.uuid];
+            game.playerCards[player.id + card.uuid] = implementation;
 
-        game.removeListener('cardClicked', implementation.cardClick);
-        game.removeListener('beforeCardPlayed', implementation.beforeCardPlayed);
-        game.removeListener('afterCardPlayed', implementation.afterCardPlayed);
-        game.removeListener('cardsStanding', implementation.cardsStanding);
-    }
-};
+            game.on('cardClicked', implementation.cardClick);
+            game.on('beforeCardPlayed', implementation.beforeCardPlayed);
+            game.on('afterCardPlayed', implementation.afterCardPlayed);
+            game.on('cardsStanding', implementation.cardsStanding);
+        },
+        unregister: function(game, player, card) {
+            var implementation = game.playerCards[player.id + card.uuid];
+
+            game.removeListener('cardClicked', implementation.cardClick);
+            game.removeListener('beforeCardPlayed', implementation.beforeCardPlayed);
+            game.removeListener('afterCardPlayed', implementation.afterCardPlayed);
+            game.removeListener('cardsStanding', implementation.cardsStanding);
+        }
+    };
+}
+
+// 01059 - Dragonstone Port
+locations['01059'] = factionCostReductionLocation('baratheon');
 
 // 01118 - Blood Orange Grove
-class BloodOrangeGrove {
-    constructor(player, card) {
-        this.player = player;
-        this.card = card;
-
-        this.cardClick = this.cardClick.bind(this);
-        this.beforeCardPlayed = this.beforeCardPlayed.bind(this);
-        this.afterCardPlayed = this.afterCardPlayed.bind(this);
-        this.cardsStanding = this.cardsStanding.bind(this);
-    }
-
-    cardClick(game, player, card) {
-        if(this.player !== player || this.card.uuid !== card.uuid) {
-            return;
-        }
-
-        if(player.phase !== 'marshal') {
-            return;
-        }
-
-        var cardInPlay = _.find(player.cardsInPlay, c => {
-            return c.card.uuid === card.uuid;
-        });
-
-        if(!cardInPlay || cardInPlay.kneeled) {
-            return;
-        }
-
-        cardInPlay.kneeled = true;
-        game.clickHandled = true;
-        this.active = true;
-    }
-
-    beforeCardPlayed(game, player, card) {
-        if(this.player !== player) {
-            return;
-        }
-
-        if(this.active && !this.abilityUsed && card.faction_code === 'martell' && card.cost > 0) {
-            card.cost -= 1;
-            this.abilityUsed = true;
-            this.cost = card.cost;
-
-            game.addMessage(player.name + ' uses ' + this.card.label + ' to reduce the cost of ' + card.label + ' by 1');
-        }
-    }
-
-    afterCardPlayed(game, player, card) {
-        if(this.card !== card) {
-            return;
-        }
-
-        card.cost = this.cost;
-    }
-
-    cardsStanding() {
-        this.abilityUsed = false;
-        this.active = false;
-    }
-}
-locations['01118'] = {
-    register: function(game, player, card) {
-
-        var implementation = new BloodOrangeGrove(player, card);
-
-        game.playerCards[player.id + card.uuid] = implementation;
-
-        game.on('cardClicked', implementation.cardClick);
-        game.on('beforeCardPlayed', implementation.beforeCardPlayed);
-        game.on('afterCardPlayed', implementation.afterCardPlayed);
-        game.on('cardsStanding', implementation.cardsStanding);
-    },
-    unregister: function(game, player, card) {
-        var implementation = game.playerCards[player.id + card.uuid];
-
-        game.removeListener('cardClicked', implementation.cardClick);
-        game.removeListener('beforeCardPlayed', implementation.beforeCardPlayed);
-        game.removeListener('afterCardPlayed', implementation.afterCardPlayed);
-        game.removeListener('cardsStanding', implementation.cardsStanding);
-    }
-};
+locations['01118'] = factionCostReductionLocation('martell');
 
 // 01156 - Heart Tree Grove
-class HeartTreeGrove {
-    constructor(player, card) {
-        this.player = player;
-        this.card = card;
-
-        this.cardClick = this.cardClick.bind(this);
-        this.beforeCardPlayed = this.beforeCardPlayed.bind(this);
-        this.afterCardPlayed = this.afterCardPlayed.bind(this);
-        this.cardsStanding = this.cardsStanding.bind(this);
-    }
-
-    cardClick(game, player, card) {
-        if(this.player !== player || this.card.uuid !== card.uuid) {
-            return;
-        }
-
-        if(player.phase !== 'marshal') {
-            return;
-        }
-
-        var cardInPlay = _.find(player.cardsInPlay, c => {
-            return c.card.uuid === card.uuid;
-        });
-
-        if(!cardInPlay || cardInPlay.kneeled) {
-            return;
-        }
-
-        cardInPlay.kneeled = true;
-        game.clickHandled = true;
-        this.active = true;
-    }
-
-    beforeCardPlayed(game, player, card) {
-        if(this.player !== player) {
-            return;
-        }
-
-        if(this.active && !this.abilityUsed && card.faction_code === 'stark' && card.cost > 0) {
-            card.cost -= 1;
-            this.abilityUsed = true;
-            this.cost = card.cost;
-
-            game.addMessage(player.name + ' uses ' + this.card.label + ' to reduce the cost of ' + card.label + ' by 1');
-        }
-    }
-
-    afterCardPlayed(game, player, card) {
-        if(this.card !== card) {
-            return;
-        }
-
-        card.cost = this.cost;
-    }
-
-    cardsStanding(game) {
-        this.abilityUsed = false;
-        this.active = false;
-    }
-}
-locations['01156'] = {
-    register: function(game, player, card) {
-
-        var implementation = new HeartTreeGrove(player, card);
-
-        game.playerCards[player.id + card.uuid] = implementation;
-
-        game.on('cardClicked', implementation.cardClick);
-        game.on('beforeCardPlayed', implementation.beforeCardPlayed);
-        game.on('afterCardPlayed', implementation.afterCardPlayed);
-        game.on('cardsStanding', implementation.cardsStanding);
-    },
-    unregister: function(game, player, card) {
-        var implementation = game.playerCards[player.id + card.uuid];
-
-        game.removeListener('cardClicked', implementation.cardClick);
-        game.removeListener('beforeCardPlayed', implementation.beforeCardPlayed);
-        game.removeListener('afterCardPlayed', implementation.afterCardPlayed);
-        game.removeListener('cardsStanding', implementation.cardsStanding);
-    }
-};
+locations['01156'] = factionCostReductionLocation('stark');
 
 module.exports = locations;

--- a/server/game/cards/locations.js
+++ b/server/game/cards/locations.js
@@ -124,10 +124,22 @@ function factionCostReductionLocation(factionCode) {
 // 01059 - Dragonstone Port
 locations['01059'] = factionCostReductionLocation('baratheon');
 
+// 01080 - Sea Tower
+locations['01080'] = factionCostReductionLocation('greyjoy');
+
+// 01099 - Western Fiefdom
+locations['01099'] = factionCostReductionLocation('lannister');
+
 // 01118 - Blood Orange Grove
 locations['01118'] = factionCostReductionLocation('martell');
 
 // 01156 - Heart Tree Grove
 locations['01156'] = factionCostReductionLocation('stark');
+
+// 01175 - Illyrio's Estate
+locations['01175'] = factionCostReductionLocation('targaryen');
+
+// 01194 - Rose Garden
+locations['01194'] = factionCostReductionLocation('tyrell');
 
 module.exports = locations;


### PR DESCRIPTION
Introduces a new class, `FactionCostReduction`, that reduces the cost of the next marshaled card for the faction specified in the constructor. `FactionCostReduction` replaces `DragonstonePort`, `BloodOrangeGrove` and `HeartTreeGrove` which were all identical minus the faction code used. 

It also introduces a function `factionCostReductionLocation` which takes a faction code and returns a card implementation that uses `FactionCostReduction` for that faction code. This function is now used to generate both the replaced reducer locations as well as implement the remaining reducer locations.