### PR TITLE
plot deck/phase updates

### DIFF
--- a/client/GameBoard.jsx
+++ b/client/GameBoard.jsx
@@ -113,22 +113,37 @@ class InnerGameBoard extends React.Component {
     }
 
     onPlotDeckClick() {
-        if (this.state.showUsedPlotDeck) { this.setState({ showUsedPlotDeck: !this.state.showUsedPlotDeck }); }
-        if (this.state.showOtherPlayerUsedPlotDeck) { this.setState({ showOtherPlayerUsedPlotDeck: !this.state.showOtherPlayerUsedPlotDeck }); }
+        if (this.state.showUsedPlotDeck) {
+            this.setState({ showUsedPlotDeck: !this.state.showUsedPlotDeck });
+        }
+
+        if (this.state.showOtherPlayerUsedPlotDeck) {
+            this.setState({ showOtherPlayerUsedPlotDeck: !this.state.showOtherPlayerUsedPlotDeck });
+        }
 
         this.setState({ showPlotDeck: !this.state.showPlotDeck });
     }
 
     onUsedPlotDeckClick() {
-        if (this.state.showPlotDeck) { this.setState({ showPlotDeck: !this.state.showPlotDeck }); }
-        if (this.state.showOtherPlayerUsedPlotDeck) { this.setState({ showOtherPlayerUsedPlotDeck: !this.state.showOtherPlayerUsedPlotDeck }); }
+        if (this.state.showPlotDeck) {
+            this.setState({ showPlotDeck: !this.state.showPlotDeck });
+        }
+
+        if (this.state.showOtherPlayerUsedPlotDeck) {
+            this.setState({ showOtherPlayerUsedPlotDeck: !this.state.showOtherPlayerUsedPlotDeck });
+        }
 
         this.setState({ showUsedPlotDeck: !this.state.showUsedPlotDeck });
     }
 
     onOtherPlayerUsedPlotDeckClick() {
-        if (this.state.showPlotDeck) { this.setState({ showPlotDeck: !this.state.showPlotDeck }); }
-        if (this.state.showUsedPlotDeck) { this.setState({ showUsedPlotDeck: !this.state.showUsedPlotDeck }); }
+        if (this.state.showPlotDeck) {
+            this.setState({ showPlotDeck: !this.state.showPlotDeck });
+        }
+
+        if (this.state.showUsedPlotDeck) {
+            this.setState({ showUsedPlotDeck: !this.state.showUsedPlotDeck });
+        }
 
         this.setState({ showOtherPlayerUsedPlotDeck: !this.state.showOtherPlayerUsedPlotDeck });
     }
@@ -280,34 +295,6 @@ class InnerGameBoard extends React.Component {
         return plotDeck;
     }
 
-    getUsedPlotDeck(deck) {
-        var index = 0;
-
-        var usedPlotDeck = _.map(deck, card => {
-            var plotClass = 'plot-card';
-
-            // if (card === this.state.selectedPlot) {
-            //     plotClass += ' selected';
-            // }
-
-            var usedPlotCard = (
-                <div key={'card' + index.toString()} className='card-wrapper'>
-                    <div className='card-frame'>
-                        <div className={plotClass} onMouseOver={this.onMouseOver ? this.onMouseOver.bind(this, card) : null}
-                            onMouseOut={this.onMouseOut}>
-                            <img className='plot-card' src={'/img/cards/' + card.code + '.png'} />
-                        </div>
-                    </div>
-                </div>);
-
-            index++;
-
-            return usedPlotCard;
-        });
-
-        return usedPlotDeck;
-    }
-
     onDragOver(event) {
         event.preventDefault();
     }
@@ -336,9 +323,9 @@ class InnerGameBoard extends React.Component {
         }
 
         var plotDeck = this.getPlotDeck(thisPlayer.plotDeck);
-        var thisPlayerUsedPlotDeck = this.getUsedPlotDeck(thisPlayer.plotDiscard);
+        var thisPlayerUsedPlotDeck = this.getPlotDeck(thisPlayer.plotDiscard);
         if (otherPlayer) {
-            var otherPlayerUsedPlotDeck = this.getUsedPlotDeck(otherPlayer.plotDiscard);
+            var otherPlayerUsedPlotDeck = this.getPlotDeck(otherPlayer.plotDiscard);
         }
 
         var thisPlayerCards = [];
@@ -362,8 +349,6 @@ class InnerGameBoard extends React.Component {
         for (i = otherPlayerCards.length; i < 2; i++) {
             thisPlayerCards.push(<div key={'other-empty' + i} />);
         }
-
-        console.log(thisPlayer.activePlot);
 
         return (
             <div className='game-board'>
@@ -391,7 +376,7 @@ class InnerGameBoard extends React.Component {
 
                                         <img className='vertical' src='/img/cards/cardback.jpg' />
                                     </div>
-                                    <div className='panel horizontal-card' onMouseOver={this.onMouseOver.bind(this, _.last((otherPlayer ? otherPlayer.plotDiscard : null)))}
+                                    <div className='panel horizontal-card' onMouseOver={otherPlayer ? this.onMouseOver.bind(this, _.last(otherPlayer.plotDiscard)) : null}
                                         onMouseOut={this.onMouseOut} onClick={this.onOtherPlayerUsedPlotDeckClick}>
                                         <div className='panel-header'>
                                             {'Active Plot'}

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -46,6 +46,7 @@ class Player {
         this.readyToStart = false;
         this.cardsInPlay = [];
         this.limitedPlayed = false;
+        this.activePlot = undefined;
         this.plotDiscard = [];
         this.deadPile = [];
         this.discardPile = [];
@@ -234,11 +235,6 @@ class Player {
     startPlotPhase() {
         this.phase = 'plot';
 
-        if (this.plotDeck.length === 0) {
-            this.plotDeck = this.plotDiscard;
-            this.plotDiscard = [];
-        }
-
         this.menuTitle = 'Choose your plot';
         this.buttons = [
             { command: 'selectplot', text: 'Done' }
@@ -287,17 +283,26 @@ class Player {
     }
 
     revealPlot() {
-        this.selectedPlot.facedown = false;
-
         this.menuTitle = '';
         this.buttons = [];
 
-        this.plotDiscard.push(this.selectedPlot.card);
+        this.selectedPlot.facedown = false;
+        if (this.activePlot !== null && this.activePlot !== undefined) {
+            this.plotDiscard.push(this.activePlot.card);
+        }
+
+        this.activePlot = this.selectedPlot;
+        console.log(this.activePlot.card.code);
+
         this.plotDeck = _.reject(this.plotDeck, card => {
             return card.uuid === this.selectedPlot.card.uuid;
         });
 
-        this.activePlot = this.selectedPlot;
+        if (this.plotDeck.length === 0) {
+            this.plotDeck = this.plotDiscard;
+            this.plotDiscard = [];
+        }
+
         this.plotRevealed = true;
 
         this.selectedPlot = undefined;
@@ -849,6 +854,7 @@ class Player {
             plotDeck: isActivePlayer ? this.plotDeck : undefined,
             numPlotCards: this.plotDeck.length,
             plotSelected: !!this.selectedPlot,
+            activePlot: this.activePlot,
             firstPlayer: this.firstPlayer,
             plotDiscard: this.plotDiscard,
             selectedAttachment: this.selectedAttachment,

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -287,12 +287,11 @@ class Player {
         this.buttons = [];
 
         this.selectedPlot.facedown = false;
-        if (this.activePlot !== null && this.activePlot !== undefined) {
+        if (this.activePlot) {
             this.plotDiscard.push(this.activePlot.card);
         }
 
         this.activePlot = this.selectedPlot;
-        console.log(this.activePlot.card.code);
 
         this.plotDeck = _.reject(this.plotDeck, card => {
             return card.uuid === this.selectedPlot.card.uuid;


### PR DESCRIPTION
Updated plot decks to now be able to click on Active Plot to view either player's used plots. Also fixed logic where current plot was being added to used pile too soon (creates an invalid games state). Plots should only be added (as per rules) to used pile when a new plot is revealed. As well this fixes the logic when users get to the 7th plot where used pile should recycle into the unused pile (making used pile 0 again).