### PR TITLE
Allow initiative modifying cards

### DIFF
--- a/server/game/cards/locations.js
+++ b/server/game/cards/locations.js
@@ -2,6 +2,16 @@ const _ = require('underscore');
 
 var locations = {};
 
+// 01039 - The Kingsroad
+locations['01039'] = {
+    register: function(game, player, card) {
+        // TODO: Full Kingsroad behaviour.
+        card.initiative = 1;
+    },
+    unregister: function(game, player, card) {
+    }
+};
+
 // 01040 - The Roseroad
 class TheRoseRoad {
     constructor(player, card) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -210,10 +210,6 @@ class Game extends EventEmitter {
                     highestInitiative = totalInitiative;
                     highestPlayer = p;
                 }
-                var explanation = _.map(initiativeCards, c => {
-                    return c.name + ': ' + c.initiative;
-                });
-                this.addMessage(p.name + ' has ' + totalInitiative + ' initiative (' + explanation + ')');
             });
 
             _.each(this.players, p => {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -202,10 +202,7 @@ class Game extends EventEmitter {
             var highestPlayer = undefined;
             var highestInitiative = -1;
             _.each(this.players, p => {
-                var initiativeCards = p.initiativeCardsInPlay();
-                var totalInitiative = _.reduce(initiativeCards, (memo, c) => {
-                    return memo + c.initiative;
-                }, 0);
+                var totalInitiative = p.getTotalInitiative();
                 if (totalInitiative > highestInitiative) {
                     highestInitiative = totalInitiative;
                     highestPlayer = p;

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -202,10 +202,18 @@ class Game extends EventEmitter {
             var highestPlayer = undefined;
             var highestInitiative = -1;
             _.each(this.players, p => {
-                if (p.selectedPlot.card.initiative > highestInitiative) {
-                    highestInitiative = p.selectedPlot.card.initiative;
+                var initiativeCards = p.initiativeCardsInPlay();
+                var totalInitiative = _.reduce(initiativeCards, (memo, c) => {
+                    return memo + c.initiative;
+                }, 0);
+                if (totalInitiative > highestInitiative) {
+                    highestInitiative = totalInitiative;
                     highestPlayer = p;
                 }
+                var explanation = _.map(initiativeCards, c => {
+                    return c.name + ': ' + c.initiative;
+                });
+                this.addMessage(p.name + ' has ' + totalInitiative + ' initiative (' + explanation + ')');
             });
 
             _.each(this.players, p => {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -865,18 +865,14 @@ class Player {
         return state;
     }
 
-    initiativeCardsInPlay() {
-        var cards = [this.selectedPlot.card];
-
-        _.chain(this.cardsInPlay).map(cip => {
+    getTotalInitiative() {
+        var plotInitiative = this.selectedPlot.card.initiative;
+        var initiativeModifier = _.chain(this.cardsInPlay).map(cip => {
             return [cip.card].concat(cip.attachments);
-        }).flatten(true).filter(card => {
-            return !!card.initiative;
-        }).each(card => {
-            cards.push(card);
-        });
-
-        return cards;
+        }).flatten(true).reduce((memo, card) => {
+            return memo + (card.initiative || 0);
+        }, 0);
+        return plotInitiative + initiativeModifier;
     }
 }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -864,6 +864,20 @@ class Player {
 
         return state;
     }
+
+    initiativeCardsInPlay() {
+        var cards = [this.selectedPlot.card];
+
+        _.chain(this.cardsInPlay).map(cip => {
+            return [cip.card].concat(cip.attachments);
+        }).flatten(true).filter(card => {
+            return !!card.initiative;
+        }).each(card => {
+            cards.push(card);
+        });
+
+        return cards;
+    }
 }
 
 module.exports = Player;


### PR DESCRIPTION
This allows cards that modify initiative (such as Kingsroad - see [full list](https://thronesdb.com/find?q=x%3AInitiative&sort=name&view=card)) to be implemented. The game now asks `Player` for a list of all cards in play that modify the initiative. The player determines this by looking for an initiative value on the card - plots inherently have one, it can be added to cards that modify initiative.

A similar approach can be taken for cards that modify the amount of gold collected at the start of the marshal phase, as well as cards that modify the reserve value. I do have a couple concerns that I'd like feedback on, which I'll detail as separate comments on the code.

As always, feel free to scrap if you don't like this direction.