### PR TITLE
Small power comparison fixes and power claim fix

### DIFF
--- a/server/game/game.js
+++ b/server/game/game.js
@@ -699,8 +699,8 @@ class Game extends EventEmitter {
             } else if (winner.currentChallenge === 'power') {
                 while (claim > 0) {
                     if (loser.power > 0) {
-                        loser.power -= 1;
-                        winner.power += 1;
+                        loser.power--;
+                        winner.power++;
                         claim--;
 
                         if (winner.getTotalPower() => 15) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -701,13 +701,13 @@ class Game extends EventEmitter {
                     if (loser.power > 0) {
                         loser.power -= 1;
                         winner.power += 1;
-		        claim--;
+                        claim--;
 
                         if (winner.getTotalPower() => 15) {
                             this.addMessage(winner.name + ' has won the game');
                         }
                     } else {
-		        claim = 0;
+                        claim = 0;
 		    }
 		}
             }

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -626,7 +626,7 @@ class Game extends EventEmitter {
 
                 this.addMessage(winner.name + ' has gained 1 power from an unopposed challenge');
 
-                if (winner.getTotalPower() > 15) {
+                if (winner.getTotalPower() => 15) {
                     this.addMessage(winner.name + ' has won the game');
                 }
             }
@@ -673,7 +673,7 @@ class Game extends EventEmitter {
                 this.addMessage(winner.name + ' gains 1 power on ' + card.card.label + ' from Renown');
             }
 
-            if (winner.getTotalPower() > 15) {
+            if (winner.getTotalPower() => 15) {
                 this.addMessage(winner.name + ' has won the game');
             }
         });
@@ -697,14 +697,19 @@ class Game extends EventEmitter {
             } else if (winner.currentChallenge === 'intrigue') {
                 loser.discardAtRandom(claim);
             } else if (winner.currentChallenge === 'power') {
-                if (loser.power > 0) {
-                    loser.power -= claim;
-                    winner.power += claim;
+                while (claim > 0) {
+                    if (loser.power > 0) {
+                        loser.power -= 1;
+                        winner.power += 1;
+		        claim--;
 
-                    if (winner.getTotalPower() > 15) {
-                        this.addMessage(winner.name + ' has won the game');
-                    }
-                }
+                        if (winner.getTotalPower() => 15) {
+                            this.addMessage(winner.name + ' has won the game');
+                        }
+                    } else {
+		        claim = 0;
+		    }
+		}
             }
         }
 


### PR DESCRIPTION
Some small things I noticed while reading through the code, now since my node.js is currently quite rusty these fixes might ruin intended behavior and in that case feel free to ignore this pull request. But I'd thought it good to point them out. :)

Power comparison fix: All winner.getTotalPower() check for "> 15", wouldn't this lead to a player needing 16 power to win?

Power claim fix: When applying power claim to a losing player the code currently only checks to see if that player has any power (ie. loser.power > 0) and then subtracts the claim from that players power and adds it to the winner. This could lead to a player having negative power/a player getting power that didn't exist. An example would be that the losing player has 1 power and has just lost a power challenge with claim 2. 
This fix is supposed to correct that by taking the claim in steps of one power until there is no power left or no claim left. Might be fancier ways of fixing this problem though.