### PR TITLE
Enforce card restriction for character reducers

### DIFF
--- a/server/game/cards/characters.js
+++ b/server/game/cards/characters.js
@@ -1,30 +1,30 @@
 const _ = require('underscore');
-const factionCostReducer = require('./reducer.js').factionCostReducer;
+const factionCharacterCostReducer = require('./reducer.js').factionCharacterCostReducer;
 
 var characters = {};
 
 // 01056 - Dragonstone Faithful
-characters['01506'] = factionCostReducer('baratheon');
+characters['01506'] = factionCharacterCostReducer('baratheon');
 
 // 01074 - Iron Islands Fishmonger
-characters['01074'] = factionCostReducer('greyjoy');
+characters['01074'] = factionCharacterCostReducer('greyjoy');
 
 // 01094 - Lannisport Merchant
-characters['01094'] = factionCostReducer('lannister');
+characters['01094'] = factionCharacterCostReducer('lannister');
 
 // 01110 - Desert Scavenger
-characters['01110'] = factionCostReducer('martell');
+characters['01110'] = factionCharacterCostReducer('martell');
 
 // 01133 - Steward At The Wall
-characters['01133'] = factionCostReducer('thenightswatch');
+characters['01133'] = factionCharacterCostReducer('thenightswatch');
 
 // 01152 - Winterfell Steward
-characters['01152'] = factionCostReducer('stark');
+characters['01152'] = factionCharacterCostReducer('stark');
 
 // 01170 - Targaryen Loyalist
-characters['01170'] = factionCostReducer('targaryen');
+characters['01170'] = factionCharacterCostReducer('targaryen');
 
 // 01188 - Garden Caretaker
-characters['01188'] = factionCostReducer('tyrell');
+characters['01188'] = factionCharacterCostReducer('tyrell');
 
 module.exports = characters;

--- a/server/game/cards/reducer.js
+++ b/server/game/cards/reducer.js
@@ -30,9 +30,16 @@ function factionCostReducer(factionCode) {
     });
 }
 
+function factionCharacterCostReducer(factionCode) {
+    return getReducer((player, card) => {
+        return card.faction_code === factionCode && card.type_code === 'character';
+    });
+}
+
 module.exports = {
     getReducer: getReducer,
-    factionCostReducer: factionCostReducer
+    factionCostReducer: factionCostReducer,
+    factionCharacterCostReducer: factionCharacterCostReducer
 };
 
 class Reducer {


### PR DESCRIPTION
Character-based faction cost reducers (such as Dragonstone Faithful for
Baratheon) only reduces the cost of the next character. This is in
contrast with the location-based reducers, which reduces the cost of any
type of card for the faction.