### PR TITLE
Plot phase enhancements

### DIFF
--- a/server/game/cards/plots.js
+++ b/server/game/cards/plots.js
@@ -246,12 +246,12 @@ plots['01006'] = {
         var plot = new BuildingOrders(player);
 
         game.playerPlots[player.id] = plot;
-        game.on('plotRevealed', plot.revealed);
+        game.on('whenRevealed', plot.revealed);
         game.on('customCommand', plot.cardSelected);
     },
     unregister(game, player) {
         var plot = game.playerPlots[player.id];
-        game.removeListener('plotRevealed', plot.revealed);
+        game.removeListener('whenRevealed', plot.revealed);
         game.removeListener('customCommand', plot.cardSelected);
     }
 };
@@ -296,10 +296,10 @@ plots['01007'] = {
         var plot = new CallingTheBanners(player);
 
         game.playerPlots[player.id] = plot;
-        game.on('plotRevealed', plot.revealed);
+        game.on('whenRevealed', plot.revealed);
     },
     unregister(game, player) {
-        game.removeListener('plotRevealed', game.playerPlots[player.id].revealed);
+        game.removeListener('whenRevealed', game.playerPlots[player.id].revealed);
     }
 };
 
@@ -372,7 +372,7 @@ plots['01008'] = {
 
         game.playerPlots[player.id] = plot;
 
-        game.on('plotRevealed', plot.revealed);
+        game.on('whenRevealed', plot.revealed);
         game.on('customCommand', plot.challengeTypeSelected);
         game.on('beforeClaim', plot.beforeClaim);
         game.on('afterClaim', plot.afterClaim);
@@ -380,7 +380,7 @@ plots['01008'] = {
     unregister(game, player) {
         var plot = game.playerPlots[player.id];
 
-        game.removeListener('plotRevealed', plot.revealed);
+        game.removeListener('whenRevealed', plot.revealed);
         game.removeListener('customCommand', plot.challengeTypeSelected);
         game.removeListener('beforeClaim', plot.beforeClaim);
         game.removeListener('afterClaim', plot.afterClaim);
@@ -474,13 +474,13 @@ plots['01009'] = {
         var plot = new Confiscation(player);
 
         game.playerPlots[player.id] = plot;
-        game.on('plotRevealed', plot.revealed);
+        game.on('whenRevealed', plot.revealed);
         game.on('cardClicked', plot.cardClicked);
     },
     unregister(game, player) {
         var plot = game.playerPlots[player.id];
 
-        game.removeListener('plotRevealed', plot.revealed);
+        game.removeListener('whenRevealed', plot.revealed);
         game.removeListener('cardClicked', plot.cardClicked);
     }
 };
@@ -507,10 +507,10 @@ plots['01010'] = {
         var plot = new CountingCoppers(player);
 
         game.playerPlots[player.id] = plot;
-        game.on('plotRevealed', plot.revealed);
+        game.on('whenRevealed', plot.revealed);
     },
     unregister(game, player) {
-        game.removeListener('plotRevealed', game.playerPlots[player.id].revealed);
+        game.removeListener('whenRevealed', game.playerPlots[player.id].revealed);
     }
 };
 
@@ -587,12 +587,12 @@ plots['01011'] = {
         var plot = new FilthyAccusation(player);
 
         game.playerPlots[player.id] = plot;
-        game.on('plotRevealed', plot.revealed);
+        game.on('whenRevealed', plot.revealed);
         game.on('cardClicked', plot.cardClicked);
     },
     unregister(game, player) {
         var plot = game.playerPlots[player.id];
-        game.removeListener('plotRevealed', plot.revealed);
+        game.removeListener('whenRevealed', plot.revealed);
         game.removeListener('cardClicked', plot.cardClicked);
     }
 };
@@ -640,10 +640,10 @@ plots['01013'] = {
         var plot = new HeadsOnSpikes(player);
 
         game.playerPlots[player.id] = plot;
-        game.on('plotRevealed', plot.reveal);
+        game.on('whenRevealed', plot.reveal);
     },
     unregister(game, player) {
-        game.removeListener('plotRevealed', game.playerPlots[player.id].reveal);
+        game.removeListener('whenRevealed', game.playerPlots[player.id].reveal);
     }
 };
 
@@ -772,14 +772,14 @@ plots['01015'] = {
 
         game.playerPlots[player.id] = plot;
 
-        game.on('plotRevealed', plot.revealed);
+        game.on('whenRevealed', plot.revealed);
         game.on('cardClicked', plot.cardClicked);
         game.on('customCommand', plot.doneClicked);
     },
     unregister(game, player) {
         var plot = game.playerPlots[player.id];
 
-        game.removeListener('plotRevealed', plot.revealed);
+        game.removeListener('whenRevealed', plot.revealed);
         game.removeListener('cardClicked', plot.cardClicked);
         game.removeListener('customCommand', plot.doneClicked);
     }
@@ -960,12 +960,12 @@ plots['01022'] = {
         var plot = new Summons(player);
 
         game.playerPlots[player.id] = plot;
-        game.on('plotRevealed', plot.revealed);
+        game.on('whenRevealed', plot.revealed);
         game.on('customCommand', plot.cardSelected);
     },
     unregister(game, player) {
         var plot = game.playerPlots[player.id];
-        game.removeListener('plotRevealed', plot.revealed);
+        game.removeListener('whenRevealed', plot.revealed);
         game.removeListener('customCommand', plot.cardSelected);
     }
 };
@@ -1002,10 +1002,10 @@ plots['02039'] = {
 
         game.playerPlots[player.id] = plot;
 
-        game.on('plotRevealed', plot.revealed);
+        game.on('whenRevealed', plot.revealed);
     },
     unregister(game, player) {
-        game.removeListener('plotRevealed', game.playerPlots[player.id].revealed);
+        game.removeListener('whenRevealed', game.playerPlots[player.id].revealed);
     }
 };
 
@@ -1078,13 +1078,13 @@ plots['03049'] = {
         var plot = new TheLongWinter(player);
 
         game.playerPlots[player.id] = plot;
-        game.on('plotRevealed', plot.revealed);
+        game.on('whenRevealed', plot.revealed);
         game.on('cardClicked', plot.cardSelected);
     },
     unregister(game, player) {
         var plot = game.playerPlots[player.id];
 
-        game.removeListener('plotRevealed', plot.revealed);
+        game.removeListener('whenRevealed', plot.revealed);
         game.removeListener('cardClicked', plot.cardSelected);
     }
 };

--- a/server/game/cards/plots.js
+++ b/server/game/cards/plots.js
@@ -218,7 +218,7 @@ class BuildingOrders {
         }
 
         if(arg === 'done') {
-            game.revealDone(player);
+            game.playerRevealDone(player);
         }
 
         var card = _.find(player.drawDeck, c => {
@@ -238,7 +238,7 @@ class BuildingOrders {
 
         game.addMessage(player.name + ' uses ' + player.activePlot.card.label + ' to reveal ' + card.label + ' and add it to their hand');
 
-        game.revealDone(player);
+        game.playerRevealDone(player);
     }
 }
 plots['01006'] = {
@@ -335,7 +335,7 @@ class CalmOverWesteros {
 
         this.challengeType = arg;
 
-        game.revealDone(player);
+        game.playerRevealDone(player);
     }
 
     beforeClaim(game, challengeType, winner, loser) {
@@ -447,7 +447,7 @@ class Confiscation {
             });
 
             if(!card) {
-                game.revealDone(player);
+                game.playerRevealDone(player);
 
                 return;
             }
@@ -466,7 +466,7 @@ class Confiscation {
         player.selectCard = false;
         game.clickHandled = true;
 
-        game.revealDone(player);
+        game.playerRevealDone(player);
     }
 }
 plots['01009'] = {
@@ -554,7 +554,7 @@ class FilthyAccusation {
             });
 
             if(!otherPlayer) {
-                game.revealDone(player);
+                game.playerRevealDone(player);
 
                 return;
             }
@@ -564,14 +564,14 @@ class FilthyAccusation {
             });
 
             if(!card) {
-                game.revealDone(player);
+                game.playerRevealDone(player);
 
                 return;
             }
         }
 
         if(card.card.type_code !== 'character' || card.kneeled) {
-            game.revealDone(player);
+            game.playerRevealDone(player);
             return;
         }
 
@@ -579,7 +579,7 @@ class FilthyAccusation {
 
         game.addMessage(player.name + ' uses ' + player.activePlot.card.label + ' to kneel ' + card.card.label);
 
-        game.revealDone(player);
+        game.playerRevealDone(player);
     }
 }
 plots['01011'] = {
@@ -729,7 +729,7 @@ class MarchedToTheWall {
 
         if(!stillToDiscard) {
             this.waitingForClick = false;
-            game.revealDone(player);
+            game.playerRevealDone(player);
         } else {
             player.menuTitle = 'Waiting for oppoent to apply plot effect';
             player.buttons = [];
@@ -755,10 +755,10 @@ class MarchedToTheWall {
                 });
 
                 if(otherPlayer) {
-                    game.revealDone(otherPlayer);
+                    game.playerRevealDone(otherPlayer);
                 }
             } else {
-                game.revealDone(player);
+                game.playerRevealDone(player);
             }
         } else {
             player.menuTitle = 'Waiting for oppoent to apply plot effect';
@@ -932,7 +932,7 @@ class Summons {
         }
 
         if(arg === 'done') {
-            game.revealDone(player);
+            game.playerRevealDone(player);
         }
 
         var card = _.find(player.drawDeck, c => {
@@ -952,7 +952,7 @@ class Summons {
 
         game.addMessage(player.name + ' uses ' + player.activePlot.card.label + ' to reveal ' + card.label + ' and add it to their hand');
 
-        game.revealDone(player);
+        game.playerRevealDone(player);
     }
 }
 plots['01022'] = {
@@ -1069,7 +1069,7 @@ class TheLongWinter {
         delete this.waitingForPlayers[player.id];
 
         if(!_.any(this.waitingForPlayers)) {
-            game.revealDone(this.player);
+            game.playerRevealDone(this.player);
         }
     }
 }

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -272,6 +272,7 @@ class Game extends EventEmitter {
             // reveal plots when everyone has selected
             _.each(this.getPlayers(), p => {
                 p.revealPlot();
+                this.emit('plotRevealed', this, p);
             });
 
             // determine initiative winner
@@ -372,7 +373,7 @@ class Game extends EventEmitter {
         firstPlayer.buttons = [];
 
         this.pauseForPlot = false;
-        this.emit('plotRevealed', this, player);
+        this.emit('whenRevealed', this, player);
 
         if (!this.pauseForPlot) {
             this.playerRevealDone(player);

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -323,36 +323,50 @@ class Game extends EventEmitter {
         }
     }
 
-    revealDone(player) {
+    playerRevealDone(player) {
         var otherPlayer = this.getOtherPlayer(player);
+        var firstPlayer = player.firstPlayer ? player : otherPlayer;
 
         player.revealFinished = true;
 
-        if (otherPlayer && !otherPlayer.revealFinished) {
-            this.revealPlot(otherPlayer);
+        this.resolvePlotEffects(firstPlayer);
+    }
 
-            return;
+    resolvePlotEffects(firstPlayer) {
+        firstPlayer.menuTitle = 'Select player to resolve their plot';
+        firstPlayer.buttons = [];
+
+        _.each(this.getPlayers(), p => {
+            if (p.hasWhenRevealed() && !p.revealFinished) {
+                firstPlayer.buttons.push({command: 'resolvePlotEffect', text: p.name, arg: p.id});
+            }
+        });
+
+        if (_.isEmpty(firstPlayer.buttons)) {
+            firstPlayer.menuTitle = 'Any reactions or actions?';
+            firstPlayer.buttons = [{command: 'doneWhenRealedEffects', text: 'Done'}]
         }
 
-        if (!otherPlayer) {
-            this.beginMarshal(player);
-
-            return;
-        }
-
-        var firstPlayer = player.firstPlayer ? player : otherPlayer;
-
-        if (player.plotRevealed && otherPlayer.plotRevealed) {
-            this.beginMarshal(firstPlayer);
+        var otherPlayer = this.getOtherPlayer(firstPlayer);
+        if (otherPlayer) {
+            otherPlayer.menuTitle = 'Waiting for first player resolve plot phase';
+            otherPlayer.buttons = [];
         }
     }
 
-    revealPlot(player) {
+    resolvePlayerPlotEffect(playerId) {
+        var player = this.getPlayers()[playerId];
+        var otherPlayer = this.getOtherPlayer(player);
+        var firstPlayer = player.firstPlayer ? player : otherPlayer;
+
+        firstPlayer.menuTitle = 'Waiting for opponent to resolve plot effect';
+        firstPlayer.buttons = [];
+
         this.pauseForPlot = false;
         this.emit('plotRevealed', this, player);
 
         if (!this.pauseForPlot) {
-            this.revealDone(player);
+            this.playerRevealDone(player);
         }
     }
 
@@ -376,14 +390,13 @@ class Game extends EventEmitter {
                 player.firstPlayer = false;
             }
 
-            player.drawPhase();
             player.menuTitle = '';
             player.buttons = [];
         });
 
         this.addMessage(player.name + ' has selected ' + firstPlayer.name + ' to be the first player');
 
-        this.revealPlot(firstPlayer);
+        this.resolvePlotEffects(firstPlayer);
     }
 
     attachCard(player, card) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -310,6 +310,15 @@ class Game extends EventEmitter {
         }
     }
 
+    drawPhase(firstPlayer) {
+        _.each(this.getPlayers(), p => {
+            this.emit('beginDrawPhase', this, p);
+            p.drawPhase();
+        });
+
+        this.beginMarshal(firstPlayer);
+    }
+
     beginMarshal(player) {
         this.emit('beginMarshal', this, player);
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -311,7 +311,13 @@ class Player extends Spectator {
     }
 
     hasWhenRevealed() {
-        return this.activePlot.card.text.indexOf('When Revealed:') !== -1;
+        var plotText = this.activePlot.card.text;
+
+        if (!_.isNull(plotText) && !_.isUndefined(plotText)) {
+            return this.activePlot.card.text.indexOf('When Revealed:') !== -1;
+        } else {
+            return false;
+        }
     }
 
     drawPhase() {
@@ -823,7 +829,7 @@ class Player extends Spectator {
 
     getTotalInitiative() {
         var plotInitiative = 0;
-        
+
         if(this.activePlot && this.activePlot.card.initiative) {
             plotInitiative = this.activePlot.card.initiative;
         }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -310,6 +310,10 @@ class Player extends Spectator {
         this.selectedPlot = undefined;
     }
 
+    hasWhenRevealed() {
+        return this.activePlot.card.text.indexOf('When Revealed:') !== -1;
+    }
+
     drawPhase() {
         this.gold = 0;
         this.phase = 'draw';

--- a/server/index.js
+++ b/server/index.js
@@ -498,6 +498,28 @@ io.on('connection', function (socket) {
         sendGameState(game);
     });
 
+    socket.on('resolvePlotEffect', function (playerId) {
+        var game = findGameForPlayer(socket.id);
+
+        if (!game) {
+            return;
+        }
+
+        game.resolvePlayerPlotEffect(playerId);
+        sendGameState(game);
+    });
+
+    socket.on('doneWhenRealedEffects', function () {
+        var game = findGameForPlayer(socket.id);
+
+        if (!game) {
+            return;
+        }
+
+        game.beginMarshal(game.getPlayers()[socket.id]);
+        sendGameState(game);
+    });
+
     socket.on('cardclick', function (card) {
         var game = findGameForPlayer(socket.id);
 

--- a/server/index.js
+++ b/server/index.js
@@ -505,7 +505,9 @@ io.on('connection', function (socket) {
             return;
         }
 
-        game.resolvePlayerPlotEffect(playerId);
+        runAndCatchErrors(game, () => {
+            game.resolvePlayerPlotEffect(playerId);
+        });
         sendGameState(game);
     });
 
@@ -516,7 +518,9 @@ io.on('connection', function (socket) {
             return;
         }
 
-        game.beginMarshal(game.getPlayers()[socket.id]);
+        runAndCatchErrors(game, () => {
+            game.drawPhase(game.getPlayers()[socket.id]);
+        });
         sendGameState(game);
     });
 

--- a/test/server/plots/02039-pentoshi.spec.js
+++ b/test/server/plots/02039-pentoshi.spec.js
@@ -26,10 +26,11 @@ describe('Trading With The Pentoshi', () => {
 
     describe('When a player has trading revealed and that player is first player', () => {
         it('should give the other player 3 gold', () => {
-            game.selectPlot(player1.id, pentoshi);                 
+            game.selectPlot(player1.id, pentoshi);
             game.selectPlot(player2.id, testPlot);
-            
+
             game.setFirstPlayer(player1.id, 'me');
+            game.resolvePlayerPlotEffect(player1.id);
 
             expect(player2.gold).toBe(3);
             expect(player1.gold).toBe(0);
@@ -38,10 +39,11 @@ describe('Trading With The Pentoshi', () => {
 
     describe('When a player has trading revealed and the other player is first player', () => {
         it('should give the other player 3 gold', () => {
-            game.selectPlot(player1.id, pentoshi);                 
+            game.selectPlot(player1.id, pentoshi);
             game.selectPlot(player2.id, testPlot);
-            
+
             game.setFirstPlayer(player1.id, 'other');
+            game.resolvePlayerPlotEffect(player1.id);
 
             expect(player2.gold).toBe(3);
             expect(player1.gold).toBe(0);
@@ -52,8 +54,10 @@ describe('Trading With The Pentoshi', () => {
         it('should give both players 3 gold', () => {
             game.selectPlot(player1.id, pentoshi);
             game.selectPlot(player2.id, pentoshi);
-            
+
             game.setFirstPlayer(player1.id, 'me');
+            game.resolvePlayerPlotEffect(player1.id);
+            game.resolvePlayerPlotEffect(player2.id);
 
             expect(player2.gold).toBe(3);
             expect(player1.gold).toBe(3);


### PR DESCRIPTION
Adding the ability for first player to resolve plot effect (even if there is only 1) in the order of their choosing. As well adding a formal draw phase and emitter for that phase's beginning due to some things that may take effect during draw phase (such as Time of Plenty). Note that now there is also a distinction between a static ability that is turned on as soon as a plot is flipped (plotRevealed emission event) and the "When Revealed" ability (whenRevealed emission event). This is to avoid conflicts between cards (for example Blood of the Dragon with a 5 strength character that has Crown of Gold and Confiscation).