### PR TITLE
Always check win condition when power is gained.

### DIFF
--- a/server/game/cards/plots.js
+++ b/server/game/cards/plots.js
@@ -15,10 +15,8 @@ class AClashOfKings {
 
     afterChallenge(game, challengeType, winner, loser) {
         if(winner === this.player && challengeType === 'power' && loser.power > 0) {
-            loser.power--;
-            winner.power++;
-
             game.addMessage(winner.name + ' uses ' + winner.activePlot.card.label + ' to move 1 power from ' + loser.name + '\'s faction card');
+            game.transferPower(winner, loser, 1);
         }
     }
 }
@@ -47,9 +45,8 @@ class AFeastForCrows {
             return;
         }
 
-        winner.power += 2;
-
         game.addMessage(winner.name + ' uses ' + winner.activePlot.card.label + ' to gain 2 power');
+        game.addPower(winner, 2);
     }
 }
 plots['01002'] = {
@@ -620,7 +617,7 @@ class HeadsOnSpikes {
         if(card.type_code === 'character') {
             message += ' and gain 2 power for their faction';
             otherPlayer.deadPile.push(card);
-            player.power += 2;
+            game.addPower(player, 2);
         } else {
             otherPlayer.discardPile.push(card);
         }

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -767,9 +767,7 @@ class Game extends EventEmitter {
 
                 this.addMessage(winner.name + ' has gained 1 power from an unopposed challenge');
 
-                if (winner.getTotalPower() >= 15) {
-                    this.addMessage(winner.name + ' has won the game');
-                }
+                this.checkWinCondition(winner);
             }
 
             // XXX This should be after claim but needs a bit of reworking to make that possible
@@ -783,6 +781,12 @@ class Game extends EventEmitter {
                 player.menuTitle = 'Waiting for opponent to initiate challenge';
                 player.buttons = [];
             }
+        }
+    }
+
+    checkWinCondition(player) {
+        if (player.getTotalPower() >= 15) {
+            this.addMessage(player.name + ' has won the game');
         }
     }
 
@@ -814,9 +818,7 @@ class Game extends EventEmitter {
                 this.addMessage(winner.name + ' gains 1 power on ' + card.card.label + ' from Renown');
             }
 
-            if (winner.getTotalPower() >= 15) {
-                this.addMessage(winner.name + ' has won the game');
-            }
+            this.checkWinCondition(winner);
         });
     }
 
@@ -844,9 +846,7 @@ class Game extends EventEmitter {
                         winner.power++;
                         claim--;
 
-                        if (winner.getTotalPower() >= 15) {
-                            this.addMessage(winner.name + ' has won the game');
-                        }
+                        this.checkWinCondition(winner);
                     } else {
                         claim = 0;
                     }
@@ -904,9 +904,7 @@ class Game extends EventEmitter {
 
             dominanceWinner.power++;
 
-            if (dominanceWinner.getTotalPower() >= 15) {
-                this.addMessage(dominanceWinner.name + ' has won the game');
-            }
+            this.checkWinCondition(dominanceWinner);
         } else {
             this.addMessage('There was a tie for dominance');
             this.addMessage('No one wins dominance');

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -765,7 +765,6 @@ class Game extends EventEmitter {
             if (loser.challengeStrength === 0) {
                 this.addMessage(winner.name + ' has gained 1 power from an unopposed challenge');
                 this.addPower(winner, 1);
-                this.checkWinCondition(winner);
             }
 
             // XXX This should be after claim but needs a bit of reworking to make that possible
@@ -784,12 +783,14 @@ class Game extends EventEmitter {
 
     addPower(player, power) {
         player.power += power;
+        this.checkWinCondition(player);
     }
 
     transferPower(winner, loser, power) {
         var appliedPower = Math.min(loser.power, power);
         loser.power -= appliedPower;
         winner.power += appliedPower;
+        this.checkWinCondition(winner);
     }
 
     checkWinCondition(player) {
@@ -849,7 +850,6 @@ class Game extends EventEmitter {
                 loser.discardAtRandom(claim);
             } else if (winner.currentChallenge === 'power') {
                 this.transferPower(winner, loser, claim);
-                this.checkWinCondition(winner);
             }
         }
 
@@ -902,8 +902,6 @@ class Game extends EventEmitter {
             this.addMessage(dominanceWinner.name + ' wins dominance');
 
             this.addPower(dominanceWinner, 1);
-
-            this.checkWinCondition(dominanceWinner);
         } else {
             this.addMessage('There was a tie for dominance');
             this.addMessage('No one wins dominance');

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -763,10 +763,8 @@ class Game extends EventEmitter {
             this.emit('afterChallenge', this, winner.currentChallenge, winner, loser);
 
             if (loser.challengeStrength === 0) {
-                winner.power++;
-
                 this.addMessage(winner.name + ' has gained 1 power from an unopposed challenge');
-
+                this.addPower(winner, 1);
                 this.checkWinCondition(winner);
             }
 
@@ -782,6 +780,16 @@ class Game extends EventEmitter {
                 player.buttons = [];
             }
         }
+    }
+
+    addPower(player, power) {
+        player.power += power;
+    }
+
+    transferPower(winner, loser, power) {
+        var appliedPower = Math.min(loser.power, power);
+        loser.power -= appliedPower;
+        winner.power += appliedPower;
     }
 
     checkWinCondition(player) {
@@ -840,17 +848,8 @@ class Game extends EventEmitter {
             } else if (winner.currentChallenge === 'intrigue') {
                 loser.discardAtRandom(claim);
             } else if (winner.currentChallenge === 'power') {
-                while (claim > 0) {
-                    if (loser.power > 0) {
-                        loser.power--;
-                        winner.power++;
-                        claim--;
-
-                        this.checkWinCondition(winner);
-                    } else {
-                        claim = 0;
-                    }
-                }
+                this.transferPower(winner, loser, claim);
+                this.checkWinCondition(winner);
             }
         }
 
@@ -902,7 +901,7 @@ class Game extends EventEmitter {
         if (dominanceWinner) {
             this.addMessage(dominanceWinner.name + ' wins dominance');
 
-            dominanceWinner.power++;
+            this.addPower(dominanceWinner, 1);
 
             this.checkWinCondition(dominanceWinner);
         } else {

--- a/test/server/game.power.spec.js
+++ b/test/server/game.power.spec.js
@@ -1,0 +1,48 @@
+/*global describe, it, beforeEach, spyOn, expect*/
+
+const Game = require('../../server/game/game.js');
+const Player = require('../../server/game/player.js');
+
+describe('the Game', () => {
+    var game = {};
+    var winner = new Player('1', 'Player 1', true);
+    var loser = new Player('1', 'Player 1', true);
+
+    beforeEach(() => {
+        game = new Game('1', 'Test Game');
+
+        game.initialise();
+
+        game.players[winner.id] = winner;
+        game.players[loser.id] = loser;
+    });
+
+    describe('the transferPower() function', () => {
+        describe('when the loser has enough power', () => {
+            it('should transfer the exact amount of power', () => {
+                winner.power = 1;
+                loser.power = 2;
+
+                game.transferPower(winner, loser, 2);
+
+                expect(winner.power).toBe(3);
+            });
+        });
+
+        describe('when the loser does not have enough power', () => {
+            beforeEach(() => {
+                winner.power = 1;
+                loser.power = 2;
+                game.transferPower(winner, loser, 3);
+            });
+
+            it('should increase the winner power by the losers total power', () => {
+                expect(winner.power).toBe(3);
+            });
+
+            it('should set the losers power to 0', () => {
+                expect(loser.power).toBe(0);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Previously power was being modified directly in multiple places and the win condition wasn't being checked in all of them. Additionally, the win condition was duplicated in multiple spots. This should make things a bit more consistent.

In the future this could also emit a 'powerGained' event, which may be needed for cards like [Edmure Tully](https://thronesdb.com/card/04041) and [Eddard Stark (WotN)](https://thronesdb.com/card/03003).