### PR TITLE
Introduce reserve modifier cards

### DIFF
--- a/server/game/cards/characters.js
+++ b/server/game/cards/characters.js
@@ -44,6 +44,15 @@ characters['01094'] = factionCharacterCostReducer('lannister');
 // 01110 - Desert Scavenger
 characters['01110'] = factionCharacterCostReducer('martell');
 
+// 01127 -  Samwell Tarly
+characters['01127'] = {
+    register: function(game, player, card) {
+        card.reserve = 1;
+    },
+    unregister: function(game, player, card) {
+    }
+};
+
 // 01133 - Steward At The Wall
 characters['01133'] = factionCharacterCostReducer('thenightswatch');
 

--- a/server/game/cards/locations.js
+++ b/server/game/cards/locations.js
@@ -3,6 +3,16 @@ const factionCostReducer = require('./reducer.js').factionCostReducer;
 
 var locations = {};
 
+// 01038 - The Iron Throne
+locations['01038'] = {
+    register: function(game, player, card) {
+        card.reserve = 1;
+        // TODO: Provides 8 STR in dominance phase.
+    },
+    unregister: function(game, player, card) {
+    }
+};
+
 // 01039 - The Kingsroad
 class TheKingsRoad {
     constructor(player, card) {
@@ -144,11 +154,23 @@ locations['02064'] = {
     }
 };
 
+// 02086 - Northern Rookery
+characters['02086'] = {
+    register: function(game, player, card) {
+        card.reserve = 1;
+        // TODO: +1 draw when marshalled
+    },
+    unregister: function(game, player, card) {
+    }
+};
+
+
 // 04058 - The God's Eye
 locations['04058'] = {
     register: function(game, player, card) {
         card.income = 1;
-        // TODO: +1 Reserve modifier
+        card.reserve = 1;
+        // TODO: Cannot be discarded
     },
     unregister: function(game, player, card) {
     }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -335,7 +335,7 @@ class Player extends Spectator {
         this.menuTitle = 'Marshal your cards';
 
         this.gold += this.getTotalIncome();
-        this.reserve = this.activePlot.card.reserve || 0;
+        this.reserve = this.getTotalReserve();
         this.claim = this.activePlot.card.claim || 0;
 
         this.limitedPlayed = false;
@@ -854,6 +854,12 @@ class Player extends Spectator {
     getTotalIncome() {
         return this.getTotalPlotStat(card => {
             return card.income;
+        });
+    }
+
+    getTotalReserve() {
+        return this.getTotalPlotStat(card => {
+            return card.reserve;
         });
     }
 

--- a/test/server/player.plotstats.spec.js
+++ b/test/server/player.plotstats.spec.js
@@ -7,6 +7,9 @@ describe('the Game', () => {
     var game = {};
     var player = new Player('1', 'Player 1', true);
     var testPlot = { card: { income: 5 } };
+    var income = (card) => {
+        return card.income;
+    };
 
     beforeEach(() => {
         game = new Game('1', 'Test Game');
@@ -21,30 +24,30 @@ describe('the Game', () => {
         player.cardsInPlay.push({ card: { }, attachments: [] });
     });
 
-    describe('the getTotalIncome() function', () => {
-        describe('when income is only provided by plot', () => {
-            it('should equal the plot income value', () => {
-                expect(player.getTotalIncome()).toBe(5);
+    describe('the getTotalPlotStat() function', () => {
+        describe('when property is only provided by plot', () => {
+            it('should equal the plot value', () => {
+                expect(player.getTotalPlotStat(income)).toBe(5);
             });
         });
 
-        describe('when an income modifying card is in play', () => {
+        describe('when a property modifying card is in play', () => {
             beforeEach(() => {
                 player.cardsInPlay.push({ card: { income: 1 }, attachments: [] });
             });
 
-            it('should include both the plot income and the modifier', () => {
-                expect(player.getTotalIncome()).toBe(6);
+            it('should include both the plot value and the modifier', () => {
+                expect(player.getTotalPlotStat(income)).toBe(6);
             });
         });
 
-        describe('when an income modifying attachment is in play', () => {
+        describe('when a property modifying attachment is in play', () => {
             beforeEach(() => {
                 player.cardsInPlay.push({ card: {}, attachments: [{ income: 1 }] });
             });
 
-            it('should include both the plot income and the modifier', () => {
-                expect(player.getTotalIncome()).toBe(6);
+            it('should include both the plot value and the modifier', () => {
+                expect(player.getTotalPlotStat(income)).toBe(6);
             });
         });
     });


### PR DESCRIPTION
Introduces all of the simple reserve modifying cards.

I also changed the test for `Player.getTotalIncome` to be a general test for `Player.getTotalPlotStat`. It seemed needless to introduce a separate test for `getTotalReserve` (or `getTotalInitiative` for tha matter) when they all use the same method.