### PR TITLE
Draw deck improvements

### DIFF
--- a/server/game/cards/plots.js
+++ b/server/game/cards/plots.js
@@ -217,9 +217,7 @@ class BuildingOrders {
             game.playerRevealDone(player);
         }
 
-        var card = _.find(player.drawDeck, c => {
-            return c.uuid === arg;
-        });
+        var card = player.findDrawDeckCardByUuid(arg);
 
         if(!card) {
             return;
@@ -915,9 +913,7 @@ class Summons {
             game.playerRevealDone(player);
         }
 
-        var card = _.find(player.drawDeck, c => {
-            return c.uuid === arg;
-        });
+        var card = player.findDrawDeckCardByUuid(arg);
 
         if(!card) {
             return;

--- a/server/game/cards/plots.js
+++ b/server/game/cards/plots.js
@@ -225,11 +225,7 @@ class BuildingOrders {
             return;
         }
 
-        player.drawDeck = _.reject(player.drawDeck, c => {
-            return c.uuid === card.uuid;
-        });
-
-        player.hand.push(card);
+        player.moveFromDrawDeckToHand(card);
         player.shuffleDrawDeck();
 
         game.addMessage(player.name + ' uses ' + player.activePlot.card.label + ' to reveal ' + card.label + ' and add it to their hand');
@@ -927,11 +923,7 @@ class Summons {
             return;
         }
 
-        player.drawDeck = _.reject(player.drawDeck, c => {
-            return c.uuid === card.uuid;
-        });
-
-        player.hand.push(card);
+        player.moveFromDrawDeckToHand(card);
         player.shuffleDrawDeck();
 
         game.addMessage(player.name + ' uses ' + player.activePlot.card.label + ' to reveal ' + card.label + ' and add it to their hand');

--- a/server/game/cards/plots.js
+++ b/server/game/cards/plots.js
@@ -192,9 +192,8 @@ class BuildingOrders {
             return;
         }
 
-        var top10 = _.first(player.drawDeck, 10);
-        var attachmentsAndLocations = _.reject(top10, card => {
-            return card.type_code !== 'attachment' && card.type_code !== 'location';
+        var attachmentsAndLocations = player.searchDrawDeck(10, card => {
+            return card.type_code === 'attachment' || card.type_code === 'location';
         });
 
         var buttons = _.map(attachmentsAndLocations, card => {
@@ -895,9 +894,8 @@ class Summons {
             return;
         }
 
-        var top10 = _.first(player.drawDeck, 10);
-        var characters = _.reject(top10, card => {
-            return card.type_code !== 'character';
+        var characters = player.searchDrawDeck(10, card => {
+            return card.type_code === 'character';
         });
 
         var buttons = _.map(characters, card => {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -21,6 +21,22 @@ class Player extends Spectator {
         this.drawDeck = _.rest(this.drawDeck, numCards);
     }
 
+    searchDrawDeck(limit, predicate) {
+        var cards = this.drawDeck;
+
+        if (_.isFunction(limit)) {
+            predicate = limit;
+        } else {
+            if (limit > 0) {
+                cards = _.first(this.drawDeck, limit);
+            } else {
+                cards = _.last(this.drawDeck, -limit);
+            }
+        }
+
+        return _.filter(cards, predicate);
+    }
+
     shuffleDrawDeck() {
         this.drawDeck = _.shuffle(this.drawDeck);
     }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -37,6 +37,13 @@ class Player extends Spectator {
         return _.filter(cards, predicate);
     }
 
+    moveFromDrawDeckToHand(card) {
+        this.drawDeck = _.reject(this.drawDeck, c => {
+            return c.uuid === card.uuid;
+        });
+        this.hand.push(card);
+    }
+
     shuffleDrawDeck() {
         this.drawDeck = _.shuffle(this.drawDeck);
     }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -44,6 +44,12 @@ class Player extends Spectator {
         this.hand.push(card);
     }
 
+    findDrawDeckCardByUuid(uuid) {
+        return _.find(this.drawDeck, c => {
+            return c.uuid === uuid;
+        });
+    }
+
     shuffleDrawDeck() {
         this.drawDeck = _.shuffle(this.drawDeck);
     }

--- a/test/server/player/player.moveFromDrawDeckToHand.spec.js
+++ b/test/server/player/player.moveFromDrawDeckToHand.spec.js
@@ -1,0 +1,34 @@
+/*global describe, it, beforeEach, expect*/
+/* eslint camelcase: 0 */
+
+const Player = require('../../../server/game/player.js');
+
+describe('the Player', () => {
+    var player = new Player('1', 'Player 1', true);
+    var drawDeck = [
+      { uuid: '1111' },
+      { uuid: '2222' },
+      { uuid: '333' }
+    ];
+    var cardToMove = drawDeck[1];
+
+    beforeEach(() => {
+        player.initialise();
+        player.drawDeck = drawDeck;
+        player.hand = [];
+    });
+
+    describe('the moveFromDrawDeckToHand() function', () => {
+        it('should add the card to the players hand', () => {
+            player.moveFromDrawDeckToHand(cardToMove);
+
+            expect(player.hand).toContain(cardToMove);
+        });
+
+        it('should remove the card from the draw deck', () => {
+            player.moveFromDrawDeckToHand(cardToMove);
+
+            expect(player.drawDeck).not.toContain(cardToMove);
+        });
+    });
+});

--- a/test/server/player/player.searchDrawDeck.spec.js
+++ b/test/server/player/player.searchDrawDeck.spec.js
@@ -1,0 +1,72 @@
+/*global describe, it, beforeEach, expect*/
+/* eslint camelcase: 0 */
+
+const Player = require('../../../server/game/player.js');
+
+describe('the Player', () => {
+    var player = new Player('1', 'Player 1', true);
+    var drawDeck = [
+      { name: 'foo' },
+      { name: 'bar' },
+      { name: 'baz' },
+      { name: 'ball' }
+    ];
+
+    beforeEach(() => {
+        player.initialise();
+        player.drawDeck = drawDeck;
+    });
+
+    describe('the searchDrawDeck() function', () => {
+        describe('when no limit is passed', () => {
+            it('should search all cards in the deck', () => {
+                var cards = player.searchDrawDeck(() => {
+                    return true;
+                });
+                expect(cards.length).toBe(drawDeck.length);
+            });
+
+            it('should filter the results using the predicate', () => {
+                var cards = player.searchDrawDeck((card) => {
+                    return card.name === 'bar';
+                });
+
+                expect(cards.length).toBe(1);
+            });
+        });
+
+        describe('when a limit is passed but no predicate', () => {
+            describe('when the limit is positive', () => {
+                it('should return from the top of the deck', () => {
+                    var cards = player.searchDrawDeck(2);
+
+                    expect(cards.length).toBe(2);
+                    expect(cards[0].name).toBe('foo');
+                    expect(cards[1].name).toBe('bar');
+                });
+            });
+
+            describe('when the limit is negative', () => {
+                it('should return from the bottom of the deck', () => {
+                    var cards = player.searchDrawDeck(-2);
+
+                    expect(cards.length).toBe(2);
+                    expect(cards[0].name).toBe('baz');
+                    expect(cards[1].name).toBe('ball');
+                });
+            });
+        });
+
+        describe('when both a limit and a predicate are passed', () => {
+            it('should limit and filter', () => {
+                var cards = player.searchDrawDeck(3, (card) => {
+                    return card.name[0] === 'b';
+                });
+
+                expect(cards.length).toBe(2);
+                expect(cards[0].name).toBe('bar');
+                expect(cards[1].name).toBe('baz');
+            });
+        });
+    });
+});


### PR DESCRIPTION
Saw some minor repetition that would get worse as more cards are implemented. Minor refactor that introduces methods to:
* Search the top or bottom X cards of the draw deck - [Summons](https://thronesdb.com/card/01022), [Building Orders](https://thronesdb.com/card/01006), [I Never Bet Against My Family](https://thronesdb.com/card/02050), etc
* Search the entire deck for a certain type of card - [Wolf Dreams](https://thronesdb.com/card/02042), [Ser Hobber Redwyne](https://thronesdb.com/card/02043), etc
* Move a specific card from the draw deck to the player's hand.