### PR TITLE
Implement card preview in chat

### DIFF
--- a/client/GameBoard.jsx
+++ b/client/GameBoard.jsx
@@ -511,7 +511,7 @@ export class InnerGameBoard extends React.Component {
                     <CardZoom imageUrl={this.state.cardToZoom ? '/img/cards/' + this.state.cardToZoom.code + '.png' : ''}
                         orientation={this.state.cardToZoom ? this.state.cardToZoom.type_code === 'plot' ? 'horizontal' : 'vertical' : 'vertical'}
                         show={!!this.state.cardToZoom} />
-                    <Messages messages={this.props.state.messages} />
+                    <Messages messages={this.props.state.messages} onCardMouseOver={this.onMouseOver} onCardMouseOut={this.onMouseOut} />
                 </div>
             </div>);
     }

--- a/client/GameComponents/Messages.jsx
+++ b/client/GameComponents/Messages.jsx
@@ -15,6 +15,8 @@ class InnerMessages extends React.Component {
         this.state = {
             message: ''
         };
+
+        this.formatMessageText = this.formatMessageText.bind(this);
     }
 
     componentDidUpdate() {
@@ -24,10 +26,28 @@ class InnerMessages extends React.Component {
     getMessage() {
         var index = 0;
         var messages = _.map(this.props.messages, message => {
-            return <div key={'message'+index++} className='message'>{message.message}</div>;
+            return <div key={'message'+index++} className='message'>{this.formatMessageText(message.message)}</div>;
         });
 
         return messages;
+    }
+
+    formatMessageText(message) {
+        var index = 0;
+        return _.map(message, fragment => {
+            if(fragment.code && fragment.label) {
+                return (
+                    <span key={index++}
+                        className='card-link'
+                        onMouseOver={this.props.onCardMouseOver.bind(this, fragment)}
+                        onMouseOut={this.props.onCardMouseOut.bind(this)}>
+                        {fragment.label}
+                    </span>
+                );
+            } else {
+                return fragment;
+            }
+        });
     }
 
     sendMessage() {

--- a/server/game/cards/locations.js
+++ b/server/game/cards/locations.js
@@ -49,7 +49,7 @@ class TheKingsRoad {
 
         player.discardCard(card, player.discardPile);
 
-        game.addMessage(player.name + ' scarifices ' + card.label + ' to reduce the cost of the next character they marshal by 3');        
+        game.addMessage('{0} sacrifices {1} to reduce the cost of the next character they marshal by 3', player.name, card);
 
         this.active = true;
     }
@@ -61,15 +61,14 @@ class TheKingsRoad {
 
         if (this.active && !this.abilityUsed && card.type_code === 'character' && card.cost > 0) {
             this.cost = card.cost;
-            
+
             card.cost -= 3;
             if (card.cost < 0) {
                 card.cost = 0;
             }
 
             this.abilityUsed = true;
-
-            game.addMessage(player.name + ' uses ' + this.card.label + ' to reduce the cost of ' + card.label + ' by 3');
+            game.addMessage('{0} uses {1} to reduce the cost of {2} by 3', player.name, this.card, card);
         }
     }
 

--- a/server/game/cards/plots.js
+++ b/server/game/cards/plots.js
@@ -15,7 +15,7 @@ class AClashOfKings {
 
     afterChallenge(game, challengeType, winner, loser) {
         if(winner === this.player && challengeType === 'power' && loser.power > 0) {
-            game.addMessage(winner.name + ' uses ' + winner.activePlot.card.label + ' to move 1 power from ' + loser.name + '\'s faction card');
+            game.addMessage('{0} uses {1} to move 1 power from {2}\'s faction card', winner.name, winner.activePlot.card, loser.name);
             game.transferPower(winner, loser, 1);
         }
     }
@@ -45,7 +45,7 @@ class AFeastForCrows {
             return;
         }
 
-        game.addMessage(winner.name + ' uses ' + winner.activePlot.card.label + ' to gain 2 power');
+        game.addMessage('{0} uses {1} to gain 2 power', winner.name, winner.activePlot.card);
         game.addPower(winner, 2);
     }
 }
@@ -120,7 +120,7 @@ class ANobleCause {
 
             this.abilityUsed = true;
 
-            game.addMessage(player.name + ' uses ' + player.activePlot.card.label + ' to reduce the cost of ' + card.label + ' by 2');
+            game.addMessage('{0} uses {1} to reduce the cost of {2} by 2', player.name, player.activePlot.card, card);
         }
     }
 
@@ -163,7 +163,7 @@ class AStormOfSwords {
 
         player.challenges['military'].max++;
 
-        game.addMessage(player.name + ' uses ' + player.activePlot.card.label + ' to gain an additional military challenge this round');
+        game.addMessage('{0} uses {1} to gain an additional military challenge this round', player.name, player.activePlot.card);
     }
 }
 plots['01005'] = {
@@ -226,7 +226,7 @@ class BuildingOrders {
         player.moveFromDrawDeckToHand(card);
         player.shuffleDrawDeck();
 
-        game.addMessage(player.name + ' uses ' + player.activePlot.card.label + ' to reveal ' + card.label + ' and add it to their hand');
+        game.addMessage('{0} uses {1} to reveal {2} and add it to their hand', player.name, player.activePlot.card, card);
 
         game.playerRevealDone(player);
     }
@@ -274,7 +274,7 @@ class CallingTheBanners {
             return count;
         }, 0);
 
-        game.addMessage(player.name + ' uses ' + player.activePlot.card.label + ' to gain ' + characterCount + ' gold');
+        game.addMessage('{0} uses {1} to gain {2} gold', player.name, player.activePlot.card, characterCount);
         player.gold += characterCount;
     }
 
@@ -338,8 +338,8 @@ class CalmOverWesteros {
         this.claim = winner.activePlot.card.claim;
         winner.activePlot.card.claim--;
 
-        game.addMessage(loser.name + ' uses ' + loser.activePlot.card.label + ' to reduce the claim value of ' +
-            winner.name + '\'s ' + challengeType + 'challenge to ' + winner.activePlot.card.claim);
+        game.addMessage('{0} uses {1} to reduce the claim value of {2}\'s {3} challenge to {4}',
+            loser.name, loser.activePlot.card, winner.name, challengeType, winner.activePlot.card.claim);
     }
 
     afterClaim(game, challengeType, winner) {
@@ -448,7 +448,7 @@ class Confiscation {
 
         attachmentPlayer.discardPile.push(clicked);
 
-        game.addMessage(player.name + ' uses ' + player.activePlot.card.label + ' to discard ' + clicked.label);
+        game.addMessage('{0} uses {1} to discard {2}', player.name, player.activePlot.card, clicked);
 
         player.selectCard = false;
         game.clickHandled = true;
@@ -486,7 +486,7 @@ class CountingCoppers {
 
         player.drawCardsToHand(3);
 
-        game.addMessage(player.name + ' draws 3 cards from ' + player.activePlot.card.label);
+        game.addMessage('{0} draws 3 cards from {1}', player.name, player.activePlot.card);
     }
 }
 plots['01010'] = {
@@ -562,7 +562,7 @@ class FilthyAccusation {
 
         card.kneeled = true;
 
-        game.addMessage(player.name + ' uses ' + player.activePlot.card.label + ' to kneel ' + card.card.label);
+        game.addMessage('{0} uses {1} to kneel {2}', player.name, player.activePlot.card, card.card);
 
         game.playerRevealDone(player);
     }
@@ -606,20 +606,21 @@ class HeadsOnSpikes {
 
         var cardIndex = _.random(0, otherPlayer.hand.length - 1);
         var card = otherPlayer.hand[cardIndex];
-        var message = player.name + ' uses ' + player.activePlot.card.label + ' to discard ' + card.label +
-            ' from ' + otherPlayer.name + '\'s hand';
+        var message = '{0} uses {1} to discard {2} from {3}\'s hand';
 
         otherPlayer.removeFromHand(card);
 
+
         if(card.type_code === 'character') {
-            message += ' and gain 2 power for their faction';
+            message = '{0} uses {1} to discard {2} from {3}\'s hand and gain 2 power for their faction';
             otherPlayer.deadPile.push(card);
             game.addPower(player, 2);
         } else {
             otherPlayer.discardPile.push(card);
         }
 
-        game.addMessage(message);
+
+        game.addMessage(message, player.name, player.activePlot.card, card, otherPlayer.name);
     }
 }
 plots['01013'] = {
@@ -705,7 +706,7 @@ class MarchedToTheWall {
             return;
         }
 
-        game.addMessage(player.name + ' discards ' + clicked.label);
+        game.addMessage('{0} discards {1}', player.name, clicked);
 
         player.discardCard(clicked, player.discardPile);
         player.doneDiscard = true;
@@ -830,8 +831,8 @@ class NavalSuperority {
             this.plotGold = otherPlayer.activePlot.gold;
             otherPlayer.activePlot.card.income = 0;
 
-            game.addMessage(player.name + ' uses ' + player.activePlot.card.label + ' to reduce the gold value of '
-                + otherPlayer.activePlot.card.label + ' to 0');
+            game.addMessage('{0} uses {1} to reduce the gold value of {2} to 0',
+                player.name, player.activePlot.card, otherPlayer.activePlot.card);
         }
     }
 }
@@ -863,8 +864,7 @@ class SneakAttack {
 
         player.challenges.maxTotal = 1;
 
-        game.addMessage(player.name + ' uses ' + player.activePlot.card.label +
-            ' to make the maximum number of challenges able to be initiated by ' + player.name + ' this round be 1');
+        game.addMessage('{0} uses {1} to make the maximum number of challenges able to be initiated by {0} this round be 1', player.name, player.activePlot.card);
     }
 }
 plots['01021'] = {
@@ -926,7 +926,7 @@ class Summons {
         player.moveFromDrawDeckToHand(card);
         player.shuffleDrawDeck();
 
-        game.addMessage(player.name + ' uses ' + player.activePlot.card.label + ' to reveal ' + card.label + ' and add it to their hand');
+        game.addMessage('{0} uses {1} to reveal {2} and add it to their hand', player.name, player.activePlot.card, card);
 
         game.playerRevealDone(player);
     }
@@ -965,7 +965,7 @@ class TradingWithThePentoshi {
         if(otherPlayer) {
             otherPlayer.gold += 3;
 
-            game.addMessage(otherPlayer.name + ' gains 3 gold from ' + player.activePlot.card.label);
+            game.addMessage('{0} gains 3 gold from {1}', otherPlayer.name, player.activePlot.card);
         }
     }
 }
@@ -1004,7 +1004,7 @@ class TheLongWinter {
                 if(!_.any(p.cardsInPlay, card => {
                     return card.power > 0;
                 })) {
-                    game.addMessage(p.name + ' discards 1 power from their faction card from ' + player.activePlot.card.label);
+                    game.addMessage('{0} discards 1 power from their faction card from {1}', p.name, player.activePlot.card);
                     p.power--;
                 } else {
                     p.menuTitle = 'Select a card to discard power from';
@@ -1037,7 +1037,7 @@ class TheLongWinter {
             return;
         }
 
-        game.addMessage(player.name + ' discards 1 power form ' + cardInPlay.card.label + ' from ' + this.player.activePlot.card.label);
+        game.addMessage('{0} discards 1 power from {1} from {2}', player.name, cardInPlay.card, this.player.activePlot.card.label);
         cardInPlay.power--;
 
         delete this.waitingForPlayers[player.id];

--- a/server/game/cards/plots.js
+++ b/server/game/cards/plots.js
@@ -1037,7 +1037,7 @@ class TheLongWinter {
             return;
         }
 
-        game.addMessage('{0} discards 1 power from {1} from {2}', player.name, cardInPlay.card, this.player.activePlot.card.label);
+        game.addMessage('{0} discards 1 power from {1} from {2}', player.name, cardInPlay.card, this.player.activePlot.card);
         cardInPlay.power--;
 
         delete this.waitingForPlayers[player.id];

--- a/server/game/cards/reducer.js
+++ b/server/game/cards/reducer.js
@@ -87,7 +87,7 @@ class Reducer {
             this.abilityUsed = true;
             this.active = false;
 
-            game.addMessage(player.name + ' uses ' + this.card.label + ' to reduce the cost of ' + card.label + ' by 1');
+            game.addMessage('{0} uses {1} to reduce the cost of {2} by 1', player.name, this.card, card);
         }
     }
 

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -855,7 +855,7 @@ class Game extends EventEmitter {
             if(this.hasKeyword(card.card, 'Insight')) {
                 winner.drawCardsToHand(1);
 
-                this.addMessage('{0} draws a card from Insight on {1}', winner.name, card.card.label);
+                this.addMessage('{0} draws a card from Insight on {1}', winner.name, card.card);
             }
 
             if(this.hasKeyword(card.card, 'Intimidate')) {
@@ -865,7 +865,7 @@ class Game extends EventEmitter {
             if(this.hasKeyword(card.card, 'Pillage')) {
                 loser.discardFromDraw(1);
 
-                this.addMessage('{0} discards a card from the top of their deck from Pillage on {1}', loser.name, card.card.label);
+                this.addMessage('{0} discards a card from the top of their deck from Pillage on {1}', loser.name, card.card);
             }
 
             if(this.hasKeyword(card.card, 'Renown')) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -22,7 +22,25 @@ class Game extends EventEmitter {
     }
 
     addMessage(message) {
-        this.messages.push({ date: new Date(), message: message });
+        var args = Array.from(arguments).slice(1);
+        var formattedMessage = this.formatMessage(message, args);
+        this.messages.push({ date: new Date(), message: formattedMessage });
+    }
+
+    formatMessage(format, args) {
+        var messageFragments = format.split(/(\{\d+\})/);
+        return _.map(messageFragments, fragment => {
+            var argMatch = fragment.match(/\{(\d+)\}/);
+            if(argMatch) {
+                var arg = args[argMatch[1]];
+                if(arg) {
+                    return arg;
+                }
+                return '';
+            }
+
+            return fragment;
+        });
     }
 
     isSpectator(player) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -165,7 +165,7 @@ class Game extends EventEmitter {
         }
 
         if(player.mulligan()) {
-            this.addMessage(player.name + ' has taken a mulligan');
+            this.addMessage('{0} has taken a mulligan', player.name);
         }
     }
 
@@ -178,7 +178,7 @@ class Game extends EventEmitter {
 
         player.keep();
 
-        this.addMessage(player.name + ' has kept their hand');
+        this.addMessage('{0} has kept their hand', player.name);
     }
 
     playCard(playerId, card, isDrop) {
@@ -244,7 +244,7 @@ class Game extends EventEmitter {
 
         player.setupDone();
 
-        this.addMessage(player.name + ' has finished setup');
+        this.addMessage('{0} has finished setup', player.name);
 
         if(!_.all(this.getPlayers(), p => {
             return p.setup;
@@ -295,7 +295,7 @@ class Game extends EventEmitter {
             plotImplementation.register(this, player);
         }
 
-        this.addMessage(player.name + ' has selected a plot');
+        this.addMessage('{0} has selected a plot', player.name);
 
         if(!_.all(this.getPlayers(), p => {
             return !!p.selectedPlot;
@@ -442,7 +442,7 @@ class Game extends EventEmitter {
             player.buttons = [];
         });
 
-        this.addMessage(player.name + ' has selected ' + firstPlayer.name + ' to be the first player');
+        this.addMessage('{0} has selected {1} to be the first player', player.name, firstPlayer.name);
 
         this.resolvePlotEffects(firstPlayer);
     }
@@ -508,7 +508,7 @@ class Game extends EventEmitter {
                     return false;
                 }
 
-                this.addMessage(player.name + ' has chosen ' + otherCardInPlay.card.label + ' as a stealth target');
+                this.addMessage('{0} has chosen {1} as a stealth target', player.name, otherCardInPlay.card);
                 player.stealthCard.stealthTarget = otherCardInPlay;
 
                 if(this.doStealth(player)) {
@@ -573,7 +573,7 @@ class Game extends EventEmitter {
 
             cardInPlay.power = player.setPower;
 
-            this.addMessage(player.name + ' uses the /power command to set the power of ' + cardInPlay.card.label + ' to ' + player.setPower);
+            this.addMessage('{0} uses the /power command to set the power of {1} to {2}', player.name, cardInPlay.card, player.setPower);
             this.doneSetPower(player.id);
 
             return true;
@@ -640,11 +640,11 @@ class Game extends EventEmitter {
         if(!player.showDeck) {
             player.showDrawDeck();
 
-            this.addMessage(player.name + ' is looking at their deck');
+            this.addMessage('{0} is looking at their deck', player.name);
         } else {
             player.showDeck = false;
 
-            this.addMessage(player.name + ' stops looking at their deck');
+            this.addMessage('{0} stops looking at their deck', player.name);
         }
     }
 
@@ -656,7 +656,7 @@ class Game extends EventEmitter {
         }
 
         if(player.drop(card, source, target)) {
-            this.addMessage(player.name + ' has moved a card from their ' + source + ' to their ' + target);
+            this.addMessage('{0} has moved a card from their {1} to their {2}', player.name, source, target);
         }
     }
 
@@ -669,7 +669,7 @@ class Game extends EventEmitter {
 
         player.marshalDone();
 
-        this.addMessage(player.name + ' has finished marshalling');
+        this.addMessage('{0} has finished marshalling', player.name);
 
         var unMarshalledPlayer = _.find(this.getPlayers(), p => {
             return !p.marshalled;
@@ -738,7 +738,7 @@ class Game extends EventEmitter {
             return true;
         }
 
-        this.addMessage(player.name + ' has initiated a ' + player.currentChallenge + ' challenge with strength ' + player.challengeStrength);
+        this.addMessage('{0} has initiated a {1} challenge with strength {2}', player.name, player.currentChallenge, player.challengeStrength);
 
         var otherPlayer = this.getOtherPlayer(player);
 
@@ -784,7 +784,7 @@ class Game extends EventEmitter {
 
         player.doneChallenge(false);
 
-        this.addMessage(player.name + ' has defended with strength ' + player.challengeStrength);
+        this.addMessage('{0} has defended with strength {1}', player.name, player.challengeStrength);
 
         var challenger = _.find(this.getPlayers(), p => {
             return p.id !== player.id;
@@ -804,13 +804,13 @@ class Game extends EventEmitter {
 
             winner.challenges[winner.currentChallenge].won++;
 
-            this.addMessage(winner.name + ' won a ' + winner.currentChallenge + '  challenge ' +
-                winner.challengeStrength + ' vs ' + loser.challengeStrength);
+            this.addMessage('{0} won a {1} challenge {2} vs {3}',
+                winner.name, winner.currentChallenge, winner.challengeStrength, loser.challengeStrength);
 
             this.emit('afterChallenge', this, winner.currentChallenge, winner, loser);
 
             if(loser.challengeStrength === 0) {
-                this.addMessage(winner.name + ' has gained 1 power from an unopposed challenge');
+                this.addMessage('{0} has gained 1 power from an unopposed challenge', winner.name);
                 this.addPower(winner, 1);
             }
 
@@ -842,7 +842,7 @@ class Game extends EventEmitter {
 
     checkWinCondition(player) {
         if(player.getTotalPower() >= 15) {
-            this.addMessage(player.name + ' has won the game');
+            this.addMessage('{0} has won the game', player.name);
         }
     }
 
@@ -855,7 +855,7 @@ class Game extends EventEmitter {
             if(this.hasKeyword(card.card, 'Insight')) {
                 winner.drawCardsToHand(1);
 
-                this.addMessage(winner.name + ' draws a card from Insight on ' + card.card.label);
+                this.addMessage('{0} draws a card from Insight on {1}', winner.name, card.card.label);
             }
 
             if(this.hasKeyword(card.card, 'Intimidate')) {
@@ -865,13 +865,13 @@ class Game extends EventEmitter {
             if(this.hasKeyword(card.card, 'Pillage')) {
                 loser.discardFromDraw(1);
 
-                this.addMessage(loser.name + ' discards a card from the top of their deck from Pillage on ' + card.card.label);
+                this.addMessage('{0} discards a card from the top of their deck from Pillage on {1}', loser.name, card.card.label);
             }
 
             if(this.hasKeyword(card.card, 'Renown')) {
                 card.power++;
 
-                this.addMessage(winner.name + ' gains 1 power on ' + card.card.label + ' from Renown');
+                this.addMessage('{0} gains 1 power on {1} from Renown', winner.name, card.card);
             }
 
             this.checkWinCondition(winner);
@@ -883,7 +883,7 @@ class Game extends EventEmitter {
         var claim = winner.activePlot.card.claim;
 
         if(claim <= 0) {
-            this.addMessage('The claim value for ' + winner.currentChallenge + ' is 0, no claim occurs');
+            this.addMessage('The claim value for {0} is 0, no claim occurs', winner.currentChallenge);
         } else {
             if(winner.currentChallenge === 'military') {
                 winner.menuTitle = 'Waiting for opponent to apply claim effects';
@@ -946,7 +946,7 @@ class Game extends EventEmitter {
         });
 
         if(dominanceWinner) {
-            this.addMessage(dominanceWinner.name + ' wins dominance');
+            this.addMessage('{0} wins dominance', dominanceWinner.name);
 
             this.addPower(dominanceWinner, 1);
         } else {
@@ -1040,7 +1040,7 @@ class Game extends EventEmitter {
         if(player[stat] < 0) {
             player[stat] = 0;
         } else {
-            this.addMessage(player.name + ' sets ' + stat + ' to ' + player[stat] + ' (' + (value > 0 ? '+' : '') + value + ')');
+            this.addMessage('{0} sets {1} to {2} ({3})', player.name, stat, player[stat], (value > 0 ? '+' : '') + value);
         }
     }
 
@@ -1077,7 +1077,7 @@ class Game extends EventEmitter {
         }
 
         if(this.isSpectator(player)) {
-            this.addMessage('<' + player.name + '> ' + message);
+            this.addMessage('<{0}> {1}', player.name,  message);
             return;
         }
 
@@ -1086,7 +1086,7 @@ class Game extends EventEmitter {
                 num = this.getNumberOrDefault(args[1], 1);
             }
 
-            this.addMessage(player.name + ' uses the /draw command to draw ' + num + ' cards to their hand');
+            this.addMessage('{0} uses the /draw command to draw {1} cards to their hand', player.name, num);
 
             player.drawCardsToHand(num);
 
@@ -1115,7 +1115,7 @@ class Game extends EventEmitter {
                 num = this.getNumberOrDefault(args[1], 1);
             }
 
-            this.addMessage(player.name + ' uses the /discard command to discard ' + num + ' cards at random');
+            this.addMessage('{0} uses the /discard command to discard {1} cards at random', player.name, num);
 
             player.discardAtRandom(num);
 
@@ -1123,14 +1123,14 @@ class Game extends EventEmitter {
         }
 
         if(message.indexOf('/pillage') !== -1) {
-            this.addMessage(player.name + ' uses the /pillage command to discard a card from the top of their draw deck');
+            this.addMessage('{0} uses the /pillage command to discard a card from the top of their draw deck', player.name);
 
             player.discardFromDraw(1);
 
             return;
         }
 
-        this.addMessage('<' + player.name + '> ' + message);
+        this.addMessage('<{0}> {1}', player.name,  message);
     }
 
     doneSetPower(playerId) {
@@ -1155,7 +1155,7 @@ class Game extends EventEmitter {
             return;
         }
 
-        this.addMessage(player.name + ' ' + reason);
+        this.addMessage('{0} {1}', player.name, reason);
     }
 
     concede(playerId) {
@@ -1165,12 +1165,12 @@ class Game extends EventEmitter {
             return;
         }
 
-        this.addMessage(player.name + ' concedes');
+        this.addMessage('{0} concedes', player.name);
 
         var otherPlayer = this.getOtherPlayer(player);
 
         if(otherPlayer) {
-            this.addMessage(otherPlayer.name + ' wins the game');
+            this.addMessage('{0} wins the game', otherPlayer.name);
         }
     }
 
@@ -1211,7 +1211,7 @@ class Game extends EventEmitter {
             return;
         }
 
-        this.addMessage(player.name + ' has cancelled claim effects');
+        this.addMessage('{0} has cancelled claim effects', player.name);
 
         player.doneClaim();
 
@@ -1228,7 +1228,7 @@ class Game extends EventEmitter {
             return;
         }
 
-        this.addMessage(player.name + ' shuffles their deck');
+        this.addMessage('{0} shuffles their deck', player.name);
 
         player.shuffleDrawDeck();
     }

--- a/server/index.js
+++ b/server/index.js
@@ -333,7 +333,7 @@ io.on('connection', function(socket) {
 
         runAndCatchErrors(game, () => {
             game.players[socket.id] = new Spectator(socket.id, socket.request.user.username);
-            game.addMessage(socket.request.user.username + ' has joined the game as a spectator');
+            game.addMessage('{0} has joined the game as a spectator', socket.request.user.username);
             socket.join(game.id);
             _.each(game.players, (player, key) => {
                 io.to(key).emit('joingame', game.getState(player.id));

--- a/test/server/game/game.chat.spec.js
+++ b/test/server/game/game.chat.spec.js
@@ -35,7 +35,7 @@ describe('the Game', () => {
                     game.chat(player1.id, 'Test Message');
 
                     expect(game.messages.length).toBe(1);
-                    expect(game.messages[0].message.indexOf('Test Message')).not.toBe(-1);
+                    expect(game.messages[0].message.join('')).toEqual('<Player 1> Test Message');
                 });
             });
 
@@ -181,10 +181,10 @@ describe('the Game', () => {
         describe('when called by a spectator in the game', () => {
             describe('with no slashes', function () {
                 it('should add their chat message', () => {
-                    game.chat(player1.id, 'Test Message');
+                    game.chat(spectator.id, 'Test Message');
 
                     expect(game.messages.length).toBe(1);
-                    expect(game.messages[0].message.indexOf('Test Message')).not.toBe(-1);
+                    expect(game.messages[0].message.join('')).toEqual('<Spectator 1> Test Message');
                 });
             });
 

--- a/test/server/game/game.formatMessage.spec.js
+++ b/test/server/game/game.formatMessage.spec.js
@@ -1,0 +1,51 @@
+/*global describe, it, beforeEach, expect*/
+
+const Game = require('../../../server/game/game.js');
+
+describe('the Game', () => {
+    var game = {};
+    var args = [
+        'foo',
+        { bar: 'baz' }
+    ];
+
+    beforeEach(() => {
+        game = new Game('1', 'Test Game');
+    });
+
+    describe('formatMessage function', () => {
+        describe('when there are no embedded args', () => {
+            it('should return an array with just the format', () => {
+                var message = game.formatMessage('Hello world', args);
+
+                expect(message).toEqual(['Hello world']);
+            });
+        });
+
+        describe('when there are embedded args', () => {
+            it('should split the message text', () => {
+                var message = game.formatMessage('Hello {0} world', args);
+                expect(message.length).toEqual(3);
+                expect(message[0]).toEqual('Hello ');
+                expect(message[2]).toEqual(' world');
+            });
+
+            it('should replace the argument', () => {
+                var message = game.formatMessage('Hello {0} world', args);
+                expect(message[1]).toEqual(args[0]);
+            });
+
+            it('should allow multiple and repeated arguments', () => {
+                var message = game.formatMessage('Hello {1} world {0} !!! {1}', args);
+                expect(message[1]).toEqual(args[1]);
+                expect(message[3]).toEqual(args[0]);
+                expect(message[5]).toEqual(args[1]);
+            });
+
+            it('should handle argument indices beyond what was passed', () => {
+                var message = game.formatMessage('Hello {2} world', args);
+                expect(message[1]).toEqual('');
+            });
+        });
+    });
+});


### PR DESCRIPTION
Reworks `Game.addMessage` to work as a general-purpose formatter when constructing messages for chat. It may now take a list of optional arguments that are interpolated into the message. 

```
// server side
this.addMessage('{0} discards {1}', player.name, card);

// what appears client side
Player 1 discard Tyrion Lannister
```

* In general, the usage of addMessage going forward should favor argument replacement over concating strings together. This provides consistency, allows other rich data to be interpolated into the message (player data, challenge type + icon, etc), and allows a way forward in the future should translation ever be desired.
* Arguments can be either strings or JSON data. Currently no enforcement of what type of JSON data, is left up to the client to interpret. 
* On the client side, JSON data is converted to the appropriate JSX. In this specific PR, when card JSON is passed to the client it will render the card name and allow players to hover over it for the card preview image. 

### Preview
![chat-card-hover](https://cloud.githubusercontent.com/assets/145077/20334304/dcdd3442-ab6d-11e6-8fdb-082b2a756fbf.png)

This PR also converts all usages of addMessage to use the new formatter instead of manually building strings. I know this may conflict w/ the ongoing refactor, so let me know if you want me to re-PR it without the conversions, just the feature itself.