### PR TITLE
Update stealth targeting requirements

### DIFF
--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -59,6 +59,21 @@ class DrawCard extends BaseCard {
         return this.strengthModifier + this.cardData.strength;
     }
 
+    needsStealthTarget() {
+        return this.isStealth() && !this.stealthTarget;
+    }
+
+    useStealthToBypass(targetCard) {
+        if(!this.isStealth() || targetCard.isStealth()) {
+            return false;
+        }
+
+        targetCard.stealth = true;
+        this.stealthTarget = targetCard;
+
+        return true;
+    }
+
     canAttach(player, card) {
         if(this.getType() !== 'attachment' || card.hasKeyword('No Attachments')) {
             return false;

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -93,6 +93,11 @@ class DrawCard extends BaseCard {
         this.kneeled = false;
     }
 
+    resetForChallenge() {
+        this.stealth = false;
+        this.stealthTarget = undefined;
+    }
+
     getSummary(isActivePlayer, hideWhenFaceup) {
         var baseSummary = super.getSummary(isActivePlayer, hideWhenFaceup);
 

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -484,12 +484,11 @@ class Game extends EventEmitter {
                     return false;
                 }
 
-                if(!otherPlayer.addToStealth(otherCardInPlay)) {
+                if(!player.stealthCard.useStealthToBypass(otherCardInPlay)) {
                     return false;
                 }
 
-                this.addMessage('{0} has chosen {1} as a stealth target', player, otherCardInPlay.card);
-                player.stealthCard.stealthTarget = otherCardInPlay;
+                this.addMessage('{0} has chosen {1} as the stealth target for {2}', player, otherCardInPlay, player.stealthCard);
 
                 if(this.doStealth(player)) {               
                     return true;
@@ -696,7 +695,7 @@ class Game extends EventEmitter {
 
     doStealth(player) {
         var stealthCard = player.cardsInChallenge.find(card => {
-            return !card.stealthTarget && card.isStealth();
+            return card.needsStealthTarget();
         });
 
         if(stealthCard) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -700,16 +700,6 @@ class Player extends Spectator {
         this.pickingStealth = false;
     }
 
-    addToStealth(card) {
-        if(!card.hasIcon(this.currentChallenge)) {
-            return false;
-        }
-
-        card.stealth = true;
-
-        return true;
-    }
-
     canAddToChallenge(cardId) {
         var card = this.findCardInPlayByUuid(cardId);
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -680,7 +680,7 @@ class Player extends Spectator {
 
         this.cardsInChallenge = _([]);
         this.cardsInPlay.each(card => {
-            card.stealth = undefined;
+            card.resetForChallenge();
         });
         this.selectCard = false;
         this.selectingChallengers = false;

--- a/test/server/card/drawcard.usestealthtobypass.spec.js
+++ b/test/server/card/drawcard.usestealthtobypass.spec.js
@@ -1,0 +1,65 @@
+/*global describe, it, beforeEach, expect, spyOn*/
+
+const DrawCard = require('../../../server/game/drawcard.js');
+
+describe('the DrawCard', () => {
+    var cardDataWithStealth = { text: 'Stealth.' };
+    var cardDataWithoutStealth = { text: '' };
+    var source;
+    var target;
+
+    describe('the useStealthToBypass() function', () => {
+        describe('when the card does not have stealth', () => {
+            beforeEach(() => {
+                source = new DrawCard({}, cardDataWithoutStealth);
+                target = new DrawCard({}, cardDataWithoutStealth);
+            });
+
+            it('should return false.', () => {
+                expect(source.useStealthToBypass(target)).toBe(false);
+            });
+        });
+
+        describe('when the card has stealth and the target does not', () => {
+            beforeEach(() => {
+                source = new DrawCard({}, cardDataWithStealth);
+                target = new DrawCard({}, cardDataWithoutStealth);
+            });
+
+            it('should return true.', () => {
+                expect(source.useStealthToBypass(target)).toBe(true);
+            });
+
+            it('should mark the target card as being bypassed', () => {
+                source.useStealthToBypass(target);
+                expect(target.stealth).toBe(true);
+            });
+
+            it('should set the stealth target on the source card', () => {
+                source.useStealthToBypass(target);
+                expect(source.stealthTarget).toBe(target);
+            });
+        });
+
+        describe('when both cards have stealth', () => {
+            beforeEach(() => {
+                source = new DrawCard({}, cardDataWithStealth);
+                target = new DrawCard({}, cardDataWithStealth);
+            });
+
+            it('should return false', () => {
+                expect(source.useStealthToBypass(target)).toBe(false);
+            });
+
+            it('should not mark the target card as being bypassed', () => {
+                source.useStealthToBypass(target);
+                expect(target.stealth).toBeFalsy();
+            });
+
+            it('should not set the stealth target on the source card', () => {
+                source.useStealthToBypass(target);
+                expect(source.stealthTarget).toBeUndefined();
+            });
+        });
+    });
+});


### PR DESCRIPTION
* A character with stealth may no longer be chosen as a target for stealth. 
* Removes the requirement that the targeted character has the icon for the current challenge. Per the rules, the only requirement is that it be a character the opposing player controls.
* This is useful for cards that have an ability triggered when they bypass a character by stealth (such as [Wolves of the North](https://thronesdb.com/card/03006)).
* Resets all stealth targeting / bypass effect at the start of each challenge.

Fixes #54.