### PR TITLE
Fix keyword related issues

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -26,13 +26,26 @@ class BaseCard {
         this.tokens = {};
 
         this.menu = _([]);
-        this.keywords = this.parseKeywords(cardData.text || '');
+        this.parseCard(cardData.text || '');
     }
 
-    parseKeywords(text) {
+    parseCard(text) {
         var firstLine = text.split('\n')[0];
         var potentialKeywords = _.map(firstLine.split('.'), k => k.toLowerCase().trim());
-        return _.filter(potentialKeywords, keyword => _.contains(ValidKeywords, keyword));
+        this.keywords = [];
+        this.allowedAttachmentTrait = 'any';
+        _.each(potentialKeywords, keyword => {
+            if(_.contains(ValidKeywords, keyword)) {
+                this.keywords.push(keyword);
+            } else if(keyword.indexOf('no attachment') === 0) {
+                var match = keyword.match(/no attachments except <b>(.*)<\/b>/);
+                if(match) {
+                    this.allowedAttachmentTrait = match[1];
+                } else {
+                    this.allowedAttachmentTrait = 'none';
+                }
+            }
+        });
     }
 
     registerEvents(events) {
@@ -56,7 +69,7 @@ class BaseCard {
     }
 
     hasTrait(trait) {
-        return this.cardData.traits && this.cardData.traits.indexOf(trait + '.') !== -1;
+        return this.cardData.traits && this.cardData.traits.toLowerCase().indexOf(trait.toLowerCase() + '.') !== -1;
     }
 
     leavesPlay() {

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -1,6 +1,15 @@
 const uuid = require('node-uuid');
 const _ = require('underscore');
 
+const ValidKeywords = [
+    'insight',
+    'intimidate',
+    'pillage',
+    'renown',
+    'stealth',
+    'terminal'
+];
+
 class BaseCard {
     constructor(owner, cardData) {
         this.owner = owner;
@@ -17,6 +26,13 @@ class BaseCard {
         this.tokens = {};
 
         this.menu = _([]);
+        this.keywords = this.parseKeywords(cardData.text || '');
+    }
+
+    parseKeywords(text) {
+        var firstLine = text.split('\n')[0];
+        var potentialKeywords = _.map(firstLine.split('.'), k => k.toLowerCase().trim());
+        return _.filter(potentialKeywords, keyword => _.contains(ValidKeywords, keyword));
     }
 
     registerEvents(events) {
@@ -32,11 +48,11 @@ class BaseCard {
     }
 
     hasKeyword(keyword) {
-        if(!this.cardData.text || this.isBlank()) {
+        if(this.isBlank()) {
             return false;
         }
 
-        return this.cardData.text.toLowerCase().indexOf(keyword.toLowerCase() + '.') !== -1;
+        return _.contains(this.keywords, keyword.toLowerCase());
     }
 
     hasTrait(trait) {

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -89,8 +89,12 @@ class DrawCard extends BaseCard {
     }
 
     canAttach(player, card) {
-        if(this.getType() !== 'attachment' || card.hasKeyword('No Attachments')) {
+        if(this.getType() !== 'attachment' || card.allowedAttachmentTrait === 'none') {
             return false;
+        }
+
+        if(card.allowedAttachmentTrait !== 'any') {
+            return this.hasTrait(card.allowedAttachmentTrait);
         }
 
         return true;

--- a/test/server/card/drawcard.canAttach.spec.js
+++ b/test/server/card/drawcard.canAttach.spec.js
@@ -1,0 +1,72 @@
+/*global describe, it, beforeEach, expect*/
+/* eslint camelcase: 0 */
+
+const DrawCard = require('../../../server/game/drawcard.js');
+
+describe('the DrawCard', () => {
+    var owner = {};
+    var player = {};
+    var targetCard;
+    var attachment;
+
+    describe('the canAttach() function', () => {
+        describe('when the card is not an attachment', () => {
+            beforeEach(() => {
+                targetCard = new DrawCard(owner, { text: '' });
+                attachment = new DrawCard(owner, { type_code: 'event' });
+            });
+
+            it('should return false', () => {
+                expect(attachment.canAttach(player, targetCard)).toBe(false);
+            });
+        });
+
+        describe('when the target card does not allow attachments', () => {
+            beforeEach(() => {
+                targetCard = new DrawCard(owner, { text: 'No attachments.' });
+                attachment = new DrawCard(owner, { type_code: 'attachment' });
+            });
+
+            it('should return false', () => {
+                expect(attachment.canAttach(player, targetCard)).toBe(false);
+            });
+        });
+
+        describe('when the target card only allows certain kinds of attachments', () => {
+            beforeEach(() => {
+                targetCard = new DrawCard(owner, { text: 'No attachments except <b>Weapon</b>.' });
+            });
+
+            describe('and the attachment has that trait', () => {
+                beforeEach(() => {
+                    attachment = new DrawCard(owner, { type_code: 'attachment', traits: 'Condition. Weapon.' });
+                });
+
+                it('should return true', () => {
+                    expect(attachment.canAttach(player, targetCard)).toBe(true);
+                });
+            });
+
+            describe('and the attachment does not have that trait', () => {
+                beforeEach(() => {
+                    attachment = new DrawCard(owner, { type_code: 'attachment', traits: 'Condition.' });
+                });
+
+                it('should return false', () => {
+                    expect(attachment.canAttach(player, targetCard)).toBe(false);
+                });
+            });
+        });
+
+        describe('when there are no restrictions', () => {
+            beforeEach(() => {
+                targetCard = new DrawCard(owner, { text: '' });
+                attachment = new DrawCard(owner, { type_code: 'attachment', traits: '' });
+            });
+
+            it('should return true', () => {
+                expect(attachment.canAttach(player, targetCard)).toBe(true);
+            });
+        });
+    });
+});

--- a/test/server/card/drawcard.hasKeyword.spec.js
+++ b/test/server/card/drawcard.hasKeyword.spec.js
@@ -1,0 +1,39 @@
+/*global describe, it, beforeEach, expect*/
+
+const DrawCard = require('../../../server/game/drawcard.js');
+
+describe('the DrawCard', () => {
+    var owner = {};
+    var card;
+
+    describe('the hasKeyword() function', () => {
+        describe('when the card mentions a keyword in its body', () => {
+            beforeEach(() => {
+                card = new DrawCard(owner, { text: 'Each <i>Ranger</i> character you control cannot be bypassed by stealth.\n<b>Interrupt:</b> When Benjen Stark is killed, gain 2 power for your faction. Then, shuffle him back into your deck instead of placing him in your dead pile."' });
+            });
+
+            it('should return false.', () => {
+                expect(card.hasKeyword('Stealth')).toBe(false);
+            });
+        });
+
+        describe('when the card has a keyword line', () => {
+            beforeEach(() => {
+                card = new DrawCard(owner, { text: 'Intimidate. Renown. Notarealkeyword.\nRobert Baratheon gets +1 STR for each other kneeling character in play.' });
+            });
+
+            it('should return true for each keyword', () => {
+                expect(card.hasKeyword('Intimidate')).toBe(true);
+                expect(card.hasKeyword('Renown')).toBe(true);
+            });
+
+            it('should not be case sensitive', () => {
+                expect(card.hasKeyword('InTiMiDaTe')).toBe(true);
+            });
+
+            it('should reject non-valid keywords', () => {
+                expect(card.hasKeyword('Notarealkeyword')).toBe(false);
+            });
+        });
+    });
+});


### PR DESCRIPTION
* Parses out a list of keywords when a card is constructed based on the first line of the card text. Only exact matches are considered.
* No longer considers 'no attachment' to be a keyword. Instead, it's tracked separately and allows characters to exclude attachments that don't match a certain trait - [most notably weapon](https://thronesdb.com/find?q=x%3A%22no+attachments+except%22&view=card&sort=name&page=1).
* It provides a place that 'ambush' can be parsed in the future.

This PR makes me sad.

Fixes #76 .