### PR TITLE
Convert taxation phase to new game flow.

### DIFF
--- a/server/game/game.js
+++ b/server/game/game.js
@@ -78,7 +78,7 @@ class Game extends EventEmitter {
     }
 
     getPlayersInFirstPlayerOrder() {
-        return _.sortBy(this.getPlayers(), 'firstPlayer');
+        return _.sortBy(this.getPlayers(), player => !player.firstPlayer);
     }
 
     getPlayersAndSpectators() {

--- a/server/game/gamesteps/playerorderprompt.js
+++ b/server/game/gamesteps/playerorderprompt.js
@@ -1,0 +1,46 @@
+const _ = require('underscore');
+const UiPrompt = require('./uiprompt.js');
+
+/**
+ * Represents a UI Prompt that prompts each player individually in first-player
+ * order. Inheritors should call completePlayer() when the prompt for the
+ * current player has been completed. Overriding skipCondition will exclude
+ * any matching players from the prompt.
+ */
+class PlayerOrderPrompt extends UiPrompt {
+    constructor(game) {
+        super(game);
+        this.players = game.getPlayersInFirstPlayerOrder();
+    }
+
+    get currentPlayer() {
+        return this.players[0];
+    }
+
+    skipPlayers() {
+        this.players = _.reject(this.players, p => this.skipCondition(p));
+    }
+
+    skipCondition(player) {
+        return false;
+    }
+
+    completePlayer() {
+        this.players.shift();
+    }
+
+    isComplete() {
+        return this.players.length === 0;
+    }
+
+    activeCondition(player) {
+        return player === this.currentPlayer;
+    }
+
+    continue() {
+        this.skipPlayers();
+        return super.continue();
+    }
+}
+
+module.exports = PlayerOrderPrompt;

--- a/server/game/gamesteps/taxation/discardtoreserveprompt.js
+++ b/server/game/gamesteps/taxation/discardtoreserveprompt.js
@@ -7,14 +7,14 @@ class DiscardToReservePrompt extends PlayerOrderPrompt {
             buttons: [
                 { command: 'menuButton', text: 'Done' }
             ]
-        }
+        };
     }
 
     waitingPrompt() {
         return { menuTitle: 'Waiting for opponent to discard down to reserve' };
     }
 
-    onMenuCommand(player, arg) {
+    onMenuCommand(player) {
         if(player !== this.currentPlayer) {
             return false;
         }

--- a/server/game/gamesteps/taxation/discardtoreserveprompt.js
+++ b/server/game/gamesteps/taxation/discardtoreserveprompt.js
@@ -1,0 +1,32 @@
+const PlayerOrderPrompt = require('../playerorderprompt.js');
+
+class DiscardToReservePrompt extends PlayerOrderPrompt {
+    activePrompt() {
+        return {
+            menuTitle: 'Discard down to ' + this.currentPlayer.reserve + ' cards',
+            buttons: [
+                { command: 'menuButton', text: 'Done' }
+            ]
+        }
+    }
+
+    waitingPrompt() {
+        return { menuTitle: 'Waiting for opponent to discard down to reserve' };
+    }
+
+    onMenuCommand(player, arg) {
+        if(player !== this.currentPlayer) {
+            return false;
+        }
+
+        if(player.isBelowReserve()) {
+            this.completePlayer();
+        }
+    }
+
+    skipCondition(player) {
+        return player.isBelowReserve();
+    }
+}
+
+module.exports = DiscardToReservePrompt;

--- a/server/game/gamesteps/taxation/endroundprompt.js
+++ b/server/game/gamesteps/taxation/endroundprompt.js
@@ -7,14 +7,14 @@ class EndRoundPrompt extends PlayerOrderPrompt {
             buttons: [
                 { command: 'menuButton', text: 'End Round' }
             ]
-        }
+        };
     }
 
     waitingPrompt() {
         return { menuTitle: 'Waiting for opponent to end the round' };
     }
 
-    onMenuCommand(player, arg) {
+    onMenuCommand(player) {
         if(player !== this.currentPlayer) {
             return false;
         }

--- a/server/game/gamesteps/taxation/endroundprompt.js
+++ b/server/game/gamesteps/taxation/endroundprompt.js
@@ -1,0 +1,26 @@
+const PlayerOrderPrompt = require('../playerorderprompt.js');
+
+class EndRoundPrompt extends PlayerOrderPrompt {
+    activePrompt() {
+        return {
+            menuTitle: '',
+            buttons: [
+                { command: 'menuButton', text: 'End Round' }
+            ]
+        }
+    }
+
+    waitingPrompt() {
+        return { menuTitle: 'Waiting for opponent to end the round' };
+    }
+
+    onMenuCommand(player, arg) {
+        if(player !== this.currentPlayer) {
+            return false;
+        }
+
+        this.completePlayer();
+    }
+}
+
+module.exports = EndRoundPrompt;

--- a/server/game/gamesteps/taxationphase.js
+++ b/server/game/gamesteps/taxationphase.js
@@ -11,15 +11,15 @@ class TaxationPhase extends Phase {
             new SimpleStep(game, () => this.returnGold()),
             new DiscardToReservePrompt(game),
             new EndRoundPrompt(game),
-            new SimpleStep(game, () => this.startPlotPhase()),
+            new SimpleStep(game, () => this.startPlotPhase())
         ]);
     }
 
     returnGold() {
-      _.each(this.game.getPlayersInFirstPlayerOrder(), player => {
-          player.taxation();
-          this.game.emit('onAfterTaxation', player);
-      });
+        _.each(this.game.getPlayersInFirstPlayerOrder(), player => {
+            player.taxation();
+            this.game.emit('onAfterTaxation', player);
+        });
     }
 
     // Temporary step until plot phase / round structure is more defined.

--- a/server/game/gamesteps/taxationphase.js
+++ b/server/game/gamesteps/taxationphase.js
@@ -1,0 +1,33 @@
+const _ = require('underscore');
+const Phase = require('./phase.js');
+const SimpleStep = require('./simplestep.js');
+const DiscardToReservePrompt = require('./taxation/discardtoreserveprompt.js');
+const EndRoundPrompt = require('./taxation/endroundprompt.js');
+
+class TaxationPhase extends Phase {
+    constructor(game) {
+        super(game);
+        this.initialise([
+            new SimpleStep(game, () => this.returnGold()),
+            new DiscardToReservePrompt(game),
+            new EndRoundPrompt(game),
+            new SimpleStep(game, () => this.startPlotPhase()),
+        ]);
+    }
+
+    returnGold() {
+      _.each(this.game.getPlayersInFirstPlayerOrder(), player => {
+          player.taxation();
+          this.game.emit('onAfterTaxation', player);
+      });
+    }
+
+    // Temporary step until plot phase / round structure is more defined.
+    startPlotPhase() {
+        _.each(this.game.getPlayers(), player => {
+            player.startPlotPhase();
+        });
+    }
+}
+
+module.exports = TaxationPhase;

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -1016,6 +1016,10 @@ class Player extends Spectator {
         });
     }
 
+    isBelowReserve() {
+        return this.hand.size() <= this.reserve;
+    }
+
     getSummaryForCardList(list, isActivePlayer, hideWhenFaceup) {
         return list.map(card => {
             return card.getSummary(isActivePlayer, hideWhenFaceup);

--- a/server/index.js
+++ b/server/index.js
@@ -596,20 +596,6 @@ io.on('connection', function(socket) {
         });
     });
 
-    socket.on('doneround', function() {
-        var game = findGameForPlayer(socket.id);
-
-        if(!game) {
-            return;
-        }
-
-        runAndCatchErrors(game, () => {
-            game.doneRound(socket.id);
-
-            sendGameState(game);
-        });
-    });
-
     socket.on('changestat', function(stat, value) {
         var game = findGameForPlayer(socket.id);
 

--- a/test/server/game/getplayers.spec.js
+++ b/test/server/game/getplayers.spec.js
@@ -9,6 +9,8 @@ describe('Game', function() {
 
         this.notSetPlayer1 = { id: '1', name: 'test' };
         this.notSetPlayer2 = { id: '2', name: 'test' };
+        this.setFalsePlayer1 = { id: '1', name: 'test', firstPlayer: false };
+        this.setFalsePlayer2 = { id: '2', name: 'test2', firstPlayer: false };
         this.setPlayer1 = { id: '1', name: 'test', firstPlayer: true };
         this.setPlayer2 = { id: '2', name: 'test2', firstPlayer: true };
     });
@@ -91,6 +93,20 @@ describe('Game', function() {
                 it('should return player 2 then player 1', function() {
                     expect(this.players[0]).toBe(this.setPlayer2);
                     expect(this.players[1]).toBe(this.notSetPlayer1);
+                });
+            });
+
+            describe('when player 2 is first player and player 1 is explicitly not first player', function() {
+                beforeEach(function() {
+                    this.game.players['1'] = this.setFalsePlayer1;
+                    this.game.players['2'] = this.setPlayer2;
+
+                    this.players = this.game.getPlayersInFirstPlayerOrder();
+                });
+
+                it('should return player 2 then player 1', function() {
+                    expect(this.players[0]).toBe(this.setPlayer2);
+                    expect(this.players[1]).toBe(this.setFalsePlayer1);
                 });
             });
         });

--- a/test/server/gamesteps/playerorderprompt.spec.js
+++ b/test/server/gamesteps/playerorderprompt.spec.js
@@ -1,0 +1,81 @@
+/*global describe, it, beforeEach, expect, spyOn*/
+
+const PlayerOrderPrompt = require('../../../server/game/gamesteps/playerorderprompt.js');
+const Game = require('../../../server/game/game.js');
+const Player = require('../../../server/game/player.js');
+
+describe('the PlayerOrderPrompt', () => {
+    var prompt;
+    var game = {};
+    var player1;
+    var player2;
+    var activePrompt = {};
+    var waitingPrompt = {};
+
+    beforeEach(() => {
+        game = new Game('1', 'Test Game');
+        player1 = new Player('1', 'Player 1', true, game);
+        player2 = new Player('2', 'Player 2', false, game);
+        player2.firstPlayer = true;
+        game.players[0] = player1;
+        game.players[1] = player2;
+        prompt = new PlayerOrderPrompt(game);
+        spyOn(prompt, 'activePrompt').and.returnValue(activePrompt);
+        spyOn(prompt, 'waitingPrompt').and.returnValue(waitingPrompt);
+        spyOn(player1, 'setPrompt');
+        spyOn(player2, 'setPrompt');
+        spyOn(player1, 'cancelPrompt');
+        spyOn(player2, 'cancelPrompt');
+    });
+
+    describe('the continue() function', () => {
+        describe('when there is a skip condition', () => {
+            beforeEach(() => {
+                spyOn(prompt, 'skipCondition').and.callFake(p => p === player2);
+            });
+
+            it('should skip over the matching players', () => {
+                prompt.continue();
+                expect(prompt.currentPlayer).toBe(player1);
+            });
+        });
+
+        describe('when the prompt is incomplete', () => {
+            it('should prompt players in first-player order', () => {
+                prompt.continue();
+                expect(prompt.currentPlayer).toBe(player2);
+            });
+
+            it('should give the active prompt to the current player', () => {
+                prompt.continue();
+                expect(player2.setPrompt).toHaveBeenCalledWith(activePrompt);
+            });
+
+            it('should give the waiting prompt to the remaining players', () => {
+                prompt.continue();
+                expect(player1.setPrompt).toHaveBeenCalledWith(waitingPrompt);
+            });
+
+            it('should return false', () => {
+                expect(prompt.continue()).toBe(false);
+            });
+        });
+
+        describe('when each player has been completed', () => {
+            beforeEach(() => {
+                prompt.completePlayer();
+                prompt.completePlayer();
+            });
+
+            it('should set the cancel prompts for each player', () => {
+                prompt.continue();
+                expect(player1.cancelPrompt).toHaveBeenCalled();
+                expect(player2.cancelPrompt).toHaveBeenCalled();
+            });
+
+            it('should return true', () => {
+                expect(prompt.continue()).toBe(true);
+            });
+        });
+    });
+});

--- a/test/server/gamesteps/taxation/discardtoreserveprompt.spec.js
+++ b/test/server/gamesteps/taxation/discardtoreserveprompt.spec.js
@@ -1,0 +1,74 @@
+/*global describe, it, beforeEach, expect, spyOn*/
+
+const DiscardToReservePrompt = require('../../../../server/game/gamesteps/taxation/discardtoreserveprompt.js');
+const Game = require('../../../../server/game/game.js');
+const Player = require('../../../../server/game/player.js');
+
+describe('the DiscardToReservePrompt', () => {
+    var prompt;
+    var game = {};
+    var player1;
+    var player2;
+
+    beforeEach(() => {
+        game = new Game('1', 'Test Game');
+        player1 = new Player('1', 'Player 1', true, game);
+        player2 = new Player('2', 'Player 2', false, game);
+        player1.firstPlayer = true;
+        game.players[0] = player1;
+        game.players[1] = player2;
+        prompt = new DiscardToReservePrompt(game);
+        spyOn(player1, 'isBelowReserve');
+        spyOn(player2, 'isBelowReserve');
+    });
+
+    describe('the continue() function', () => {
+        describe('when all players are below reserve', () => {
+            beforeEach(() => {
+                player1.isBelowReserve.and.returnValue(true);
+                player2.isBelowReserve.and.returnValue(true);
+            });
+
+            it('should auto complete the prompt', () => {
+                expect(prompt.continue()).toBe(true);
+            });
+        });
+    });
+
+    describe('the onMenuCommand() function', () => {
+        beforeEach(() => {
+            spyOn(prompt, 'completePlayer');
+        });
+
+        describe('when called by someone other than the current player', () => {
+            it('should not complete the player', () => {
+                prompt.onMenuCommand(player2, '');
+                expect(prompt.completePlayer).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('when called by the current player', () => {
+            describe('when the player is below reserve', () => {
+                beforeEach(() => {
+                    player1.isBelowReserve.and.returnValue(true);
+                });
+
+                it('should complete the player', () => {
+                    prompt.onMenuCommand(player1, '');
+                    expect(prompt.completePlayer).toHaveBeenCalled();
+                });
+            });
+
+            describe('when the player is not below reserve', () => {
+                beforeEach(() => {
+                    player1.isBelowReserve.and.returnValue(false);
+                });
+
+                it('should not complete the player', () => {
+                    prompt.onMenuCommand(player1, '');
+                    expect(prompt.completePlayer).not.toHaveBeenCalled();
+                });
+            });
+        });
+    });
+});

--- a/test/server/plots/02039-pentoshi.spec.js
+++ b/test/server/plots/02039-pentoshi.spec.js
@@ -32,11 +32,6 @@ describe('Trading With The Pentoshi', () => {
         game.initialise();
     });
 
-    afterEach(() => {
-        game.doneRound(player1.id);
-        game.doneRound(player2.id);
-    });
-
     describe('When a player has trading revealed and that player is first player', () => {
         it('should give the other player 3 gold', () => {
             game.selectPlot(player1.id, pentoshi.uuid);

--- a/test/server/plots/02039-pentoshi.spec.js
+++ b/test/server/plots/02039-pentoshi.spec.js
@@ -1,4 +1,4 @@
-/* global describe, it, expect, beforeEach, afterEach, jasmine */
+/* global describe, it, expect, beforeEach, jasmine */
 
 const _ = require('underscore');
 


### PR DESCRIPTION
You should merge #83 first.

* Introduces `PlayerOrderPrompt` class to implement prompts that are given to each player in first-player order (contrast w/ `AllPlayerPrompt` which prompts simultaneously)
* Converts the taxation phase into steps and prompts.
* Implements a prompt when players need to discard down to their reserve value. If players already are below reserve they're skipped.

Fixes #68.