### PR TITLE
Implement a kill character prompt

### DIFF
--- a/server/game/gamesteps/attachmentprompt.js
+++ b/server/game/gamesteps/attachmentprompt.js
@@ -5,7 +5,10 @@ class AttachmentPrompt extends UiPrompt {
         super(game);
         this.player = player;
         this.attachmentCard = attachmentCard;
-        this.attached = false;
+    }
+
+    activeCondition(player) {
+        return player === this.player;
     }
 
     onCardClicked(player, targetCard) {
@@ -36,7 +39,7 @@ class AttachmentPrompt extends UiPrompt {
 
         player.dropPending = false;
         player.selectCard = false;
-        this.attached = true;
+        this.complete();
     }
 
     onMenuCommand(player) {
@@ -44,30 +47,21 @@ class AttachmentPrompt extends UiPrompt {
             return false;
         }
 
-        this.attached = true;
+        this.complete();
     }
 
-    setPrompt() {
-        if(!this.attached) {
-            this.originalPrompt = this.originalPrompt || this.player.currentPrompt();
-            this.player.setPrompt({
-                selectCard: true,
-                menuTitle: 'Select target for attachment',
-                buttons: [
-                    { text: 'Done', command: 'menuButton', arg: 'doneattachment' }
-                ]
-            });
-        } else {
-            // TODO: Should not be necessary in the end, but is for now due to
-            //       interrupts from drag/drop in the middle of steps not
-            //       converted to the new engine.
-            this.player.setPrompt(this.originalPrompt || {});
-        }
+    activePrompt() {
+        return {
+            selectCard: true,
+            menuTitle: 'Select target for attachment',
+            buttons: [
+                { text: 'Done', command: 'menuButton', arg: 'doneattachment' }
+            ]
+        };
     }
 
-    continue() {
-        this.setPrompt();
-        return this.attached;
+    waitingPrompt() {
+        return { menuTitle: 'Waiting for opponent to attach card' };
     }
 }
 

--- a/server/game/gamesteps/challenge/fulfillmilitaryclaim.js
+++ b/server/game/gamesteps/challenge/fulfillmilitaryclaim.js
@@ -1,0 +1,54 @@
+const BaseStep = require('../basestep.js');
+const SimpleStep = require('../simplestep.js');
+const KillCharacterPrompt = require('../killcharacterprompt.js');
+
+class FulfillMilitaryClaim extends BaseStep {
+    constructor(game, player, claim) {
+        super(game);
+        this.player = player;
+        this.claim = claim;
+    }
+
+    continue() {
+        if(this.claim > 0) {
+            this.game.queueStep(this.createKillPrompt());
+            return false;
+        }
+
+        // TODO: Temporary to resume game flow.
+        this.game.queueStep(new SimpleStep(this.game, () => {
+            this.player.doneClaim();
+
+            var otherPlayer = this.game.getOtherPlayer(this.player);
+
+            if(otherPlayer) {
+                otherPlayer.beginChallenge();
+            }
+        }));
+
+        return true;
+    }
+
+    createKillPrompt() {
+        var events = {
+            onKill: () => this.fulfillClaim(),
+            onCancel: () => this.cancelClaim()
+        };
+        return new KillCharacterPrompt(this.game, this.player, card => this.allowedToKill(card), events);
+    }
+
+    allowedToKill(card) {
+        return card.owner === this.player;
+    }
+
+    fulfillClaim() {
+        this.claim -= 1;
+    }
+
+    cancelClaim() {
+        this.claim = 0;
+        this.game.addMessage('{0} has cancelled claim effects', this.player);
+    }
+}
+
+module.exports = FulfillMilitaryClaim;

--- a/server/game/gamesteps/killcharacterprompt.js
+++ b/server/game/gamesteps/killcharacterprompt.js
@@ -1,0 +1,62 @@
+const _ = require('underscore');
+const UiPrompt = require('./uiprompt.js');
+
+class KillCharacterPrompt extends UiPrompt {
+    constructor(game, choosingPlayer, cardCondition, events) {
+        super(game);
+        this.choosingPlayer = choosingPlayer;
+        this.cardCondition = cardCondition;
+        this.events = events;
+        _.defaults(this.events, this.defaultEvents());
+    }
+
+    defaultEvents() {
+        return {
+            onKill: () => true,
+            onCancel: () => true
+        };
+    }
+
+    activeCondition(player) {
+        return player === this.choosingPlayer;
+    }
+
+    activePrompt() {
+        return {
+            selectCard: true,
+            menuTitle: 'Select character to kill',
+            buttons: [
+                { command: 'menuButton', text: 'Cancel' }
+            ]
+        };
+    }
+
+    waitingPrompt() {
+        return { menuTitle: 'Waiting for opponent to kill a character' };
+    }
+
+    onCardClicked(player, card) {
+        if(player !== this.choosingPlayer) {
+            return false;
+        }
+
+        if(card.getType() !== 'character' || !this.cardCondition(card)) {
+            return false;
+        }
+
+        card.owner.killCharacter(card);
+        this.events.onKill(card);
+        this.complete();
+    }
+
+    onMenuCommand(player) {
+        if(player !== this.choosingPlayer) {
+            return false;
+        }
+
+        this.events.onCancel();
+        this.complete();
+    }
+}
+
+module.exports = KillCharacterPrompt;

--- a/server/game/gamesteps/uiprompt.js
+++ b/server/game/gamesteps/uiprompt.js
@@ -16,6 +16,7 @@ class UiPrompt extends BaseStep {
     }
 
     setPrompt() {
+        this.saveOriginalPrompts();
         _.each(this.game.getPlayers(), player => {
             if(this.activeCondition(player)) {
                 player.setPrompt(this.activePrompt());
@@ -52,6 +53,30 @@ class UiPrompt extends BaseStep {
         _.each(this.game.getPlayers(), player => {
             player.cancelPrompt();
         });
+        this.restoreOriginalPrompts();
+    }
+
+    // TODO: Saving and restoring prompts shouldn't be necessary once the full
+    //       game is converted into steps + prompts.
+    saveOriginalPrompts() {
+        if(this.originalPrompts) {
+            return;
+        }
+
+        this.originalPrompts = _.map(this.game.getPlayers(), player => {
+            return {
+                player: player,
+                prompt: player.currentPrompt()
+            };
+        });
+    }
+
+    restoreOriginalPrompts() {
+        if(this.originalPrompts) {
+            _.each(this.originalPrompts, originalPrompt => {
+                originalPrompt.player.setPrompt(originalPrompt.prompt);
+            });
+        }
     }
 }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -286,7 +286,6 @@ class Player extends Spectator {
         this.plotDiscard = _([]);
         this.deadPile = _([]);
         this.discardPile = _([]);
-        this.claimToDo = 0;
     }
 
     startGame() {
@@ -465,7 +464,6 @@ class Player extends Spectator {
         this.reserve = 0;
         this.firstPlayer = false;
         this.selectedPlot = undefined;
-        this.claimToDo = 0;
         this.doneChallenges = false;
         this.plotRevealed = false;
         this.roundDone = false;
@@ -811,16 +809,6 @@ class Player extends Spectator {
         this.selectingChallengers = true;
     }
 
-    selectCharacterToKill() {
-        this.selectCard = true;
-        this.phase = 'claim';
-
-        this.menuTitle = 'Select character to kill';
-        this.buttons = [
-            { command: 'cancelclaim', text: 'Done' }
-        ];
-    }
-
     killCharacter(card) {
         var character = this.findCardInPlayByUuid(card.uuid);
 
@@ -837,8 +825,6 @@ class Player extends Spectator {
         } else {
             this.discardCard(card.uuid, this.deadPile);
         }
-
-        this.claimToDo--;
     }
 
     doneClaim() {

--- a/server/index.js
+++ b/server/index.js
@@ -722,19 +722,6 @@ io.on('connection', function(socket) {
         sendGameState(game);
     });
 
-    socket.on('cancelclaim', function() {
-        var game = findGameForPlayer(socket.id);
-
-        if(!game) {
-            return;
-        }
-
-        runAndCatchErrors(game, () => {
-            game.cancelClaim(socket.id);
-            sendGameState(game);
-        });
-    });
-
     socket.on('shuffledeck', function() {
         var game = findGameForPlayer(socket.id);
 

--- a/test/server/gamesteps/killcharacterprompt.spec.js
+++ b/test/server/gamesteps/killcharacterprompt.spec.js
@@ -1,0 +1,110 @@
+/*global describe, it, beforeEach, expect,spyOn*/
+/* eslint camelcase: 0 */
+
+const KillCharacterPrompt = require('../../../server/game/gamesteps/killcharacterprompt.js');
+const Game = require('../../../server/game/game.js');
+const Player = require('../../../server/game/player.js');
+const DrawCard = require('../../../server/game/drawcard.js');
+
+describe('the KillCharacterPrompt', () => {
+    var prompt;
+    var game;
+    var player;
+    var otherPlayer;
+    var card;
+    var events = {
+        onKill: () => true,
+        onCancel: () => true
+    };
+
+    function cardCondition(card) {
+        return card.name === 'Killable';
+    }
+
+    beforeEach(() => {
+        game = new Game('1', 'Test Game');
+        player = new Player('1', 'Player 1', true, game);
+        player.initialise();
+        otherPlayer = new Player('2', 'Player 2', false, game);
+        otherPlayer.initialise();
+        game.players[player.id] = player;
+        game.players[otherPlayer.id] = otherPlayer;
+        card = new DrawCard(player, { type_code: 'character', name: 'Killable' });
+        prompt = new KillCharacterPrompt(game, player, cardCondition, events);
+
+        player.cardsInPlay.push(card);
+        spyOn(player, 'killCharacter');
+        spyOn(events, 'onKill');
+        spyOn(events, 'onCancel');
+    });
+
+    describe('the onCardClicked() function', () => {
+        describe('when the player is not the prompted player', () => {
+            it('should return false', () => {
+                expect(prompt.onCardClicked(otherPlayer, card)).toBe(false);
+            });
+        });
+
+        describe('when the card is not a character', () => {
+            beforeEach(() => {
+                spyOn(card, 'getType').and.returnValue('event');
+            });
+
+            it('should return false', () => {
+                expect(prompt.onCardClicked(player, card)).toBe(false);
+            });
+        });
+
+        describe('when the card does not match the allowed condition', () => {
+            beforeEach(() => {
+                card.name = 'Does Not Match';
+            });
+
+            it('should return false', () => {
+                expect(prompt.onCardClicked(player, card)).toBe(false);
+            });
+        });
+
+        describe('when the card does match the condition', () => {
+            it('should kill the character', () => {
+                prompt.onCardClicked(player, card);
+                expect(player.killCharacter).toHaveBeenCalledWith(card);
+            });
+
+            it('should call the onKill event', () => {
+                prompt.onCardClicked(player, card);
+                expect(events.onKill).toHaveBeenCalledWith(card);
+            });
+
+            it('should complete the prompt', () => {
+                prompt.onCardClicked(player, card);
+                expect(prompt.isComplete()).toBe(true);
+            });
+        });
+    });
+
+    describe('the onMenuCommand() function', () => {
+        describe('when the player is not the prompted player', () => {
+            it('should return false', () => {
+                expect(prompt.onMenuCommand(otherPlayer)).toBe(false);
+            });
+        });
+
+        describe('when the player is the prompted player', () => {
+            it('should not kill a character', () => {
+                prompt.onMenuCommand(player);
+                expect(player.killCharacter).not.toHaveBeenCalled();
+            });
+
+            it('should call the onCancel event', () => {
+                prompt.onMenuCommand(player);
+                expect(events.onCancel).toHaveBeenCalledWith();
+            });
+
+            it('should complete the prompt', () => {
+                prompt.onMenuCommand(player);
+                expect(prompt.isComplete()).toBe(true);
+            });
+        });
+    });
+});


### PR DESCRIPTION
* Slightly reworks UiPrompt to save and restore the original prompt. This should centralize such logic and make it easier to remove once the entire game is converted.
* Implements a reusable kill character prompt. The prompted player must choose a character that matches the passed condition, or cancel the prompt. Should make it easier to implement cards that have "[choose and kill](https://thronesdb.com/find?q=x%3A%22choose+and+kill%22&sort=name&view=card)" or similar kill abilities.
* Implements military claim using the kill character prompt.