### PR TITLE
Gamepipeline improvements

### DIFF
--- a/server/game/gamepipeline.js
+++ b/server/game/gamepipeline.js
@@ -10,11 +10,20 @@ class GamePipeline {
         if(!_.isArray(steps)) {
             steps = [steps];
         }
+
         this.pipeline = steps;
     }
 
     get length() {
         return this.pipeline.length;
+    }
+
+    getStep(step) {
+        if(_.isFunction(step)) {
+            return step();
+        }
+
+        return step;
     }
 
     queueStep(step) {
@@ -30,7 +39,8 @@ class GamePipeline {
             return;
         }
 
-        var step = this.pipeline[0];
+        var step = this.getStep(this.pipeline[0]);
+
         if(step.cancelStep && step.isComplete) {
             step.cancelStep();
             if(!step.isComplete()) {
@@ -43,7 +53,7 @@ class GamePipeline {
 
     handleCardClicked(player, card) {
         if(this.pipeline.length > 0) {
-            var step = _.first(this.pipeline);
+            var step = this.getStep(_.first(this.pipeline));
             if(step.onCardClicked(player, card) !== false) {
                 return true;
             }
@@ -54,7 +64,7 @@ class GamePipeline {
 
     handleMenuCommand(player, arg, method) {
         if(this.pipeline.length > 0) {
-            var step = _.first(this.pipeline);
+            var step = this.getStep(_.first(this.pipeline));
             if(step.onMenuCommand(player, arg, method) !== false) {
                 return true;
             }
@@ -65,7 +75,7 @@ class GamePipeline {
 
     continue() {
         while(this.pipeline.length > 0) {
-            var currentStep = _.first(this.pipeline);
+            var currentStep = this.getStep(_.first(this.pipeline));
 
             // Explicitly check for a return of false - if no return values is
             // defined then just continue to the next step.

--- a/server/game/gamepipeline.js
+++ b/server/game/gamepipeline.js
@@ -18,9 +18,13 @@ class GamePipeline {
         return this.pipeline.length;
     }
 
-    getStep(step) {
+    getCurrentStep() {
+        var step = _.first(this.pipeline);
+
         if(_.isFunction(step)) {
-            return step();
+            var createdStep = step();
+            this.pipeline[0] = createdStep;
+            return createdStep;
         }
 
         return step;
@@ -39,7 +43,7 @@ class GamePipeline {
             return;
         }
 
-        var step = this.getStep(this.pipeline[0]);
+        var step = this.getCurrentStep();
 
         if(step.cancelStep && step.isComplete) {
             step.cancelStep();
@@ -53,7 +57,7 @@ class GamePipeline {
 
     handleCardClicked(player, card) {
         if(this.pipeline.length > 0) {
-            var step = this.getStep(_.first(this.pipeline));
+            var step = this.getCurrentStep();
             if(step.onCardClicked(player, card) !== false) {
                 return true;
             }
@@ -64,7 +68,7 @@ class GamePipeline {
 
     handleMenuCommand(player, arg, method) {
         if(this.pipeline.length > 0) {
-            var step = this.getStep(_.first(this.pipeline));
+            var step = this.getCurrentStep();
             if(step.onMenuCommand(player, arg, method) !== false) {
                 return true;
             }
@@ -75,7 +79,7 @@ class GamePipeline {
 
     continue() {
         while(this.pipeline.length > 0) {
-            var currentStep = this.getStep(_.first(this.pipeline));
+            var currentStep = this.getCurrentStep();
 
             // Explicitly check for a return of false - if no return values is
             // defined then just continue to the next step.

--- a/server/game/gamepipeline.js
+++ b/server/game/gamepipeline.js
@@ -34,7 +34,12 @@ class GamePipeline {
         if(this.pipeline.length === 0) {
             this.pipeline.unshift(step);
         } else {
-            this.queue.push(step);
+            var currentStep = this.getCurrentStep();
+            if(currentStep.queueStep) {
+                currentStep.queueStep(step);
+            } else {
+                this.queue.push(step);
+            }
         }
     }
 

--- a/server/game/gamesteps/phase.js
+++ b/server/game/gamesteps/phase.js
@@ -1,4 +1,3 @@
-const _ = require('underscore');
 const BaseStep = require('./basestep.js');
 const GamePipeline = require('../gamepipeline.js');
 
@@ -10,6 +9,10 @@ class Phase extends BaseStep {
 
     initialise(steps) {
         this.pipeline.initialise(steps);
+    }
+
+    queueStep(step) {
+        this.pipeline.queueStep(step);
     }
 
     isComplete() {

--- a/test/server/gamepipeline/cancelStep.spec.js
+++ b/test/server/gamepipeline/cancelStep.spec.js
@@ -1,49 +1,52 @@
-/*global describe, it, beforeEach, expect, jasmine*/
+/*global describe, it, beforeEach, expect, spyOn */
+/* eslint no-invalid-this: 0 */
 
 const GamePipeline = require('../../../server/game/gamepipeline.js');
 
 describe('the GamePipeline', function() {
-    var pipeline;
-    var step;
-
     beforeEach(function() {
-        pipeline = new GamePipeline();
+        this.pipeline = new GamePipeline();
     });
 
     describe('the cancelStep() function', function() {
         describe('when the next step is normal', function() {
-            beforeEach(() => {
-                step = jasmine.createSpy('step');
-                pipeline.initialise([step]);
+            beforeEach(function() {
+                this.step = {};
+                this.pipeline.initialise([this.step]);
             });
 
             it('should remove the step', function() {
-                pipeline.cancelStep();
-                expect(pipeline.length).toBe(0);
+                this.pipeline.cancelStep();
+                expect(this.pipeline.length).toBe(0);
             });
         });
 
         describe('when the next step is cancellable', function() {
-            beforeEach(() => {
-                step = jasmine.createSpyObj('step', ['cancelStep', 'isComplete']);
-                pipeline.initialise([step]);
+            beforeEach(function() {
+                this.step = {
+                    cancelStep: function() {},
+                    isComplete: function() {}
+                };
+                spyOn(this.step, 'cancelStep');
+                spyOn(this.step, 'isComplete');
+                this.pipeline.initialise([this.step]);
             });
 
             it('should call cancelStep on the step', function() {
-                pipeline.cancelStep();
-                expect(step.cancelStep).toHaveBeenCalled();
+                this.pipeline.cancelStep();
+                expect(this.step.cancelStep).toHaveBeenCalled();
             });
 
-            it('should keep the step if it is not complete', () => {
-                step.isComplete.and.returnValue(false);
-                pipeline.cancelStep();
-                expect(pipeline.length).toBe(1);
+            it('should keep the step if it is not complete', function() {
+                this.step.isComplete.and.returnValue(false);
+                this.pipeline.cancelStep();
+                expect(this.pipeline.length).toBe(1);
             });
 
-            it('should remove the step if it is complete', () => {
-                step.isComplete.and.returnValue(true);
-                pipeline.cancelStep();
-                expect(pipeline.length).toBe(0);
+            it('should remove the step if it is complete', function() {
+                this.step.isComplete.and.returnValue(true);
+                this.pipeline.cancelStep();
+                expect(this.pipeline.length).toBe(0);
             });
         });
     });

--- a/test/server/gamepipeline/continue.spec.js
+++ b/test/server/gamepipeline/continue.spec.js
@@ -97,5 +97,30 @@ describe('the GamePipeline', function() {
                 expect(pipeline.pipeline[1]).toBe(step1);
             });
         });
+
+        describe('when a step is a factory function', () => {
+            var container;
+
+            beforeEach(() => {
+                container = {
+                    factory: () => step1
+                };
+                spyOn(container, 'factory').and.callThrough();
+                // Setup a failing step so execution can happen multiple times.
+                spyOn(step1, 'continue').and.returnValue(false);
+                pipeline.initialise([container.factory]);
+            });
+
+            it('should only call the factory once', () => {
+                pipeline.continue();
+                pipeline.continue();
+                expect(container.factory.calls.count()).toBe(1);
+            });
+
+            it('should inline the factory-created step', () => {
+                pipeline.continue();
+                expect(pipeline.pipeline[0]).toBe(step1);
+            });
+        });
     });
 });

--- a/test/server/gamepipeline/continue.spec.js
+++ b/test/server/gamepipeline/continue.spec.js
@@ -1,125 +1,122 @@
 /*global describe, it, beforeEach, expect, spyOn*/
+/* eslint no-invalid-this: 0 */
 
 const BaseStep = require('../../../server/game/gamesteps/basestep.js');
 const GamePipeline = require('../../../server/game/gamepipeline.js');
 
 describe('the GamePipeline', function() {
-    var pipeline;
-    var step1 = new BaseStep(null);
-    var step2 = new BaseStep(null);
-
     beforeEach(function() {
-        pipeline = new GamePipeline();
+        this.pipeline = new GamePipeline();
+        this.step1 = new BaseStep(null);
+        this.step2 = new BaseStep(null);
     });
 
     describe('the continue() function', function() {
         describe('when the pipeline is empty', function() {
-            beforeEach(() => {
-                pipeline.initialise([]);
+            beforeEach(function() {
+                this.pipeline.initialise([]);
             });
 
             it('should return true', function() {
-                expect(pipeline.continue()).toBe(true);
+                expect(this.pipeline.continue()).toBe(true);
             });
         });
 
-        describe('when a steps continue function returns false', () => {
-            beforeEach(() => {
-                spyOn(step1, 'continue').and.returnValue(false);
-                spyOn(step2, 'continue').and.returnValue(true);
-                pipeline.initialise([step1, step2]);
+        describe('when a steps continue function returns false', function() {
+            beforeEach(function() {
+                spyOn(this.step1, 'continue').and.returnValue(false);
+                spyOn(this.step2, 'continue').and.returnValue(true);
+                this.pipeline.initialise([this.step1, this.step2]);
             });
 
-            it('should return false', () => {
-                expect(pipeline.continue()).toBe(false);
+            it('should return false', function() {
+                expect(this.pipeline.continue()).toBe(false);
             });
 
-            it('should not call continue on later steps', () => {
-                pipeline.continue();
-                expect(step2.continue).not.toHaveBeenCalled();
-            });
-        });
-
-        describe('when a steps continue function returns true', () => {
-            beforeEach(() => {
-                spyOn(step1, 'continue').and.returnValue(true);
-                spyOn(step2, 'continue').and.returnValue(true);
-                pipeline.initialise([step1, step2]);
-            });
-
-            it('should return true', () => {
-                expect(pipeline.continue()).toBe(true);
-            });
-
-            it('should call continue on each step', () => {
-                pipeline.continue();
-                expect(step1.continue).toHaveBeenCalled();
-                expect(step2.continue).toHaveBeenCalled();
+            it('should not call continue on later steps', function() {
+                this.pipeline.continue();
+                expect(this.step2.continue).not.toHaveBeenCalled();
             });
         });
 
-        describe('when a steps continue function lacks a return value', () => {
-            beforeEach(() => {
-                spyOn(step1, 'continue').and.returnValue(undefined);
-                spyOn(step2, 'continue').and.returnValue(undefined);
-                pipeline.initialise([step1, step2]);
+        describe('when a steps continue function returns true', function() {
+            beforeEach(function() {
+                spyOn(this.step1, 'continue').and.returnValue(true);
+                spyOn(this.step2, 'continue').and.returnValue(true);
+                this.pipeline.initialise([this.step1, this.step2]);
             });
 
-            it('should return true', () => {
-                expect(pipeline.continue()).toBe(true);
+            it('should return true', function() {
+                expect(this.pipeline.continue()).toBe(true);
             });
 
-            it('should call continue on each step', () => {
-                pipeline.continue();
-                expect(step1.continue).toHaveBeenCalled();
-                expect(step2.continue).toHaveBeenCalled();
+            it('should call continue on each step', function() {
+                this.pipeline.continue();
+                expect(this.step1.continue).toHaveBeenCalled();
+                expect(this.step2.continue).toHaveBeenCalled();
             });
         });
 
-        describe('when a step queues more steps', () => {
-            beforeEach(() => {
-                spyOn(step1, 'continue').and.callFake(() => {
-                    pipeline.queueStep(step2);
+        describe('when a steps continue function lacks a return value', function() {
+            beforeEach(function() {
+                spyOn(this.step1, 'continue').and.returnValue(undefined);
+                spyOn(this.step2, 'continue').and.returnValue(undefined);
+                this.pipeline.initialise([this.step1, this.step2]);
+            });
+
+            it('should return true', function() {
+                expect(this.pipeline.continue()).toBe(true);
+            });
+
+            it('should call continue on each step', function() {
+                this.pipeline.continue();
+                expect(this.step1.continue).toHaveBeenCalled();
+                expect(this.step2.continue).toHaveBeenCalled();
+            });
+        });
+
+        describe('when a step queues more steps', function() {
+            beforeEach(function() {
+                spyOn(this.step1, 'continue').and.callFake(() => {
+                    this.pipeline.queueStep(this.step2);
                     return false;
                 });
-                spyOn(step2, 'continue').and.returnValue(false);
-                pipeline.initialise([step1]);
+                spyOn(this.step2, 'continue').and.returnValue(false);
+                this.pipeline.initialise([this.step1]);
             });
 
-            it('should call continue on the queued step', () => {
-                pipeline.continue();
-                expect(step2.continue).toHaveBeenCalled();
+            it('should call continue on the queued step', function() {
+                this.pipeline.continue();
+                expect(this.step2.continue).toHaveBeenCalled();
             });
 
-            it('should place the queued step before the executed step', () => {
-                pipeline.continue();
-                expect(pipeline.pipeline[0]).toBe(step2);
-                expect(pipeline.pipeline[1]).toBe(step1);
+            it('should place the queued step before the executed step', function() {
+                this.pipeline.continue();
+                expect(this.pipeline.pipeline[0]).toBe(this.step2);
+                expect(this.pipeline.pipeline[1]).toBe(this.step1);
             });
         });
 
-        describe('when a step is a factory function', () => {
-            var container;
-
-            beforeEach(() => {
-                container = {
-                    factory: () => step1
+        describe('when a step is a factory function', function() {
+            beforeEach(function() {
+                this.container = {
+                    factory: () => this.step1
                 };
-                spyOn(container, 'factory').and.callThrough();
+                spyOn(this.container, 'factory').and.callThrough();
                 // Setup a failing step so execution can happen multiple times.
-                spyOn(step1, 'continue').and.returnValue(false);
-                pipeline.initialise([container.factory]);
+                spyOn(this.step1, 'continue').and.returnValue(false);
+                this.pipeline.initialise([this.container.factory]);
             });
 
-            it('should only call the factory once', () => {
-                pipeline.continue();
-                pipeline.continue();
-                expect(container.factory.calls.count()).toBe(1);
+            it('should only call the factory once', function() {
+                this.pipeline.continue();
+                this.pipeline.continue();
+                expect(this.container.factory.calls.count()).toBe(1);
             });
 
-            it('should inline the factory-created step', () => {
-                pipeline.continue();
-                expect(pipeline.pipeline[0]).toBe(step1);
+            it('should inline the factory-created step', function() {
+                this.pipeline.continue();
+                expect(this.pipeline.pipeline[0]).toBe(this.step1);
             });
         });
     });

--- a/test/server/gamepipeline/queuestep.spec.js
+++ b/test/server/gamepipeline/queuestep.spec.js
@@ -1,0 +1,72 @@
+/*global describe, it, beforeEach, expect, spyOn */
+/* eslint no-invalid-this: 0 */
+
+const GamePipeline = require('../../../server/game/gamepipeline.js');
+
+describe('the GamePipeline', function() {
+    beforeEach(function() {
+        this.step = {};
+        this.pipeline = new GamePipeline();
+    });
+
+    describe('the queueStep() function', function() {
+        describe('when the pipeline is empty', function() {
+
+            it('should add the step directly to the pipeline', function() {
+                this.pipeline.queueStep(this.step);
+                expect(this.pipeline.length).toBe(1);
+                expect(this.pipeline.pipeline[0]).toBe(this.step);
+            });
+
+            it('should leave the queue empty', function() {
+                this.pipeline.queueStep(this.step);
+                expect(this.pipeline.queue.length).toBe(0);
+            });
+        });
+
+        describe('when the pipeline is not empty', function() {
+            describe('when the next step is normal', function() {
+                beforeEach(function() {
+                    this.existingStep = {};
+                    this.pipeline.initialise([this.existingStep]);
+                });
+
+                it('should not modify the pipeline', function() {
+                    this.pipeline.queueStep(this.step);
+                    expect(this.pipeline.length).toBe(1);
+                });
+
+                it('should add it to the queue', function() {
+                    this.pipeline.queueStep(this.step);
+                    expect(this.pipeline.queue.length).toBe(1);
+                    expect(this.pipeline.queue[0]).toBe(this.step);
+                });
+            });
+
+            describe('when the next step is queueable', function() {
+                beforeEach(function() {
+                    this.existingStep = {
+                        queueStep: function() {}
+                    };
+                    spyOn(this.existingStep, 'queueStep');
+                    this.pipeline.initialise([this.existingStep]);
+                });
+
+                it('should call queueStep on the existing step', function() {
+                    this.pipeline.queueStep(this.step);
+                    expect(this.existingStep.queueStep).toHaveBeenCalledWith(this.step);
+                });
+
+                it('should not modify the pipeline', function() {
+                    this.pipeline.queueStep(this.step);
+                    expect(this.pipeline.length).toBe(1);
+                });
+
+                it('should leave the queue empty', function() {
+                    this.pipeline.queueStep(this.step);
+                    expect(this.pipeline.queue.length).toBe(0);
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
* Allows a factory method to be passed into the pipeline instead of just a game step.
* When queuing steps, if the current step itself is a pipeline, then pass it to the current step instead of adding it to the top-level queue. This fixes a bug where a step queued by the second-to-last step of a phase was being executed after the last step of the phase instead of before.