### PR TITLE
Convert plot phase up until plot resolution

### DIFF
--- a/client/GameBoard.jsx
+++ b/client/GameBoard.jsx
@@ -371,7 +371,7 @@ export class InnerGameBoard extends React.Component {
     onCommand(command, arg, method) {
         var commandArg = arg;
 
-        if(command === 'selectplot') {
+        if(arg === 'plotselected') {
             if(!this.state.selectedPlot) {
                 return;
             }

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -1023,10 +1023,13 @@ class Game extends EventEmitter {
         });
         this.pipeline = new GamePipeline();
         this.pipeline.initialise([
-            new SetupPhase(this),
-            new PlotPhase(this)
+            new SetupPhase(this)
         ]);
         this.pipeline.continue();
+    }
+
+    beginRound() {
+        this.queueStep(new PlotPhase(this));
     }
 
     queueStep(step) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -168,52 +168,6 @@ class Game extends EventEmitter {
         this.pipeline.continue();
     }
 
-    firstPlayerPrompt(initiativeWinner) {
-        initiativeWinner.firstPlayer = true;
-        initiativeWinner.menuTitle = 'Select a first player';
-        initiativeWinner.buttons = [
-            { command: 'firstplayer', text: 'Me', arg: 'me' }
-        ];
-
-        if(_.size(this.getPlayers()) > 1) {
-            initiativeWinner.buttons.push({ command: 'firstplayer', text: 'Opponent', arg: 'opponent' });
-        }
-
-        var otherPlayer = this.getOtherPlayer(initiativeWinner);
-
-        if(otherPlayer) {
-            otherPlayer.menuTitle = 'Waiting for opponent to select first player';
-            otherPlayer.buttons = [];
-        }
-    }
-
-    selectPlot(playerId, plotId) {
-        var player = this.getPlayerById(playerId);
-
-        if(!player || !player.selectPlot(plotId)) {
-            return;
-        }
-
-        this.addMessage('{0} has selected a plot', player);
-
-        if(!_.all(this.getPlayers(), p => {
-            return !!p.selectedPlot;
-        })) {
-            player.menuTitle = 'Waiting for opponent to select plot';
-            player.buttons = [];
-        } else {
-            // determine initiative winner
-            // initiative winner sets the first player
-            // note that control flow for the plot phase after this continues under
-            // the setFirstPlayer function
-            if(_.size(this.players) === 1) {
-                this.setFirstPlayer(player.id, 'me');
-            } else {
-                this.firstPlayerPrompt(initiativeWinner);
-            }
-        }
-    }
-
     drawPhase(firstPlayer) {
         _.each(this.getPlayers(), p => {
             this.emit('beginDrawPhase', this, p);
@@ -292,35 +246,6 @@ class Game extends EventEmitter {
         if(player.activePlot.onReveal(player)) {
             this.playerRevealDone(player);
         }
-    }
-
-    setFirstPlayer(sourcePlayer, who) {
-        var firstPlayer = undefined;
-
-        var player = this.getPlayerById(sourcePlayer);
-
-        if(!player) {
-            return;
-        }
-
-        _.each(this.getPlayers(), player => {
-            if(player.id === sourcePlayer && who === 'me') {
-                player.firstPlayer = true;
-                firstPlayer = player;
-            } else if(player.id !== sourcePlayer && who !== 'me') {
-                player.firstPlayer = true;
-                firstPlayer = player;
-            } else {
-                player.firstPlayer = false;
-            }
-
-            player.menuTitle = '';
-            player.buttons = [];
-        });
-
-        this.addMessage('{0} has selected {1} to be the first player', player, firstPlayer);
-
-        this.resolvePlotEffects(firstPlayer);
     }
 
     handleChallenge(player, otherPlayer, cardId) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -7,6 +7,7 @@ const Spectator = require('./spectator.js');
 const BaseCard = require('./basecard.js');
 const GamePipeline = require('./gamepipeline.js');
 const SetupPhase = require('./gamesteps/setupphase.js');
+const PlotPhase = require('./gamesteps/plotphase.js');
 const DominancePhase = require('./gamesteps/dominancephase.js');
 const StandingPhase = require('./gamesteps/standingphase.js');
 const TaxationPhase = require('./gamesteps/taxationphase.js');
@@ -201,46 +202,7 @@ class Game extends EventEmitter {
             player.menuTitle = 'Waiting for opponent to select plot';
             player.buttons = [];
         } else {
-            var initiativeWinner = undefined;
-            var highestInitiative = -1;
-            var lowestPower = -1;
-
-            this.emit('onPlotFlip');
-
-            // reveal plots when everyone has selected (flip them faceup)
-            _.each(this.getPlayers(), p => {
-                p.revealPlot();
-            });
-
             // determine initiative winner
-            _.each(this.getPlayers(), p => {
-                var playerInitiative = p.getTotalInitiative();
-                var playerPower = p.power;
-
-                if(playerInitiative === highestInitiative) {
-                    if(playerPower === lowestPower) {
-                        var diceRoll = _.random(1, 20);
-                        if(diceRoll % 2 === 0) {
-                            highestInitiative = playerInitiative;
-                            lowestPower = playerPower;
-                            initiativeWinner = p;
-                        }
-                    }
-
-                    if(playerPower < lowestPower) {
-                        highestInitiative = playerInitiative;
-                        lowestPower = playerPower;
-                        initiativeWinner = p;
-                    }
-                }
-
-                if(playerInitiative > highestInitiative) {
-                    highestInitiative = playerInitiative;
-                    lowestPower = playerPower;
-                    initiativeWinner = p;
-                }
-            });
-
             // initiative winner sets the first player
             // note that control flow for the plot phase after this continues under
             // the setFirstPlayer function
@@ -1136,7 +1098,8 @@ class Game extends EventEmitter {
         });
         this.pipeline = new GamePipeline();
         this.pipeline.initialise([
-            new SetupPhase(this)
+            new SetupPhase(this),
+            new PlotPhase(this)
         ]);
         this.pipeline.continue();
     }

--- a/server/game/gamesteps/plot/firstplayerprompt.js
+++ b/server/game/gamesteps/plot/firstplayerprompt.js
@@ -23,12 +23,23 @@ class FirstPlayerPrompt extends UIPrompt {
         };
     }
 
-    onMenuCommand(player, firstPlayer) {
+    onMenuCommand(player, playerId) {
         if(player !== this.player) {
             return false;
         }
 
-        console.log(firstPlayer);
+        var firstPlayer = this.game.getPlayerById(playerId);
+        if(!firstPlayer) {
+            return;
+        }
+
+        firstPlayer.firstPlayer = true;
+        var otherPlayer = this.game.getOtherPlayer(firstPlayer);
+        if(otherPlayer) {
+            otherPlayer.firstPlayer = false;
+        }    
+
+        this.game.addMessage('{0} has selected {1} to be the first player', player, firstPlayer);        
     }
 
     continue() {

--- a/server/game/gamesteps/plot/firstplayerprompt.js
+++ b/server/game/gamesteps/plot/firstplayerprompt.js
@@ -7,27 +7,28 @@ class FirstPlayerPrompt extends UIPrompt {
         this.player = player;
     }
 
+    activeCondition(player) {
+        return player === this.player;
+    }
+
+    activePrompt() {
+        var otherPlayer = this.game.getOtherPlayer(this.player);
+
+        return {
+            menuTitle: 'Select first player',
+            buttons: [
+                { text: this.player.name, command: 'menuButton', arg: this.player.id },
+                { text: otherPlayer.name, command: 'menuButton', arg: otherPlayer.id }
+            ]
+        };
+    }
+
     onMenuCommand(player, firstPlayer) {
         if(player !== this.player) {
             return false;
         }
 
         console.log(firstPlayer);
-    }
-
-    setPrompt() {
-        this.originalPrompt = this.originalPrompt || this.player.currentPrompt();
-
-        var otherPlayer = this.game.getOtherPlayer(this.player);
-
-        this.player.setPrompt({
-            selectCard: true,
-            menuTitle: 'Select first player',
-            buttons: [
-                { text: this.player.name, command: 'menuButton', arg: 'me' },
-                { text: otherPlayer.name, command: 'menuButton', arg: 'opponent'}
-            ]
-        });
     }
 
     continue() {

--- a/server/game/gamesteps/plot/firstplayerprompt.js
+++ b/server/game/gamesteps/plot/firstplayerprompt.js
@@ -1,3 +1,5 @@
+const _ = require('underscore');
+
 const UIPrompt = require('../uiprompt.js');
 
 class FirstPlayerPrompt extends UIPrompt {
@@ -12,14 +14,13 @@ class FirstPlayerPrompt extends UIPrompt {
     }
 
     activePrompt() {
-        var otherPlayer = this.game.getOtherPlayer(this.player);
+        var players = [this.player].concat(_.reject(this.game.getPlayers(), p => p === this.player));
 
         return {
             menuTitle: 'Select first player',
-            buttons: [
-                { text: this.player.name, command: 'menuButton', arg: this.player.id },
-                { text: otherPlayer.name, command: 'menuButton', arg: otherPlayer.id }
-            ]
+            buttons: _.map(players, player => {
+                return { text: player.name, command: 'menuButton', arg: player.id };
+            })
         };
     }
 
@@ -33,19 +34,13 @@ class FirstPlayerPrompt extends UIPrompt {
             return;
         }
 
-        firstPlayer.firstPlayer = true;
-        var otherPlayer = this.game.getOtherPlayer(firstPlayer);
-        if(otherPlayer) {
-            otherPlayer.firstPlayer = false;
-        }    
+        _.each(this.game.getPlayers(), player => {
+            player.firstPlayer = firstPlayer === player
+        });
 
-        this.game.addMessage('{0} has selected {1} to be the first player', player, firstPlayer);        
-    }
+        this.game.addMessage('{0} has selected {1} to be the first player', player, firstPlayer);
 
-    continue() {
-        this.setPrompt();
-
-        return false;
+        this.complete();
     }
 }
 

--- a/server/game/gamesteps/plot/firstplayerprompt.js
+++ b/server/game/gamesteps/plot/firstplayerprompt.js
@@ -1,0 +1,39 @@
+const UIPrompt = require('../uiprompt.js');
+
+class FirstPlayerPrompt extends UIPrompt {
+    constructor(game, player) {
+        super(game);
+
+        this.player = player;
+    }
+
+    onMenuCommand(player, firstPlayer) {
+        if(player !== this.player) {
+            return false;
+        }
+
+        console.log(firstPlayer);
+    }
+
+    setPrompt() {
+        this.originalPrompt = this.originalPrompt || this.player.currentPrompt();
+
+        var otherPlayer = this.game.getOtherPlayer(this.player);
+
+        this.player.setPrompt({
+            selectCard: true,
+            menuTitle: 'Select first player',
+            buttons: [
+                { text: this.player.name, command: 'menuButton', arg: 'me' },
+                { text: otherPlayer.name, command: 'menuButton', arg: 'opponent'}
+            ]
+        });
+    }
+
+    continue() {
+        this.setPrompt();
+        return this.attached;
+    }
+}
+
+module.exports = FirstPlayerPrompt;

--- a/server/game/gamesteps/plot/firstplayerprompt.js
+++ b/server/game/gamesteps/plot/firstplayerprompt.js
@@ -33,7 +33,8 @@ class FirstPlayerPrompt extends UIPrompt {
 
     continue() {
         this.setPrompt();
-        return this.attached;
+
+        return false;
     }
 }
 

--- a/server/game/gamesteps/plot/plotrevealprompt.js
+++ b/server/game/gamesteps/plot/plotrevealprompt.js
@@ -1,0 +1,52 @@
+const UIPrompt = require('../uiprompt.js');
+
+class PlotRevealPrompt extends UIPrompt {
+    constructor(game, player) {
+        super(game);
+
+        this.player = player;
+    }
+
+    activeCondition(player) {
+        return player === this.player;
+    }
+
+    activePrompt() {
+        var otherPlayer = this.game.getOtherPlayer(this.player);
+
+        return {
+            menuTitle: 'Select first player',
+            buttons: [
+                { text: this.player.name, command: 'menuButton', arg: this.player.id },
+                { text: otherPlayer.name, command: 'menuButton', arg: otherPlayer.id }
+            ]
+        };
+    }
+
+    onMenuCommand(player, playerId) {
+        if(player !== this.player) {
+            return false;
+        }
+
+        var firstPlayer = this.game.getPlayerById(playerId);
+        if(!firstPlayer) {
+            return;
+        }
+
+        firstPlayer.firstPlayer = true;
+        var otherPlayer = this.game.getOtherPlayer(firstPlayer);
+        if(otherPlayer) {
+            otherPlayer.firstPlayer = false;
+        }    
+
+        this.game.addMessage('{0} has selected {1} to be the first player', player, firstPlayer);        
+    }
+
+    continue() {
+        this.setPrompt();
+
+        return false;
+    }
+}
+
+module.exports = PlotRevealPrompt;

--- a/server/game/gamesteps/plot/revealplotorderprompt.js
+++ b/server/game/gamesteps/plot/revealplotorderprompt.js
@@ -1,0 +1,42 @@
+const _ = require('underscore');
+
+const UIPrompt = require('../uiprompt.js');
+
+class RevealPlotOrderPrompt extends UIPrompt {
+    constructor(game, player) {
+        super(game);
+
+        this.player = player;
+    }
+
+    activeCondition(player) {
+        return player === this.player;
+    }
+
+    activePrompt() {
+        var playersWithRevealEffects = _.find(this.game.getPlayers, player => {
+            return player.activePlot.hasRevealEffect();
+        });
+
+        return {
+            menuTitle: 'Select a player to resolve their plot effects',
+            buttons: _.map(playersWithRevealEffects, player => {
+                return { text: player.name, command: 'menuButton', arg: player.id };
+            })
+        };
+    }
+
+    onMenuCommand(player, playerId) {
+        if(player !== this.player) {
+            return false;
+        }     
+    }
+
+    continue() {
+        this.setPrompt();
+
+        return false;
+    }
+}
+
+module.exports = RevealPlotOrderPrompt;

--- a/server/game/gamesteps/plot/selectplotprompt.js
+++ b/server/game/gamesteps/plot/selectplotprompt.js
@@ -1,0 +1,30 @@
+const AllPlayerPrompt = require('../allplayerprompt.js');
+
+class SelectPlotPrompt extends AllPlayerPrompt {
+    completionCondition(player) {
+        return !!player.selectedPlot;
+    }
+
+    activePrompt() {
+        return {
+            menuTitle: 'Select a plot',
+            buttons: [
+                { command: 'menuButton', arg: 'plotselected', text: 'Done' }
+            ]
+        };
+    }
+
+    waitingPrompt() {
+        return { menuTitle: 'Waiting for opponent to select plot' };
+    }
+
+    onMenuCommand(player, plotId) {
+        if(!player.selectPlot(plotId)) {
+            return;
+        }
+        
+        this.game.addMessage('{0} has selected a plot', player);
+    }
+}
+
+module.exports = SelectPlotPrompt;

--- a/server/game/gamesteps/plotphase.js
+++ b/server/game/gamesteps/plotphase.js
@@ -1,0 +1,69 @@
+const _ = require('underscore');
+const Phase = require('./phase.js');
+const SimpleStep = require('./simplestep.js');
+const SelectPlotPrompt = require('./plot/selectplotprompt.js');
+const FirstPlayerPrompt = require('./plot/firstplayerprompt.js');
+
+class PlotPhase extends Phase {
+    constructor(game) {
+        super(game);
+        this.initialise([
+            new SimpleStep(game, () => this.startPlotPhase()),
+            new SelectPlotPrompt(game),
+            new SimpleStep(game, () => this.flipPlotsFaceup()),
+            new SimpleStep(game, () => this.determineInitiative())
+        ]);
+    }
+
+    startPlotPhase() {
+        _.each(this.game.getPlayers(), player => {
+            player.startPlotPhase();
+        });
+    }
+
+    flipPlotsFaceup() {
+        this.game.emit('onPlotFlip');
+
+        _.each(this.game.getPlayers(), player => {
+            player.flipPlotFaceup();
+        });
+    }
+
+    determineInitiative() {
+        var initiativeWinner = undefined;
+        var highestInitiative = -1;
+        var lowestPower = -1;
+
+        _.each(this.game.getPlayers(), p => {
+            var playerInitiative = p.getTotalInitiative();
+            var playerPower = p.power;
+
+            if(playerInitiative === highestInitiative) {
+                if(playerPower === lowestPower) {
+                    var randomNumber = _.random(0, 1);
+                    if(randomNumber === 0) {
+                        highestInitiative = playerInitiative;
+                        lowestPower = playerPower;
+                        initiativeWinner = p;
+                    }
+                }
+
+                if(playerPower < lowestPower) {
+                    highestInitiative = playerInitiative;
+                    lowestPower = playerPower;
+                    initiativeWinner = p;
+                }
+            }
+
+            if(playerInitiative > highestInitiative) {
+                highestInitiative = playerInitiative;
+                lowestPower = playerPower;
+                initiativeWinner = p;
+            }
+        });
+
+        this.game.queueStep(new FirstPlayerPrompt(this.game, initiativeWinner));
+    }
+}
+
+module.exports = PlotPhase;

--- a/server/game/gamesteps/plotphase.js
+++ b/server/game/gamesteps/plotphase.js
@@ -3,6 +3,7 @@ const Phase = require('./phase.js');
 const SimpleStep = require('./simplestep.js');
 const SelectPlotPrompt = require('./plot/selectplotprompt.js');
 const FirstPlayerPrompt = require('./plot/firstplayerprompt.js');
+const RevealPlotOrderPrompt = require('./plot/revealplotorderprompt.js');
 
 class PlotPhase extends Phase {
     constructor(game) {
@@ -14,7 +15,9 @@ class PlotPhase extends Phase {
             new SimpleStep(game, () => this.determineInitiative()),
             () => {
                 return new FirstPlayerPrompt(game, this.initiativeWinner);
-            }
+            },
+            new SimpleStep(game, () => this.startPlotRevealEffects()),
+            new RevealPlotOrderPrompt(game)
         ]);
     }
 
@@ -22,6 +25,14 @@ class PlotPhase extends Phase {
         _.each(this.game.getPlayers(), player => {
             player.startPlotPhase();
         });
+    }
+
+    startPlotRevealEffects() {
+        if(!_.any(this.game.getPlayers(), player => {
+            return player.activePlot.hasRevealEffect() && !player.revealFinished;
+        })) {
+            return;
+        }
     }
 
     flipPlotsFaceup() {

--- a/server/game/gamesteps/plotphase.js
+++ b/server/game/gamesteps/plotphase.js
@@ -3,7 +3,6 @@ const Phase = require('./phase.js');
 const SimpleStep = require('./simplestep.js');
 const SelectPlotPrompt = require('./plot/selectplotprompt.js');
 const FirstPlayerPrompt = require('./plot/firstplayerprompt.js');
-const RevealPlotOrderPrompt = require('./plot/revealplotorderprompt.js');
 
 class PlotPhase extends Phase {
     constructor(game) {
@@ -16,8 +15,7 @@ class PlotPhase extends Phase {
             () => {
                 return new FirstPlayerPrompt(game, this.initiativeWinner);
             },
-            new SimpleStep(game, () => this.startPlotRevealEffects()),
-            new RevealPlotOrderPrompt(game)
+            new SimpleStep(game, () => this.startPlotRevealEffects())
         ]);
     }
 
@@ -27,12 +25,9 @@ class PlotPhase extends Phase {
         });
     }
 
+    // Temporarily go back into the old flow.
     startPlotRevealEffects() {
-        if(!_.any(this.game.getPlayers(), player => {
-            return player.activePlot.hasRevealEffect() && !player.revealFinished;
-        })) {
-            return;
-        }
+        this.game.resolvePlotEffects(this.game.getFirstPlayer());
     }
 
     flipPlotsFaceup() {

--- a/server/game/gamesteps/plotphase.js
+++ b/server/game/gamesteps/plotphase.js
@@ -11,7 +11,10 @@ class PlotPhase extends Phase {
             new SimpleStep(game, () => this.startPlotPhase()),
             new SelectPlotPrompt(game),
             new SimpleStep(game, () => this.flipPlotsFaceup()),
-            new SimpleStep(game, () => this.determineInitiative())
+            new SimpleStep(game, () => this.determineInitiative()),
+            () => {
+                return new FirstPlayerPrompt(game, this.initiativeWinner);
+            }
         ]);
     }
 
@@ -62,7 +65,7 @@ class PlotPhase extends Phase {
             }
         });
 
-        this.game.queueStep(new FirstPlayerPrompt(this.game, initiativeWinner));
+        this.initiativeWinner = initiativeWinner;
     }
 }
 

--- a/server/game/gamesteps/setupphase.js
+++ b/server/game/gamesteps/setupphase.js
@@ -13,7 +13,8 @@ class SetupPhase extends Phase {
             new SimpleStep(game, () => this.startGame()),
             new SetupCardsPrompt(game),
             new CheckAttachmentsPrompt(game),
-            new SimpleStep(game, () => this.setupDone())
+            new SimpleStep(game, () => this.setupDone()),
+            new SimpleStep(game, () => this.beginRound())
         ]);
     }
 
@@ -28,6 +29,10 @@ class SetupPhase extends Phase {
         _.each(this.game.getPlayers(), p => {
             p.setupDone();
         });
+    }
+
+    beginRound() {
+        this.game.beginRound();
     }
 }
 

--- a/server/game/gamesteps/setupphase.js
+++ b/server/game/gamesteps/setupphase.js
@@ -27,8 +27,6 @@ class SetupPhase extends Phase {
     setupDone() {
         _.each(this.game.getPlayers(), p => {
             p.setupDone();
-            // TODO: Temporarily trigger plot phase here until it's also converted.
-            p.startPlotPhase();
         });
     }
 }

--- a/server/game/gamesteps/taxationphase.js
+++ b/server/game/gamesteps/taxationphase.js
@@ -24,9 +24,7 @@ class TaxationPhase extends Phase {
 
     // Temporary step until plot phase / round structure is more defined.
     startPlotPhase() {
-        _.each(this.game.getPlayers(), player => {
-            player.startPlotPhase();
-        });
+        this.game.beginRound();
     }
 }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -455,10 +455,6 @@ class Player extends Spectator {
     startPlotPhase() {
         this.phase = 'plot';
 
-        this.menuTitle = 'Choose your plot';
-        this.buttons = [
-            { command: 'selectplot', text: 'Done' }
-        ];
         this.gold = 0;
         this.claim = 0;
         this.reserve = 0;
@@ -508,7 +504,7 @@ class Player extends Spectator {
         return true;
     }
 
-    revealPlot() {
+    flipPlotFaceup() {
         this.menuTitle = '';
         this.buttons = [];
 

--- a/server/index.js
+++ b/server/index.js
@@ -426,34 +426,6 @@ io.on('connection', function(socket) {
         });
     });
 
-    socket.on('selectplot', function(plot) {
-        var game = findGameForPlayer(socket.id);
-
-        if(!game) {
-            return;
-        }
-
-        runAndCatchErrors(game, () => {
-            game.selectPlot(socket.id, plot);
-
-            sendGameState(game);
-        });
-    });
-
-    socket.on('firstplayer', function(arg) {
-        var game = findGameForPlayer(socket.id);
-
-        if(!game) {
-            return;
-        }
-
-        runAndCatchErrors(game, () => {
-            game.setFirstPlayer(socket.id, arg);
-
-            sendGameState(game);
-        });
-    });
-
     socket.on('resolvePlotEffect', function(playerId) {
         var game = findGameForPlayer(socket.id);
 


### PR DESCRIPTION
* Converts the 'choose plot' and 'choose first player' prompts into the new game flow.
* Ensures that at the end of the taxation phase the plot phase is triggered again.
* Continues to use the old flow for plot resolution (converted in separate PR) to make it safer to merge this.