### PR TITLE
Fix dragging cards from dead/discard to play.

### DIFF
--- a/server/game/game.js
+++ b/server/game/game.js
@@ -140,11 +140,7 @@ class Game extends EventEmitter {
 
         var card = player.findCardByUuid(player.hand, cardId);
 
-        if(!card) {
-            return;
-        }
-
-        if(this.pipeline.handleCardClicked(player, card)) {
+        if(card && !isDrop && this.pipeline.handleCardClicked(player, card)) {
             this.pipeline.continue();
             return;
         }


### PR DESCRIPTION
The pipeline click handler added to Game.playCard was returning if it
couldn't find the card within the player's hand. This method is also
called when a card is dragged into the play area. By returning early,
cards dragged from the dead and discard piles would disappear instead of
be put into play.