### PR TITLE
Allow dupes for unique attachments

### DIFF
--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -37,6 +37,12 @@ class DrawCard extends BaseCard {
         this.dupes.push(card);
     }
 
+    removeDuplicate() {
+        var firstDupe = this.dupes.first();
+        this.dupes.shift();
+        return firstDupe;
+    }
+
     isLimited() {
         return this.hasKeyword('Limited');
     }

--- a/server/game/gamesteps/setupphase.js
+++ b/server/game/gamesteps/setupphase.js
@@ -12,8 +12,8 @@ class SetupPhase extends Phase {
             new KeepOrMulliganPrompt(game),
             new SimpleStep(game, () => this.startGame()),
             new SetupCardsPrompt(game),
-            new CheckAttachmentsPrompt(game),
             new SimpleStep(game, () => this.setupDone()),
+            new CheckAttachmentsPrompt(game),
             new SimpleStep(game, () => this.beginRound())
         ]);
     }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -869,10 +869,9 @@ class Player extends Spectator {
 
     removeAttachment(attachment) {
         attachment.parent.attachments = this.removeCardByUuid(attachment.parent.attachments, attachment.uuid);
-
-        attachment.leavesPlay();        
+        attachment.parent = undefined;
+        attachment.leavesPlay();
         if(attachment.isTerminal()) {
-            attachment.parent = undefined;
             attachment.owner.discardPile.push(attachment);
         } else {
             attachment.owner.hand.push(attachment);

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -367,6 +367,8 @@ class Player extends Spectator {
 
         if(card.getType() === 'attachment' && this.phase !== 'setup' && !dupeCard) {
             this.promptForAttachment(card);
+            // Hacky workaround for drag and drop.
+            this.dropPending = sourceList === this.discardPile;
             return true;
         }
 
@@ -642,8 +644,7 @@ class Player extends Spectator {
 
                 this.game.playCard(this.id, cardId, true, sourceList);
 
-                if(card.getType() === 'attachment') {
-                    this.dropPending = true;
+                if(this.dropPending) {
                     return true;
                 }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -852,7 +852,7 @@ class Player extends Spectator {
         card.dupes = _([]);
 
         card.attachments.each(attachment => {
-            this.removeAttachment(attachment);
+            this.removeAttachment(attachment, false);
         });
 
         this.cardsInPlay = this.removeCardByUuid(this.cardsInPlay, cardId);
@@ -867,11 +867,13 @@ class Player extends Spectator {
         this.game.emit('onCardLeftPlay', this, card);
     }
 
-    removeAttachment(attachment) {
-        if(attachment.dupes.size() > 0) {
+    removeAttachment(attachment, allowSave = true) {
+        while(attachment.dupes.size() > 0) {
             var dupe = attachment.removeDuplicate();
             dupe.owner.discardPile.push(dupe);
-            return;
+            if(allowSave) {
+                return;
+            }
         }
 
         attachment.parent.attachments = this.removeCardByUuid(attachment.parent.attachments, attachment.uuid);

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -365,7 +365,7 @@ class Player extends Spectator {
             this.game.addMessage('{0} ambushes with {1} costing {2}', this, card, cost);
         }
 
-        if(card.getType() === 'attachment' && this.phase !== 'setup') {
+        if(card.getType() === 'attachment' && this.phase !== 'setup' && !dupeCard) {
             this.promptForAttachment(card);
             return true;
         }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -868,6 +868,12 @@ class Player extends Spectator {
     }
 
     removeAttachment(attachment) {
+        if(attachment.dupes.size() > 0) {
+            var dupe = attachment.removeDuplicate();
+            dupe.owner.discardPile.push(dupe);
+            return;
+        }
+
         attachment.parent.attachments = this.removeCardByUuid(attachment.parent.attachments, attachment.uuid);
         attachment.parent = undefined;
         attachment.leavesPlay();

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -42,12 +42,6 @@ class Player extends Spectator {
         });
     }
 
-    findCardInPlayByCode(code) {
-        return this.cardsInPlay.find(card => {
-            return card.code === code;
-        });
-    }
-
     removeCardByUuid(list, uuid) {
         return _(list.reject(card => {
             return card.uuid === uuid;
@@ -55,9 +49,7 @@ class Player extends Spectator {
     }
 
     findCardByName(list, name) {
-        return list.find(card => {
-            return card.name === name;
-        });
+        return this.findCard(list, card => card.name === name);
     }
 
     findCardByUuidInAnyList(uuid) {
@@ -85,32 +77,7 @@ class Player extends Spectator {
     }
 
     findCardByUuid(list, uuid) {
-        var returnedCard = undefined;
-
-        if(!list) {
-            return undefined;
-        }
-
-        list.each(card => {
-            if(card.attachments) {
-                var attachment = this.findCardByUuid(card.attachments, uuid);
-
-                if(attachment) {
-                    returnedCard = attachment;
-                    return;
-                }
-            }
-
-            if(card.card && card.uuid === uuid) {
-                returnedCard = card;
-                return;
-            } else if(card.uuid === uuid) {
-                returnedCard = card;
-                return;
-            }
-        });
-
-        return returnedCard;
+        return this.findCard(list, card => card.uuid === uuid);
     }
 
     findCardInPlayByUuid(uuid) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -114,25 +114,27 @@ class Player extends Spectator {
     }
 
     findCardInPlayByUuid(uuid) {
-        var returnedCard = undefined;
+        return this.findCard(this.cardsInPlay, card => card.uuid === uuid);
+    }
 
-        this.cardsInPlay.each(card => {
+    findCard(cards, predicate) {
+        if(!cards) {
+            return;
+        }
+
+        return cards.reduce((matchingCard, card) => {
+            if(matchingCard) {
+                return matchingCard;
+            }
+
+            if(predicate(card)) {
+                return card;
+            }
+
             if(card.attachments) {
-                var attachment = this.findCardByUuid(card.attachments, uuid);
-                if(attachment) {
-                    returnedCard = attachment;
-
-                    return;
-                }
+                return card.attachments.find(predicate);
             }
-
-            if(card.uuid === uuid) {
-                returnedCard = card;
-                return;
-            }
-        });
-
-        return returnedCard;
+        }, undefined);
     }
 
     getDuplicateInPlay(card) {
@@ -140,7 +142,7 @@ class Player extends Spectator {
             return undefined;
         }
 
-        return this.cardsInPlay.find(playCard => {
+        return this.findCard(this.cardsInPlay, playCard => {
             return playCard.code === card.code || playCard.name === card.name;
         });
     }

--- a/test/server/player/find.spec.js
+++ b/test/server/player/find.spec.js
@@ -1,53 +1,54 @@
 /*global describe, it, beforeEach, expect*/
-/* eslint camelcase: 0 */
-
-const _ = require('underscore');
+/* eslint camelcase: 0, no-invalid-this: 0 */
 
 const Player = require('../../../server/game/player.js');
+const DrawCard = require('../../../server/game/drawcard.js');
 
-describe('the Player', () => {
-    var player = new Player('1', 'Player 1', true);
-    var attachment = { uuid: '1111', code: '1', label: 'Attachment', type_code: 'attachment' };
-    var cardWithNoAttachments = { uuid: '2222', code: '2', label: 'Character', type_code: 'character' };
-    var cardWithAttachment = { attachments: _([attachment]), uuid: '3333', code: '3', label: 'Character', type_code: 'character' };
+describe('the Player', function() {
+    beforeEach(function() {
+        this.player = new Player('1', 'Player 1', true);
+        this.attachment = new DrawCard(this.player, { code: '1', label: 'Attachment', type_code: 'attachment' });
+        this.attachment.uuid = '1111';
+        this.cardWithNoAttachments = new DrawCard(this.player, { code: '2', label: 'Character', type_code: 'character' });
+        this.cardWithNoAttachments.uuid = '2222';
+        this.cardWithAttachment = new DrawCard(this.player, { code: '3', label: 'Character', type_code: 'character' });
+        this.cardWithAttachment.uuid = '3333';
+        this.cardWithAttachment.attachments.push(this.attachment);
 
-    beforeEach(() => {
-        player.initialise();
+        this.player.initialise();
 
-        player.cardsInPlay.push(cardWithNoAttachments);
-        player.cardsInPlay.push(cardWithAttachment);
+        this.player.cardsInPlay.push(this.cardWithNoAttachments);
+        this.player.cardsInPlay.push(this.cardWithAttachment);
     });
 
-    describe('the findCardInPlayByUuid() function', () => {
-        var card = undefined;
+    describe('the findCardInPlayByUuid() function', function() {
+        describe('when called for a card that isn\'t in play', function() {
+            it('should return undefined', function() {
+                this.card = this.player.findCardInPlayByUuid('notinplay');
 
-        describe('when called for a card that isn\'t in play', () => {
-            it('should return undefined', () => {
-                card = player.findCardInPlayByUuid('notinplay');
-
-                expect(card).toBe(undefined);
+                expect(this.card).toBe(undefined);
             });
         });
 
-        describe('when called for a card that is in play', () => {
-            beforeEach(() => {
-                card = player.findCardInPlayByUuid('2222');
+        describe('when called for a card that is in play', function() {
+            beforeEach(function() {
+                this.card = this.player.findCardInPlayByUuid('2222');
             });
 
-            it('should return the card', () => {
-                expect(card).not.toBe(undefined);
-                expect(card.code).toBe('2');
+            it('should return the card', function() {
+                expect(this.card).not.toBe(undefined);
+                expect(this.card.code).toBe('2');
             });
         });
 
-        describe('when called for an attachment that is on a card in play', () => {
-            beforeEach(() => {
-                card = player.findCardInPlayByUuid('1111');
+        describe('when called for an attachment that is on a card in play', function() {
+            beforeEach(function() {
+                this.card = this.player.findCardInPlayByUuid('1111');
             });
 
-            it('should return the attachment', () => {
-                expect(card).not.toBe(undefined);
-                expect(card.code).toBe('1');
+            it('should return the attachment', function() {
+                expect(this.card).not.toBe(undefined);
+                expect(this.card.code).toBe('1');
             });
         });
     });

--- a/test/server/player/getduplicateinplay.spec.js
+++ b/test/server/player/getduplicateinplay.spec.js
@@ -1,7 +1,8 @@
-/* global describe, it, beforeEach, expect, spyOn, jasmine */
+/* global describe, it, beforeEach, expect, jasmine */
 /* eslint camelcase: 0, no-invalid-this: 0 */
 
 const Player = require('../../../server/game/player.js');
+const DrawCard = require('../../../server/game/drawcard.js');
 
 describe('Player', function() {
     describe('getDuplicateInPlay', function() {
@@ -9,15 +10,13 @@ describe('Player', function() {
             this.player = new Player('1', 'Player 1', true);
             this.player.initialise();
 
-            this.dupeCard = { code: '1', name: 'Test' };
+            this.dupeCard = new DrawCard(this.player, { code: '1', name: 'Test' });
 
             this.player.cardsInPlay.push(this.dupeCard);
 
-            this.findSpy = spyOn(this.player, 'findCardByUuid');
             this.cardSpy = jasmine.createSpyObj('card', ['isUnique']);
 
             this.cardSpy.isUnique.and.returnValue(true);
-            this.findSpy.and.returnValue(this.cardSpy);
         });
 
         describe('when the card is not unique', function() {
@@ -58,6 +57,22 @@ describe('Player', function() {
             });
         });
 
+        describe('when there is a matching attached card in play', function() {
+            beforeEach(function() {
+                this.attachedCard = new DrawCard(this.player, { code: '3', name: 'Attached', type_code: 'attachment' });
+                this.dupeCard.attachments.push(this.attachedCard);
+
+                this.cardSpy.code = '3';
+                this.cardSpy.name = 'Attached';
+
+                this.dupe = this.player.getDuplicateInPlay(this.cardSpy);
+            });
+
+            it('should return the duplicate attached card', function() {
+                expect(this.dupe).toBe(this.attachedCard);
+            });
+        });
+
         describe('when there is a card that doesnt match by name or code', function() {
             beforeEach(function() {
                 this.cardSpy.code = '6';
@@ -66,7 +81,7 @@ describe('Player', function() {
                 this.dupe = this.player.getDuplicateInPlay(this.cardSpy);
             });
 
-            it('should return dupe', function() {
+            it('should return undefined', function() {
                 expect(this.dupe).toBe(undefined);
             });
         });

--- a/test/server/player/playcard.spec.js
+++ b/test/server/player/playcard.spec.js
@@ -75,19 +75,51 @@ describe('Player', function() {
                 spyOn(this.player, 'promptForAttachment');
 
                 this.cardSpy.getType.and.returnValue('attachment');
-                this.canPlay = this.player.playCard('');
             });
 
-            it('should return true', function() {
-                expect(this.canPlay).toBe(true);
+            describe('and there is no duplicate out', function() {
+                beforeEach(function() {
+                    this.canPlay = this.player.playCard('');
+                });
+
+                it('should return true', function() {
+                    expect(this.canPlay).toBe(true);
+                });
+
+                it('should prompt for attachment target', function() {
+                    expect(this.player.promptForAttachment).toHaveBeenCalled();
+                });
+
+                it('should not remove the card from hand', function() {
+                    expect(this.player.removeFromHand).not.toHaveBeenCalled();
+                });
             });
 
-            it('should prompt for attachment target', function() {
-                expect(this.player.promptForAttachment).toHaveBeenCalled();
-            });
+            describe('and there is a duplicate out', function() {
+                beforeEach(function() {
+                    spyOn(this.player, 'getDuplicateInPlay').and.returnValue(this.dupeCardSpy);
+                    this.canPlay = this.player.playCard('');
+                });
 
-            it('should not remove the card from hand', function() {
-                expect(this.player.removeFromHand).not.toHaveBeenCalled();
+                it('should return true', function() {
+                    expect(this.canPlay).toBe(true);
+                });
+
+                it('should not prompt for attachment target', function() {
+                    expect(this.player.promptForAttachment).not.toHaveBeenCalled();
+                });
+
+                it('should remove the card from hand', function() {
+                    expect(this.player.removeFromHand).toHaveBeenCalled();
+                });
+
+                it('should add a duplicate to the existing card in play', function() {
+                    expect(this.dupeCardSpy.addDuplicate).toHaveBeenCalledWith(this.cardSpy);
+                });
+
+                it('should not add a new card to play', function() {
+                    expect(this.player.cardsInPlay).not.toContain(this.cardSpy);
+                });
             });
         });
 
@@ -99,7 +131,7 @@ describe('Player', function() {
             describe('and this is the setup phase', function() {
                 beforeEach(function() {
                     this.player.phase = 'setup';
-                    
+
                     this.canPlay = this.player.playCard('');
                 });
 

--- a/test/server/player/removeattachment.spec.js
+++ b/test/server/player/removeattachment.spec.js
@@ -101,5 +101,41 @@ describe('Player', function() {
                 });
             });
         });
+
+        describe('when the removal cannot be saved', function() {
+            beforeEach(function() {
+                this.dupe = new DrawCard(this.attachmentOwner, {});
+                this.dupe2 = new DrawCard(this.attachmentOwner, {});
+                this.attachment.addDuplicate(this.dupe);
+                this.attachment.addDuplicate(this.dupe2);
+                this.player.removeAttachment(this.attachment, false);
+            });
+
+            it('should remove all dupes', function() {
+                expect(this.attachment.dupes.size()).toBe(0);
+            });
+
+            it('should place all dupes in the owners discard pile', function() {
+                expect(this.attachmentOwner.discardPile).toContain(this.dupe);
+                expect(this.attachmentOwner.discardPile).toContain(this.dupe2);
+            });
+
+            it('should leave play', function() {
+                expect(this.attachment.leavesPlay).toHaveBeenCalled();
+            });
+
+            it('should remove the attachment from its parent', function() {
+                expect(this.card.attachments).not.toContain(this.attachment);
+            });
+
+            it('should unset its parent property', function() {
+                expect(this.attachment.parent).toBeUndefined();
+            });
+
+            it('should return the attachment to its owners hand', function() {
+                expect(this.attachmentOwner.hand).toContain(this.attachment);
+                expect(this.attachmentOwner.discardPile).not.toContain(this.attachment);
+            });
+        });
     });
 });

--- a/test/server/player/removeattachment.spec.js
+++ b/test/server/player/removeattachment.spec.js
@@ -22,6 +22,36 @@ describe('Player', function() {
             spyOn(this.attachment, 'isTerminal');
         });
 
+        describe('when the attachment has a duplicate', function() {
+            beforeEach(function() {
+                this.dupe = new DrawCard(this.attachmentOwner, {});
+                this.attachment.addDuplicate(this.dupe);
+                this.player.removeAttachment(this.attachment);
+            });
+
+            it('should remove the dupe', function() {
+                expect(this.attachment.dupes).not.toContain(this.dupe);
+            });
+
+            it('should place the dupe in the owners discard pile', function() {
+                expect(this.attachmentOwner.discardPile).toContain(this.dupe);
+            });
+
+            it('should not remove the attachment', function() {
+                expect(this.card.attachments).toContain(this.attachment);
+            });
+
+            it('should not have the attachment leave play', function() {
+                expect(this.attachment.leavesPlay).not.toHaveBeenCalled();
+            });
+
+            it('should not move the attachment', function() {
+                expect(this.attachment.parent).toBe(this.card);
+                expect(this.attachmentOwner.hand).not.toContain(this.attachment);
+                expect(this.attachmentOwner.discardPile).not.toContain(this.attachment);
+            });
+        });
+
         describe('when the attachment has no duplicates', function() {
             describe('when the attachment is terminal', function() {
                 beforeEach(function() {

--- a/test/server/player/removeattachment.spec.js
+++ b/test/server/player/removeattachment.spec.js
@@ -1,0 +1,75 @@
+/* global describe, it, beforeEach, expect, spyOn */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+const Player = require('../../../server/game/player.js');
+const DrawCard = require('../../../server/game/drawcard.js');
+
+describe('Player', function() {
+    beforeEach(function() {
+        this.player = new Player('1', 'Player 1', true);
+        this.player.initialise();
+        this.attachmentOwner = new Player('2', 'Player 2', false);
+        this.attachmentOwner.initialise();
+        this.attachment = new DrawCard(this.attachmentOwner, {});
+        this.card = new DrawCard(this.player, {});
+        this.player.cardsInPlay.push(this.card);
+        this.player.attach(this.attachment, this.card.uuid);
+    });
+
+    describe('removeAttachment', function() {
+        beforeEach(function() {
+            spyOn(this.attachment, 'leavesPlay');
+            spyOn(this.attachment, 'isTerminal');
+        });
+
+        describe('when the attachment has no duplicates', function() {
+            describe('when the attachment is terminal', function() {
+                beforeEach(function() {
+                    this.attachment.isTerminal.and.returnValue(true);
+                    this.player.removeAttachment(this.attachment);
+                });
+
+                it('should leave play', function() {
+                    expect(this.attachment.leavesPlay).toHaveBeenCalled();
+                });
+
+                it('should remove the attachment from its parent', function() {
+                    expect(this.card.attachments).not.toContain(this.attachment);
+                });
+
+                it('should unset its parent property', function() {
+                    expect(this.attachment.parent).toBeUndefined();
+                });
+
+                it('should return the attachment to its owners discard pile', function() {
+                    expect(this.attachmentOwner.hand).not.toContain(this.attachment);
+                    expect(this.attachmentOwner.discardPile).toContain(this.attachment);
+                });
+            });
+
+            describe('when the attachment is not terminal', function() {
+                beforeEach(function() {
+                    this.attachment.isTerminal.and.returnValue(false);
+                    this.player.removeAttachment(this.attachment);
+                });
+
+                it('should leave play', function() {
+                    expect(this.attachment.leavesPlay).toHaveBeenCalled();
+                });
+
+                it('should remove the attachment from its parent', function() {
+                    expect(this.card.attachments).not.toContain(this.attachment);
+                });
+
+                it('should unset its parent property', function() {
+                    expect(this.attachment.parent).toBeUndefined();
+                });
+
+                it('should return the attachment to its owners hand', function() {
+                    expect(this.attachmentOwner.hand).toContain(this.attachment);
+                    expect(this.attachmentOwner.discardPile).not.toContain(this.attachment);
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
* Marshaling a unique attachment that is already in play is treated like marshaling any other duplicate.
* Duplicate attachments are automatically placed rather than asking the player to choose where to attach it.
* Discarding the attachment via an ability (e.g. Confiscation) will discard from duplicates first, if any.
* Manually dragging an attachment with duplicates to the discard pile will not lose the duplicates.
* Minor change to the setup phase - cards are flipped and dupes consolidated prior to choosing attachment placement (per rules about setup phase).
* Minor cleanup of the find card methods on player.

Currently it isn't possible to tell in the UI whether an attachment has duplicates. I didn't want to interfere with your ongoing refactor of the client card rendering.

Fixes #63 