### PR TITLE
Convert defenders + DUCK to new flow

### DIFF
--- a/server/game/game.js
+++ b/server/game/game.js
@@ -15,7 +15,6 @@ const StandingPhase = require('./gamesteps/standingphase.js');
 const TaxationPhase = require('./gamesteps/taxationphase.js');
 const Challenge = require('./challenge.js');
 const ChallengeFlow = require('./gamesteps/challenge/challengeflow.js');
-const FulfillMilitaryClaim = require('./gamesteps/challenge/fulfillmilitaryclaim.js');
 const MenuPrompt = require('./gamesteps/menuprompt.js');
 const SelectCardPrompt = require('./gamesteps/selectcardprompt.js');
 
@@ -200,7 +199,6 @@ class Game extends EventEmitter {
     }
 
     processCardClicked(player, cardId) {
-        var otherPlayer = this.getOtherPlayer(player);
         var card = this.findAnyCardInPlayByUuid(cardId);
 
         if(!card) {
@@ -379,46 +377,6 @@ class Game extends EventEmitter {
         this.pipeline.continue();
     }
 
-    determineWinner(challenger, player) {
-        var winner = undefined;
-        var loser = undefined;
-
-        if(challenger) {
-            if(challenger.challengeStrength >= player.challengeStrength) {
-                loser = player;
-                winner = challenger;
-            } else {
-                loser = challenger;
-                winner = player;
-            }
-
-            winner.challenges[winner.currentChallenge].won++;
-
-            this.addMessage('{0} won a {1} challenge {2} vs {3}',
-                winner, winner.currentChallenge, winner.challengeStrength, loser.challengeStrength);
-
-            this.raiseEvent('afterChallenge', winner.currentChallenge, winner, loser, challenger);
-
-            if(loser.challengeStrength === 0) {
-                this.addMessage('{0} has gained 1 power from an unopposed challenge', winner);
-                this.addPower(winner, 1);
-
-                this.raiseEvent('onUnopposedWin', winner);
-            }
-
-            // XXX This should be after claim but needs a bit of reworking to make that possible
-            this.applyKeywords(winner, loser);
-
-            if(winner === challenger) {
-                this.applyClaim(winner, loser);
-            } else {
-                this.raiseEvent('onChallengeFinished', winner.currentChallenge, winner, loser, challenger);
-
-                this.promptForChallenge(challenger);
-            }
-        }
-    }
-
     addPower(player, power) {
         player.power += power;
 
@@ -441,62 +399,6 @@ class Game extends EventEmitter {
         if(player.getTotalPower() >= 15) {
             this.addMessage('{0} has won the game', player);
         }
-    }
-
-    applyKeywords(winner, loser) {
-        winner.cardsInChallenge.each(card => {
-            if(card.hasKeyword('Insight')) {
-                winner.drawCardsToHand(1);
-
-                this.addMessage('{0} draws a card from Insight on {1}', winner, card);
-            }
-
-            if(card.hasKeyword('Intimidate')) {
-                // something
-            }
-
-            if(card.hasKeyword('Pillage')) {
-                loser.discardFromDraw(1);
-
-                this.addMessage('{0} discards a card from the top of their deck from Pillage on {1}', loser, card);
-            }
-
-            if(card.isRenown()) {
-                card.power++;
-
-                this.addMessage('{0} gains 1 power on {1} from Renown', winner, card);
-            }
-
-            this.checkWinCondition(winner);
-        });
-    }
-
-    applyClaim(winner, loser) {
-        this.raiseEvent('beforeClaim', this, winner.currentChallenge, winner, loser);
-        var claim = winner.activePlot.getClaim();
-        claim = winner.modifyClaim(winner, winner.currentChallenge, claim);
-
-        if(loser) {
-            claim = loser.modifyClaim(winner, winner.currentChallenge, claim);
-        }
-
-        if(claim <= 0) {
-            this.addMessage('The claim value for {0} is 0, no claim occurs', winner.currentChallenge);
-        } else {
-            if(winner.currentChallenge === 'military') {
-                this.queueStep(new FulfillMilitaryClaim(this, loser, claim));
-                this.pipeline.continue();
-                return;
-            } else if(winner.currentChallenge === 'intrigue') {
-                loser.discardAtRandom(claim);
-            } else if(winner.currentChallenge === 'power') {
-                this.transferPower(winner, loser, claim);
-            }
-        }
-
-        this.raiseEvent('afterClaim', this, winner.currentChallenge, winner, loser);
-        loser.doneClaim();
-        this.promptForChallenge(winner);
     }
 
     doneChallenges(playerId) {

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -3,6 +3,7 @@ const BaseStep = require('../basestep.js');
 const GamePipeline = require('../../gamepipeline.js');
 const SimpleStep = require('../simplestep.js');
 const ChooseStealthTargets = require('./choosestealthtargets.js');
+const FulfillMilitaryClaim = require('./fulfillmilitaryclaim.js');
 
 class ChallengeFlow extends BaseStep {
     constructor(game, challenge) {
@@ -17,10 +18,12 @@ class ChallengeFlow extends BaseStep {
             new SimpleStep(this.game, () => this.announceAttackerStrength()),
             new SimpleStep(this.game, () => this.promptForDefenders()),
             // TODO: Action window
-            // Determine winner
-            // Unopposed bonus
-            // Claim
-            // Keywords
+            new SimpleStep(this.game, () => this.determineWinner()),
+            new SimpleStep(this.game, () => this.unopposedPower()),
+            new SimpleStep(this.game, () => this.applyClaim()),
+            new SimpleStep(this.game, () => this.applyKeywords()),
+            // TODO: Temporary to resume game flow.
+            new SimpleStep(this.game, () => this.game.promptForChallenge(this.challenge.attackingPlayer))
         ]);
     }
 
@@ -89,16 +92,101 @@ class ChallengeFlow extends BaseStep {
     }
 
     chooseDefenders(defenders) {
-      this.challenge.defendingPlayer.cardsInChallenge = _(defenders);
-      this.challenge.defendingPlayer.doneChallenge(false);
+        this.challenge.defendingPlayer.cardsInChallenge = _(defenders);
+        this.challenge.defendingPlayer.doneChallenge(false);
 
-      if(this.challenge.defendingPlayer.challengeStrength > 0) {
-          this.game.addMessage('{0} has defended with strength {1}', this.challenge.defendingPlayer, this.challenge.defendingPlayer.challengeStrength);
-      }
+        if(this.challenge.defendingPlayer.challengeStrength > 0) {
+            this.game.addMessage('{0} has defended with strength {1}', this.challenge.defendingPlayer, this.challenge.defendingPlayer.challengeStrength);
+        }
 
-      // TODO: Temporarily re-enter old game flow
-      this.game.determineWinner(this.challenge.attackingPlayer, this.challenge.defendingPlayer);
-      return true;
+        return true;
+    }
+
+    determineWinner() {
+        if(this.challenge.attackingPlayer.challengeStrength >= this.challenge.defendingPlayer.challengeStrength) {
+            this.loser = this.challenge.defendingPlayer;
+            this.winner = this.challenge.attackingPlayer;
+        } else {
+            this.loser = this.challenge.attackingPlayer;
+            this.winner = this.challenge.defendingPlayer;
+        }
+
+        this.winner.challenges[this.winner.currentChallenge].won++;
+
+        this.game.addMessage('{0} won a {1} challenge {2} vs {3}',
+            this.winner, this.challenge.challengeType, this.winner.challengeStrength, this.loser.challengeStrength);
+
+        this.game.raiseEvent('afterChallenge', this.challenge.challengeType, this.winner, this.loser, this.challenge.attackingPlayer);
+    }
+
+    unopposedPower() {
+        if(this.loser.challengeStrength === 0) {
+            this.game.addMessage('{0} has gained 1 power from an unopposed challenge', this.winner);
+            this.game.addPower(this.winner, 1);
+
+            this.game.raiseEvent('onUnopposedWin', this.winner);
+        }
+    }
+
+    applyClaim() {
+        if(this.winner !== this.challenge.attackingPlayer) {
+            return;
+        }
+
+        this.game.raiseEvent('beforeClaim', this.game, this.challenge.challengeType, this.winner, this.loser);
+        var claim = this.winner.activePlot.getClaim();
+        claim = this.winner.modifyClaim(this.winner, this.challenge.challengeType, claim);
+
+        if(this.loser) {
+            claim = this.loser.modifyClaim(this.winner, this.challenge.challengeType, claim);
+        }
+
+        if(claim <= 0) {
+            this.game.addMessage('The claim value for {0} is 0, no claim occurs', this.challenge.challengeType);
+        } else {
+            if(this.challenge.challengeType === 'military') {
+                this.game.queueStep(new FulfillMilitaryClaim(this.game, this.loser, claim));
+                return;
+            } else if(this.challenge.challengeType === 'intrigue') {
+                this.loser.discardAtRandom(claim);
+            } else if(this.challenge.challengeType === 'power') {
+                this.game.transferPower(this.winner, this.loser, claim);
+            }
+        }
+
+        this.game.raiseEvent('afterClaim', this.game, this.challenge.challengeType, this.winner, this.loser);
+    }
+
+    applyKeywords() {
+        this.winner.cardsInChallenge.each(card => {
+            if(card.hasKeyword('Insight')) {
+                this.winner.drawCardsToHand(1);
+
+                this.game.addMessage('{0} draws a card from Insight on {1}', this.winner, card);
+            }
+
+            if(card.hasKeyword('Intimidate')) {
+                // something
+            }
+
+            if(card.hasKeyword('Pillage')) {
+                this.loser.discardFromDraw(1);
+
+                this.game.addMessage('{0} discards a card from the top of their deck from Pillage on {1}', this.loser, card);
+            }
+
+            if(card.isRenown()) {
+                card.power++;
+
+                this.game.addMessage('{0} gains 1 power on {1} from Renown', this.winner, card);
+            }
+
+            this.game.checkWinCondition(this.winner);
+        });
+    }
+
+    completeChallenge() {
+        this.game.raiseEvent('onChallengeFinished', this.challenge.challengeType, this.winner, this.loser, this.challenge.attackingPlayer);
     }
 
     onCardClicked(player, card) {

--- a/server/game/gamesteps/challenge/fulfillmilitaryclaim.js
+++ b/server/game/gamesteps/challenge/fulfillmilitaryclaim.js
@@ -1,5 +1,4 @@
 const BaseStep = require('../basestep.js');
-const SimpleStep = require('../simplestep.js');
 const KillCharacterPrompt = require('../killcharacterprompt.js');
 
 class FulfillMilitaryClaim extends BaseStep {
@@ -14,17 +13,6 @@ class FulfillMilitaryClaim extends BaseStep {
             this.game.queueStep(this.createKillPrompt());
             return false;
         }
-
-        // TODO: Temporary to resume game flow.
-        this.game.queueStep(new SimpleStep(this.game, () => {
-            this.player.doneClaim();
-
-            var otherPlayer = this.game.getOtherPlayer(this.player);
-
-            if(otherPlayer) {
-                this.game.promptForChallenge(otherPlayer);
-            }
-        }));
 
         return true;
     }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -704,7 +704,6 @@ class Player extends Spectator {
             card.resetForChallenge();
         });
         this.selectCard = false;
-        this.selectingChallengers = false;
     }
 
     startChallenge(challengeType) {
@@ -737,19 +736,7 @@ class Player extends Spectator {
         return card;
     }
 
-    addToChallenge(card) {
-        card.selected = !card.selected;
-
-        if(card.selected) {
-            this.cardsInChallenge.push(card);
-        } else {
-            this.cardsInChallenge = this.removeCardByUuid(this.cardsInChallenge, card.uuid);
-        }
-    }
-
     doneChallenge(myChallenge) {
-        this.selectingChallengers = false;
-
         var strength = this.cardsInChallenge.reduce((memo, card) => {
             card.kneeled = true;
 
@@ -767,20 +754,6 @@ class Player extends Spectator {
         this.cardsInPlay.each(card => {
             card.resetForChallenge();
         });
-    }
-
-    beginDefend(challenge) {
-        this.menuTitle = 'Select defenders';
-        this.buttons = [
-            { text: 'Done', command: 'donedefend' }
-        ];
-
-        this.selectCard = true;
-        this.currentChallenge = challenge;
-        this.phase = 'challenge';
-        this.cardsInChallenge = _([]);
-
-        this.selectingChallengers = true;
     }
 
     killCharacter(card) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -776,14 +776,6 @@ class Player extends Spectator {
         }
     }
 
-    doneClaim() {
-        this.phase = 'challenge';
-        this.selectCard = false;
-
-        this.menuTitle = 'Waiting for opponent to issue challenge';
-        this.buttons = [];
-    }
-
     getDominance() {
         var cardStrength = this.cardsInPlay.reduce((memo, card) => {
             if(!card.kneeled && card.getType() === 'character') {

--- a/server/index.js
+++ b/server/index.js
@@ -507,20 +507,6 @@ io.on('connection', function(socket) {
 
     });
 
-    socket.on('donedefend', function() {
-        var game = findGameForPlayer(socket.id);
-
-        if(!game) {
-            return;
-        }
-
-        runAndCatchErrors(game, () => {
-            game.doneDefend(socket.id);
-
-            sendGameState(game);
-        });
-    });
-
     socket.on('doneallchallenges', function() {
         var game = findGameForPlayer(socket.id);
 


### PR DESCRIPTION
* [x] **Merge #106 first (compare for just these [two commits](https://github.com/ystros/throneteki/compare/eb077d2b0993cf3e1efe3e8f9c9bf951177f982e...ystros:challenges-phase-defenders?expand=1))**

* Converts selecting defenders to a select card prompt.
* Moves determining winner, awarding unopposed, applying claim and applying keywords into the challenge flow.

I moved keywords after claim per the rules, which may introduce a bug based on your previous "needs reworking" comment, but I couldn't immediately identify why it was done in that order.
