### PR TITLE
Challenge refactor

### DIFF
--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -60,6 +60,7 @@ class Challenge {
     }
 
     determineWinner() {
+        this.calculateStrength();
         if(this.attackerStrength >= this.defenderStrength) {
             this.loser = this.defendingPlayer;
             this.winner = this.attackingPlayer;

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -59,6 +59,20 @@ class Challenge {
         return _.filter(this.attackers, card => card.needsStealthTarget());
     }
 
+    determineWinner() {
+        if(this.attackerStrength >= this.defenderStrength) {
+            this.loser = this.defendingPlayer;
+            this.winner = this.attackingPlayer;
+        } else {
+            this.loser = this.attackingPlayer;
+            this.winner = this.defendingPlayer;
+        }
+
+        this.winner.winChallenge(this.challengeType);
+        this.loser.loseChallenge(this.challengeType);
+        this.strengthDifference = this.winner.challengeStrength - this.loser.challengeStrength;
+    }
+
     isUnopposed() {
         return this.defenderStrength <= 0;
     }

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -73,6 +73,10 @@ class Challenge {
         this.strengthDifference = this.winner.challengeStrength - this.loser.challengeStrength;
     }
 
+    isAttackerTheWinner() {
+        return this.winner === this.attackingPlayer;
+    }
+
     isUnopposed() {
         return this.defenderStrength <= 0;
     }

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -1,12 +1,14 @@
 const _ = require('underscore');
 
 class Challenge {
-    constructor(attackingPlayer, defendingPlayer, challengeType) {
+    constructor(game, attackingPlayer, defendingPlayer, challengeType) {
+        this.game = game;
         this.attackingPlayer = attackingPlayer;
         this.defendingPlayer = defendingPlayer;
         this.challengeType = challengeType;
         this.attackers = [];
         this.defenders = [];
+        this.registerEvents(['onCardLeftPlay'])
     }
 
     resetCards() {
@@ -101,6 +103,28 @@ class Challenge {
         }
 
         return claim;
+    }
+
+    onCardLeftPlay(e, player, card) {
+        this.removeFromChallenge(card);
+    }
+
+    registerEvents(events) {
+        this.events = [];
+
+        _.each(events, event => {
+            this[event] = this[event].bind(this);
+
+            this.game.on(event, this[event]);
+
+            this.events.push(event);
+        });
+    }
+
+    unregisterEvents() {
+        _.each(this.events, event => {
+            this.game.removeListener(event, this[event]);
+        });
     }
 }
 

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -34,6 +34,16 @@ class Challenge {
         this.defendingPlayer.cardsInChallenge = _(defenders);
     }
 
+    removeFromChallenge(card) {
+        this.attackers = _.reject(this.attackers, c => c === card);
+        this.defenders = _.reject(this.defenders, c => c === card);
+        this.calculateStrength();
+
+        // TODO: Remove duplicated logic
+        this.attackingPlayer.cardsInChallenge = _(this.attackers);
+        this.defendingPlayer.cardsInChallenge = _(this.defenders);
+    }
+
     markAsParticipating(cards) {
         _.each(cards, card => {
             card.kneeled = true;

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -1,8 +1,62 @@
+const _ = require('underscore');
+
 class Challenge {
     constructor(attackingPlayer, defendingPlayer, challengeType) {
         this.attackingPlayer = attackingPlayer;
         this.defendingPlayer = defendingPlayer;
         this.challengeType = challengeType;
+        this.attackers = [];
+        this.defenders = [];
+    }
+
+    resetCards() {
+        this.attackingPlayer.resetForChallenge();
+        this.defendingPlayer.resetForChallenge();
+    }
+
+    initiateChallenge() {
+        this.attackingPlayer.initiateChallenge(this.challengeType);
+    }
+
+    addAttackers(attackers) {
+        this.attackers = attackers;
+        this.markAsParticipating(attackers);
+
+        // TODO: Remove duplicated logic.
+        this.attackingPlayer.cardsInChallenge = _(attackers);
+    }
+
+    addDefenders(defenders) {
+        this.defenders = defenders;
+        this.markAsParticipating(defenders);
+
+        // TODO: Remove duplicated logic.
+        this.defendingPlayer.cardsInChallenge = _(defenders);
+    }
+
+    markAsParticipating(cards) {
+        _.each(cards, card => {
+            card.kneeled = true;
+        });
+    }
+
+    calculateStrength() {
+        this.attackerStrength = this.calculateStrengthFor(this.attackers);
+        this.defenderStrength = this.calculateStrengthFor(this.defenders);
+
+        // TODO: Remove duplicated logic
+        this.attackingPlayer.challengeStrength = this.attackerStrength;
+        this.defendingPlayer.challengeStrength = this.defenderStrength;
+    }
+
+    calculateStrengthFor(cards) {
+        return _.reduce(cards, (sum, card) => {
+            return sum + card.getStrength();
+        }, 0);
+    }
+
+    getStealthAttackers() {
+        return _.filter(this.attackers, card => card.needsStealthTarget());
     }
 }
 

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -58,6 +58,10 @@ class Challenge {
     getStealthAttackers() {
         return _.filter(this.attackers, card => card.needsStealthTarget());
     }
+
+    isUnopposed() {
+        return this.defenderStrength <= 0;
+    }
 }
 
 module.exports = Challenge;

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -80,6 +80,17 @@ class Challenge {
     isUnopposed() {
         return this.defenderStrength <= 0;
     }
+
+    getClaim() {
+        var claim = this.winner.activePlot.getClaim();
+        claim = this.winner.modifyClaim(this.winner, this.challengeType, claim);
+
+        if(this.loser) {
+            claim = this.loser.modifyClaim(this.winner, this.challengeType, claim);
+        }
+
+        return claim;
+    }
 }
 
 module.exports = Challenge;

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -112,7 +112,7 @@ class ChallengeFlow extends BaseStep {
     }
 
     unopposedPower() {
-        if(this.challenge.isUnopposed() && this.challenge.winner === this.challenge.attackingPlayer) {
+        if(this.challenge.isUnopposed() && this.challenge.isAttackerTheWinner()) {
             this.game.addMessage('{0} has gained 1 power from an unopposed challenge', this.challenge.winner);
             this.game.addPower(this.challenge.winner, 1);
 
@@ -121,7 +121,7 @@ class ChallengeFlow extends BaseStep {
     }
 
     applyClaim() {
-        if(this.challenge.winner !== this.challenge.attackingPlayer) {
+        if(!this.challenge.isAttackerTheWinner()) {
             return;
         }
 

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -27,7 +27,6 @@ class ChallengeFlow extends BaseStep {
 
     announceChallenge() {
         this.game.addMessage('{0} is initiating a {1} challenge', this.challenge.attackingPlayer, this.challenge.challengeType);
-        this.challenge.attackingPlayer.startChallenge(this.challenge.challengeType);
     }
 
     promptForAttackers() {
@@ -48,7 +47,7 @@ class ChallengeFlow extends BaseStep {
             return false;
         }
 
-        return this.challenge.attackingPlayer.canAddToChallenge(card.uuid);
+        return this.challenge.attackingPlayer.canAddToChallenge(card, this.challenge.challengeType);
     }
 
     chooseAttackers(player, attackers) {
@@ -57,13 +56,10 @@ class ChallengeFlow extends BaseStep {
 
         this.game.raiseEvent('onChallenge', this.challenge.attackingPlayer, this.challenge.challengeType);
 
-        this.challenge.attackingPlayer.doneChallenge(true);
+        this.challenge.attackingPlayer.initiateChallenge(this.challenge.challengeType);
+        this.challenge.attackingPlayer.doneChallenge();
 
         this.game.raiseEvent('onAttackersDeclared', this.challenge.attackingPlayer, this.challenge.challengeType);
-
-        if(this.challenge.defendingPlayer) {
-            this.challenge.defendingPlayer.currentChallenge = this.challenge.challengeType;
-        }
 
         return true;
     }
@@ -90,12 +86,12 @@ class ChallengeFlow extends BaseStep {
     }
 
     allowAsDefender(card) {
-        return this.challenge.defendingPlayer.canAddToChallenge(card.uuid);
+        return this.challenge.defendingPlayer.canAddToChallenge(card, this.challenge.challengeType);
     }
 
     chooseDefenders(defenders) {
         this.challenge.defendingPlayer.cardsInChallenge = _(defenders);
-        this.challenge.defendingPlayer.doneChallenge(false);
+        this.challenge.defendingPlayer.doneChallenge();
 
         if(this.challenge.defendingPlayer.challengeStrength > 0) {
             this.game.addMessage('{0} has defended with strength {1}', this.challenge.defendingPlayer, this.challenge.defendingPlayer.challengeStrength);
@@ -113,8 +109,9 @@ class ChallengeFlow extends BaseStep {
             this.winner = this.challenge.defendingPlayer;
         }
 
-        this.winner.challenges[this.winner.currentChallenge].won++;
-        this.loser.challenges[this.loser.currentChallenge].lost++;
+
+        this.winner.winChallenge(this.challenge.challengeType);
+        this.loser.loseChallenge(this.challenge.challengeType);
 
         this.game.addMessage('{0} won a {1} challenge {2} vs {3}',
             this.winner, this.challenge.challengeType, this.winner.challengeStrength, this.loser.challengeStrength);

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -126,12 +126,7 @@ class ChallengeFlow extends BaseStep {
         }
 
         this.game.raiseEvent('beforeClaim', this.game, this.challenge.challengeType, this.challenge.winner, this.challenge.loser);
-        var claim = this.challenge.winner.activePlot.getClaim();
-        claim = this.challenge.winner.modifyClaim(this.challenge.winner, this.challenge.challengeType, claim);
-
-        if(this.challenge.loser) {
-            claim = this.challenge.loser.modifyClaim(this.challenge.winner, this.challenge.challengeType, claim);
-        }
+        var claim = this.challenge.getClaim();
 
         if(claim <= 0) {
             this.game.addMessage('The claim value for {0} is 0, no claim occurs', this.challenge.challengeType);

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -95,8 +95,8 @@ class ChallengeFlow extends BaseStep {
         this.challenge.addDefenders(defenders);
         this.challenge.calculateStrength();
 
-        if(this.challenge.defendingPlayer.challengeStrength > 0) {
-            this.game.addMessage('{0} has defended with strength {1}', this.challenge.defendingPlayer, this.challenge.defendingPlayer.challengeStrength);
+        if(!this.challenge.isUnopposed()) {
+            this.game.addMessage('{0} has defended with strength {1}', this.challenge.defendingPlayer, this.challenge.defenderStrength);
         }
 
         return true;
@@ -124,7 +124,7 @@ class ChallengeFlow extends BaseStep {
     }
 
     unopposedPower() {
-        if(this.loser.challengeStrength === 0) {
+        if(this.challenge.isUnopposed() && this.winner === this.challenge.attackingPlayer) {
             this.game.addMessage('{0} has gained 1 power from an unopposed challenge', this.winner);
             this.game.addPower(this.winner, 1);
 

--- a/server/game/gamesteps/challengephase.js
+++ b/server/game/gamesteps/challengephase.js
@@ -64,8 +64,15 @@ class ChallengePhase extends Phase {
             return;
         }
 
-        var challenge = new Challenge(attackingPlayer, defendingPlayer, challengeType);
+        var challenge = new Challenge(this.game, attackingPlayer, defendingPlayer, challengeType);
+        this.game.currentChallenge = challenge;
         this.game.queueStep(new ChallengeFlow(this.game, challenge));
+        this.game.queueStep(new SimpleStep(this.game, () => this.cleanupChallenge()));
+    }
+
+    cleanupChallenge() {
+        this.game.currentChallenge.unregisterEvents();
+        this.game.currentChallenge = null;
     }
 
     chooseOpponent(attackingPlayer) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -715,13 +715,7 @@ class Player extends Spectator {
         this.selectCard = false;
     }
 
-    startChallenge(challengeType) {
-        this.currentChallenge = challengeType;
-    }
-
-    canAddToChallenge(cardId) {
-        var card = this.findCardInPlayByUuid(cardId);
-
+    canAddToChallenge(card, challengeType) {
         if(this.challengerLimit && this.cardsInChallenge.size() >= this.challengerLimit) {
             return false;
         }
@@ -730,7 +724,11 @@ class Player extends Spectator {
             return false;
         }
 
-        if(!card.hasIcon(this.currentChallenge)) {
+        if(!card.inPlay) {
+            return false;
+        }
+
+        if(!card.hasIcon(challengeType)) {
             return false;
         }
 
@@ -745,7 +743,20 @@ class Player extends Spectator {
         return card;
     }
 
-    doneChallenge(myChallenge) {
+    initiateChallenge(challengeType) {
+        this.challenges[challengeType].performed++;
+        this.challenges.complete++;
+    }
+
+    winChallenge(challengeType) {
+        this.challenges[challengeType].won++;
+    }
+
+    loseChallenge(challengeType) {
+        this.challenges[challengeType].lost++;
+    }
+
+    doneChallenge() {
         var strength = this.cardsInChallenge.reduce((memo, card) => {
             card.kneeled = true;
 
@@ -753,12 +764,6 @@ class Player extends Spectator {
         }, 0);
 
         this.challengeStrength = strength;
-        this.selectCard = false;
-
-        if(myChallenge) {
-            this.challenges[this.currentChallenge].performed++;
-            this.challenges.complete++;
-        }
 
         this.cardsInPlay.each(card => {
             card.resetForChallenge();

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -756,15 +756,7 @@ class Player extends Spectator {
         this.challenges[challengeType].lost++;
     }
 
-    doneChallenge() {
-        var strength = this.cardsInChallenge.reduce((memo, card) => {
-            card.kneeled = true;
-
-            return memo + card.getStrength();
-        }, 0);
-
-        this.challengeStrength = strength;
-
+    resetForChallenge() {
         this.cardsInPlay.each(card => {
             card.resetForChallenge();
         });

--- a/test/server/challenge/determinewinner.spec.js
+++ b/test/server/challenge/determinewinner.spec.js
@@ -1,0 +1,103 @@
+/*global describe, it, beforeEach, expect, spyOn*/
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+const Challenge = require('../../../server/game/challenge.js');
+const Player = require('../../../server/game/player.js');
+const DrawCard = require('../../../server/game/drawcard.js');
+
+describe('Challenge', function() {
+    beforeEach(function() {
+        this.attackingPlayer = new Player('1', 'Player 1', true);
+        spyOn(this.attackingPlayer, 'winChallenge');
+        spyOn(this.attackingPlayer, 'loseChallenge');
+        this.defendingPlayer = new Player('2', 'Player 2', true);
+        spyOn(this.defendingPlayer, 'winChallenge');
+        spyOn(this.defendingPlayer, 'loseChallenge');
+
+        this.attackerCard = new DrawCard(this.attackingPlayer, {});
+        this.defenderCard = new DrawCard(this.defendingPlayer, {});
+
+        this.challenge = new Challenge(this.attackingPlayer, this.defendingPlayer, 'military');
+    });
+
+    describe('determineWinner()', function() {
+        describe('when the attacker has higher strength', function() {
+            beforeEach(function() {
+                spyOn(this.attackerCard, 'getStrength').and.returnValue(5);
+                spyOn(this.defenderCard, 'getStrength').and.returnValue(4);
+                this.challenge.addAttackers([this.attackerCard]);
+                this.challenge.addDefenders([this.defenderCard]);
+                this.challenge.determineWinner();
+            });
+
+            it('should have the attacking player be the winner', function() {
+                expect(this.challenge.winner).toBe(this.attackingPlayer);
+            });
+
+            it('should mark the win for the attacking player', function() {
+                expect(this.attackingPlayer.winChallenge).toHaveBeenCalledWith('military');
+            });
+
+            it('should have the defending player be the loser', function() {
+                expect(this.challenge.loser).toBe(this.defendingPlayer);
+            });
+
+            it('should mark the loss for the defending player', function() {
+                expect(this.defendingPlayer.loseChallenge).toHaveBeenCalledWith('military');
+            });
+        });
+
+
+        describe('when the attacker and defender have equal strength', function() {
+            beforeEach(function() {
+                spyOn(this.attackerCard, 'getStrength').and.returnValue(5);
+                spyOn(this.defenderCard, 'getStrength').and.returnValue(5);
+                this.challenge.addAttackers([this.attackerCard]);
+                this.challenge.addDefenders([this.defenderCard]);
+                this.challenge.determineWinner();
+            });
+
+            it('should have the attacking player be the winner', function() {
+                expect(this.challenge.winner).toBe(this.attackingPlayer);
+            });
+
+            it('should mark the win for the attacking player', function() {
+                expect(this.attackingPlayer.winChallenge).toHaveBeenCalledWith('military');
+            });
+
+            it('should have the defending player be the loser', function() {
+                expect(this.challenge.loser).toBe(this.defendingPlayer);
+            });
+
+            it('should mark the loss for the defending player', function() {
+                expect(this.defendingPlayer.loseChallenge).toHaveBeenCalledWith('military');
+            });
+        });
+
+        describe('when the defender has higher strength', function() {
+            beforeEach(function() {
+                spyOn(this.attackerCard, 'getStrength').and.returnValue(4);
+                spyOn(this.defenderCard, 'getStrength').and.returnValue(5);
+                this.challenge.addAttackers([this.attackerCard]);
+                this.challenge.addDefenders([this.defenderCard]);
+                this.challenge.determineWinner();
+            });
+
+            it('should have the defending player be the winner', function() {
+                expect(this.challenge.winner).toBe(this.defendingPlayer);
+            });
+
+            it('should mark the win for the defending player', function() {
+                expect(this.defendingPlayer.winChallenge).toHaveBeenCalledWith('military');
+            });
+
+            it('should have the attacking player be the loser', function() {
+                expect(this.challenge.loser).toBe(this.attackingPlayer);
+            });
+
+            it('should mark the loss for the attacking player', function() {
+                expect(this.attackingPlayer.loseChallenge).toHaveBeenCalledWith('military');
+            });
+        });
+    });
+});

--- a/test/server/challenge/determinewinner.spec.js
+++ b/test/server/challenge/determinewinner.spec.js
@@ -1,4 +1,4 @@
-/*global describe, it, beforeEach, expect, spyOn*/
+/*global describe, it, beforeEach, expect, spyOn, jasmine*/
 /* eslint camelcase: 0, no-invalid-this: 0 */
 
 const Challenge = require('../../../server/game/challenge.js');
@@ -7,6 +7,7 @@ const DrawCard = require('../../../server/game/drawcard.js');
 
 describe('Challenge', function() {
     beforeEach(function() {
+        this.gameSpy = jasmine.createSpyObj('game', ['on']);
         this.attackingPlayer = new Player('1', 'Player 1', true);
         spyOn(this.attackingPlayer, 'winChallenge');
         spyOn(this.attackingPlayer, 'loseChallenge');
@@ -17,7 +18,7 @@ describe('Challenge', function() {
         this.attackerCard = new DrawCard(this.attackingPlayer, {});
         this.defenderCard = new DrawCard(this.defendingPlayer, {});
 
-        this.challenge = new Challenge(this.attackingPlayer, this.defendingPlayer, 'military');
+        this.challenge = new Challenge(this.gameSpy, this.attackingPlayer, this.defendingPlayer, 'military');
     });
 
     describe('determineWinner()', function() {

--- a/test/server/challenge/removefromchallenge.spec.js
+++ b/test/server/challenge/removefromchallenge.spec.js
@@ -1,4 +1,4 @@
-/*global describe, it, beforeEach, expect, spyOn*/
+/*global describe, it, beforeEach, expect, spyOn, jasmine*/
 /* eslint camelcase: 0, no-invalid-this: 0 */
 
 const Challenge = require('../../../server/game/challenge.js');
@@ -7,6 +7,8 @@ const DrawCard = require('../../../server/game/drawcard.js');
 
 describe('Challenge', function() {
     beforeEach(function() {
+        this.gameSpy = jasmine.createSpyObj('game', ['on']);
+
         this.attackingPlayer = new Player('1', 'Player 1', true);
         spyOn(this.attackingPlayer, 'winChallenge');
         this.defendingPlayer = new Player('2', 'Player 2', true);
@@ -17,7 +19,7 @@ describe('Challenge', function() {
         this.defenderCard = new DrawCard(this.defendingPlayer, {});
         spyOn(this.defenderCard, 'getStrength').and.returnValue(3);
 
-        this.challenge = new Challenge(this.attackingPlayer, this.defendingPlayer, 'military');
+        this.challenge = new Challenge(this.gameSpy, this.attackingPlayer, this.defendingPlayer, 'military');
         this.challenge.addAttackers([this.attackerCard]);
         this.challenge.addDefenders([this.defenderCard]);
     });

--- a/test/server/challenge/removefromchallenge.spec.js
+++ b/test/server/challenge/removefromchallenge.spec.js
@@ -1,0 +1,72 @@
+/*global describe, it, beforeEach, expect, spyOn*/
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+const Challenge = require('../../../server/game/challenge.js');
+const Player = require('../../../server/game/player.js');
+const DrawCard = require('../../../server/game/drawcard.js');
+
+describe('Challenge', function() {
+    beforeEach(function() {
+        this.attackingPlayer = new Player('1', 'Player 1', true);
+        spyOn(this.attackingPlayer, 'winChallenge');
+        this.defendingPlayer = new Player('2', 'Player 2', true);
+        spyOn(this.defendingPlayer, 'winChallenge');
+
+        this.attackerCard = new DrawCard(this.attackingPlayer, {});
+        spyOn(this.attackerCard, 'getStrength').and.returnValue(5);
+        this.defenderCard = new DrawCard(this.defendingPlayer, {});
+        spyOn(this.defenderCard, 'getStrength').and.returnValue(3);
+
+        this.challenge = new Challenge(this.attackingPlayer, this.defendingPlayer, 'military');
+        this.challenge.addAttackers([this.attackerCard]);
+        this.challenge.addDefenders([this.defenderCard]);
+    });
+
+    describe('removeFromChallenge()', function() {
+        describe('when the card is an attacker', function() {
+            beforeEach(function() {
+                this.challenge.removeFromChallenge(this.attackerCard);
+            });
+
+            it('should remove the card from the attacker list', function() {
+                expect(this.challenge.attackers).not.toContain(this.attackerCard);
+            });
+
+            it('should recalculate challenge strengths', function() {
+                expect(this.challenge.attackerStrength).toBe(0);
+                expect(this.challenge.defenderStrength).toBe(3);
+            });
+        });
+
+        describe('when the card is a defender', function() {
+            beforeEach(function() {
+                this.challenge.removeFromChallenge(this.defenderCard);
+            });
+
+            it('should remove the card from the defender list', function() {
+                expect(this.challenge.defenders).not.toContain(this.defenderCard);
+            });
+
+            it('should recalculate challenge strengths', function() {
+                expect(this.challenge.attackerStrength).toBe(5);
+                expect(this.challenge.defenderStrength).toBe(0);
+            });
+        });
+
+        describe('when the card is not in the challenge', function() {
+            beforeEach(function() {
+                this.challenge.removeFromChallenge(new DrawCard(this.attackingPlayer, {}));
+            });
+
+            it('should not modify the participating cards', function() {
+                expect(this.challenge.attackers).toContain(this.attackerCard);
+                expect(this.challenge.defenders).toContain(this.defenderCard);
+            });
+
+            it('should not modify challenge strengths', function() {
+                expect(this.challenge.attackerStrength).toBe(5);
+                expect(this.challenge.defenderStrength).toBe(3);
+            });
+        });
+    });
+});


### PR DESCRIPTION
* Moves most of the challenge logic to the Challenge class.
* Sets the challenge object as currentChallenge on Game (note: this is being used by Superior Claim on master but isn't implemented there)
* Removes Player.currentChallenge
* Works toward removing Player.challengeStrength and Player.cardsInChallenge (not quite there yet)
* Removes characters that are discarded or killed from the current challenge (needed to make challenge action windows useful).
