### PR TITLE
Add action windows in challenges phase

### DIFF
--- a/server/game/gamesteps/actionwindow.js
+++ b/server/game/gamesteps/actionwindow.js
@@ -1,0 +1,46 @@
+const PlayerOrderPrompt = require('./playerorderprompt.js');
+
+class ActionWindow extends PlayerOrderPrompt {
+    activePrompt() {
+        return {
+            menuTitle: 'Any actions or reactions?',
+            buttons: [
+                { command: 'menuButton', text: 'Done' }
+            ]
+        };
+    }
+
+    onMenuCommand(player) {
+        if(this.currentPlayer !== player) {
+            return false;
+        }
+
+        if(this.tookAction) {
+            this.setPlayers(this.rotatedPlayerOrder(this.currentPlayer));
+        } else {
+            this.completePlayer();
+        }
+
+        this.tookAction = false;
+
+        return true;
+    }
+
+    onCardClicked() {
+        // For now, assume ANY card click means that the player has taken an
+        // action and re-prompt all players in rotated first player order.
+        this.tookAction = true;
+
+        return false;
+    }
+
+    rotatedPlayerOrder(player) {
+        var players = this.game.getPlayersInFirstPlayerOrder();
+        var splitIndex = players.indexOf(player);
+        var beforePlayer = players.slice(0, splitIndex);
+        var afterPlayer = players.slice(splitIndex + 1);
+        return afterPlayer.concat(beforePlayer).concat([player]);
+    }
+}
+
+module.exports = ActionWindow;

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -4,6 +4,7 @@ const GamePipeline = require('../../gamepipeline.js');
 const SimpleStep = require('../simplestep.js');
 const ChooseStealthTargets = require('./choosestealthtargets.js');
 const FulfillMilitaryClaim = require('./fulfillmilitaryclaim.js');
+const ActionWindow = require('../actionwindow.js');
 
 class ChallengeFlow extends BaseStep {
     constructor(game, challenge) {
@@ -15,10 +16,10 @@ class ChallengeFlow extends BaseStep {
             new SimpleStep(this.game, () => this.announceChallenge()),
             new SimpleStep(this.game, () => this.promptForAttackers()),
             () => new ChooseStealthTargets(this.game, this.challenge, this.challenge.getStealthAttackers()),
-            // TODO: Action window
             new SimpleStep(this.game, () => this.announceAttackerStrength()),
+            new ActionWindow(this.game),
             new SimpleStep(this.game, () => this.promptForDefenders()),
-            // TODO: Action window
+            new ActionWindow(this.game),
             new SimpleStep(this.game, () => this.determineWinner()),
             new SimpleStep(this.game, () => this.unopposedPower()),
             new SimpleStep(this.game, () => this.applyClaim()),

--- a/server/game/gamesteps/playerorderprompt.js
+++ b/server/game/gamesteps/playerorderprompt.js
@@ -29,6 +29,10 @@ class PlayerOrderPrompt extends UiPrompt {
         this.players.shift();
     }
 
+    setPlayers(players) {
+        this.players = players;
+    }
+
     isComplete() {
         return this.players.length === 0;
     }

--- a/test/server/gamesteps/actionwindow.spec.js
+++ b/test/server/gamesteps/actionwindow.spec.js
@@ -1,0 +1,99 @@
+/*global describe, it, beforeEach, expect*/
+/* eslint no-invalid-this: 0 */
+
+const ActionWindow = require('../../../server/game/gamesteps/actionwindow.js');
+const Game = require('../../../server/game/game.js');
+const Player = require('../../../server/game/player.js');
+
+describe('ActionWindow', function() {
+    beforeEach(function() {
+        this.game = new Game('1', 'Test Game');
+        this.player1 = new Player('1', 'Player 1', true, this.game);
+        this.player2 = new Player('2', 'Player 2', false, this.game);
+        this.player2.firstPlayer = true;
+        this.game.players[0] = this.player1;
+        this.game.players[1] = this.player2;
+
+        this.prompt = new ActionWindow(this.game);
+    });
+
+    it('should prompt in first player order', function() {
+        expect(this.prompt.currentPlayer).toBe(this.player2);
+    });
+
+    describe('onMenuCommand()', function() {
+        describe('when it is the current player',function() {
+            beforeEach(function() {
+                this.prompt.onMenuCommand(this.player2);
+            });
+
+            it('should make the next player be the current player', function() {
+                expect(this.prompt.currentPlayer).toBe(this.player1);
+            });
+        });
+
+        describe('when it is not the current player',function() {
+            beforeEach(function() {
+                this.prompt.onMenuCommand(this.player1);
+            });
+
+            it('should not change the current player', function() {
+                expect(this.prompt.currentPlayer).toBe(this.player2);
+            });
+        });
+    });
+
+    describe('onCardClicked()', function() {
+        describe('when a player takes an action', function() {
+            beforeEach(function() {
+                // Complete the window for player 2
+                this.prompt.onMenuCommand(this.player2);
+
+                // Player 1 clicks something
+                this.prompt.onCardClicked(this.player1);
+            });
+
+            it('should not change the current player', function() {
+                expect(this.prompt.currentPlayer).toBe(this.player1);
+            });
+
+            it('should re-prompt other players once the current player is done', function() {
+                this.prompt.onMenuCommand(this.player1);
+                expect(this.prompt.currentPlayer).toBe(this.player2);
+            });
+
+            it('should require two consecutive passes before completing', function() {
+                // Complete after taking action
+                this.prompt.onMenuCommand(this.player1);
+                // Complete without taking action
+                this.prompt.onMenuCommand(this.player2);
+
+                expect(this.prompt.isComplete()).toBe(false);
+                expect(this.prompt.currentPlayer).toBe(this.player1);
+            });
+        });
+    });
+
+    describe('continue()', function() {
+        describe('when not all players are done', function() {
+            beforeEach(function() {
+                this.prompt.onMenuCommand(this.player2);
+            });
+
+            it('should return false', function() {
+                expect(this.prompt.continue()).toBe(false);
+            });
+        });
+
+        describe('when all players are done', function() {
+            beforeEach(function() {
+                this.prompt.onMenuCommand(this.player2);
+                this.prompt.onMenuCommand(this.player1);
+            });
+
+            it('should return true', function() {
+                expect(this.prompt.continue()).toBe(true);
+            });
+        });
+    });
+});


### PR DESCRIPTION
* Prompts players in first player order for actions.
* If a player clicks a card (best approximation currently for using an ability or playing a card), then any players that have passed will be prompted again.
* The window ends once both players have passed.

This is implemented according to the rules text as much as possible. Let me know if it's too much clicking for you. It could also be implemented as a simultaneous prompt instead, where if any player plays something then the other player has to reconfirm they are done. That may be better for game flow but is less in accordance with the rules.