### PR TITLE
Remove deprecated select card prompt

### DIFF
--- a/server/game/cards/characters/01/rattleshirtsraiders.js
+++ b/server/game/cards/characters/01/rattleshirtsraiders.js
@@ -16,6 +16,10 @@ class RattleshirtsRaiders extends DrawCard {
             return;
         }
 
+        if(!challenger.cardsInChallenge.contains(this)) {
+            return;
+        }
+
         this.game.promptForSelect(this.owner, {
             activePromptTitle: 'Select attachment to discard',
             waitingPromptTitle: 'Waiting for opponent to use ' + this.name,

--- a/server/game/cards/characters/01/rattleshirtsraiders.js
+++ b/server/game/cards/characters/01/rattleshirtsraiders.js
@@ -16,38 +16,15 @@ class RattleshirtsRaiders extends DrawCard {
             return;
         }
 
-        var buttons = [{ text: 'Done', command: 'plot', method: 'cancelSelect' }];
-
-        this.game.promptForSelectDeprecated(this.owner, this.onCardSelected.bind(this), 'Select attachment to discard', buttons);
+        this.game.promptForSelect(this.owner, {
+            activePromptTitle: 'Select attachment to discard',
+            waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
+            cardCondition: card => card.inPlay && card.owner === loser && card.getType() === 'attachment',
+            onSelect: (p, card) => this.onCardSelected(p, card)
+        });
     }
 
-    cancelSelect(player) {
-        if(!this.inPlay || this.owner !== player) {
-            return;
-        }
-
-        this.game.cancelSelect(player);
-    }
-
-    onCardSelected(player, cardId) {
-        if(!this.inPlay || this.owner !== player) {
-            return false;
-        }
-
-        var otherPlayer = this.game.getOtherPlayer(player);
-        if(!otherPlayer) {
-            return false;
-        }
-
-        var card = player.findCardInPlayByUuid(cardId);
-        
-        if(!card) {
-            card = otherPlayer.findCardInPlayByUuid(cardId);
-        }
-        if(!card || card.getType() !== 'attachment' || card.owner === this.owner) {
-            return false;
-        }
-
+    onCardSelected(player, card) {
         card.parent.owner.discardCard(card);
         
         return true;

--- a/server/game/cards/plots/01/powerbehindthethrone.js
+++ b/server/game/cards/plots/01/powerbehindthethrone.js
@@ -20,24 +20,15 @@ class PowerBehindTheThrone extends PlotCard {
     }
 
     discardToken(player) {
-        var buttons = [{ text: 'Done', command: 'plot', method: 'cancelStand' }];
-
-        this.selecting = true;
-
-        this.game.promptForSelectDeprecated(player, this.onCardSelected.bind(this), 'Select a character to stand', buttons);
+        this.game.promptForSelect(player, {
+            activePromptTitle: 'Select a character to stand',
+            waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
+            cardCondition: card => card.inPlay && card.owner === player && card.kneeled,
+            onSelect: (p, card) => this.onCardSelected(p, card)
+        });
     }
 
-    onCardSelected(player, cardId) {
-        if(!this.inPlay || this.owner !== player) {
-            return false;
-        }
-
-        var card = player.findCardInPlayByUuid(cardId);
-
-        if(!card || !card.kneeled) {
-            return false;
-        }
-
+    onCardSelected(player, card) {
         this.game.addMessage('{0} uses {1} to remove a stand token and stand {2}', player, this, card);
 
         card.kneeled = false;
@@ -47,17 +38,7 @@ class PowerBehindTheThrone extends PlotCard {
         return true;
     }
 
-    cancelStand(player) {
-        if(!this.inPlay || this.owner !== player) {
-            return;
-        }
-
-        this.game.cancelSelect(player);
-    }
-
     leavesPlay() {
-        this.selecting = false;
-
         super.leavesPlay();
     }
 }

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -537,6 +537,8 @@ class Game extends EventEmitter {
         if(otherPlayer && otherPlayer.activePlot && otherPlayer.activePlot[method]) {
             otherPlayer.activePlot[method](player, arg);
         }
+
+        this.pipeline.continue();
     }
 
     agendaCardCommand(playerId, method, arg) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -168,19 +168,6 @@ class Game extends EventEmitter {
             return;
         }
 
-        var handled = false;
-        if(player === this.selectPlayer && this.selectCallback) {
-            handled = this.selectCallback(player, cardId);
-
-            if(handled) {
-                if(!this.multiSelect) {
-                    player.selectCard = false;
-                }
-
-                return;
-            }
-        }
-
         if(player.activePlot && !player.activePlot.canPlay(player, cardId)) {
             return;
         }
@@ -229,21 +216,7 @@ class Game extends EventEmitter {
                 return;
         }
 
-        var handled = false;
-
-        if(player === this.selectPlayer && this.selectCallback) {
-            handled = this.selectCallback(player, cardId);
-
-            if(handled) {
-                if(!this.multiSelect) {
-                    player.selectCard = false;
-                }
-
-                return;
-            }
-        }
-
-        handled = this.processCardClicked(player, cardId);
+        var handled = this.processCardClicked(player, cardId);
 
         if(!handled) {
             var cardInPlay = player.findCardInPlayByUuid(cardId);
@@ -276,17 +249,6 @@ class Game extends EventEmitter {
         if(this.pipeline.handleCardClicked(player, card)) {
             this.pipeline.continue();
             return;
-        }
-
-        var handled = false;
-        if(player === this.selectPlayer && this.selectCallback) {
-            handled = this.selectCallback(player, cardId);
-
-            if(handled) {
-                player.selectCard = false;
-
-                return;
-            }
         }
     }
 
@@ -558,35 +520,6 @@ class Game extends EventEmitter {
 
     promptForSelect(player, properties) {
         this.queueStep(new SelectCardPrompt(this, player, properties));
-    }
-
-    /**
-     * @deprecated - use promptForSelect or promptWithMenu instead.
-     */
-    promptForSelectDeprecated(player, callback, menuTitle, buttons, multiSelect) {
-        player.selectCard = true;
-
-        this.selectPlayer = player;
-        this.selectCallback = callback;
-
-        player.oldMenuTitle = player.menuTitle;
-        player.oldButtons = player.buttons;
-
-        player.menuTitle = menuTitle;
-        player.buttons = buttons;
-
-        this.multiSelect = multiSelect;
-    }
-
-    cancelSelect(player) {
-        player.selectCard = false;
-
-        this.selectPlayer = undefined;
-        this.selectCallback = undefined;
-
-        player.menuTitle = player.oldMenuTitle;
-        player.buttons = player.oldButtons;
-
     }
 
     menuButton(playerId, arg, method) {

--- a/server/game/gamesteps/uiprompt.js
+++ b/server/game/gamesteps/uiprompt.js
@@ -16,7 +16,6 @@ class UiPrompt extends BaseStep {
     }
 
     setPrompt() {
-        this.saveOriginalPrompts();
         _.each(this.game.getPlayers(), player => {
             if(this.activeCondition(player)) {
                 player.setPrompt(this.activePrompt());
@@ -53,30 +52,6 @@ class UiPrompt extends BaseStep {
         _.each(this.game.getPlayers(), player => {
             player.cancelPrompt();
         });
-        this.restoreOriginalPrompts();
-    }
-
-    // TODO: Saving and restoring prompts shouldn't be necessary once the full
-    //       game is converted into steps + prompts.
-    saveOriginalPrompts() {
-        if(this.originalPrompts) {
-            return;
-        }
-
-        this.originalPrompts = _.map(this.game.getPlayers(), player => {
-            return {
-                player: player,
-                prompt: player.currentPrompt()
-            };
-        });
-    }
-
-    restoreOriginalPrompts() {
-        if(this.originalPrompts) {
-            _.each(this.originalPrompts, originalPrompt => {
-                originalPrompt.player.setPrompt(originalPrompt.prompt);
-            });
-        }
     }
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -562,34 +562,6 @@ io.on('connection', function(socket) {
         sendGameState(game);
     });
 
-    socket.on('donesetpower', function() {
-        var game = findGameForPlayer(socket.id);
-
-        if(!game) {
-            return;
-        }
-
-        runAndCatchErrors(game, () => {
-            game.doneSetPower(socket.id);
-        });
-
-        sendGameState(game);
-    });
-
-    socket.on('donesetstrength', function() {
-        var game = findGameForPlayer(socket.id);
-
-        if(!game) {
-            return;
-        }
-
-        runAndCatchErrors(game, () => {
-            game.doneSetStrength(socket.id);
-        });
-
-        sendGameState(game);
-    });
-
     socket.on('shuffledeck', function() {
         var game = findGameForPlayer(socket.id);
 

--- a/test/server/game/chat.spec.js
+++ b/test/server/game/chat.spec.js
@@ -20,6 +20,32 @@ describe('the Game', function() {
         player1.setPower = undefined;
     });
 
+    describe('the getNumberOrDefault() function', function() {
+        describe('with no arguments', function() {
+            it('should return the default', function () {
+                expect(game.getNumberOrDefault('', 1)).toBe(1);
+            });
+        });
+
+        describe('with a string argument', function() {
+            it('should return the default', function () {
+                expect(game.getNumberOrDefault('test', 1)).toBe(1);
+            });
+        });
+
+        describe('with a negative argument', function() {
+            it('should return the default', function () {
+                expect(game.getNumberOrDefault('-1', 1)).toBe(1);
+            });
+        });
+
+        describe('with a valid argument', function() {
+            it('should return the parsed value', function () {
+                expect(game.getNumberOrDefault('3', 1)).toBe(3);
+            });
+        });
+    });
+
     describe('the chat() function', function() {
         describe('when called by a player not in the game', function() {
             it('should not add any chat messages', function() {
@@ -37,52 +63,6 @@ describe('the Game', function() {
                     expect(game.messages.length).toBe(1);
                     expect(game.messages[0].message[1].name).toBe(player1.name);
                     expect(game.messages[0].message.join('')).toContain('Test Message');
-                });
-            });
-
-            describe('with a /power command', function() {
-                describe('with no arguments', function() {
-                    it('should prompt the user to change power to 1', function () {
-                        game.chat(player1.id, '/power');
-
-                        expect(game.messages.length).toBe(0);
-                        expect(player1.setPower).toBe(1);
-                    });
-                });
-
-                describe('with a string argument', function() {
-                    it('should prompt the user to change power to 1', function () {
-                        game.chat(player1.id, '/power test');
-
-                        expect(game.messages.length).toBe(0);
-                        expect(player1.setPower).toBe(1);
-                    });
-                });
-
-                describe('with a negative argument', function() {
-                    it('should prompt the user to change power to 1', function () {
-                        game.chat(player1.id, '/power -1');
-
-                        expect(game.messages.length).toBe(0);
-                        expect(player1.setPower).toBe(1);
-                    });
-                });
-
-                describe('with a valid argument', function() {
-                    it('should prompt the user to change power to the argument', function () {
-                        game.chat(player1.id, '/power 3');
-
-                        expect(game.messages.length).toBe(0);
-                        expect(player1.setPower).toBe(3);
-                    });
-                });
-
-                describe('half way through a message', function() {
-                    it('should not trigger the /power command', function() {
-                        game.chat(player1.id, 'test test /power test');
-
-                        expect(player1.setPower).toBe(undefined);
-                    });
                 });
             });
 
@@ -124,6 +104,14 @@ describe('the Game', function() {
 
                         expect(game.messages.length).toBe(1);
                         expect(player1.drawCardsToHand).toHaveBeenCalledWith(4);
+                    });
+                });
+
+                describe('half way through a message', function() {
+                    it('should not trigger the /draw command', function() {
+                        game.chat(player1.id, 'test test /draw test');
+
+                        expect(player1.drawCardsToHand).not.toHaveBeenCalled();
                     });
                 });
             });


### PR DESCRIPTION
* Converts the remaining usages of the deprecated select card prompt to the new prompt.
* Removes the deprecated methods and the associated callback mechanism.
* Removes saving and restoring of old prompts (should no longer be needed now that everything uses the pipeline)
* Slight fix to Rattleshirt's ability.

Fixes #103.

