### PR TITLE
Fix click handler for attachments.

### DIFF
--- a/client/GameComponents/Card.jsx
+++ b/client/GameComponents/Card.jsx
@@ -67,7 +67,7 @@ class Card extends React.Component {
             var returnedAttachment = (<Card key={attachment.uuid} style={style} source={this.props.source} card={attachment}
                             onMouseOver={this.props.disableMouseOver ? null : this.onMouseOver.bind(this, attachment)}
                             onMouseOut={this.props.disableMouseOver ? null : this.onMouseOut}
-                            onClick={ev => this.onClick(ev, attachment, this.props.source)}
+                            onClick={this.props.onClick}
                             onDragStart={ev => this.onCardDragStart(ev, attachment, this.props.source)} />);
 
             offset += 10;


### PR DESCRIPTION
The parent card should just pass along the external handler it was given rather than try to call it's own internal handler.

Fixes #112. 