### PR TITLE
Fix Kingsroad kneel in discard pile.

### DIFF
--- a/server/game/cards/reducer.js
+++ b/server/game/cards/reducer.js
@@ -53,6 +53,7 @@ class Reducer extends DrawCard {
 
     leavesPlay() {
         this.abilityUsed = false;
+        super.leavesPlay();
     }
 }
 


### PR DESCRIPTION
Reducer wasn't called its parent version of leavesPlay, so power,
strength and kneeling were not being reset on reducer cards.