### PR TITLE
Wildfire Assault should explicitly kill.

### DIFF
--- a/server/game/cards/plots/01/wildfireassault.js
+++ b/server/game/cards/plots/01/wildfireassault.js
@@ -35,7 +35,7 @@ class WildfireAssault extends PlotCard {
             var paramIndex = 2;
 
             _.each(toKill, card => {
-                player.discardCard(card.uuid, player.deadPile);
+                player.killCharacter(card, false);
 
                 params += '{' + paramIndex++ + '} ';
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -743,14 +743,14 @@ class Player extends Spectator {
         });
     }
 
-    killCharacter(card) {
+    killCharacter(card, allowSave = true) {
         var character = this.findCardInPlayByUuid(card.uuid);
 
         if(!character) {
             return;
         }
 
-        if(!character.dupes.isEmpty()) {
+        if(!character.dupes.isEmpty() && allowSave) {
             var discardedDupe = character.dupes.first();
 
             character.dupes = _(character.dupes.slice(1));


### PR DESCRIPTION
Previously, Wildfire Assault just moved the non-selected characters into
the player's deadpile. However, doing so did not fire the
onCharacterKilled event, which can trigger reactions (e.g. Catelyn Stark
gaining power).