### PR TITLE
Fix strength prompt crash

### DIFF
--- a/server/game/game.js
+++ b/server/game/game.js
@@ -597,6 +597,9 @@ class Game extends EventEmitter {
         _.each(this.getPlayers(), player => {
             player.initialise();
         });
+        this.allCards = _(_.reduce(this.getPlayers(), (cards, player) => {
+            return cards.concat(player.allCards.toArray());
+        }, []));
         this.pipeline = new GamePipeline();
         this.pipeline.initialise([
             new SetupPhase(this),

--- a/server/game/gamesteps/selectcardprompt.js
+++ b/server/game/gamesteps/selectcardprompt.js
@@ -33,6 +33,7 @@ class SelectCardPrompt extends UiPrompt {
         this.properties = properties;
         _.defaults(this.properties, this.defaultProperties());
         this.selectedCards = [];
+        this.savePreviouslySelectedCards();
     }
 
     defaultProperties() {
@@ -44,6 +45,11 @@ class SelectCardPrompt extends UiPrompt {
             onMenuCommand: () => true,
             onCancel: () => true
         };
+    }
+
+    savePreviouslySelectedCards() {
+        this.previouslySelectedCards = this.game.allCards.filter(card => card.selected);
+        _.each(this.previouslySelectedCards, card => card.selected = false);
     }
 
     activeCondition(player) {
@@ -137,6 +143,8 @@ class SelectCardPrompt extends UiPrompt {
         _.each(this.selectedCards, card => {
             card.selected = false;
         });
+        // Restore previous selections.
+        _.each(this.previouslySelectedCards, card => card.selected = true);
     }
 }
 

--- a/server/game/gamesteps/selectcardprompt.js
+++ b/server/game/gamesteps/selectcardprompt.js
@@ -81,7 +81,7 @@ class SelectCardPrompt extends UiPrompt {
             return false;
         }
 
-        if(this.properties.numCards === 1) {
+        if(this.properties.numCards === 1 && this.selectedCards.length === 1) {
             this.fireOnSelect();
         }
     }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -235,6 +235,7 @@ class Player extends Spectator {
     }
 
     initDrawDeck() {
+        this.allCards = _(this.drawCards.clone());
         this.drawDeck = this.drawCards;
         this.drawDeck.each(card => card.location = 'draw deck');
         this.shuffleDrawDeck();

--- a/test/server/gamesteps/selectcardprompt.spec.js
+++ b/test/server/gamesteps/selectcardprompt.spec.js
@@ -72,6 +72,17 @@ describe('the SelectCardPrompt', function() {
                     expect(this.properties.onSelect).toHaveBeenCalledWith(this.player, this.card);
                 });
 
+                describe('when the card is selected from a previous prompt', function() {
+                    beforeEach(function() {
+                        this.card.selected = true;
+                    });
+
+                    it('should not fire the onSelect event', function() {
+                        this.prompt.onCardClicked(this.player, this.card);
+                        expect(this.properties.onSelect).not.toHaveBeenCalled();
+                    })
+                });
+
                 describe('when onSelect returns true', function() {
                     beforeEach(function() {
                         this.properties.onSelect.and.returnValue(true);

--- a/test/server/gamesteps/selectcardprompt.spec.js
+++ b/test/server/gamesteps/selectcardprompt.spec.js
@@ -1,4 +1,4 @@
-/*global describe, it, beforeEach, expect,spyOn*/
+/*global describe, it, beforeEach, expect,spyOn, jasmine*/
 /* eslint camelcase: 0, no-invalid-this: 0 */
 
 const _ = require('underscore');
@@ -15,6 +15,9 @@ describe('the SelectCardPrompt', function() {
         this.card = {};
 
         this.player.cardsInPlay.push(this.card);
+
+        this.previousCard = { selected: true };
+        this.game.allCards = _([this.previousCard]);
 
         this.properties = {
             cardCondition: function() {
@@ -40,6 +43,10 @@ describe('the SelectCardPrompt', function() {
         beforeEach(function() {
             this.properties.numCards = 1;
             this.prompt = new SelectCardPrompt(this.game, this.player, this.properties);
+        });
+
+        it('should unselect the cards when the prompt starts', function() {
+            expect(this.previousCard.selected).toBe(false);
         });
 
         describe('the onCardClicked() function', function() {
@@ -77,7 +84,7 @@ describe('the SelectCardPrompt', function() {
                     it('should not fire the onSelect event', function() {
                         this.prompt.onCardClicked(this.player, this.card);
                         expect(this.properties.onSelect).not.toHaveBeenCalled();
-                    })
+                    });
                 });
 
                 describe('when onSelect returns true', function() {
@@ -88,6 +95,13 @@ describe('the SelectCardPrompt', function() {
                     it('should complete the prompt', function() {
                         this.prompt.onCardClicked(this.player, this.card);
                         expect(this.prompt.isComplete()).toBe(true);
+                    });
+
+                    it('should reselect the card when the prompt is completed', function() {
+                        this.prompt.onCardClicked(this.player, this.card);
+                        this.prompt.continue();
+
+                        expect(this.previousCard.selected).toBe(true);
                     });
                 });
 
@@ -159,6 +173,13 @@ describe('the SelectCardPrompt', function() {
                         it('should complete the prompt', function() {
                             this.prompt.onMenuCommand(this.player, 'another');
                             expect(this.prompt.isComplete()).toBe(true);
+                        });
+
+                        it('should reselect the card when the prompt is completed', function() {
+                            this.prompt.onMenuCommand(this.player, 'another');
+                            this.prompt.continue();
+
+                            expect(this.previousCard.selected).toBe(true);
                         });
                     });
                 });

--- a/test/server/gamesteps/selectcardprompt.spec.js
+++ b/test/server/gamesteps/selectcardprompt.spec.js
@@ -1,21 +1,18 @@
 /*global describe, it, beforeEach, expect,spyOn*/
 /* eslint camelcase: 0, no-invalid-this: 0 */
 
+const _ = require('underscore');
 const SelectCardPrompt = require('../../../server/game/gamesteps/selectcardprompt.js');
-const Game = require('../../../server/game/game.js');
-const Player = require('../../../server/game/player.js');
-const DrawCard = require('../../../server/game/drawcard.js');
 
 describe('the SelectCardPrompt', function() {
     beforeEach(function() {
-        this.game = new Game('1', 'Test Game');
-        this.player = new Player('1', 'Player 1', true, this.game);
-        this.player.initialise();
-        this.otherPlayer = new Player('2', 'Player 2', false, this.game);
-        this.otherPlayer.initialise();
-        this.game.players[this.player.id] = this.player;
-        this.game.players[this.otherPlayer.id] = this.otherPlayer;
-        this.card = new DrawCard(this.player, {});
+        this.game = jasmine.createSpyObj('game', ['getPlayers']);
+
+        this.player = jasmine.createSpyObj('player1', ['setPrompt', 'cancelPrompt']);
+        this.player.cardsInPlay = _([]);
+        this.otherPlayer = jasmine.createSpyObj('player2', ['setPrompt', 'cancelPrompt']);
+
+        this.card = {};
 
         this.player.cardsInPlay.push(this.card);
 
@@ -171,7 +168,7 @@ describe('the SelectCardPrompt', function() {
 
     describe('for a multiple card prompt', function() {
         beforeEach(function() {
-            this.card2 = new DrawCard(this.player, {});
+            this.card2 = {};
             this.properties.numCards = 2;
             this.prompt = new SelectCardPrompt(this.game, this.player, this.properties);
         });
@@ -221,7 +218,7 @@ describe('the SelectCardPrompt', function() {
                     this.properties.cardCondition.and.returnValue(true);
                     this.prompt.onCardClicked(this.player, this.card);
                     this.prompt.onCardClicked(this.player, this.card2);
-                    this.card3 = new DrawCard(this.player, {});
+                    this.card3 = {};
                 });
 
                 it('should select the card', function() {
@@ -235,7 +232,7 @@ describe('the SelectCardPrompt', function() {
                     this.properties.cardCondition.and.returnValue(true);
                     this.prompt.onCardClicked(this.player, this.card);
                     this.prompt.onCardClicked(this.player, this.card2);
-                    this.card3 = new DrawCard(this.player, {});
+                    this.card3 = {};
                 });
 
                 it('should not select the card', function() {


### PR DESCRIPTION
The cause of the crash was when people were in the middle of selecting either attackers or defenders, clicked to select their characters, then decided to set the strength of one of those characters. Clicking on the character in the set strength prompt would unselect it (since it was already selected in the previous prompt) and fire the select handler with no card.

The select card prompt now clears all previous selections when it activates. As a nicety, it restores the old selections once complete.