### PR TITLE
Implement Rains of Castamere

### DIFF
--- a/less/site.less
+++ b/less/site.less
@@ -689,6 +689,7 @@ h4 {
 
 .menu-pane {
   text-align: center;
+  z-index: 110;
 }
 
 .icon-military {

--- a/server/game/cards/agendas/fealty.js
+++ b/server/game/cards/agendas/fealty.js
@@ -7,8 +7,6 @@ class Fealty extends Reducer {
         });
 
         this.menu.push({ text: 'Kneel your faction card', method: 'onClick' });
-
-        this.registerEvents(['cardsStanding']);
     }
 
     onClick(player) {
@@ -45,10 +43,6 @@ class Fealty extends Reducer {
         }
 
         return currentCost;
-    }
-
-    cardsStanding() {
-        this.controller.faction.kneeled = false;
     }
 }
 

--- a/server/game/cards/agendas/therainsofcastamere.js
+++ b/server/game/cards/agendas/therainsofcastamere.js
@@ -1,0 +1,85 @@
+const _ = require('underscore');
+
+const AgendaCard = require('../../agendacard.js');
+
+class TheRainsOfCastamere extends AgendaCard {
+    constructor(owner, cardData) {
+        super(owner, cardData);
+
+        this.registerEvents(['onDecksPrepared', 'onPlotFlip', 'afterChallenge']);
+    }
+
+    onDecksPrepared() {
+        var schemePartition = this.owner.plotDeck.partition(card => card.hasTrait('Scheme'));
+        this.schemes = schemePartition[0];
+        this.owner.plotDeck = _(schemePartition[1]);
+    }
+
+    onPlotFlip() {
+        this.removeExistingSchemeFromGame();
+    }
+
+    removeExistingSchemeFromGame() {
+      var previousPlot = this.owner.activePlot;
+
+      if(!previousPlot || !previousPlot.hasTrait('Scheme')) {
+          return;
+      }
+
+      previousPlot.leavesPlay(this.owner);
+      this.owner.activePlot = undefined;
+    }
+
+    afterChallenge(e, challenge) {
+        if(challenge.challengeType !== 'intrigue' || challenge.winner !== this.owner || challenge.strengthDifference < 5) {
+            return;
+        }
+
+        if(this.owner.faction.kneeled) {
+            return;
+        }
+
+        this.game.promptWithMenu(this.owner, this, {
+            activePrompt: {
+                menuTitle: 'Trigger Scheme plot?',
+                buttons: this.menuButtons()
+            },
+            waitingPromptTitle: 'Waiting for opponent to use' + this.name
+        });
+    }
+
+    menuButtons() {
+        var buttons = _.map(this.schemes, scheme => {
+            return { text: scheme.name, command: 'menuButton', method: 'revealScheme', arg: scheme.uuid, card: scheme.getSummary(true) };
+        });
+
+        buttons.push({ text: 'Done', command: 'menuButton', method: 'cancelScheme' });
+        return buttons;
+    }
+
+    revealScheme(player, schemeId) {
+        var scheme = _.find(this.schemes, card => card.uuid === schemeId);
+
+        if(!scheme) {
+            return false;
+        }
+
+        this.removeExistingSchemeFromGame();
+
+        this.schemes = _.reject(this.schemes, card => card === scheme);
+
+        player.selectedPlot = scheme;
+        player.flipPlotFaceup();
+        scheme.onReveal(player);
+
+        return true;
+    }
+
+    cancelScheme() {
+        return true;
+    }
+}
+
+TheRainsOfCastamere.code = '05045';
+
+module.exports = TheRainsOfCastamere;

--- a/server/game/cards/agendas/therainsofcastamere.js
+++ b/server/game/cards/agendas/therainsofcastamere.js
@@ -26,8 +26,7 @@ class TheRainsOfCastamere extends AgendaCard {
           return;
       }
 
-      previousPlot.leavesPlay(this.owner);
-      this.owner.activePlot = undefined;
+      this.owner.removeActivePlot();
     }
 
     afterChallenge(e, challenge) {

--- a/server/game/cards/agendas/therainsofcastamere.js
+++ b/server/game/cards/agendas/therainsofcastamere.js
@@ -74,6 +74,8 @@ class TheRainsOfCastamere extends AgendaCard {
         player.flipPlotFaceup();
         scheme.onReveal(player);
 
+        player.faction.kneeled = true;
+
         return true;
     }
 

--- a/server/game/cards/agendas/therainsofcastamere.js
+++ b/server/game/cards/agendas/therainsofcastamere.js
@@ -71,7 +71,7 @@ class TheRainsOfCastamere extends AgendaCard {
 
         player.selectedPlot = scheme;
         player.flipPlotFaceup();
-        scheme.onReveal(player);
+        player.revealPlot();
 
         player.faction.kneeled = true;
 

--- a/server/game/cards/agendas/therainsofcastamere.js
+++ b/server/game/cards/agendas/therainsofcastamere.js
@@ -64,6 +64,8 @@ class TheRainsOfCastamere extends AgendaCard {
             return false;
         }
 
+        this.game.addMessage('{0} uses {1} to reveal {2}', player, this, scheme);
+
         this.removeExistingSchemeFromGame();
 
         this.schemes = _.reject(this.schemes, card => card === scheme);

--- a/server/game/cards/agendas/therainsofcastamere.js
+++ b/server/game/cards/agendas/therainsofcastamere.js
@@ -20,13 +20,13 @@ class TheRainsOfCastamere extends AgendaCard {
     }
 
     removeExistingSchemeFromGame() {
-      var previousPlot = this.owner.activePlot;
+        var previousPlot = this.owner.activePlot;
 
-      if(!previousPlot || !previousPlot.hasTrait('Scheme')) {
-          return;
-      }
+        if(!previousPlot || !previousPlot.hasTrait('Scheme')) {
+            return;
+        }
 
-      this.owner.removeActivePlot();
+        this.owner.removeActivePlot();
     }
 
     afterChallenge(e, challenge) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -600,6 +600,7 @@ class Game extends EventEmitter {
         this.allCards = _(_.reduce(this.getPlayers(), (cards, player) => {
             return cards.concat(player.allCards.toArray());
         }, []));
+        this.raiseEvent('onDecksPrepared');
         this.pipeline = new GamePipeline();
         this.pipeline.initialise([
             new SetupPhase(this),

--- a/server/game/gamesteps/plot/resolveplots.js
+++ b/server/game/gamesteps/plot/resolveplots.js
@@ -15,7 +15,7 @@ class ResolvePlots extends BaseStep {
         }
 
         _.each(this.playersWithRevealEffects, player => {
-            player.activePlot.onReveal(player);
+            player.revealPlot();
         });
 
         return true;
@@ -41,7 +41,7 @@ class ResolvePlots extends BaseStep {
         }
 
         this.playersWithRevealEffects = _.reject(this.playersWithRevealEffects, p => p === player);
-        player.activePlot.onReveal(player);
+        player.revealPlot();
 
         return true;
     }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -529,9 +529,6 @@ class Player extends Spectator {
     }
 
     flipPlotFaceup() {
-        this.menuTitle = '';
-        this.buttons = [];
-
         this.selectedPlot.flipFaceup();
 
         if(this.activePlot) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -495,7 +495,6 @@ class Player extends Spectator {
         this.reserve = 0;
         this.firstPlayer = false;
         this.selectedPlot = undefined;
-        this.plotRevealed = false;
         this.roundDone = false;
         this.challenges = {
             complete: 0,
@@ -543,8 +542,6 @@ class Player extends Spectator {
             this.plotDeck = this.plotDiscard;
             this.plotDiscard = _([]);
         }
-
-        this.plotRevealed = true;
 
         this.selectedPlot = undefined;
     }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -531,8 +531,8 @@ class Player extends Spectator {
         this.selectedPlot.flipFaceup();
 
         if(this.activePlot) {
-            this.activePlot.leavesPlay(this);
-            this.plotDiscard.push(this.activePlot);
+            var previousPlot = this.removeActivePlot();
+            this.plotDiscard.push(previousPlot);
         }
 
         this.activePlot = this.selectedPlot;
@@ -544,6 +544,15 @@ class Player extends Spectator {
         }
 
         this.selectedPlot = undefined;
+    }
+
+    removeActivePlot() {
+        if(this.activePlot) {
+            var plot = this.activePlot;
+            plot.leavesPlay(this);
+            this.activePlot = undefined;
+            return plot;
+        }
     }
 
     drawPhase() {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -555,6 +555,12 @@ class Player extends Spectator {
         }
     }
 
+    revealPlot() {
+        this.activePlot.onReveal(this);
+        this.reserve = this.getTotalReserve();
+        this.claim = this.activePlot.claim || 0;
+    }
+
     drawPhase() {
         this.game.addMessage('{0} draws {1} cards for the draw phase', this, this.drawPhaseCards);
         this.drawCardsToHand(this.drawPhaseCards);

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -819,6 +819,8 @@ class Player extends Spectator {
 
             card.kneeled = false;
         });
+
+        this.faction.kneeled = false;
     }
 
     taxation() {

--- a/test/server/agendas/05045 - therainsofcastamere.spec.js
+++ b/test/server/agendas/05045 - therainsofcastamere.spec.js
@@ -7,7 +7,7 @@ const TheRainsOfCastamere = require('../../../server/game/cards/agendas/therains
 
 describe('The Rains of Castamere', function() {
     function createPlotSpy(uuid, hasTrait) {
-        var plot = jasmine.createSpyObj('plot', ['hasTrait', 'onReveal']);
+        var plot = jasmine.createSpyObj('plot', ['hasTrait']);
         plot.uuid = uuid;
         plot.hasTrait.and.callFake(hasTrait);
         return plot;
@@ -29,7 +29,7 @@ describe('The Rains of Castamere', function() {
         this.scheme1 = scheme('3333');
         this.scheme2 = scheme('4444');
 
-        this.player = jasmine.createSpyObj('player', ['flipPlotFaceup', 'removeActivePlot']);
+        this.player = jasmine.createSpyObj('player', ['flipPlotFaceup', 'removeActivePlot', 'revealPlot']);
         this.player.game = this.gameSpy;
         this.player.faction = {};
 
@@ -170,6 +170,10 @@ describe('The Rains of Castamere', function() {
                 expect(this.player.flipPlotFaceup).not.toHaveBeenCalled();
             });
 
+            it('should not reveal a plot', function() {
+                expect(this.player.revealPlot).not.toHaveBeenCalled();
+            });
+
             it('should return false', function() {
                 expect(this.result).toBe(false);
             });
@@ -196,7 +200,7 @@ describe('The Rains of Castamere', function() {
                 });
 
                 it('should reveal the plot', function() {
-                    expect(this.scheme1.onReveal).toHaveBeenCalledWith(this.player);
+                    expect(this.player.revealPlot).toHaveBeenCalled();
                 });
 
                 it('should return true', function() {
@@ -224,7 +228,7 @@ describe('The Rains of Castamere', function() {
                 });
 
                 it('should reveal the plot', function() {
-                    expect(this.scheme1.onReveal).toHaveBeenCalledWith(this.player);
+                    expect(this.player.revealPlot).toHaveBeenCalled();
                 });
 
                 it('should return true', function() {
@@ -256,7 +260,7 @@ describe('The Rains of Castamere', function() {
                 });
 
                 it('should reveal the plot', function() {
-                    expect(this.scheme1.onReveal).toHaveBeenCalledWith(this.player);
+                    expect(this.player.revealPlot).toHaveBeenCalled();
                 });
 
                 it('should return true', function() {

--- a/test/server/agendas/05045 - therainsofcastamere.spec.js
+++ b/test/server/agendas/05045 - therainsofcastamere.spec.js
@@ -7,7 +7,7 @@ const TheRainsOfCastamere = require('../../../server/game/cards/agendas/therains
 
 describe('The Rains of Castamere', function() {
     function createPlotSpy(uuid, hasTrait) {
-        var plot = jasmine.createSpyObj('plot', ['hasTrait', 'leavesPlay', 'onReveal']);
+        var plot = jasmine.createSpyObj('plot', ['hasTrait', 'onReveal']);
         plot.uuid = uuid;
         plot.hasTrait.and.callFake(hasTrait);
         return plot;
@@ -29,7 +29,7 @@ describe('The Rains of Castamere', function() {
         this.scheme1 = scheme('3333');
         this.scheme2 = scheme('4444');
 
-        this.player = jasmine.createSpyObj('player', ['flipPlotFaceup']);
+        this.player = jasmine.createSpyObj('player', ['flipPlotFaceup', 'removeActivePlot']);
         this.player.game = this.gameSpy;
         this.player.faction = {};
 
@@ -77,7 +77,7 @@ describe('The Rains of Castamere', function() {
             });
 
             it('should not make the plot leave play directly', function() {
-                expect(this.plot1.leavesPlay).not.toHaveBeenCalled();
+                expect(this.player.removeActivePlot).not.toHaveBeenCalled();
             });
         });
 
@@ -88,12 +88,8 @@ describe('The Rains of Castamere', function() {
                 this.agenda.onPlotFlip();
             });
 
-            it('should remove the plot directly', function() {
-                expect(this.player.activePlot).toBeUndefined();
-            });
-
-            it('should make the plot leave play directly', function() {
-                expect(this.scheme1.leavesPlay).toHaveBeenCalled();
+            it('should remove the active plot from the game', function() {
+                expect(this.player.removeActivePlot).toHaveBeenCalled();
             });
         });
     });
@@ -248,7 +244,7 @@ describe('The Rains of Castamere', function() {
                 });
 
                 it('should remove the current plot from play', function() {
-                    expect(this.scheme2.leavesPlay).toHaveBeenCalledWith(this.player);
+                    expect(this.player.removeActivePlot).toHaveBeenCalled();
                 });
 
                 it('should remove the revealed scheme from the choices list', function() {

--- a/test/server/agendas/05045 - therainsofcastamere.spec.js
+++ b/test/server/agendas/05045 - therainsofcastamere.spec.js
@@ -1,0 +1,260 @@
+/* global describe, it, expect, beforeEach, jasmine */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+const _ = require('underscore');
+
+const TheRainsOfCastamere = require('../../../server/game/cards/agendas/therainsofcastamere.js');
+
+describe('The Rains of Castamere', function() {
+    function createPlotSpy(uuid, hasTrait) {
+        var plot = jasmine.createSpyObj('plot', ['hasTrait', 'leavesPlay', 'onReveal']);
+        plot.uuid = uuid;
+        plot.hasTrait.and.callFake(hasTrait);
+        return plot;
+    }
+
+    function plot(uuid) {
+        return createPlotSpy(uuid, () => false);
+    }
+
+    function scheme(uuid) {
+        return createPlotSpy(uuid, (trait) => trait === 'Scheme');
+    }
+
+    beforeEach(function() {
+        this.gameSpy = jasmine.createSpyObj('game', ['on', 'promptWithMenu']);
+
+        this.plot1 = plot('1111');
+        this.plot2 = plot('2222');
+        this.scheme1 = scheme('3333');
+        this.scheme2 = scheme('4444');
+
+        this.player = jasmine.createSpyObj('player', ['flipPlotFaceup']);
+        this.player.game = this.gameSpy;
+        this.player.faction = {};
+
+        this.agenda = new TheRainsOfCastamere(this.player, {});
+    });
+
+    describe('onDecksPrepared()', function() {
+        beforeEach(function() {
+            this.player.plotDeck = _([this.plot1, this.scheme1, this.plot2, this.scheme2]);
+
+            this.agenda.onDecksPrepared();
+        });
+
+        it('should remove the schemes from the players plot deck', function() {
+            expect(this.player.plotDeck.toArray()).toEqual([this.plot1, this.plot2]);
+        });
+
+        it('should save the schemes for later use', function() {
+            expect(this.agenda.schemes).toEqual([this.scheme1, this.scheme2]);
+        });
+    });
+
+    describe('onPlotFlip()', function() {
+        describe('when there is no active plot', function() {
+            beforeEach(function() {
+                this.player.activePlot = undefined;
+            });
+
+            it('should not crash', function() {
+                expect(() => {
+                    this.agenda.onPlotFlip();
+                }).not.toThrow();
+            });
+        });
+
+        describe('when the active plot is not a scheme', function() {
+            beforeEach(function() {
+                this.player.activePlot = this.plot1;
+
+                this.agenda.onPlotFlip();
+            });
+
+            it('should not remove the plot directly', function() {
+                expect(this.player.activePlot).toBe(this.plot1);
+            });
+
+            it('should not make the plot leave play directly', function() {
+                expect(this.plot1.leavesPlay).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('when the active plot is a scheme', function() {
+            beforeEach(function() {
+                this.player.activePlot = this.scheme1;
+
+                this.agenda.onPlotFlip();
+            });
+
+            it('should remove the plot directly', function() {
+                expect(this.player.activePlot).toBeUndefined();
+            });
+
+            it('should make the plot leave play directly', function() {
+                expect(this.scheme1.leavesPlay).toHaveBeenCalled();
+            });
+        });
+    });
+
+    describe('afterChallenge()', function() {
+        beforeEach(function() {
+            this.event = {};
+            this.challenge = { challengeType: 'intrigue', winner: this.player, strengthDifference: 5 };
+        });
+
+        describe('when the challenge type is not intrigue', function() {
+            beforeEach(function() {
+                this.challenge.challengeType = 'power';
+
+                this.agenda.afterChallenge(this.event, this.challenge);
+            });
+
+            it('should not prompt the player', function() {
+                expect(this.gameSpy.promptWithMenu).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('when the challenge winner is not the Castamere player', function() {
+            beforeEach(function() {
+                this.challenge.winner = {};
+
+                this.agenda.afterChallenge(this.event, this.challenge);
+            });
+
+            it('should not prompt the player', function() {
+                expect(this.gameSpy.promptWithMenu).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('when the strength difference is less than 5', function() {
+            beforeEach(function() {
+                this.challenge.strengthDifference = 4;
+
+                this.agenda.afterChallenge(this.event, this.challenge);
+            });
+
+            it('should not prompt the player', function() {
+                expect(this.gameSpy.promptWithMenu).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('when the player faction card is already knelt', function() {
+            beforeEach(function() {
+                this.player.faction.kneeled = true;
+
+                this.agenda.afterChallenge(this.event, this.challenge);
+            });
+
+            it('should not prompt the player', function() {
+                expect(this.gameSpy.promptWithMenu).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('when all triggering criteria are met', function() {
+            it('should prompt the player', function() {
+                this.agenda.afterChallenge(this.event, this.challenge);
+                expect(this.gameSpy.promptWithMenu).toHaveBeenCalled();
+            });
+        })
+    });
+
+    describe('revealScheme()', function() {
+        beforeEach(function() {
+            this.agenda.schemes = [this.scheme1, this.scheme2];
+        });
+
+        describe('when the argument is not one of the schemes', function() {
+            beforeEach(function() {
+                this.result = this.agenda.revealScheme(this.player, 'notfound');
+            });
+
+            it('should not flip a plot', function() {
+                expect(this.player.flipPlotFaceup).not.toHaveBeenCalled();
+            });
+
+            it('should return false', function() {
+                expect(this.result).toBe(false);
+            });
+        });
+
+        describe('when the argument is a scheme', function() {
+            describe('and there is no active plot', function() {
+                beforeEach(function() {
+                    this.player.activePlot = undefined;
+
+                    this.result = this.agenda.revealScheme(this.player, this.scheme1.uuid);
+                });
+
+                it('should remove the revealed scheme from the choices list', function() {
+                    expect(this.agenda.schemes).not.toContain(this.scheme1);
+                });
+
+                it('should flip the plot face up', function() {
+                    expect(this.player.flipPlotFaceup).toHaveBeenCalled();
+                });
+
+                it('should reveal the plot', function() {
+                    expect(this.scheme1.onReveal).toHaveBeenCalledWith(this.player);
+                });
+
+                it('should return true', function() {
+                    expect(this.result).toBe(true);
+                });
+            });
+
+            describe('and the active plot is not a scheme', function() {
+                beforeEach(function() {
+                    this.player.activePlot = this.plot1;
+
+                    this.result = this.agenda.revealScheme(this.player, this.scheme1.uuid);
+                });
+
+                it('should remove the revealed scheme from the choices list', function() {
+                    expect(this.agenda.schemes).not.toContain(this.scheme1);
+                });
+
+                it('should flip the plot face up', function() {
+                    expect(this.player.flipPlotFaceup).toHaveBeenCalled();
+                });
+
+                it('should reveal the plot', function() {
+                    expect(this.scheme1.onReveal).toHaveBeenCalledWith(this.player);
+                });
+
+                it('should return true', function() {
+                    expect(this.result).toBe(true);
+                });
+            });
+
+            describe('when the active plot is a scheme', function() {
+                beforeEach(function() {
+                    this.player.activePlot = this.scheme2;
+
+                    this.result = this.agenda.revealScheme(this.player, this.scheme1.uuid);
+                });
+
+                it('should remove the current plot from play', function() {
+                    expect(this.scheme2.leavesPlay).toHaveBeenCalledWith(this.player);
+                });
+
+                it('should remove the revealed scheme from the choices list', function() {
+                    expect(this.agenda.schemes).not.toContain(this.scheme1);
+                });
+
+                it('should flip the plot face up', function() {
+                    expect(this.player.flipPlotFaceup).toHaveBeenCalled();
+                });
+
+                it('should reveal the plot', function() {
+                    expect(this.scheme1.onReveal).toHaveBeenCalledWith(this.player);
+                });
+
+                it('should return true', function() {
+                    expect(this.result).toBe(true);
+                });
+            });
+        });
+    });
+});

--- a/test/server/agendas/05045 - therainsofcastamere.spec.js
+++ b/test/server/agendas/05045 - therainsofcastamere.spec.js
@@ -22,7 +22,7 @@ describe('The Rains of Castamere', function() {
     }
 
     beforeEach(function() {
-        this.gameSpy = jasmine.createSpyObj('game', ['on', 'promptWithMenu']);
+        this.gameSpy = jasmine.createSpyObj('game', ['on', 'promptWithMenu', 'addMessage']);
 
         this.plot1 = plot('1111');
         this.plot2 = plot('2222');

--- a/test/server/agendas/05045 - therainsofcastamere.spec.js
+++ b/test/server/agendas/05045 - therainsofcastamere.spec.js
@@ -177,6 +177,10 @@ describe('The Rains of Castamere', function() {
             it('should return false', function() {
                 expect(this.result).toBe(false);
             });
+
+            it('should not kneel the player faction card', function() {
+                expect(this.player.faction.kneeled).toBeFalsy();
+            });
         });
 
         describe('when the argument is a scheme', function() {
@@ -202,6 +206,10 @@ describe('The Rains of Castamere', function() {
                 it('should return true', function() {
                     expect(this.result).toBe(true);
                 });
+
+                it('should kneel the player faction card', function() {
+                    expect(this.player.faction.kneeled).toBe(true);
+                });
             });
 
             describe('and the active plot is not a scheme', function() {
@@ -225,6 +233,10 @@ describe('The Rains of Castamere', function() {
 
                 it('should return true', function() {
                     expect(this.result).toBe(true);
+                });
+
+                it('should kneel the player faction card', function() {
+                    expect(this.player.faction.kneeled).toBe(true);
                 });
             });
 
@@ -253,6 +265,10 @@ describe('The Rains of Castamere', function() {
 
                 it('should return true', function() {
                     expect(this.result).toBe(true);
+                });
+
+                it('should kneel the player faction card', function() {
+                    expect(this.player.faction.kneeled).toBe(true);
                 });
             });
         });

--- a/test/server/gamesteps/plot/resolveplots.spec.js
+++ b/test/server/gamesteps/plot/resolveplots.spec.js
@@ -1,4 +1,4 @@
-/*global describe, it, beforeEach, expect, jasmine, spyOn*/
+/*global describe, it, beforeEach, expect, jasmine */
 /* eslint no-invalid-this: 0 */
 
 const ResolvePlots = require('../../../../server/game/gamesteps/plot/resolveplots.js');

--- a/test/server/gamesteps/plot/resolveplots.spec.js
+++ b/test/server/gamesteps/plot/resolveplots.spec.js
@@ -2,26 +2,14 @@
 /* eslint no-invalid-this: 0 */
 
 const ResolvePlots = require('../../../../server/game/gamesteps/plot/resolveplots.js');
-const Game = require('../../../../server/game/game.js');
-const Player = require('../../../../server/game/player.js');
-const PlotCard = require('../../../../server/game/plotcard.js');
 
 describe('the ResolvePlots', function() {
     beforeEach(function() {
-        this.game = new Game({}, '');
-        this.player = new Player('1', 'Player 1', true, this.game);
-        this.otherPlayer = new Player('2', 'Player 2', false, this.game);
-        this.otherPlayer.firstPlayer = true;
+        this.game = jasmine.createSpyObj('game', ['getPlayerById', 'getFirstPlayer', 'promptWithMenu']);
+        this.player = jasmine.createSpyObj('player', ['setPrompt', 'cancelPrompt', 'revealPlot']);
+        this.otherPlayer = jasmine.createSpyObj('player', ['setPrompt', 'cancelPrompt', 'revealPlot']);
 
-        this.game.players[this.player.id] = this.player;
-        this.game.players[this.otherPlayer.id] = this.otherPlayer;
-
-        this.player.activePlot = new PlotCard({}, {});
-        this.otherPlayer.activePlot = new PlotCard({}, {});
-
-        spyOn(this.player.activePlot, 'onReveal');
-        spyOn(this.otherPlayer.activePlot, 'onReveal');
-        spyOn(this.game, 'promptWithMenu');
+        this.game.getFirstPlayer.and.returnValue(this.otherPlayer);
     });
 
     describe('the continue() function', function() {
@@ -50,9 +38,9 @@ describe('the ResolvePlots', function() {
                 expect(this.game.promptWithMenu).not.toHaveBeenCalled();
             });
 
-            it('should call the onReveal for the plot', function() {
+            it('should reveal the plot', function() {
                 this.prompt.continue();
-                expect(this.player.activePlot.onReveal).toHaveBeenCalledWith(this.player);
+                expect(this.player.revealPlot).toHaveBeenCalled();
             });
 
             it('should return true', function() {
@@ -70,10 +58,10 @@ describe('the ResolvePlots', function() {
                 expect(this.game.promptWithMenu).toHaveBeenCalledWith(this.otherPlayer, this.prompt, jasmine.any(Object));
             });
 
-            it('should not call onReveal on any plot', function() {
+            it('should not reveal any plot', function() {
                 this.prompt.continue();
-                expect(this.player.activePlot.onReveal).not.toHaveBeenCalled();
-                expect(this.otherPlayer.activePlot.onReveal).not.toHaveBeenCalled();
+                expect(this.player.revealPlot).not.toHaveBeenCalled();
+                expect(this.otherPlayer.revealPlot).not.toHaveBeenCalled();
             });
 
             it('should return false', function() {
@@ -88,10 +76,14 @@ describe('the ResolvePlots', function() {
         });
 
         describe('when the player ID does not exist', function() {
-            it('should not call onReveal', function() {
+            beforeEach(function() {
+                this.game.getPlayerById.and.returnValue(undefined);
+            });
+
+            it('should not reveal a plot', function() {
                 this.prompt.resolvePlayer(this.player, 54321);
-                expect(this.player.activePlot.onReveal).not.toHaveBeenCalled();
-                expect(this.otherPlayer.activePlot.onReveal).not.toHaveBeenCalled();
+                expect(this.player.revealPlot).not.toHaveBeenCalled();
+                expect(this.otherPlayer.revealPlot).not.toHaveBeenCalled();
             });
 
             it('should not modify the resolution list', function() {
@@ -101,9 +93,13 @@ describe('the ResolvePlots', function() {
         });
 
         describe('when the player ID does exist', function() {
+            beforeEach(function() {
+                this.game.getPlayerById.and.returnValue(this.otherPlayer);
+            });
+
             it('should call onReveal', function() {
                 this.prompt.resolvePlayer(this.player, this.otherPlayer.id);
-                expect(this.otherPlayer.activePlot.onReveal).toHaveBeenCalledWith(this.otherPlayer);
+                expect(this.otherPlayer.revealPlot).toHaveBeenCalled();
             });
 
             it('should remove the resolved player from the list', function() {


### PR DESCRIPTION
* Removes schemes from the normal plot deck when the player has Rains of Castamere agenda.
* Prompts to trigger a scheme plot when winning an intrigue challenge by 5 or more.
* Move standing of faction card into the stand phase instead of handled case-by-case as it was with Fealty.

There is probably some weirdness around reserve if the opponent has a Kings of Summer/Winter agenda. They're persistent effects but currently only modify reserve when the plot phase starts. It should be whenever a plot enters play, but that will require serious reworking of those agendas.

Completes #32.

_"A coat of gold, a coat of red, a lion still has claws"_