### PR TITLE
Fix attachment overlap and menus under cards.

### DIFF
--- a/client/GameComponents/Card.jsx
+++ b/client/GameComponents/Card.jsx
@@ -88,18 +88,16 @@ class Card extends React.Component {
             return null;
         }
 
-        var offset = 10;
+        var index = 1;
         var attachments = _.map(this.props.card.attachments, attachment => {
-            var style = { top: offset + 'px', zIndex: -offset };
-
-            var returnedAttachment = (<Card key={attachment.uuid} style={style} source={this.props.source} card={attachment}
+            var returnedAttachment = (<Card key={attachment.uuid} source={this.props.source} card={attachment} className={"attachment attachment-" + index} wrapped={false}
                             onMouseOver={this.props.disableMouseOver ? null : this.onMouseOver.bind(this, attachment)}
                             onMouseOut={this.props.disableMouseOver ? null : this.onMouseOut}
                             onClick={this.props.onClick}
                             onMenuItemClick={this.props.onMenuItemClick}
                             onDragStart={ev => this.onCardDragStart(ev, attachment, this.props.source)} />);
 
-            offset += 10;
+            index += 1;
 
             return returnedAttachment;
         });
@@ -128,7 +126,7 @@ class Card extends React.Component {
                 zIndex: offset,
                 position: 'absolute' };
 
-            var returnedDupe = (<Card key={dupe.uuid} style={style} source={this.props.source} card={dupe}
+            var returnedDupe = (<Card key={dupe.uuid} style={style} source={this.props.source} card={dupe} wrapped={false}
                             onMouseOver={this.props.disableMouseOver ? null : this.onMouseOver.bind(this, dupe)}
                             onMouseOut={this.props.disableMouseOver ? null : this.onMouseOut} />);
 
@@ -162,9 +160,28 @@ class Card extends React.Component {
     }
 
     render() {
+        if(!this.props.wrapped) {
+            return this.getCard();
+        }
+
+        var wrapperClass = 'card-wrapper';
+        if(this.props.source === 'selected plot') {
+            wrapperClass += ' selected-plot';
+        }
+
+        return (
+                <div className={wrapperClass}>
+                    <div className='card-frame'>
+                        {this.getCard()}
+                        {this.getDupes()}
+                        {this.getAttachments()}
+                    </div>
+                </div>);
+    }
+
+    getCard() {
         var cardClass = '';
         var imageClass = '';
-        var wrapperClass = 'card-wrapper';
 
         if(!this.props.card) {
             return <div />;
@@ -189,31 +206,23 @@ class Card extends React.Component {
             cardClass += ' new';
         }
 
-        if(this.props.source === 'play area' && this.props.card.type === 'attachment' && this.props.card.attached) {
-            wrapperClass += ' attachment';
-        } else if(this.props.source === 'selected plot') {
-            wrapperClass += ' selected-plot';
+        if(this.props.className) {
+            cardClass += ' ' + this.props.className;
         }
 
         return (
-                <div className={wrapperClass} style={this.props.style}>
-                    <div className='card-frame'>
-                        <div className={cardClass}
-                            onMouseOver={this.props.disableMouseOver ? null : this.onMouseOver.bind(this, this.props.card)}
-                            onMouseOut={this.props.disableMouseOver ? null : this.onMouseOut}
-                            onClick={ev => this.onClick(ev, this.props.card, this.props.source)}
-                            onDragStart={ev => this.onCardDragStart(ev, this.props.card, this.props.source)}
-                            draggable>
-                            <div>
-                                <span className='card-name'>{this.props.card.name}</span>
-                                <img className={imageClass} src={'/img/cards/' + (!this.isFacedown() ? (this.props.card.code + '.png') : 'cardback.jpg')} />
-                            </div>
-                            {this.getCounters()}
-                            {this.getMenu()}
-                        </div>
-                        {this.getDupes()}
-                        {this.getAttachments()}
+                <div className={cardClass} style={this.props.style}
+                    onMouseOver={this.props.disableMouseOver ? null : this.onMouseOver.bind(this, this.props.card)}
+                    onMouseOut={this.props.disableMouseOver ? null : this.onMouseOut}
+                    onClick={ev => this.onClick(ev, this.props.card, this.props.source)}
+                    onDragStart={ev => this.onCardDragStart(ev, this.props.card, this.props.source)}
+                    draggable>
+                    <div>
+                        <span className='card-name'>{this.props.card.name}</span>
+                        <img className={imageClass} src={'/img/cards/' + (!this.isFacedown() ? (this.props.card.code + '.png') : 'cardback.jpg')} />
                     </div>
+                    {this.getCounters()}
+                    {this.getMenu()}
                 </div>);
     }
 }
@@ -238,6 +247,7 @@ Card.propTypes = {
         tokens: React.PropTypes.object,
         type: React.PropTypes.string
     }).isRequired,
+    className: React.PropTypes.string,
     disableMouseOver: React.PropTypes.bool,
     horizontal: React.PropTypes.bool,
     onClick: React.PropTypes.func,
@@ -245,7 +255,11 @@ Card.propTypes = {
     onMouseOut: React.PropTypes.func,
     onMouseOver: React.PropTypes.func,
     source: React.PropTypes.oneOf(['hand', 'discard pile', 'play area', 'dead pile', 'draw deck', 'plot deck', 'revealed plots', 'selected plot', 'attachment', 'agenda', 'faction']).isRequired,
-    style: React.PropTypes.object
+    style: React.PropTypes.object,
+    wrapped: React.PropTypes.bool
+};
+Card.defaultProps = {
+    wrapped: true
 };
 
 export default Card;

--- a/client/GameComponents/Card.jsx
+++ b/client/GameComponents/Card.jsx
@@ -179,7 +179,7 @@ class Card extends React.Component {
 
     getCard() {
         var cardClass = '';
-        var imageClass = '';
+        var imageClass = 'card-image';
 
         if(!this.props.card) {
             return <div />;
@@ -187,13 +187,13 @@ class Card extends React.Component {
 
         if(this.props.card.kneeled || this.props.horizontal) {
             cardClass = 'horizontal-card';
-            imageClass = 'kneeled card';
+            imageClass += ' vertical kneeled';
         } else if(this.props.card.type === 'plot') {
             cardClass = 'plot-card';
-            imageClass = 'plot-card';
+            imageClass += ' horizontal';
         } else {
             cardClass = 'card';
-            imageClass = 'card';
+            imageClass += ' vertical';
         }
 
         if(this.props.card.selected) {

--- a/client/GameComponents/Card.jsx
+++ b/client/GameComponents/Card.jsx
@@ -178,7 +178,7 @@ class Card extends React.Component {
     }
 
     getCard() {
-        var cardClass = '';
+        var cardClass = 'card';
         var imageClass = 'card-image';
 
         if(!this.props.card) {
@@ -186,13 +186,13 @@ class Card extends React.Component {
         }
 
         if(this.props.card.kneeled || this.props.horizontal) {
-            cardClass = 'horizontal-card';
+            cardClass += ' horizontal';
             imageClass += ' vertical kneeled';
         } else if(this.props.card.type === 'plot') {
             cardClass = 'plot-card';
             imageClass += ' horizontal';
         } else {
-            cardClass = 'card';
+            cardClass += ' vertical';
             imageClass += ' vertical';
         }
 

--- a/client/GameComponents/Card.jsx
+++ b/client/GameComponents/Card.jsx
@@ -154,21 +154,16 @@ class Card extends React.Component {
     }
 
     render() {
-        if(!this.props.wrapped) {
-            return this.getCard();
+        if(this.props.wrapped) {
+            return (
+                    <div className='card-wrapper' style={this.props.style}>
+                        {this.getCard()}
+                        {this.getDupes()}
+                        {this.getAttachments()}
+                    </div>);
         }
 
-        var wrapperClass = 'card-wrapper';
-        if(this.props.source === 'selected plot') {
-            wrapperClass += ' selected-plot';
-        }
-
-        return (
-                <div className={wrapperClass} style={this.props.style}>
-                    {this.getCard()}
-                    {this.getDupes()}
-                    {this.getAttachments()}
-                </div>);
+        return this.getCard();
     }
 
     getCard() {

--- a/client/GameComponents/Card.jsx
+++ b/client/GameComponents/Card.jsx
@@ -189,7 +189,7 @@ class Card extends React.Component {
             cardClass += ' horizontal';
             imageClass += ' vertical kneeled';
         } else if(this.props.card.type === 'plot') {
-            cardClass = 'plot-card';
+            cardClass += ' horizontal';
             imageClass += ' horizontal';
         } else {
             cardClass += ' vertical';

--- a/client/GameComponents/Card.jsx
+++ b/client/GameComponents/Card.jsx
@@ -171,11 +171,9 @@ class Card extends React.Component {
 
         return (
                 <div className={wrapperClass}>
-                    <div className='card-frame'>
-                        {this.getCard()}
-                        {this.getDupes()}
-                        {this.getAttachments()}
-                    </div>
+                    {this.getCard()}
+                    {this.getDupes()}
+                    {this.getAttachments()}
                 </div>);
     }
 

--- a/client/GameComponents/Card.jsx
+++ b/client/GameComponents/Card.jsx
@@ -118,19 +118,13 @@ class Card extends React.Component {
             return;
         }
 
-        var offset = -10;
+        var index = 1;
         var dupes = _.map(facedownDupes, dupe => {
-            var style = {
-                top: offset + 'px',
-                left: '0px',
-                zIndex: offset,
-                position: 'absolute' };
-
-            var returnedDupe = (<Card key={dupe.uuid} style={style} source={this.props.source} card={dupe} wrapped={false}
+            var returnedDupe = (<Card key={dupe.uuid} className={'card-dupe card-dupe-' + index} source={this.props.source} card={dupe} wrapped={false}
                             onMouseOver={this.props.disableMouseOver ? null : this.onMouseOver.bind(this, dupe)}
                             onMouseOut={this.props.disableMouseOver ? null : this.onMouseOut} />);
 
-            offset -= 10;
+            index += 1;
 
             return returnedDupe;
         });

--- a/client/GameComponents/Card.jsx
+++ b/client/GameComponents/Card.jsx
@@ -172,7 +172,6 @@ class Card extends React.Component {
         return (
                 <div className={wrapperClass} style={this.props.style}>
                     {this.getCard()}
-                    {this.getMenu()}
                     {this.getDupes()}
                     {this.getAttachments()}
                 </div>);
@@ -210,17 +209,19 @@ class Card extends React.Component {
         }
 
         return (
-                <div className={cardClass}
-                    onMouseOver={this.props.disableMouseOver ? null : this.onMouseOver.bind(this, this.props.card)}
-                    onMouseOut={this.props.disableMouseOver ? null : this.onMouseOut}
-                    onClick={ev => this.onClick(ev, this.props.card, this.props.source)}
-                    onDragStart={ev => this.onCardDragStart(ev, this.props.card, this.props.source)}
-                    draggable>
-                    <div>
-                        <span className='card-name'>{this.props.card.name}</span>
-                        <img className={imageClass} src={'/img/cards/' + (!this.isFacedown() ? (this.props.card.code + '.png') : 'cardback.jpg')} />
+                <div className='card-frame'>
+                    <div className={cardClass}
+                        onMouseOver={this.props.disableMouseOver ? null : this.onMouseOver.bind(this, this.props.card)}
+                        onMouseOut={this.props.disableMouseOver ? null : this.onMouseOut}
+                        onClick={ev => this.onClick(ev, this.props.card, this.props.source)}
+                        onDragStart={ev => this.onCardDragStart(ev, this.props.card, this.props.source)}
+                        draggable>
+                        <div>
+                            <span className='card-name'>{this.props.card.name}</span>
+                            <img className={imageClass} src={'/img/cards/' + (!this.isFacedown() ? (this.props.card.code + '.png') : 'cardback.jpg')} />
+                        </div>
+                        {this.getCounters()}
                     </div>
-                    {this.getCounters()}
                     {this.getMenu()}
                 </div>);
     }

--- a/client/GameComponents/Card.jsx
+++ b/client/GameComponents/Card.jsx
@@ -170,8 +170,9 @@ class Card extends React.Component {
         }
 
         return (
-                <div className={wrapperClass}>
+                <div className={wrapperClass} style={this.props.style}>
                     {this.getCard()}
+                    {this.getMenu()}
                     {this.getDupes()}
                     {this.getAttachments()}
                 </div>);
@@ -209,7 +210,7 @@ class Card extends React.Component {
         }
 
         return (
-                <div className={cardClass} style={this.props.style}
+                <div className={cardClass}
                     onMouseOver={this.props.disableMouseOver ? null : this.onMouseOver.bind(this, this.props.card)}
                     onMouseOut={this.props.disableMouseOver ? null : this.onMouseOut}
                     onClick={ev => this.onClick(ev, this.props.card, this.props.source)}

--- a/client/GameComponents/PlayerRow.jsx
+++ b/client/GameComponents/PlayerRow.jsx
@@ -196,8 +196,8 @@ class PlayerRow extends React.Component {
                     <div className='panel-header'>
                         {'Draw (' + this.props.numDrawCards + ')'}
                     </div>
-                    <div className='card ignore-mouse-events'>
-                        <img className='card' src='/img/cards/cardback.jpg' />
+                    <div className='card vertical ignore-mouse-events'>
+                        <img className='card-image vertical' src='/img/cards/cardback.jpg' />
                     </div>
                     {drawDeckMenu}
                     {drawDeckPopup}

--- a/client/GameComponents/PlayerRow.jsx
+++ b/client/GameComponents/PlayerRow.jsx
@@ -81,7 +81,7 @@ class PlayerRow extends React.Component {
         }
     }
 
-    getHand() {
+    getHand(needsSquish) {
         var cardIndex = 0;
         var handLength = this.props.hand ? this.props.hand.length : 0;
         var requiredWidth = handLength * 64;
@@ -91,9 +91,12 @@ class PlayerRow extends React.Component {
         var hand = _.map(this.props.hand, card => {
             var left = (64 - offset) * cardIndex++;
 
-            var style = {
-                left: left + 'px'
-            };
+            var style = {};
+            if(needsSquish) {
+                style = {
+                    left: left + 'px'
+                };
+            }
 
             return (<Card key={card.uuid} card={card} style={style} disableMouseOver={!this.props.isMe} source='hand'
                          onMouseOver={this.props.onMouseOver}
@@ -160,12 +163,13 @@ class PlayerRow extends React.Component {
 
     render() {
         var className = 'panel hand';
+        var needsSquish = this.props.hand && this.props.hand.length * 64 > 342;
 
-        if(this.props.hand && this.props.hand.length * 64 > 342) {
+        if(needsSquish) {
             className += ' squish';
         }
 
-        var hand = this.getHand();
+        var hand = this.getHand(needsSquish);
         var drawDeckPopup = this.getDrawDeck();
 
         var drawDeckMenu = this.state.showDrawMenu ?

--- a/less/site.less
+++ b/less/site.less
@@ -448,23 +448,24 @@ h4 {
   border-radius: 4px;
   box-shadow: 0 0 12px rgba(0, 0, 0, 0.4), inset 0 0 0 1px rgba(255, 255, 255, 0.1);
   position: relative;
+  z-index: @layer-cards;
 }
 
-.horizontal-card {
-  img.kneeled {
-    position: absolute;
-    transform: rotate(90deg);
-    left: 9px;
-    top: -10px;
-    width: @card-width;
-    height: @card-height;
-  }
-}
+// .horizontal-card {
+//   img.kneeled {
+//     position: absolute;
+//     transform: rotate(90deg);
+//     left: 9px;
+//     top: -10px;
+//     width: @card-width;
+//     height: @card-height;
+//   }
+// }
 
-.horizontal-card > img.horizontal {
-  height: @card-width;
-  width: @card-height;
-}
+// .horizontal-card > img.horizontal {
+//   height: @card-width;
+//   width: @card-height;
+// }
 
 .card-row .horizontal-card {
     margin-bottom: @card-height - @card-width;
@@ -495,6 +496,7 @@ h4 {
   width: @card-width;
   border-radius: 4px;
   box-shadow: 0 0 12px rgba(0,0,0,0.4), inset 0 0 0 1px rgba(255,255,255,0.1);
+  overflow: hidden;
   z-index: @layer-cards;
 }
 
@@ -510,11 +512,33 @@ h4 {
   box-shadow: 0 0 1px 2px #d0d834;
 }
 
-.card > * > img {
+.card-image {
+  left: 0;
   position: absolute;
-  top: 0px;
-  left: 0px;
+  top: 0;
+
+  &.vertical {
+    height: @card-height;
+    width: @card-width;
+  }
+
+  &.horizontal {
+    height: @card-width;
+    width: @card-height;
+  }
+
+  &.kneeled {
+    left: 9px;
+    top: -10px;
+    transform: rotate(90deg);
+  }
 }
+
+// .card > * > img {
+//   position: absolute;
+//   top: 0px;
+//   left: 0px;
+// }
 
 .card-name {
   // display: none;
@@ -528,11 +552,11 @@ h4 {
 }
 
 .plot-card {
-  img {
-    position: absolute;
-    top: 0;
-    left: 0;
-  }
+  // img {
+  //   position: absolute;
+  //   top: 0;
+  //   left: 0;
+  // }
 
   display: inline-block;
   position: relative;

--- a/less/site.less
+++ b/less/site.less
@@ -451,6 +451,10 @@ h4 {
   vertical-align: middle;
 }
 
+.card-frame {
+  position: relative;
+}
+
 .card {
   position: relative;
   border-radius: 4px;

--- a/less/site.less
+++ b/less/site.less
@@ -613,12 +613,6 @@ h4 {
 
 .generate-attachments(5, 1);
 
-
-.card-frame {
-  // position: relative;
-  // z-index: @layer-cards;
-}
-
 // .attachment > div {
 //   float: left;
 // }

--- a/less/site.less
+++ b/less/site.less
@@ -508,7 +508,7 @@ h4 {
   line-height: 14px;
 }
 
-.squish .card {
+.squish .card-wrapper {
   position: absolute;
 }
 

--- a/less/site.less
+++ b/less/site.less
@@ -7,6 +7,15 @@
 @card-width: 64px;
 @card-height: 84px;
 
+// Z-index layers
+@layer-cards: 1;
+@layer-pile-header: 2;
+@layer-card-collection-draw: 15;
+@layer-card-menu: 20;
+@layer-card-collection: 100;
+@layer-prompt: 110;
+@layer-top: 9999;
+
 @font-face {
   font-family: thronesdb;
   src: url('/fonts/thronesdb.ttf');
@@ -77,7 +86,7 @@ h3 {
   position: fixed;
   left: 10px;
   top: 60px;
-  z-index: 9999;
+  z-index: @layer-top;
 }
 
 .card-group {
@@ -563,7 +572,7 @@ h4 {
   position: absolute;
   top: 0;
   left: 0;
-  z-index: 2;
+  z-index: @layer-pile-header;
   padding: 1px 4px;
   font-size: 10px;
   line-height: 14px;
@@ -581,7 +590,7 @@ h4 {
 
 .card-frame {
   position: relative;
-  z-index: 1;
+  z-index: @layer-cards;
 }
 
 .attachment > div {
@@ -657,7 +666,7 @@ h4 {
 }
 
 .popup {
-  z-index: 100;
+  z-index: @layer-card-collection;
 }
 
 .draw {
@@ -667,7 +676,7 @@ h4 {
     bottom: 85px;
     width: 590px;
     min-height: 92px;
-    z-index: 15;
+    z-index: @layer-card-collection-draw;
 
     .card {
       float: left;
@@ -696,7 +705,7 @@ h4 {
 
 .menu-pane {
   text-align: center;
-  z-index: 110;
+  z-index: @layer-prompt;
 }
 
 .icon-military {
@@ -887,7 +896,7 @@ h4 {
   top: -5px;
   font-size: 12px;
   line-height: 16px;
-  z-index: 20;
+  z-index: @layer-card-menu;
 }
 
 .menu > div {

--- a/less/site.less
+++ b/less/site.less
@@ -271,14 +271,14 @@ h3 {
   width: 100%;
 }
 
-.plot > img, .plot-card > img, .discard-plot > img {
+.plot > img, .discard-plot > img {
   width: 100%;
 }
 
-.plot-popup > .plot-card > img {
-  width: initial;
-  height: 100%;
-}
+// .plot-popup > .plot-card > img {
+//   width: initial;
+//   height: 100%;
+// }
 
 .discard, .draw, .faction, .agenda {
   position: relative;
@@ -345,9 +345,9 @@ h4 {
   margin-top: auto;
 }
 
-.plot-card.selected {
-  box-shadow: 0 0 1px 2px @brand-primary;
-}
+// .plot-card.selected {
+//   box-shadow: 0 0 1px 2px @brand-primary;
+// }
 
 .discard-plot {
   height: 110px;
@@ -559,20 +559,20 @@ h4 {
   position: absolute;
 }
 
-.plot-card {
-  // img {
-  //   position: absolute;
-  //   top: 0;
-  //   left: 0;
-  // }
-
-  display: inline-block;
-  position: relative;
-  height: @card-width;
-  width: @card-height;
-  border-radius: 4px;
-  box-shadow: 0 0 12px rgba(0,0,0,0.4), inset 0 0 0 1px rgba(255,255,255,0.1);
-}
+// .plot-card {
+//   // img {
+//   //   position: absolute;
+//   //   top: 0;
+//   //   left: 0;
+//   // }
+//
+//   display: inline-block;
+//   position: relative;
+//   height: @card-width;
+//   width: @card-height;
+//   border-radius: 4px;
+//   box-shadow: 0 0 12px rgba(0,0,0,0.4), inset 0 0 0 1px rgba(255,255,255,0.1);
+// }
 
 .shadow {
   box-shadow: 0 0 12px rgba(0,0,0,0.4), inset 0 0 0 1px rgba(255,255,255,0.1);

--- a/less/site.less
+++ b/less/site.less
@@ -11,7 +11,7 @@
 
 // Z-index layers
 @layer-cards: 10;
-@layer-pile-header: 2;
+@layer-pile-header: 20;
 @layer-card-menu: 20;
 @layer-card-collection: 100;
 @layer-prompt: 110;
@@ -441,15 +441,15 @@ h4 {
   width: @card-height;
 }
 
-.horizontal-card {
-  height: @card-width;
-  width: @card-height;
-  padding: 0px;
-  border-radius: 4px;
-  box-shadow: 0 0 12px rgba(0, 0, 0, 0.4), inset 0 0 0 1px rgba(255, 255, 255, 0.1);
-  position: relative;
-  z-index: @layer-cards;
-}
+// .horizontal-card {
+//   height: @card-width;
+//   width: @card-height;
+//   padding: 0px;
+//   border-radius: 4px;
+//   box-shadow: 0 0 12px rgba(0, 0, 0, 0.4), inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+//   position: relative;
+//   z-index: @layer-cards;
+// }
 
 // .horizontal-card {
 //   img.kneeled {
@@ -467,7 +467,7 @@ h4 {
 //   width: @card-height;
 // }
 
-.card-row .horizontal-card {
+.card-row .card.horizontal {
     margin-bottom: @card-height - @card-width;
 }
 
@@ -492,23 +492,31 @@ h4 {
 .card {
   // display: inline-block;
   position: relative;
-  height: @card-height;
-  width: @card-width;
   border-radius: 4px;
   box-shadow: 0 0 12px rgba(0,0,0,0.4), inset 0 0 0 1px rgba(255,255,255,0.1);
   overflow: hidden;
   z-index: @layer-cards;
+
+  &.vertical {
+    height: @card-height;
+    width: @card-width;
+  }
+
+  &.horizontal {
+    height: @card-width;
+    width: @card-height;
+  }
 }
 
-.card.selected, .horizontal-card.selected {
+.card.selected {
   box-shadow: 0 0 1px 4px @brand-primary;
 }
 
-.card.new, .horizontal-card.new {
+.card.new {
   // box-shadow: 0 0 1px 2px @brand-info;
 }
 
-.card.controlled, .horizontal-card.controlled {
+.card.controlled {
   box-shadow: 0 0 1px 2px #d0d834;
 }
 

--- a/less/site.less
+++ b/less/site.less
@@ -12,9 +12,9 @@
 // Z-index layers
 @layer-cards: 10;
 @layer-pile-header: 20;
-@layer-card-menu: 20;
 @layer-card-collection: 100;
 @layer-prompt: 110;
+@layer-card-menu: 120;
 @layer-top: 9999;
 
 @font-face {

--- a/less/site.less
+++ b/less/site.less
@@ -10,7 +10,6 @@
 // Z-index layers
 @layer-cards: 1;
 @layer-pile-header: 2;
-@layer-card-collection-draw: 15;
 @layer-card-menu: 20;
 @layer-card-collection: 100;
 @layer-prompt: 110;
@@ -676,7 +675,6 @@ h4 {
     bottom: 85px;
     width: 590px;
     min-height: 92px;
-    z-index: @layer-card-collection-draw;
 
     .card {
       float: left;

--- a/less/site.less
+++ b/less/site.less
@@ -582,6 +582,19 @@ h4 {
 
 .generate-attachments(5, 1);
 
+.card-dupe {
+  margin-bottom: @attachment-offset;
+  margin-top: -(@attachment-offset + @card-height);
+}
+
+.generate-card-dupes(@n, @i: 1) when (@i =< @n) {
+  .card-dupe-@{i} {
+    z-index: @layer-cards - @i;
+  }
+  .generate-card-dupes(@n, (@i + 1));
+}
+.generate-card-dupes(5, 1);
+
 .player-board {
   .card-wrapper {
     margin-right: 10px;

--- a/less/site.less
+++ b/less/site.less
@@ -275,11 +275,6 @@ h3 {
   width: 100%;
 }
 
-// .plot-popup > .plot-card > img {
-//   width: initial;
-//   height: 100%;
-// }
-
 .discard, .draw, .faction, .agenda {
   position: relative;
   width: @card-width;
@@ -344,10 +339,6 @@ h4 {
 .our-side > div:first-child {
   margin-top: auto;
 }
-
-// .plot-card.selected {
-//   box-shadow: 0 0 1px 2px @brand-primary;
-// }
 
 .discard-plot {
   height: 110px;
@@ -417,7 +408,6 @@ h4 {
   }
 
   .card {
-    // float: left;
     margin: 2px;
   }
 }
@@ -441,32 +431,6 @@ h4 {
   width: @card-height;
 }
 
-// .horizontal-card {
-//   height: @card-width;
-//   width: @card-height;
-//   padding: 0px;
-//   border-radius: 4px;
-//   box-shadow: 0 0 12px rgba(0, 0, 0, 0.4), inset 0 0 0 1px rgba(255, 255, 255, 0.1);
-//   position: relative;
-//   z-index: @layer-cards;
-// }
-
-// .horizontal-card {
-//   img.kneeled {
-//     position: absolute;
-//     transform: rotate(90deg);
-//     left: 9px;
-//     top: -10px;
-//     width: @card-width;
-//     height: @card-height;
-//   }
-// }
-
-// .horizontal-card > img.horizontal {
-//   height: @card-width;
-//   width: @card-height;
-// }
-
 .card-row .card.horizontal {
     margin-bottom: @card-height - @card-width;
 }
@@ -483,14 +447,11 @@ h4 {
 }
 
 .card-wrapper {
-  // display: inline-block;
   margin: 0px 4px 0px 0px;
-  // position: relative;
   vertical-align: middle;
 }
 
 .card {
-  // display: inline-block;
   position: relative;
   border-radius: 4px;
   box-shadow: 0 0 12px rgba(0,0,0,0.4), inset 0 0 0 1px rgba(255,255,255,0.1);
@@ -513,7 +474,7 @@ h4 {
 }
 
 .card.new {
-  // box-shadow: 0 0 1px 2px @brand-info;
+  box-shadow: 0 0 1px 2px @brand-info;
 }
 
 .card.controlled {
@@ -542,15 +503,7 @@ h4 {
   }
 }
 
-// .card > * > img {
-//   position: absolute;
-//   top: 0px;
-//   left: 0px;
-// }
-
 .card-name {
-  // display: none;
-  // // float: left;
   font-size: 10px;
   line-height: 14px;
 }
@@ -558,21 +511,6 @@ h4 {
 .squish .card {
   position: absolute;
 }
-
-// .plot-card {
-//   // img {
-//   //   position: absolute;
-//   //   top: 0;
-//   //   left: 0;
-//   // }
-//
-//   display: inline-block;
-//   position: relative;
-//   height: @card-width;
-//   width: @card-height;
-//   border-radius: 4px;
-//   box-shadow: 0 0 12px rgba(0,0,0,0.4), inset 0 0 0 1px rgba(255,255,255,0.1);
-// }
 
 .shadow {
   box-shadow: 0 0 12px rgba(0,0,0,0.4), inset 0 0 0 1px rgba(255,255,255,0.1);
@@ -628,13 +566,8 @@ h4 {
 }
 
 .attachment {
-  // height: @card-height;
-  // width: @card-width;
-  // position: absolute;
-  // left: 0;
   margin-top: @attachment-offset - @card-height;
 }
-
 
 .generate-attachments(@n, @i: 1) when (@i =< @n) {
   .attachment-@{i} {
@@ -644,10 +577,6 @@ h4 {
 }
 
 .generate-attachments(5, 1);
-
-// .attachment > div {
-//   float: left;
-// }
 
 .player-board {
   .card-wrapper {
@@ -736,7 +665,6 @@ h4 {
     min-height: 92px;
 
     .card {
-      // float: left;
       margin: 2px;
     }
   }

--- a/less/site.less
+++ b/less/site.less
@@ -7,8 +7,10 @@
 @card-width: 64px;
 @card-height: 84px;
 
+@attachment-offset: 10px;
+
 // Z-index layers
-@layer-cards: 1;
+@layer-cards: 10;
 @layer-pile-header: 2;
 @layer-card-menu: 20;
 @layer-card-collection: 100;
@@ -415,7 +417,7 @@ h4 {
   }
 
   .card {
-    float: left;
+    // float: left;
     margin: 2px;
   }
 }
@@ -445,6 +447,7 @@ h4 {
   padding: 0px;
   border-radius: 4px;
   box-shadow: 0 0 12px rgba(0, 0, 0, 0.4), inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+  position: relative;
 }
 
 .horizontal-card {
@@ -463,25 +466,36 @@ h4 {
   width: @card-height;
 }
 
+.card-row .horizontal-card {
+    margin-bottom: @card-height - @card-width;
+}
+
 .plot-group {
   >.plot {
     margin-bottom: 5px;
   }
 }
 
+.card-row, .hand {
+  display: flex;
+  justify-content: flex-start;
+}
+
 .card-wrapper {
-  display: inline-block;
+  // display: inline-block;
   margin: 0px 4px 0px 0px;
+  // position: relative;
   vertical-align: middle;
 }
 
 .card {
-  display: inline-block;
+  // display: inline-block;
   position: relative;
   height: @card-height;
   width: @card-width;
   border-radius: 4px;
   box-shadow: 0 0 12px rgba(0,0,0,0.4), inset 0 0 0 1px rgba(255,255,255,0.1);
+  z-index: @layer-cards;
 }
 
 .card.selected, .horizontal-card.selected {
@@ -489,7 +503,7 @@ h4 {
 }
 
 .card.new, .horizontal-card.new {
-  box-shadow: 0 0 1px 2px @brand-info;
+  // box-shadow: 0 0 1px 2px @brand-info;
 }
 
 .card.controlled, .horizontal-card.controlled {
@@ -503,12 +517,13 @@ h4 {
 }
 
 .card-name {
-  float: left;
+  // display: none;
+  // // float: left;
   font-size: 10px;
   line-height: 14px;
 }
 
-.squish .card-wrapper {
+.squish .card {
   position: absolute;
 }
 
@@ -581,20 +596,32 @@ h4 {
 }
 
 .attachment {
-  height: @card-height;
-  width: auto;
-  position: absolute;
-  left: 0;
+  // height: @card-height;
+  // width: @card-width;
+  // position: absolute;
+  // left: 0;
+  margin-top: @attachment-offset - @card-height;
 }
+
+
+.generate-attachments(@n, @i: 1) when (@i =< @n) {
+  .attachment-@{i} {
+    z-index: @layer-cards - @i;
+  }
+  .generate-attachments(@n, (@i + 1));
+}
+
+.generate-attachments(5, 1);
+
 
 .card-frame {
-  position: relative;
-  z-index: @layer-cards;
+  // position: relative;
+  // z-index: @layer-cards;
 }
 
-.attachment > div {
-  float: left;
-}
+// .attachment > div {
+//   float: left;
+// }
 
 .player-board {
   .card-wrapper {
@@ -613,6 +640,7 @@ h4 {
   display: flex;
   flex-direction: column;
   align-items: center;
+  z-index: @layer-cards + 1;
 }
 
 .ignore-mouse-events {
@@ -666,6 +694,11 @@ h4 {
 
 .popup {
   z-index: @layer-card-collection;
+
+  .inner {
+    display: flex;
+    flex-wrap: wrap;
+  }
 }
 
 .draw {
@@ -677,7 +710,7 @@ h4 {
     min-height: 92px;
 
     .card {
-      float: left;
+      // float: left;
       margin: 2px;
     }
   }


### PR DESCRIPTION
* Previously when a card had multiple attachments, the attachments could overlap with a location card below it. Now the row grows as more attachments are added.
![screen shot 2016-12-15 at 10 39 20 am](https://cloud.githubusercontent.com/assets/145077/21237546/4da14f12-c2b4-11e6-9ce2-20017a92246f.png) ![screen shot 2016-12-15 at 10 30 39 am](https://cloud.githubusercontent.com/assets/145077/21237571/68d3bb30-c2b4-11e6-9b9c-c1bc7298dc2b.png)
* Previously card menus would pop up underneath cards next to then. Now the menu properly appears above cards and other UI elements.
![screen shot 2016-12-15 at 10 53 41 am](https://cloud.githubusercontent.com/assets/145077/21237666/ccd327f6-c2b4-11e6-891b-f4c911676405.png)
* Removes a few of the special case CSS classes such as `.horizontal-card` and `.plot-card` in favor of using `.card` and adding modifiers (`.horizontal`, `.vertical`)
* Pulls out z-indexes into constants so that it's easier to see what the hierarchy is (not full proof due to how stacking contexts work but should make things more understandable)
* Removes manual style positioning of attachments and facedown duplicates in favor of CSS classes. Currently the classes are limited to 5 attachments on the same card, but can be increased by changing a single number in the LESS.
* Converts most positioning to use flexbox, removing a bunch of floats and absolute positioning.

Fixes #144.