### PR TITLE
Pass cards to play-related methods and events instead of IDs

### DIFF
--- a/server/game/cards/attachments/04/redgodsblessing.js
+++ b/server/game/cards/attachments/04/redgodsblessing.js
@@ -34,13 +34,8 @@ class RedGodsBlessing extends DrawCard {
         this.parent.strengthModifier -= this.getNumberOfCardsWithRhllor();
     }
 
-    onCardPlayed(event, player, cardId) {
+    onCardPlayed(event, player, card) {
         if(!this.inPlay || this.controller !== player) {
-            return;
-        }
-
-        var card = player.findCardInPlayByUuid(cardId);
-        if(!card) {
             return;
         }
 

--- a/server/game/cards/characters/01/direwolfpup.js
+++ b/server/game/cards/characters/01/direwolfpup.js
@@ -23,13 +23,8 @@ class DirewolfPup extends DrawCard {
         this.calculateStrength();
     }
 
-    onCardPlayed(e, player, cardId) {
+    onCardPlayed(e, player) {
         if(!this.inPlay || this.controller !== player) {
-            return;
-        }
-
-        var card = player.findCardInPlayByUuid(cardId);
-        if(!card) {
             return;
         }
 

--- a/server/game/cards/locations/01/greatkraken.js
+++ b/server/game/cards/locations/01/greatkraken.js
@@ -30,13 +30,8 @@ class GreatKraken extends DrawCard {
         });
     }
 
-    onCardPlayed(event, player, cardId) {
+    onCardPlayed(event, player, card) {
         if(!this.inPlay || this.controller !== player) {
-            return;
-        }
-
-        var card = player.findCardInPlayByUuid(cardId);
-        if(!card) {
             return;
         }
 

--- a/server/game/cards/locations/01/thewall.js
+++ b/server/game/cards/locations/01/thewall.js
@@ -17,13 +17,8 @@ class TheWall extends DrawCard {
         });
     }
 
-    onCardPlayed(e, player, cardId) {
+    onCardPlayed(e, player, card) {
         if(!this.inPlay || this.controller !== player) {
-            return;
-        }
-
-        var card = player.findCardInPlayByUuid(cardId);
-        if(!card) {
             return;
         }
 

--- a/server/game/cards/locations/03/winterfell.js
+++ b/server/game/cards/locations/03/winterfell.js
@@ -17,13 +17,8 @@ class Winterfell extends DrawCard {
         });
     }
 
-    onCardPlayed(e, player, cardId) {
+    onCardPlayed(e, player, card) {
         if(!this.inPlay || this.controller !== player) {
-            return;
-        }
-
-        var card = player.findCardInPlayByUuid(cardId);
-        if(!card) {
             return;
         }
 

--- a/server/game/cards/plots/01/marchingorders.js
+++ b/server/game/cards/plots/01/marchingorders.js
@@ -1,15 +1,9 @@
 const PlotCard = require('../../../plotcard.js');
 
 class MarchingOrders extends PlotCard {
-    canPlay(player, cardId) {
-        if(!this.inPlay || this.controller !== player) {
+    canPlay(player, card) {
+        if(!this.inPlay || this.controller !== player || this.controller !== card.controller) {
             return true;
-        }
-
-        var card = player.findCardByUuid(player.hand, cardId);
-
-        if(!card) {
-            return false;
         }
 
         if(card.getType() === 'location' || card.getType() === 'attachment' || card.getType() === 'event') {

--- a/server/game/cards/plots/01/reinforcement.js
+++ b/server/game/cards/plots/01/reinforcement.js
@@ -33,7 +33,7 @@ class Reinforcements extends PlotCard {
 
         this.game.addMessage('{0} uses {1} to put {2} into play from their {3}', player, this, card, hand ? 'hand' : 'discard pile');
 
-        player.playCard(card.uuid, true, hand ? player.hand : player.discardPile);
+        player.playCard(card, true);
 
         return true;
     }

--- a/server/game/cards/plots/02/heretoserve.js
+++ b/server/game/cards/plots/02/heretoserve.js
@@ -40,7 +40,7 @@ class HereToServe extends PlotCard {
 
         this.game.addMessage('{0} uses {1} to put {2} into play', player, this, card);
 
-        player.playCard(card.uuid, true, player.drawDeck);
+        player.playCard(card, true);
 
         return true;
     }

--- a/server/game/cards/plots/03/asongofsummer.js
+++ b/server/game/cards/plots/03/asongofsummer.js
@@ -37,13 +37,8 @@ class ASongOfSummer extends PlotCard {
         }
     }
 
-    onCardPlayed(e, player, cardId) {
+    onCardPlayed(e, player, card) {
         if(!this.inPlay || this.owner !== player) {
-            return;
-        }
-
-        var card = player.findCardInPlayByUuid(cardId);
-        if(!card) {
             return;
         }
 

--- a/server/game/cards/plots/03/atimeforwolves.js
+++ b/server/game/cards/plots/03/atimeforwolves.js
@@ -80,7 +80,7 @@ class ATimeForWolves extends PlotCard {
         }
 
         this.game.addMessage('{0} uses {1} to reveal {2} and put it in play', player, this, this.revealedCard);
-        player.playCard(this.revealedCard.uuid, true, player.hand);
+        player.playCard(this.revealedCard, true);
         this.revealedCard = null;
 
         return true;

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -161,14 +161,14 @@ class Game extends EventEmitter {
             return;
         }
 
-        var card = player.findCardByUuid(player.hand, cardId);
+        var card = player.findCardByUuid(sourceList, cardId);
 
         if(card && !isDrop && this.pipeline.handleCardClicked(player, card)) {
             this.pipeline.continue();
             return;
         }
 
-        if(!player.playCard(cardId, isDrop, sourceList)) {
+        if(!player.playCard(card, isDrop)) {
             return;
         }
 
@@ -217,7 +217,7 @@ class Game extends EventEmitter {
 
         switch(source) {
             case 'hand':
-                this.playCard(player.name, cardId);
+                this.playCard(player.name, cardId, false, player.hand);
                 return;
             case 'plot deck':
                 this.selectPlot(player, cardId);

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -172,7 +172,7 @@ class Game extends EventEmitter {
             return;
         }
 
-        this.raiseEvent('onCardPlayed', player, cardId);
+        this.raiseEvent('onCardPlayed', player, card);
         this.pipeline.continue();
     }
 

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -168,15 +168,6 @@ class Game extends EventEmitter {
             return;
         }
 
-        if(player.activePlot && !player.activePlot.canPlay(player, cardId)) {
-            return;
-        }
-
-        var otherPlayer = this.getOtherPlayer(player);
-        if(otherPlayer && otherPlayer.activePlot && !otherPlayer.activePlot.canPlay(player, cardId)) {
-            return;
-        }
-
         if(!player.playCard(cardId, isDrop, sourceList)) {
             return;
         }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -351,26 +351,15 @@ class Player extends Spectator {
     }
 
     canPlayCard(card) {
-        var canPlay = true;
-
         if(this.activePlot && !this.activePlot.canPlay(this, card)) {
             return false;
         }
 
-        this.cardsInPlay.each(c => {
-            canPlay = c.canPlay(this, card);
-
-            if(!canPlay) {
-                return;
-            }
-        });
-
-        if(!canPlay) {
+        if(!this.cardsInPlay.all(c => c.canPlay(this, card))) {
             return false;
         }
 
-        canPlay = card.canPlay(this, card);
-        if(!canPlay) {
+        if(!card.canPlay(this, card)) {
             return false;
         }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -353,6 +353,10 @@ class Player extends Spectator {
     canPlayCard(card) {
         var canPlay = true;
 
+        if(this.activePlot && !this.activePlot.canPlay(this, card)) {
+            return false;
+        }
+
         this.cardsInPlay.each(c => {
             canPlay = c.canPlay(this, card);
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -403,13 +403,7 @@ class Player extends Spectator {
         return true;
     }
 
-    playCard(cardId, forcePlay, sourceList) {
-        if(!sourceList) {
-            sourceList = this.hand;
-        }
-
-        var card = this.findCardByUuid(sourceList, cardId);
-
+    playCard(card, forcePlay) {
         if(!card) {
             return false;
         }

--- a/test/server/player/canplaycard.spec.js
+++ b/test/server/player/canplaycard.spec.js
@@ -1,6 +1,7 @@
 /* global describe, it, beforeEach, expect, jasmine, spyOn */
 /* eslint camelcase: 0, no-invalid-this: 0 */
 
+const _ = require('underscore');
 const Player = require('../../../server/game/player.js');
 
 describe('Player', function () {
@@ -10,18 +11,17 @@ describe('Player', function () {
 
             this.gameSpy = jasmine.createSpyObj('game', ['drop']);
             this.cardSpy = jasmine.createSpyObj('card', ['getType', 'getCost', 'isLimited', 'isUnique', 'canPlay']);
-            this.isCardUuidInListSpy = spyOn(this.player, 'isCardUuidInList');
-            this.isCardNameInListSpy = spyOn(this.player, 'isCardNameInList');
-            this.dupeSpy = spyOn(this.player, 'getDuplicateInPlay');
+            this.cardSpy.uuid = '1111';
+            this.cardSpy.name = 'Test Card';
 
-            this.isCardUuidInListSpy.and.returnValue(true);
-            this.isCardNameInListSpy.and.returnValue(false);
+            this.dupeSpy = spyOn(this.player, 'getDuplicateInPlay');
             this.dupeSpy.and.returnValue(undefined);
 
             this.cardSpy.canPlay.and.returnValue(true);
 
             this.player.initialise();
             this.player.phase = 'marshal';
+            this.player.hand = _([this.cardSpy]);
         });
 
         describe('when not setup or marshal phase', function() {
@@ -38,7 +38,7 @@ describe('Player', function () {
 
         describe('when card is not in hand', function() {
             beforeEach(function() {
-                this.isCardUuidInListSpy.and.returnValue(false);
+                this.player.hand = _([]);
 
                 this.canPlay = this.player.canPlayCard(this.cardSpy);
             });
@@ -119,10 +119,6 @@ describe('Player', function () {
             it('should return true', function() {
                 expect(this.canPlay).toBe(true);
             });
-
-            it('should not check the dead pile', function() {
-                expect(this.isCardNameInListSpy).not.toHaveBeenCalled();
-            });
         });
 
         describe('when a card is a character', function() {
@@ -136,10 +132,6 @@ describe('Player', function () {
                 it('should return true', function() {
                     expect(this.canPlay).toBe(true);
                 });
-
-                it('should not check the dead pile', function() {
-                    expect(this.isCardNameInListSpy).not.toHaveBeenCalled();
-                });
             });
 
             describe('that is unique', function() {
@@ -149,7 +141,7 @@ describe('Player', function () {
 
                 describe('and is in the dead pile', function() {
                     beforeEach(function() {
-                        this.isCardNameInListSpy.and.returnValue(true);
+                        this.player.deadPile = _([{ name: this.cardSpy.name }]);
 
                         this.canPlay = this.player.canPlayCard(this.cardSpy);
                     });

--- a/test/server/player/playcard.spec.js
+++ b/test/server/player/playcard.spec.js
@@ -14,7 +14,6 @@ describe('Player', function() {
         beforeEach(function() {
             this.canPlaySpy = spyOn(this.player, 'canPlayCard');
             this.cardSpy = jasmine.createSpyObj('card', ['getType', 'getCost', 'isUnique', 'isLimited', 'play']);
-            this.cardSpy.uuid = '1111';
             this.dupeCardSpy = jasmine.createSpyObj('dupecard', ['addDuplicate']);
 
             this.canPlaySpy.and.returnValue(true);
@@ -22,10 +21,10 @@ describe('Player', function() {
             this.cardSpy.location = 'hand';
         });
 
-        describe('when card is not in hand to play', function() {
+        describe('when card is undefined', function() {
             beforeEach(function() {
                 this.player.hand.pop();
-                this.canPlay = this.player.playCard('not found');
+                this.canPlay = this.player.playCard(undefined);
             });
 
             it('should return false', function() {
@@ -44,7 +43,7 @@ describe('Player', function() {
 
             describe('and not forcing play', function() {
                 beforeEach(function() {
-                    this.canPlay = this.player.playCard(this.cardSpy.uuid, false);
+                    this.canPlay = this.player.playCard(this.cardSpy, false);
                 });
 
                 it('should return false', function() {
@@ -58,7 +57,7 @@ describe('Player', function() {
 
             describe('and forcing play', function() {
                 beforeEach(function() {
-                    this.canPlay = this.player.playCard(this.cardSpy.uuid, true);
+                    this.canPlay = this.player.playCard(this.cardSpy, true);
                 });
 
                 it('should return true', function() {
@@ -80,7 +79,7 @@ describe('Player', function() {
 
             describe('and there is no duplicate out', function() {
                 beforeEach(function() {
-                    this.canPlay = this.player.playCard(this.cardSpy.uuid);
+                    this.canPlay = this.player.playCard(this.cardSpy);
                 });
 
                 it('should return true', function() {
@@ -99,7 +98,7 @@ describe('Player', function() {
             describe('and there is a duplicate out', function() {
                 beforeEach(function() {
                     spyOn(this.player, 'getDuplicateInPlay').and.returnValue(this.dupeCardSpy);
-                    this.canPlay = this.player.playCard(this.cardSpy.uuid);
+                    this.canPlay = this.player.playCard(this.cardSpy);
                 });
 
                 it('should return true', function() {
@@ -133,7 +132,7 @@ describe('Player', function() {
                 beforeEach(function() {
                     this.player.phase = 'setup';
 
-                    this.canPlay = this.player.playCard(this.cardSpy.uuid);
+                    this.canPlay = this.player.playCard(this.cardSpy);
                 });
 
                 it('should return true', function() {
@@ -152,7 +151,7 @@ describe('Player', function() {
 
             describe('and this is not the setup phase', function() {
                 beforeEach(function() {
-                    this.canPlay = this.player.playCard(this.cardSpy.uuid);
+                    this.canPlay = this.player.playCard(this.cardSpy);
                 });
 
                 it('should return true', function() {
@@ -172,7 +171,7 @@ describe('Player', function() {
         describe('when card is limited and not forcing play', function() {
             beforeEach(function() {
                 this.cardSpy.isLimited.and.returnValue(true);
-                this.canPlay = this.player.playCard(this.cardSpy.uuid);
+                this.canPlay = this.player.playCard(this.cardSpy);
             });
 
             it('should set the limited played flag', function() {
@@ -183,7 +182,7 @@ describe('Player', function() {
         describe('when card is limited and forcing play', function() {
             beforeEach(function() {
                 this.cardSpy.isLimited.and.returnValue(true);
-                this.canPlay = this.player.playCard(this.cardSpy.uuid, true);
+                this.canPlay = this.player.playCard(this.cardSpy, true);
             });
 
             it('should not set the limited played flag', function() {


### PR DESCRIPTION
Slight improvements to playCard and related events.
* Passes a card object directly into Player.playCard
* Gets rid of sourceList on Player.playCard
* Sends full card in the onCardPlayed event and removes all of the card lookups in those implementations.
* Removes (for now) checking with opponent cards on whether or not the player can play a card. There currently aren't any opponent cards that restrict what you can marshal / play.

Should result in no functionality changes, just slight refactoring.