### PR TITLE
Handle plot menu for current player

### DIFF
--- a/client/GameBoard.jsx
+++ b/client/GameBoard.jsx
@@ -290,7 +290,7 @@ export class InnerGameBoard extends React.Component {
                                     <CardCollection className='plot' title='Used Plots' source='revealed plots' cards={otherPlayer ? otherPlayer.plotDiscard : []}
                                                     topCard={otherPlayer ? otherPlayer.activePlot : undefined} onMouseOver={this.onMouseOver} onMouseOut={this.onMouseOut} />
                                     <CardCollection className='plot' title='Used Plots' source='revealed plots' cards={thisPlayer.plotDiscard} topCard={thisPlayer.activePlot}
-                                                    onMouseOver={this.onMouseOver} onMouseOut={this.onMouseOut} />
+                                                    onMouseOver={this.onMouseOver} onMouseOut={this.onMouseOut} onMenuItemClick={this.onMenuItemClick} />
                                 </div>
                             </div>
 

--- a/client/GameComponents/Card.jsx
+++ b/client/GameComponents/Card.jsx
@@ -53,6 +53,7 @@ class Card extends React.Component {
     onMenuItemClick(menuItem) {
         if(this.props.onMenuItemClick) {
             this.props.onMenuItemClick(this.props.source, this.props.card, menuItem);
+            this.setState({showMenu: !this.state.showMenu});
         }
     }
 

--- a/client/GameComponents/Card.jsx
+++ b/client/GameComponents/Card.jsx
@@ -32,7 +32,7 @@ class Card extends React.Component {
     }
 
     isAllowedMenuSource() {
-        return this.props.source === 'play area' || this.props.source === 'agenda';
+        return this.props.source === 'play area' || this.props.source === 'agenda' || this.props.source === 'revealed plots';
     }
 
     onClick(event, card, source) {

--- a/server/game/cards/plots/01/powerbehindthethrone.js
+++ b/server/game/cards/plots/01/powerbehindthethrone.js
@@ -20,6 +20,10 @@ class PowerBehindTheThrone extends PlotCard {
     }
 
     discardToken(player) {
+        if(!this.hasToken('stand')) {
+            return;
+        }
+
         this.game.promptForSelect(player, {
             activePromptTitle: 'Select a character to stand',
             waitingPromptTitle: 'Waiting for opponent to use ' + this.name,

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -277,6 +277,9 @@ class Game extends EventEmitter {
         }
 
         switch(source) {
+            case 'revealed plots':
+                this.callCardMenuCommand(player.activePlot, player, menuItem);
+                break;
             case 'agenda':
                 this.callCardMenuCommand(player.agenda, player, menuItem);
                 break;


### PR DESCRIPTION
* Allows the card menu to be triggered for the active plot.
* Automatically close menus once you've clicked a menu item.
* Fix bug with Power Behind the Throne that allowed it to be used multiple times.