### PR TITLE
Default prompt buttons to the 'menuButton' command

### DIFF
--- a/server/game/cards/agendas/therainsofcastamere.js
+++ b/server/game/cards/agendas/therainsofcastamere.js
@@ -49,10 +49,10 @@ class TheRainsOfCastamere extends AgendaCard {
 
     menuButtons() {
         var buttons = _.map(this.schemes, scheme => {
-            return { text: scheme.name, command: 'menuButton', method: 'revealScheme', arg: scheme.uuid, card: scheme.getSummary(true) };
+            return { text: scheme.name, method: 'revealScheme', arg: scheme.uuid, card: scheme.getSummary(true) };
         });
 
-        buttons.push({ text: 'Done', command: 'menuButton', method: 'cancelScheme' });
+        buttons.push({ text: 'Done', method: 'cancelScheme' });
         return buttons;
     }
 

--- a/server/game/cards/attachments/01/bodyguard.js
+++ b/server/game/cards/attachments/01/bodyguard.js
@@ -24,8 +24,8 @@ class BodyGuard extends DrawCard {
             activePrompt: {
                 menuTitle: 'Use ' + this.name + ' to save ' + card.name + '?',
                 buttons: [
-                    { text: 'Yes', command: 'menuButton', method: 'save' },
-                    { text: 'No', command: 'menuButton', method: 'cancel' }
+                    { text: 'Yes', method: 'save' },
+                    { text: 'No', method: 'cancel' }
                 ]
             },
             waitingPromptTitle: 'Waiting for opponent to use save effects'

--- a/server/game/cards/characters/01/euroncrowseye.js
+++ b/server/game/cards/characters/01/euroncrowseye.js
@@ -19,8 +19,8 @@ class EuronCrowsEye extends DrawCard {
             activePrompt: {
                 menuTitle: 'Trigger ' + this.name + '?',
                 buttons: [
-                    { text: 'Yes', command: 'menuButton', method: 'trigger' },
-                    { text: 'No', command: 'menuButton', method: 'cancel' }
+                    { text: 'Yes', method: 'trigger' },
+                    { text: 'No', method: 'cancel' }
                 ]
             },
             waitingPromptTitle: 'Waiting for opponent to use ' + this.name

--- a/server/game/cards/characters/01/greenbloodtrader.js
+++ b/server/game/cards/characters/01/greenbloodtrader.js
@@ -14,8 +14,8 @@ class GreenbloodTrader extends DrawCard {
             activePrompt: {
                 menuTitle: 'Trigger ' + this.name + '?',
                 buttons: [
-                    { text: 'Look at top 2 cards', command: 'menuButton', method: 'trigger' },
-                    { text: 'Cancel', command: 'menuButton', method: 'cancel' }
+                    { text: 'Look at top 2 cards', method: 'trigger' },
+                    { text: 'Cancel', method: 'cancel' }
                 ]
             },
             waitingPromptTitle: 'Waiting for opponent to use ' + this.name
@@ -30,10 +30,10 @@ class GreenbloodTrader extends DrawCard {
         this.top2Cards = player.drawDeck.first(2);
 
         var buttons = _.map(this.top2Cards, card => {
-            return { text: card.name, command: 'menuButton', method: 'cardSelected', arg: card.uuid, card: card.getSummary(true) };
+            return { text: card.name, method: 'cardSelected', arg: card.uuid, card: card.getSummary(true) };
         });
 
-        buttons.push({ text: 'Continue', command: 'menuButton', method: 'continueWithoutSelecting' });
+        buttons.push({ text: 'Continue', method: 'continueWithoutSelecting' });
 
         this.game.promptWithMenu(player, this, {
             activePrompt: {
@@ -97,10 +97,10 @@ class GreenbloodTrader extends DrawCard {
 
     continueWithoutSelecting(player) {
         var buttons = _.map(this.top2Cards, card => {
-            return { text: card.name, command: 'menuButton', method: 'moveToBottom', arg: card.uuid, card: card.getSummary(true) };
+            return { text: card.name, method: 'moveToBottom', arg: card.uuid, card: card.getSummary(true) };
         });
 
-        buttons.push({ text: 'Cancel', command: 'menuButton', method: 'cancel' });
+        buttons.push({ text: 'Cancel', method: 'cancel' });
 
         this.game.promptWithMenu(player, this, {
             activePrompt: {

--- a/server/game/cards/characters/01/littlefinger.js
+++ b/server/game/cards/characters/01/littlefinger.js
@@ -12,8 +12,8 @@ class LittleFinger extends DrawCard {
             activePrompt: {
                 menuTitle: 'Trigger ' + this.name + '?',
                 buttons: [
-                    { text: 'Draw 2 Cards', command: 'menuButton', method: 'trigger' },
-                    { text: 'Cancel', command: 'menuButton', method: 'cancel' }
+                    { text: 'Draw 2 Cards', method: 'trigger' },
+                    { text: 'Cancel', method: 'cancel' }
                 ]
             },
             waitingPromptTitle: 'Waiting for opponent to use ' + this.name

--- a/server/game/cards/characters/01/maestercressen.js
+++ b/server/game/cards/characters/01/maestercressen.js
@@ -12,8 +12,8 @@ class MaesterCressen extends DrawCard {
             activePrompt: {
                 menuTitle: 'Trigger ' + this.name + '?',
                 buttons: [
-                    { text: 'Kneel and Discard', command: 'menuButton', method: 'kneel' },
-                    { text: 'Cancel', command: 'menuButton', method: 'cancel' }
+                    { text: 'Kneel and Discard', method: 'kneel' },
+                    { text: 'Cancel', method: 'cancel' }
                 ]
             },
             waitingPromptTitle: 'Waiting for opponent to use ' + this.name

--- a/server/game/cards/characters/03/catelynstark.js
+++ b/server/game/cards/characters/03/catelynstark.js
@@ -39,8 +39,8 @@ class CatelynStark extends DrawCard {
                 activePrompt: {
                     menuTitle: 'Gain 1 power on ' + this.name + '?',
                     buttons: [
-                        { text: 'Yes', command: 'menuButton', method: 'gainPower' },
-                        { text: 'No', command: 'menuButton', method: 'cancel' }
+                        { text: 'Yes', method: 'gainPower' },
+                        { text: 'No', method: 'cancel' }
                     ]
                 },
                 waitingPromptTitle: 'Waiting for opponent to use ' + this.name

--- a/server/game/cards/events/01/seeninflames.js
+++ b/server/game/cards/events/01/seeninflames.js
@@ -26,10 +26,10 @@ class SeenInFlames extends DrawCard {
         }
 
         var buttons = otherPlayer.hand.map(card => {
-            return { text: card.name, command: 'menuButton', method: 'cardSelected', arg: card.uuid, card: card.getSummary(true) };
+            return { text: card.name, method: 'cardSelected', arg: card.uuid, card: card.getSummary(true) };
         });
 
-        buttons.push({ text: 'Cancel', command: 'menuButton', method: 'cancel' });
+        buttons.push({ text: 'Cancel', method: 'cancel' });
 
         this.game.promptWithMenu(player, this, {
             activePrompt: {

--- a/server/game/cards/locations/01/chamberofthepaintedtable.js
+++ b/server/game/cards/locations/01/chamberofthepaintedtable.js
@@ -16,8 +16,8 @@ class ChamberOfThePaintedTable extends DrawCard {
             activePrompt: {
                 menuTitle: 'Kneel ' + this.name + '?',
                 buttons: [
-                    { text: 'Yes', command: 'menuButton', method: 'gainPower' },
-                    { text: 'No', command: 'menuButton', method: 'cancel' }
+                    { text: 'Yes', method: 'gainPower' },
+                    { text: 'No', method: 'cancel' }
                 ]
             },
             waitingPromptTitle: 'Waiting for opponent to perform reactions'

--- a/server/game/cards/locations/01/greatkraken.js
+++ b/server/game/cards/locations/01/greatkraken.js
@@ -21,9 +21,9 @@ class GreatKraken extends DrawCard {
             activePrompt: {
                 menuTitle: 'Trigger ' + this.name + '?',
                 buttons: [
-                    { text: 'Draw 1 card', command: 'menuButton', method: 'drawCard' },
-                    { text: 'Gain 1 power', command: 'menuButton', method: 'gainPower' },
-                    { text: 'No', command: 'menuButton', method: 'cancel' }
+                    { text: 'Draw 1 card', method: 'drawCard' },
+                    { text: 'Gain 1 power', method: 'gainPower' },
+                    { text: 'No', method: 'cancel' }
                 ]
             },
             waitingPromptTitle: 'Waiting for opponent to perform reactions'

--- a/server/game/cards/locations/01/lannisport.js
+++ b/server/game/cards/locations/01/lannisport.js
@@ -24,8 +24,8 @@ class Lannisport extends DrawCard {
             activePrompt: {
                 menuTitle: 'Trigger ' + this.name + '?',
                 buttons: [
-                    { text: 'Draw 1 card', command: 'menuButton', method: 'drawCard' },
-                    { text: 'No', command: 'menuButton', method: 'cancel' }
+                    { text: 'Draw 1 card', method: 'drawCard' },
+                    { text: 'No', method: 'cancel' }
                 ]
             },
             waitingPromptTitle: 'Waiting for opponent to perform reactions'

--- a/server/game/cards/locations/01/theredkeep.js
+++ b/server/game/cards/locations/01/theredkeep.js
@@ -29,8 +29,8 @@ class TheRedKeep extends DrawCard {
                 activePrompt: {
                     menuTitle: 'Kneel ' + this.name + '?',
                     buttons: [
-                        { text: 'Yes', command: 'menuButton', method: 'drawTwo' },
-                        { text: 'No', command: 'menuButton', method: 'cancel' }
+                        { text: 'Yes', method: 'drawTwo' },
+                        { text: 'No', method: 'cancel' }
                     ]
                 },
                 waitingPromptTitle: 'Waiting for opponent to use ' + this.name

--- a/server/game/cards/locations/01/thewall.js
+++ b/server/game/cards/locations/01/thewall.js
@@ -48,8 +48,8 @@ class TheWall extends DrawCard {
             activePrompt: {
                 menuTitle: 'Kneel ' + this.name + '?',
                 buttons: [
-                    { text: 'Yes', command: 'menuButton', method: 'kneel' },
-                    { text: 'No', command: 'menuButton', method: 'cancel' }
+                    { text: 'Yes', method: 'kneel' },
+                    { text: 'No', method: 'cancel' }
                 ]
             },
             waitingPromptTitle: 'Waiting for opponent to use ' + this.name

--- a/server/game/cards/plots/01/buildingorders.js
+++ b/server/game/cards/plots/01/buildingorders.js
@@ -13,9 +13,9 @@ class BuildingOrders extends PlotCard {
         });
 
         var buttons = _.map(attachmentsAndLocations, card => {
-            return { text: card.name, command: 'menuButton', method: 'cardSelected', arg: card.uuid };
+            return { text: card.name, method: 'cardSelected', arg: card.uuid };
         });
-        buttons.push({ text: 'Done', command: 'menuButton', method: 'doneSelecting' });
+        buttons.push({ text: 'Done', method: 'doneSelecting' });
 
         this.game.promptWithMenu(player, this, {
             activePrompt: {

--- a/server/game/cards/plots/01/calmoverwesteros.js
+++ b/server/game/cards/plots/01/calmoverwesteros.js
@@ -10,10 +10,10 @@ class CalmOverWesteros extends PlotCard {
             activePrompt: {
                 menuTitle: 'Select a challenge type',
                 buttons: [
-                    { text: 'Military', command: 'menuButton', method: 'setChallengeType', arg: 'military' },
-                    { text: 'Intrigue', command: 'menuButton', method: 'setChallengeType', arg: 'intrigue' },
-                    { text: 'Power', command: 'menuButton', method: 'setChallengeType', arg: 'power' },
-                    { text: 'Cancel', command: 'menuButton', method: 'cancelChallengeSelect' }
+                    { text: 'Military', method: 'setChallengeType', arg: 'military' },
+                    { text: 'Intrigue', method: 'setChallengeType', arg: 'intrigue' },
+                    { text: 'Power', method: 'setChallengeType', arg: 'power' },
+                    { text: 'Cancel', method: 'cancelChallengeSelect' }
                 ]
             },
             waitingPromptTitle: 'Waiting for opponent to use ' + this.name

--- a/server/game/cards/plots/01/summons.js
+++ b/server/game/cards/plots/01/summons.js
@@ -13,9 +13,9 @@ class Summons extends PlotCard {
         });
 
         var buttons = _.map(characters, card => {
-            return { text: card.name, command: 'menuButton', method: 'cardSelected', arg: card.uuid };
+            return { text: card.name, method: 'cardSelected', arg: card.uuid };
         });
-        buttons.push({ text: 'Done', command: 'menuButton', method: 'doneSelecting' });
+        buttons.push({ text: 'Done', method: 'doneSelecting' });
 
         this.game.promptWithMenu(player, this, {
             activePrompt: {

--- a/server/game/cards/plots/02/heretoserve.js
+++ b/server/game/cards/plots/02/heretoserve.js
@@ -13,10 +13,10 @@ class HereToServe extends PlotCard {
         });
 
         var buttons = _.map(maesterCards, card => {
-            return { text: card.name, command: 'menuButton', method: 'cardSelected', arg: card.uuid, card: card.getSummary(true) };
+            return { text: card.name, method: 'cardSelected', arg: card.uuid, card: card.getSummary(true) };
         });
 
-        buttons.push({ text: 'Done', command: 'menuButton', method: 'doneSelecting' });
+        buttons.push({ text: 'Done', method: 'doneSelecting' });
 
         this.game.promptWithMenu(player, this, {
             activePrompt: {

--- a/server/game/cards/plots/02/riseofthekraken.js
+++ b/server/game/cards/plots/02/riseofthekraken.js
@@ -17,8 +17,8 @@ class RiseOfTheKraken extends PlotCard {
             activePrompt: {
                 menuTitle: 'Trigger ' + this.name + '?',
                 buttons: [
-                    { text: 'Yes', command: 'menuButton', method: 'gainPower' },
-                    { text: 'No', command: 'menuButton', method: 'cancel' }
+                    { text: 'Yes', method: 'gainPower' },
+                    { text: 'No', method: 'cancel' }
                 ]
             },
             waitingPromptTitle: 'Waiting for opponent to use ' + this.name

--- a/server/game/cards/plots/02/thelongplan.js
+++ b/server/game/cards/plots/02/thelongplan.js
@@ -24,8 +24,8 @@ class TheLongPlan extends PlotCard {
             activePrompt: {
                 menuTitle: 'Gain 1 gold from ' + this.name + '?',
                 buttons: [
-                    { text: 'Yes', command: 'menuButton', method: 'gainGold' },
-                    { text: 'No', command: 'menuButton', method: 'cancel' }
+                    { text: 'Yes', method: 'gainGold' },
+                    { text: 'No', method: 'cancel' }
                 ]
             },
             waitingPromptTitle: 'Waiting for opponent to use ' + this.name

--- a/server/game/cards/plots/03/atimeforwolves.js
+++ b/server/game/cards/plots/03/atimeforwolves.js
@@ -13,10 +13,10 @@ class ATimeForWolves extends PlotCard {
         });
 
         var buttons = _.map(direwolfCards, card => {
-            return { text: card.name, command: 'menuButton', method: 'cardSelected', arg: card.uuid };
+            return { text: card.name, method: 'cardSelected', arg: card.uuid };
         });
 
-        buttons.push({ text: 'Done', command: 'menuButton', method: 'doneSelecting' });
+        buttons.push({ text: 'Done', method: 'doneSelecting' });
 
         this.game.promptWithMenu(player, this, {
             activePrompt: {
@@ -47,8 +47,8 @@ class ATimeForWolves extends PlotCard {
         this.revealedCard = card;
 
         var buttons = [
-            { text: 'Keep in hand', command: 'menuButton', method: 'keepInHand' },
-            { text: 'Put in play', command: 'menuButton', method: 'putInPlay' }
+            { text: 'Keep in hand', method: 'keepInHand' },
+            { text: 'Put in play', method: 'putInPlay' }
         ];
 
         this.game.promptWithMenu(player, this, {

--- a/server/game/cards/plots/03/thelongwinter.js
+++ b/server/game/cards/plots/03/thelongwinter.js
@@ -61,7 +61,7 @@ class TheLongWinter extends PlotCard {
             this.game.promptForSelect(currentPlayer, {
                 activePromptTitle: 'Select a card to discard power from',
                 waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
-                additionalButtons: [{ command: 'menuButton', text: 'Faction Card', arg: 'faction' }],
+                additionalButtons: [{ text: 'Faction Card', arg: 'faction' }],
                 cardCondition: card => card.controller === currentPlayer && card.getPower() > 0,
                 onSelect: (player, card) => this.onCardSelected(player, card),
                 onMenuCommand: (player, arg) => this.selectFactionCard(player, arg),

--- a/server/game/gamesteps/actionwindow.js
+++ b/server/game/gamesteps/actionwindow.js
@@ -5,7 +5,7 @@ class ActionWindow extends PlayerOrderPrompt {
         return {
             menuTitle: 'Any actions or reactions?',
             buttons: [
-                { command: 'menuButton', text: 'Done' }
+                { text: 'Done' }
             ]
         };
     }

--- a/server/game/gamesteps/attachmentprompt.js
+++ b/server/game/gamesteps/attachmentprompt.js
@@ -43,7 +43,7 @@ class AttachmentPrompt extends UiPrompt {
             selectCard: true,
             menuTitle: 'Select target for attachment',
             buttons: [
-                { text: 'Done', command: 'menuButton', arg: 'doneattachment' }
+                { text: 'Done', arg: 'doneattachment' }
             ]
         };
     }

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -144,8 +144,8 @@ class ChallengeFlow extends BaseStep {
                 activePrompt: {
                     menuTitle: 'Perform before claim actions',
                     buttons: [
-                        { text: 'Apply Claim', command: 'menuButton', method: 'applyClaim' },
-                        { text: 'Continue', command: 'menuButton', method: 'cancelClaim' }
+                        { text: 'Apply Claim', method: 'applyClaim' },
+                        { text: 'Continue', method: 'cancelClaim' }
                     ]
                 },
                 waitingPromptTitle: 'Waiting for opponent to apply claim'

--- a/server/game/gamesteps/challengephase.js
+++ b/server/game/gamesteps/challengephase.js
@@ -31,10 +31,10 @@ class ChallengePhase extends Phase {
             activePrompt: {
                 menuTitle: '',
                 buttons: [
-                    { text: 'Military', command: 'menuButton', method: 'initiateChallenge', arg: 'military' },
-                    { text: 'Intrigue', command: 'menuButton', method: 'initiateChallenge', arg: 'intrigue' },
-                    { text: 'Power', command: 'menuButton', method: 'initiateChallenge', arg: 'power' },
-                    { text: 'Done', command: 'menuButton', method: 'completeChallenges' }
+                    { text: 'Military', method: 'initiateChallenge', arg: 'military' },
+                    { text: 'Intrigue', method: 'initiateChallenge', arg: 'intrigue' },
+                    { text: 'Power', method: 'initiateChallenge', arg: 'power' },
+                    { text: 'Done', method: 'completeChallenges' }
                 ]
             },
             waitingPromptTitle: 'Waiting for opponent to initiate challenge'

--- a/server/game/gamesteps/killcharacterprompt.js
+++ b/server/game/gamesteps/killcharacterprompt.js
@@ -26,7 +26,7 @@ class KillCharacterPrompt extends UiPrompt {
             selectCard: true,
             menuTitle: 'Select character to kill',
             buttons: [
-                { command: 'menuButton', text: 'Cancel' }
+                { text: 'Cancel' }
             ]
         };
     }

--- a/server/game/gamesteps/marshaling/marshalcardsprompt.js
+++ b/server/game/gamesteps/marshaling/marshalcardsprompt.js
@@ -14,7 +14,7 @@ class MarshalCardsPrompt extends UiPrompt {
         return {
             menuTitle: 'Marshal your cards',
             buttons: [
-                { command: 'menuButton', text: 'Done' }
+                { text: 'Done' }
             ]
         };
     }

--- a/server/game/gamesteps/plot/firstplayerprompt.js
+++ b/server/game/gamesteps/plot/firstplayerprompt.js
@@ -19,7 +19,7 @@ class FirstPlayerPrompt extends UIPrompt {
         return {
             menuTitle: 'Select first player',
             buttons: _.map(players, player => {
-                return { text: player.name, command: 'menuButton', arg: player.name };
+                return { text: player.name, arg: player.name };
             })
         };
     }

--- a/server/game/gamesteps/plot/plotrevealprompt.js
+++ b/server/game/gamesteps/plot/plotrevealprompt.js
@@ -17,8 +17,8 @@ class PlotRevealPrompt extends UIPrompt {
         return {
             menuTitle: 'Select first player',
             buttons: [
-                { text: this.player.name, command: 'menuButton', arg: this.player.name },
-                { text: otherPlayer.name, command: 'menuButton', arg: otherPlayer.name }
+                { text: this.player.name, arg: this.player.name },
+                { text: otherPlayer.name, arg: otherPlayer.name }
             ]
         };
     }

--- a/server/game/gamesteps/plot/resolveplots.js
+++ b/server/game/gamesteps/plot/resolveplots.js
@@ -26,7 +26,7 @@ class ResolvePlots extends BaseStep {
             activePrompt: {
                 menuTitle: 'Select a player to resolve their plot effects',
                 buttons: _.map(this.playersWithRevealEffects, player => {
-                    return { command: 'menuButton', method: 'resolvePlayer', text: player.name, arg: player.name };
+                    return { method: 'resolvePlayer', text: player.name, arg: player.name };
                 })
             },
             waitingPromptTitle: 'Waiting for first player to choose plot resolution order'

--- a/server/game/gamesteps/plot/selectplotprompt.js
+++ b/server/game/gamesteps/plot/selectplotprompt.js
@@ -9,7 +9,7 @@ class SelectPlotPrompt extends AllPlayerPrompt {
         return {
             menuTitle: 'Select a plot',
             buttons: [
-                { command: 'menuButton', arg: 'plotselected', text: 'Done' }
+                { arg: 'plotselected', text: 'Done' }
             ]
         };
     }

--- a/server/game/gamesteps/selectcardprompt.js
+++ b/server/game/gamesteps/selectcardprompt.js
@@ -61,7 +61,7 @@ class SelectCardPrompt extends UiPrompt {
             selectCard: true,
             menuTitle: this.properties.activePromptTitle || this.defaultActivePromptTitle(),
             buttons: this.properties.additionalButtons.concat([
-                { command: 'menuButton', text: 'Done', arg: 'done' }
+                { text: 'Done', arg: 'done' }
             ])
         };
     }

--- a/server/game/gamesteps/setup/keepormulliganprompt.js
+++ b/server/game/gamesteps/setup/keepormulliganprompt.js
@@ -9,8 +9,8 @@ class KeepOrMulliganPrompt extends AllPlayerPrompt {
         return {
             menuTitle: 'Keep Starting Hand?',
             buttons: [
-                { command: 'menuButton', arg: 'keep', text: 'Keep Hand' },
-                { command: 'menuButton', arg: 'mulligan', text: 'Mulligan' }
+                { arg: 'keep', text: 'Keep Hand' },
+                { arg: 'mulligan', text: 'Mulligan' }
             ]
         };
     }

--- a/server/game/gamesteps/setup/setupcardsprompt.js
+++ b/server/game/gamesteps/setup/setupcardsprompt.js
@@ -9,7 +9,7 @@ class SetupCardsPrompt extends AllPlayerPrompt {
         return {
             menuTitle: 'Select setup cards',
             buttons: [
-                { command: 'menuButton', arg: 'setupdone', text: 'Done' }
+                { arg: 'setupdone', text: 'Done' }
             ]
         };
     }

--- a/server/game/gamesteps/taxation/discardtoreserveprompt.js
+++ b/server/game/gamesteps/taxation/discardtoreserveprompt.js
@@ -5,7 +5,7 @@ class DiscardToReservePrompt extends PlayerOrderPrompt {
         return {
             menuTitle: 'Discard down to ' + this.currentPlayer.reserve + ' cards',
             buttons: [
-                { command: 'menuButton', text: 'Done' }
+                { text: 'Done' }
             ]
         };
     }

--- a/server/game/gamesteps/taxation/endroundprompt.js
+++ b/server/game/gamesteps/taxation/endroundprompt.js
@@ -5,7 +5,7 @@ class EndRoundPrompt extends PlayerOrderPrompt {
         return {
             menuTitle: '',
             buttons: [
-                { command: 'menuButton', text: 'End Round' }
+                { text: 'End Round' }
             ]
         };
     }

--- a/server/game/gamesteps/uiprompt.js
+++ b/server/game/gamesteps/uiprompt.js
@@ -18,7 +18,7 @@ class UiPrompt extends BaseStep {
     setPrompt() {
         _.each(this.game.getPlayers(), player => {
             if(this.activeCondition(player)) {
-                player.setPrompt(this.activePrompt());
+                player.setPrompt(this.addDefaultCommandToButtons(this.activePrompt()));
             } else {
                 player.setPrompt(this.waitingPrompt());
             }
@@ -30,6 +30,16 @@ class UiPrompt extends BaseStep {
     }
 
     activePrompt() {
+    }
+
+    addDefaultCommandToButtons(original) {
+        var prompt = _.clone(original);
+        if(prompt.buttons) {
+            _.each(prompt.buttons, button => {
+                button.command = button.command || 'menuButton';
+            });
+        }
+        return prompt;
     }
 
     waitingPrompt() {

--- a/test/server/gamesteps/uiprompt.spec.js
+++ b/test/server/gamesteps/uiprompt.spec.js
@@ -1,4 +1,5 @@
 /*global describe, it, beforeEach, expect, spyOn, jasmine*/
+/* eslint no-invalid-this: 0 */
 
 const UiPrompt = require('../../../server/game/gamesteps/uiprompt.js');
 

--- a/test/server/gamesteps/uiprompt.spec.js
+++ b/test/server/gamesteps/uiprompt.spec.js
@@ -1,69 +1,71 @@
-/*global describe, it, beforeEach, expect, spyOn*/
+/*global describe, it, beforeEach, expect, spyOn, jasmine*/
 
 const UiPrompt = require('../../../server/game/gamesteps/uiprompt.js');
-const Game = require('../../../server/game/game.js');
-const Player = require('../../../server/game/player.js');
 
-describe('the UiPrompt', () => {
-    var prompt;
-    var game = {};
-    var player1;
-    var player2;
-    var activePrompt = {};
-    var waitingPrompt = {};
+describe('the UiPrompt', function() {
+    beforeEach(function() {
+        this.player1 = jasmine.createSpyObj('player', ['setPrompt', 'cancelPrompt']);
+        this.player2 = jasmine.createSpyObj('player', ['setPrompt', 'cancelPrompt']);
 
-    beforeEach(() => {
-        game = new Game('1', 'Test Game');
-        player1 = new Player('1', { username: 'Player 1' }, true, game);
-        player2 = new Player('2', { username: 'Player 2' }, false, game);
-        game.players[player1.name] = player1;
-        game.players[player2.name] = player2;
-        prompt = new UiPrompt(game);
-        spyOn(prompt, 'activePrompt').and.returnValue(activePrompt);
-        spyOn(prompt, 'waitingPrompt').and.returnValue(waitingPrompt);
-        spyOn(prompt, 'activeCondition').and.callFake(player => {
-            return player === player2;
+        this.game = jasmine.createSpyObj('game', ['getPlayers']);
+        this.game.getPlayers.and.returnValue([this.player1, this.player2]);
+
+        this.activePrompt = {
+            menuTitle: 'Do stuff',
+            buttons: [
+                { command: 'command', text: 'Do It', arg: 'foo' }
+            ]
+        };
+        this.waitingPrompt = {};
+
+        this.prompt = new UiPrompt(this.game);
+        spyOn(this.prompt, 'activePrompt').and.returnValue(this.activePrompt);
+        spyOn(this.prompt, 'waitingPrompt').and.returnValue(this.waitingPrompt);
+        spyOn(this.prompt, 'activeCondition').and.callFake(player => {
+            return player === this.player2;
         });
-        spyOn(player1, 'setPrompt');
-        spyOn(player2, 'setPrompt');
-        spyOn(player1, 'cancelPrompt');
-        spyOn(player2, 'cancelPrompt');
     });
 
-    describe('the continue() function', () => {
-        describe('when the prompt is incomplete', () => {
-            beforeEach(() => {
-                spyOn(prompt, 'isComplete').and.returnValue(false);
+    describe('the continue() function', function() {
+        describe('when the prompt is incomplete', function() {
+            beforeEach(function() {
+                spyOn(this.prompt, 'isComplete').and.returnValue(false);
             });
 
-            it('should set the active prompt for players meeting the active condition', () => {
-                prompt.continue();
-                expect(player2.setPrompt).toHaveBeenCalledWith(activePrompt);
+            it('should set the active prompt for players meeting the active condition', function() {
+                this.prompt.continue();
+                expect(this.player2.setPrompt).toHaveBeenCalledWith(this.activePrompt);
             });
 
-            it('should set the waiting prompt for players that do not meet the active condition', () => {
-                prompt.continue();
-                expect(player1.setPrompt).toHaveBeenCalledWith(waitingPrompt);
+            it('should default the command for any buttons on the active prompt', function() {
+                this.prompt.activePrompt.and.returnValue({ buttons: [{ text: 'foo' }] });
+                this.prompt.continue();
+                expect(this.player2.setPrompt).toHaveBeenCalledWith({ buttons: [{ command: 'menuButton', text: 'foo' }] });
             });
 
-            it('should return false', () => {
-                expect(prompt.continue()).toBe(false);
+            it('should set the waiting prompt for players that do not meet the active condition', function() {
+                this.prompt.continue();
+                expect(this.player1.setPrompt).toHaveBeenCalledWith(this.waitingPrompt);
+            });
+
+            it('should return false', function() {
+                expect(this.prompt.continue()).toBe(false);
             });
         });
 
-        describe('when the prompt is complete', () => {
-            beforeEach(() => {
-                spyOn(prompt, 'isComplete').and.returnValue(true);
+        describe('when the prompt is complete', function() {
+            beforeEach(function() {
+                spyOn(this.prompt, 'isComplete').and.returnValue(true);
             });
 
-            it('should set the cancel prompts for each player', () => {
-                prompt.continue();
-                expect(player1.cancelPrompt).toHaveBeenCalled();
-                expect(player2.cancelPrompt).toHaveBeenCalled();
+            it('should set the cancel prompts for each player', function() {
+                this.prompt.continue();
+                expect(this.player1.cancelPrompt).toHaveBeenCalled();
+                expect(this.player2.cancelPrompt).toHaveBeenCalled();
             });
 
-            it('should return true', () => {
-                expect(prompt.continue()).toBe(true);
+            it('should return true', function() {
+                expect(this.prompt.continue()).toBe(true);
             });
         });
     });


### PR DESCRIPTION
This removes the need to specify the command 'menuButton' for each button in a UI prompt. If no command is specified, it will now assume it's a menuButton command. You can still set the command property to override the button's command.