### PR TITLE
Fix token styling on horizontal cards + more than 3 tokens.

### DIFF
--- a/client/GameComponents/Card.jsx
+++ b/client/GameComponents/Card.jsx
@@ -59,6 +59,7 @@ class Card extends React.Component {
 
     getCounters() {
         var counters = {};
+        var countersClass = 'counters ignore-mouse-events';
 
         if(this.props.source !== 'play area' && this.props.source !== 'faction') {
             return null;
@@ -78,8 +79,12 @@ class Card extends React.Component {
             return <div key={key} className={'counter ' + key}>{counterValue}</div>;
         });
 
+        if(counters.length > 3) {
+            countersClass += ' many-counters';
+        }
+
         return counterDivs.length !== 0 ? (
-            <div className='counters ignore-mouse-events'>
+            <div className={countersClass}>
                 {counterDivs}
             </div>) : null;
     }

--- a/less/cards.less
+++ b/less/cards.less
@@ -132,9 +132,26 @@
   right: 0;
   justify-content: center;
   display: flex;
-  flex-direction: column;
+  align-content: center;
   align-items: center;
+  flex-wrap: wrap;
   z-index: @layer-cards + 1;
+}
+
+.card.vertical .counters {
+  flex-direction: column;
+
+  &.many-counters {
+    flex-direction: row;
+  }
+}
+
+.card.horizontal .counters {
+  flex-direction: row;
+
+  &.many-counters {
+    flex-direction: column;
+  }
 }
 
 .counter {

--- a/less/cards.less
+++ b/less/cards.less
@@ -162,41 +162,29 @@
   line-height: 24px;
   text-align: center;
   margin: 2px;
+  text-shadow: 1px 1px 2px #000;
+  border-radius: 4px;
+  color: white;
 }
 
 .dupe {
   background-color: rgba(0,128,0,0.85);
-  text-shadow: 1px 1px 2px #000;
-  border-radius: 4px;
-  color: white;
 }
 
 .power {
   background-color: rgba(0,0,128,0.85);
-  text-shadow: 1px 1px 2px #000;
-  border-radius: 4px;
-  color: white;
 }
 
 .strength {
   background-color: rgba(128,0,0,0.85);
-  text-shadow: 1px 1px 2px #000;
-  border-radius: 4px;
-  color: white;
 }
 
 .stand {
   background-color: rgba(128,128,128,0.85);
-  text-shadow: 1px 1px 2px #000;
-  border-radius: 4px;
-  color: white;
 }
 
 .poison {
   background-color: rgba(43,43, 0, 0.85);
-  text-shadow: 1px 1px 2px #000;
-  border-radius: 4px;
-  color: white;
 }
 
 .plot-selected {


### PR DESCRIPTION
* Changes the orientation of the token list to be horizontal for horizontal cards.
![screen shot 2016-12-17 at 11 00 54 am](https://cloud.githubusercontent.com/assets/145077/21289078/29f24f0e-c448-11e6-85c2-167d21b2ed88.png) ![screen shot 2016-12-17 at 11 01 03 am](https://cloud.githubusercontent.com/assets/145077/21289077/2814d076-c448-11e6-99d2-344cd19d0f64.png)
* When there are 4 or more tokens, it bunches them up as best as possible.
![screen shot 2016-12-17 at 11 00 19 am](https://cloud.githubusercontent.com/assets/145077/21289081/2f4b1134-c448-11e6-978f-324b552bc0b7.png) ![screen shot 2016-12-17 at 11 00 28 am](https://cloud.githubusercontent.com/assets/145077/21289079/2c076a4a-c448-11e6-827a-eba62060b67e.png)
* Moved duplicated styling into the `.counter` class.





