### PR TITLE
Send strength stats for 0 strength characters.

### DIFF
--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -176,7 +176,7 @@ class DrawCard extends BaseCard {
             }),
             kneeled: this.kneeled,
             power: this.power,
-            strength: this.cardData.strength ? this.getStrength() : undefined,
+            strength: !_.isNull(this.cardData.strength) ? this.getStrength() : undefined,
             baseStrength: this.cardData.strength
         });
     }

--- a/test/server/card/drawcard.getsummary.spec.js
+++ b/test/server/card/drawcard.getsummary.spec.js
@@ -1,0 +1,48 @@
+/*global describe, it, beforeEach, expect*/
+/*eslint camelcase: 0, no-invalid-this: 0 */
+
+const DrawCard = require('../../../server/game/drawcard.js');
+
+describe('DrawCard', function () {
+    beforeEach(function () {
+        this.testCard = { code: '111', label: 'test 1(some pack)', name: 'test 1' };
+        this.card = new DrawCard({}, this.testCard);
+    });
+
+    describe('getSummary', function() {
+        describe('strength property', function() {
+            describe('when the card has null strength', function() {
+                beforeEach(function() {
+                    this.testCard.strength = null;
+                    this.summary = this.card.getSummary(true, true);
+                });
+
+                it('should not include the strength', function() {
+                    expect(this.summary.strength).toBeUndefined();
+                });
+            });
+
+            describe('when the card has non-zero strength', function() {
+                beforeEach(function() {
+                    this.testCard.strength = 5;
+                    this.summary = this.card.getSummary(true, true);
+                });
+
+                it('should include the strength', function() {
+                    expect(this.summary.strength).toBe(5);
+                });
+            });
+
+            describe('when the card has a zero strength', function() {
+                beforeEach(function() {
+                    this.testCard.strength = 0;
+                    this.summary = this.card.getSummary(true, true);
+                });
+
+                it('should include the strength', function() {
+                    expect(this.summary.strength).toBe(0);
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Previously, characters with 0 base strength (e.g. Lancel Lannister)
would not display their strength if it were increased via abilities,
attachments or using the /strength command. This was due to the strength
not being sent if the base strength was a falsy value. Now it explicitly
sends it unless the base strength is explicitly null, which is the case
on non-character cards.