### PR TITLE
Fix the Wall + Bronn

### DIFF
--- a/server/game/cards/characters/02/bronn.js
+++ b/server/game/cards/characters/02/bronn.js
@@ -9,7 +9,7 @@ class Bronn extends DrawCard {
         this.registerEvents(['onChallenge', 'onChallengeFinished']);
     }
 
-    onChallenge(challenge) {
+    onChallenge(e, challenge) {
         if(!this.inPlay || this.controller !== challenge.defendingPlayer) {
             return;
         }
@@ -19,7 +19,7 @@ class Bronn extends DrawCard {
         this.setIcon('power');
     }
 
-    onChallengeFinished(challenge) {
+    onChallengeFinished(e, challenge) {
         if(!this.inPlay || this.controller !== challenge.defendingPlayer) {
             return;
         }

--- a/server/game/cards/locations/01/thewall.js
+++ b/server/game/cards/locations/01/thewall.js
@@ -27,8 +27,12 @@ class TheWall extends DrawCard {
         }
     }
 
-    onUnopposedWin(winner) {
-        if(this.controller !== winner && !this.kneeled) {
+    onUnopposedWin(e, challenge) {
+        if(!this.inPlay) {
+            return;
+        }
+
+        if(this.controller !== challenge.winner && !this.kneeled) {
             this.game.addMessage('{0} is forced to kneel {1} because they lost an unopposed challenge', this.controller, this);
             this.kneeled = true;
         }


### PR DESCRIPTION
Both the Wall and Bronn were missing the event param in their event handlers, meaning neither were working as intended. Also added an in-play check for the Wall to ensure it only kneels when in the play area.

Fixes #158 