### PR TITLE
Remove duplicated responsibility from Player to Challenge

### DIFF
--- a/server/game/cards/agendas/thelordofthecrossing.js
+++ b/server/game/cards/agendas/thelordofthecrossing.js
@@ -13,7 +13,7 @@ class TheLordOfTheCrossing extends AgendaCard {
             return;
         }
 
-        player.cardsInChallenge.each(card => {
+        _.each(challenge.attackers, card => {
             var numChallenges = player.getNumberOfChallengesInitiated();
             if(numChallenges === 0) {
                 card.strengthModifier--;
@@ -34,7 +34,7 @@ class TheLordOfTheCrossing extends AgendaCard {
             this.game.addPower(challenge.winner, 1);
         }
 
-        this.controller.cardsInChallenge.each(card => {
+        _.each(challenge.attackers, card => {
             if(currentChallenge === 1) {
                 card.strengthModifier++;
             } else if(currentChallenge === 3) {

--- a/server/game/cards/attachments/01/ice.js
+++ b/server/game/cards/attachments/01/ice.js
@@ -34,7 +34,7 @@ class Ice extends DrawCard {
             return;
         }
 
-        if(!challenge.attackingPlayer.cardsInChallenge.contains(this.parent)) {
+        if(!challenge.isAttacking(this.parent)) {
             return;
         }
 

--- a/server/game/cards/characters/01/rattleshirtsraiders.js
+++ b/server/game/cards/characters/01/rattleshirtsraiders.js
@@ -16,7 +16,7 @@ class RattleshirtsRaiders extends DrawCard {
             return;
         }
 
-        if(!challenge.attackingPlayer.cardsInChallenge.contains(this)) {
+        if(!challenge.isAttacking(this)) {
             return;
         }
 

--- a/server/game/cards/characters/01/serjaimelannister.js
+++ b/server/game/cards/characters/01/serjaimelannister.js
@@ -21,9 +21,7 @@ class SerJaimeLannister extends DrawCard {
             return;
         }
 
-        if(!this.isBlank() && player.cardsInChallenge.any(card => {
-            return card.uuid === this.uuid;
-        })) {
+        if(!this.isBlank() && challenge.isAttacking(this)) {
             this.kneeled = false;
         }
     }

--- a/server/game/cards/characters/01/wildlinghorde.js
+++ b/server/game/cards/characters/01/wildlinghorde.js
@@ -10,7 +10,12 @@ class WildlingHorde extends DrawCard {
     }
 
     cardCondition(player, card) {
-        return card.inPlay && card.controller === player && card.hasTrait('Wildling') && player.isCardUuidInList(player.cardsInChallenge, card);
+        var currentChallenge = this.game.currentChallenge;
+        if(!currentChallenge) {
+            return false;
+        }
+
+        return card.inPlay && card.controller === player && card.hasTrait('Wildling') && currentChallenge.isAttacking(card);
     }
 
     kneelFactionCard(player) {

--- a/server/game/cards/characters/03/eddardstark.js
+++ b/server/game/cards/characters/03/eddardstark.js
@@ -14,25 +14,15 @@ class EddardStark extends DrawCard {
         }
 
         this.game.promptForSelect(player, {
-            cardCondition: card => this.cardCondition(card),
+            cardCondition: card => this.cardCondition(challenge, card),
             activePromptTitle: 'Select character to gain power',
             waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
             onSelect: (player, card) => this.onCardSelected(player, card)
         });
     }
 
-    cardCondition(card) {
-        if(card.getType() !== 'character') {
-            return false;
-        }
-
-        if(!this.controller.cardsInChallenge.find(c => {
-            return c.uuid !== this.uuid && c.uuid === card.uuid;
-        })) {
-            return false;
-        }
-
-        return true;
+    cardCondition(challenge, card) {
+        return card !== this && card.getType() === 'character' && challenge.isParticipating(card);
     }
 
     onCardSelected(player, card) {

--- a/server/game/cards/characters/05/cerseilannister.js
+++ b/server/game/cards/characters/05/cerseilannister.js
@@ -13,9 +13,7 @@ class CerseiLannister extends DrawCard {
             return;
         }
 
-        if(!this.isBlank() && player.cardsInChallenge.any(card => {
-            return card.uuid === this.uuid;
-        })) {
+        if(!this.isBlank() && challenge.isAttacking(this)) {
             this.kneeled = false;
         }
     }

--- a/server/game/cards/locations/01/theredkeep.js
+++ b/server/game/cards/locations/01/theredkeep.js
@@ -12,7 +12,7 @@ class TheRedKeep extends DrawCard {
             return;
         }
 
-        if(challenge.challengeType === 'power' && this.controller.cardsInChallenge.size() > 0) {
+        if(challenge.challengeType === 'power' && challenge.attackers.length > 0) {
             this.controller.challengeStrength += 2;
 
             this.game.addMessage('{0} uses {1} to add 2 to the strength of this {2} challenge', this.controller, this, challenge.challengeType);

--- a/server/game/cards/locations/01/theredkeep.js
+++ b/server/game/cards/locations/01/theredkeep.js
@@ -13,7 +13,7 @@ class TheRedKeep extends DrawCard {
         }
 
         if(challenge.challengeType === 'power' && challenge.attackers.length > 0) {
-            this.controller.challengeStrength += 2;
+            challenge.modifyAttackerStrength(2);
 
             this.game.addMessage('{0} uses {1} to add 2 to the strength of this {2} challenge', this.controller, this, challenge.challengeType);
         }

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -32,33 +32,35 @@ class Challenge {
     addAttackers(attackers) {
         this.attackers = attackers;
         this.markAsParticipating(attackers);
-
-        // TODO: Remove duplicated logic.
-        this.attackingPlayer.cardsInChallenge = _(attackers);
     }
 
     addDefenders(defenders) {
         this.defenders = defenders;
         this.markAsParticipating(defenders);
-
-        // TODO: Remove duplicated logic.
-        this.defendingPlayer.cardsInChallenge = _(defenders);
     }
 
     removeFromChallenge(card) {
         this.attackers = _.reject(this.attackers, c => c === card);
         this.defenders = _.reject(this.defenders, c => c === card);
         this.calculateStrength();
-
-        // TODO: Remove duplicated logic
-        this.attackingPlayer.cardsInChallenge = _(this.attackers);
-        this.defendingPlayer.cardsInChallenge = _(this.defenders);
     }
 
     markAsParticipating(cards) {
         _.each(cards, card => {
             card.kneeled = true;
         });
+    }
+
+    isAttacking(card) {
+        return this.attackers.includes(card);
+    }
+
+    isDefending(card) {
+        return this.defenders.includes(card);
+    }
+
+    isParticipating(card) {
+        return this.isAttacking(card) || this.isDefending(card);
     }
 
     calculateStrength() {
@@ -112,6 +114,16 @@ class Challenge {
         }
 
         return claim;
+    }
+
+    getWinnerCards() {
+        if(this.winner === this.attackingPlayer) {
+            return this.attackers;
+        } else if(this.winner === this.defendingPlayer) {
+            return this.defenders;
+        }
+
+        return [];
     }
 
     onCardLeftPlay(e, player, card) {

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -9,7 +9,11 @@ class Challenge {
         this.defendingPlayer = defendingPlayer || this.singlePlayerDefender();
         this.challengeType = challengeType;
         this.attackers = [];
+        this.attackerStrength = 0;
+        this.attackerStrengthModifier = 0;
         this.defenders = [];
+        this.defenderStrength = 0;
+        this.defenderStrengthModifier = 0;
         this.registerEvents(['onCardLeftPlay']);
     }
 
@@ -64,18 +68,24 @@ class Challenge {
     }
 
     calculateStrength() {
-        this.attackerStrength = this.calculateStrengthFor(this.attackers);
-        this.defenderStrength = this.calculateStrengthFor(this.defenders);
-
-        // TODO: Remove duplicated logic
-        this.attackingPlayer.challengeStrength = this.attackerStrength;
-        this.defendingPlayer.challengeStrength = this.defenderStrength;
+        this.attackerStrength = this.calculateStrengthFor(this.attackers) + this.attackerStrengthModifier;
+        this.defenderStrength = this.calculateStrengthFor(this.defenders) + this.defenderStrengthModifier;
     }
 
     calculateStrengthFor(cards) {
         return _.reduce(cards, (sum, card) => {
             return sum + card.getStrength();
         }, 0);
+    }
+
+    modifyAttackerStrength(value) {
+        this.attackerStrengthModifier += value;
+        this.calculateStrength();
+    }
+
+    modifyDefenderStrength(value) {
+        this.defenderStrengthModifier += value;
+        this.calculateStrength();
     }
 
     getStealthAttackers() {
@@ -86,15 +96,19 @@ class Challenge {
         this.calculateStrength();
         if(this.attackerStrength >= this.defenderStrength) {
             this.loser = this.defendingPlayer;
+            this.loserStrength = this.defenderStrength;
             this.winner = this.attackingPlayer;
+            this.winnerStrength = this.attackerStrength;
         } else {
             this.loser = this.attackingPlayer;
+            this.loserStrength = this.attackerStrength;
             this.winner = this.defendingPlayer;
+            this.winnerStrength = this.defenderStrength;
         }
 
         this.winner.winChallenge(this.challengeType);
         this.loser.loseChallenge(this.challengeType);
-        this.strengthDifference = this.winner.challengeStrength - this.loser.challengeStrength;
+        this.strengthDifference = this.winnerStrength - this.loserStrength;
     }
 
     isAttackerTheWinner() {

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -185,8 +185,9 @@ class ChallengeFlow extends BaseStep {
 
     applyKeywords() {
         var appliedIntimidate = false;
+        var winnerCards = this.challenge.getWinnerCards();
 
-        this.challenge.winner.cardsInChallenge.each(card => {
+        _.each(winnerCards, card => {
             if(card.hasKeyword('Insight')) {
                 this.challenge.winner.drawCardsToHand(1);
 

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -111,7 +111,7 @@ class ChallengeFlow extends BaseStep {
         this.challenge.determineWinner();
 
         this.game.addMessage('{0} won a {1} challenge {2} vs {3}',
-            this.challenge.winner, this.challenge.challengeType, this.challenge.winner.challengeStrength, this.challenge.loser.challengeStrength);
+            this.challenge.winner, this.challenge.challengeType, this.challenge.winnerStrength, this.challenge.loserStrength);
 
         this.game.raiseEvent('afterChallenge', this.challenge);
     }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -283,7 +283,6 @@ class Player extends Spectator {
         this.claim = 0;
         this.reserve = 0;
         this.readyToStart = false;
-        this.cardsInChallenge = _([]);
         this.limitedPlayed = 0;
         this.maxLimited = 1;
         this.activePlot = undefined;
@@ -666,7 +665,6 @@ class Player extends Spectator {
     }
 
     beginChallenge() {
-        this.cardsInChallenge = _([]);
         this.cardsInPlay.each(card => {
             card.resetForChallenge();
         });
@@ -674,10 +672,6 @@ class Player extends Spectator {
     }
 
     canAddToChallenge(card, challengeType) {
-        if(this.challengerLimit && this.cardsInChallenge.size() >= this.challengerLimit) {
-            return false;
-        }
-
         if(!card) {
             return false;
         }

--- a/test/server/cards/characters/01/01087 - serjaimelannister.spec.js
+++ b/test/server/cards/characters/01/01087 - serjaimelannister.spec.js
@@ -14,14 +14,11 @@ describe('SerJaimeLannister', function() {
         this.playerSpy.game = this.gameSpy;
         this.otherPlayerSpy.game = this.gameSpy;
 
-        this.playerSpy.cardsInChallenge = _([]);
-
         this.character = new SerJaimeLannister(this.playerSpy, {});
 
-        this.challenge = {
-            attackingPlayer: this.playerSpy,
-            challengeType: 'military'
-        };
+        this.challenge = jasmine.createSpyObj('challenge', ['isAttacking']);
+        this.challenge.attackingPlayer = this.playerSpy;
+        this.challenge.challengeType = 'military';
     });
 
     describe('when attackers are declared', function() {
@@ -86,6 +83,10 @@ describe('SerJaimeLannister', function() {
                 });
 
                 describe('and this card is not in the challenge', function() {
+                    beforeEach(function() {
+                        this.challenge.isAttacking.and.returnValue(false);
+                    });
+
                     it('should set renown', function() {
                         expect(this.character.isRenown()).toBe(true);
                     });
@@ -97,7 +98,7 @@ describe('SerJaimeLannister', function() {
 
                 describe('and this card is in the challenge', function() {
                     beforeEach(function() {
-                        this.playerSpy.cardsInChallenge.push(this.character);
+                        this.challenge.isAttacking.and.returnValue(true);
 
                         this.character.onAttackersDeclared({}, this.challenge);
                     });

--- a/test/server/cards/characters/02/02070 - redcloaks.spec.js
+++ b/test/server/cards/characters/02/02070 - redcloaks.spec.js
@@ -14,8 +14,6 @@ describe('RedCloaks', function() {
         this.playerSpy.game = this.gameSpy;
         this.otherPlayerSpy.game = this.gameSpy;
 
-        this.playerSpy.cardsInChallenge = _([]);
-
         this.card = new RedCloaks(this.playerSpy, {});
         this.card.inPlay = true;
     });


### PR DESCRIPTION
* Removes `Player.cardsInChallenge` and updates remaining usages to reference the challenge object.
* Removes `Player.challengeStrength` which was not being used when determining winner but was being used for UI and modified for cards that don't participate but do contribute strength (The Red Keep).