### PR TITLE
Re-register events when a card enters play

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -13,6 +13,7 @@ const ValidKeywords = [
     'terminal',
     'limited'
 ];
+const LocationsWithEventHandling = ['play area', 'active plot', 'faction', 'agenda'];
 
 class BaseCard {
     constructor(owner, cardData) {
@@ -72,7 +73,7 @@ class BaseCard {
     }
 
     registerEvents(events) {
-        this.events.register(events);
+        this.eventsForRegistration = events;
     }
 
     hasKeyword(keyword) {
@@ -94,10 +95,22 @@ class BaseCard {
     }
 
     leavesPlay() {
-        this.events.unregisterAll();
-
         this.inPlay = false;
         this.tokens = {};
+    }
+
+    moveTo(targetLocation) {
+        if(LocationsWithEventHandling.includes(targetLocation) && !LocationsWithEventHandling.includes(this.location)) {
+            this.events.register(this.eventsForRegistration);
+        } else if(LocationsWithEventHandling.includes(this.location) && !LocationsWithEventHandling.includes(targetLocation)) {
+            this.events.unregisterAll();
+        }
+
+        if(targetLocation !== 'play area') {
+            this.facedown = false;
+        }
+
+        this.location = targetLocation;
     }
 
     modifyDominance(player, strength) {

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -26,7 +26,6 @@ class BaseCard {
         this.code = cardData.code;
         this.name = cardData.name;
         this.facedown = false;
-        this.inPlay = false;
         this.blankCount = 0;
 
         this.tokens = {};
@@ -91,11 +90,9 @@ class BaseCard {
     }
 
     play() {
-        this.inPlay = true;
     }
 
     leavesPlay() {
-        this.inPlay = false;
         this.tokens = {};
     }
 

--- a/server/game/cards/agendas/fealty.js
+++ b/server/game/cards/agendas/fealty.js
@@ -20,7 +20,7 @@ class Fealty extends Reducer {
     }
 
     canReduce(player, card) {
-        if(!this.inPlay || this.controller !== player || !player.faction.kneeled || this.abilityUsed) {
+        if(this.controller !== player || !player.faction.kneeled || this.abilityUsed) {
             return false;
         }
 

--- a/server/game/cards/agendas/therainsofcastamere.js
+++ b/server/game/cards/agendas/therainsofcastamere.js
@@ -27,6 +27,7 @@ class TheRainsOfCastamere extends AgendaCard {
         }
 
         this.owner.removeActivePlot();
+        previousPlot.moveTo('out of game');
     }
 
     afterChallenge(e, challenge) {

--- a/server/game/cards/attachments/01/bodyguard.js
+++ b/server/game/cards/attachments/01/bodyguard.js
@@ -16,7 +16,7 @@ class BodyGuard extends DrawCard {
     }
 
     onCharacterKilled(event, player, card, allowSave) {
-        if(!this.inPlay || this.parent !== card || !allowSave) {
+        if(this.parent !== card || !allowSave) {
             return;
         }
 

--- a/server/game/cards/attachments/01/ice.js
+++ b/server/game/cards/attachments/01/ice.js
@@ -26,10 +26,6 @@ class Ice extends DrawCard {
     }
 
     afterChallenge(event, challenge) {
-        if(!this.inPlay) {
-            return;
-        }
-
         if(challenge.winner !== this.controller || challenge.challengeType !== 'military') {
             return;
         }
@@ -66,16 +62,16 @@ class Ice extends DrawCard {
         this.game.promptForSelect(this.controller, {
             activePromptTitle: 'Select a character to kill',
             waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
-            cardCondition: card => card.inPlay && card.controller !== this.controller && card.getType() === 'character',
+            cardCondition: card => card.location === 'play area' && card.controller !== this.controller && card.getType() === 'character',
             onSelect: (p, card) => this.onCardSelected(p, card)
         });
     }
 
     cancel(player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return false;
         }
-        
+
         this.game.addMessage('{0} declines to trigger {1}', player, this);
 
         return true;

--- a/server/game/cards/attachments/01/sealofthehand.js
+++ b/server/game/cards/attachments/01/sealofthehand.js
@@ -8,7 +8,7 @@ class SealOfTheHand extends DrawCard {
     }
 
     kneel(player) {
-        if(!this.inPlay || !this.parent || !this.parent.kneeled) {
+        if(!this.parent || !this.parent.kneeled) {
             return;
         }
 

--- a/server/game/cards/attachments/04/redgodsblessing.js
+++ b/server/game/cards/attachments/04/redgodsblessing.js
@@ -35,7 +35,7 @@ class RedGodsBlessing extends DrawCard {
     }
 
     onCardPlayed(event, player, card) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return;
         }
 
@@ -45,7 +45,7 @@ class RedGodsBlessing extends DrawCard {
     }
 
     onCardLeftPlay(event, player, card) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return;
         }
     

--- a/server/game/cards/characters/01/direwolfpup.js
+++ b/server/game/cards/characters/01/direwolfpup.js
@@ -24,7 +24,7 @@ class DirewolfPup extends DrawCard {
     }
 
     onCardPlayed(e, player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return;
         }
 
@@ -32,7 +32,7 @@ class DirewolfPup extends DrawCard {
     }
 
     onCardLeftPlay(e, player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return;
         }
 

--- a/server/game/cards/characters/01/euroncrowseye.js
+++ b/server/game/cards/characters/01/euroncrowseye.js
@@ -11,7 +11,7 @@ class EuronCrowsEye extends DrawCard {
 
     onPillage(event, challenge, card) {
         var player = challenge.winner;
-        if(!this.inPlay || this.controller !== player || card !== this) {
+        if(this.controller !== player || card !== this) {
             return;
         }
 
@@ -47,7 +47,7 @@ class EuronCrowsEye extends DrawCard {
     }
 
     cancel(player) {
-        if(!this.inPlay || this.isBlank() || this.controller !== player) {
+        if(this.isBlank() || this.controller !== player) {
             return false;
         }
 

--- a/server/game/cards/characters/01/goldcloaks.js
+++ b/server/game/cards/characters/01/goldcloaks.js
@@ -10,7 +10,7 @@ class GoldCloaks extends DrawCard {
     }
 
     onPhaseEnded() {
-        if(!this.inPlay || !this.wasAmbush) {
+        if(!this.wasAmbush) {
             return;
         }
 

--- a/server/game/cards/characters/01/greenbloodtrader.js
+++ b/server/game/cards/characters/01/greenbloodtrader.js
@@ -23,7 +23,7 @@ class GreenbloodTrader extends DrawCard {
     }
 
     trigger(player) {
-        if(!this.inPlay || this.isBlank() || this.controller !== player) {
+        if(this.isBlank() || this.controller !== player) {
             return false;
         }
 
@@ -47,7 +47,7 @@ class GreenbloodTrader extends DrawCard {
     }
 
     getCard(player, cardId) {
-        if(!this.inPlay || this.isBlank() || this.controller !== player) {
+        if(this.isBlank() || this.controller !== player) {
             return undefined;
         }
 
@@ -114,7 +114,7 @@ class GreenbloodTrader extends DrawCard {
     }
 
     cancel(player) {
-        if(!this.inPlay || this.isBlank() || this.controller !== player) {
+        if(this.isBlank() || this.controller !== player) {
             return false;
         }
 

--- a/server/game/cards/characters/01/khaldrogo.js
+++ b/server/game/cards/characters/01/khaldrogo.js
@@ -8,10 +8,6 @@ class KhalDrogo extends DrawCard {
     }
 
     onPlotFlip() {
-        if(!this.inPlay) {
-            return;
-        }
-
         if(!this.isBlank()) {
             this.challengeAdded = true;
             this.controller.addChallenge('military', 1);

--- a/server/game/cards/characters/01/littlefinger.js
+++ b/server/game/cards/characters/01/littlefinger.js
@@ -21,7 +21,7 @@ class LittleFinger extends DrawCard {
     }
 
     trigger(player) {
-        if(!this.inPlay || this.isBlank() || this.controller !== player) {
+        if(this.isBlank() || this.controller !== player) {
             return false;
         }
 
@@ -33,7 +33,7 @@ class LittleFinger extends DrawCard {
     }
 
     cancel(player) {
-        if(!this.inPlay || this.isBlank() || this.controller !== player) {
+        if(this.isBlank() || this.controller !== player) {
             return false;
         }
 

--- a/server/game/cards/characters/01/maestercressen.js
+++ b/server/game/cards/characters/01/maestercressen.js
@@ -24,7 +24,7 @@ class MaesterCressen extends DrawCard {
         this.game.promptForSelect(player, {
             activePromptTitle: 'Select an attachment to discard',
             waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
-            cardCondition: card => card.inPlay && card.getType() === 'attachment' && card.hasTrait('condition'),
+            cardCondition: card => card.location === 'play area' && card.getType() === 'attachment' && card.hasTrait('condition'),
             onSelect: (p, card) => this.onCardSelected(p, card)
         });
 

--- a/server/game/cards/characters/01/rattleshirtsraiders.js
+++ b/server/game/cards/characters/01/rattleshirtsraiders.js
@@ -8,7 +8,7 @@ class RattleshirtsRaiders extends DrawCard {
     }
 
     afterChallenge(event, challenge) {
-        if(!this.inPlay || challenge.attackingPlayer !== this.controller) {
+        if(challenge.attackingPlayer !== this.controller) {
             return;
         }
 
@@ -23,7 +23,7 @@ class RattleshirtsRaiders extends DrawCard {
         this.game.promptForSelect(this.controller, {
             activePromptTitle: 'Select attachment to discard',
             waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
-            cardCondition: card => card.inPlay && card.controller === challenge.loser && card.getType() === 'attachment',
+            cardCondition: card => card.location === 'play area' && card.controller === challenge.loser && card.getType() === 'attachment',
             onSelect: (p, card) => this.onCardSelected(p, card)
         });
     }

--- a/server/game/cards/characters/01/serjaimelannister.js
+++ b/server/game/cards/characters/01/serjaimelannister.js
@@ -9,7 +9,7 @@ class SerJaimeLannister extends DrawCard {
 
     onAttackersDeclared(event, challenge) {
         var player = challenge.attackingPlayer;
-        if(!this.inPlay || challenge.challengeType !== 'military') {
+        if(challenge.challengeType !== 'military') {
             return;
         }
 

--- a/server/game/cards/characters/01/thetickler.js
+++ b/server/game/cards/characters/01/thetickler.js
@@ -8,7 +8,7 @@ class TheTickler extends DrawCard {
     }
 
     onDominanceDetermined(event, player) {
-        if(!this.inPlay || this.kneeled) {
+        if(this.kneeled) {
             return;
         }
 
@@ -40,7 +40,7 @@ class TheTickler extends DrawCard {
         this.game.promptForSelect(player, {
             activePromptTitle: 'Select a copy of ' + this.topCard.name + ' to discard',
             waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
-            cardCondition: card => card.inPlay && card.name === this.topCard.name,
+            cardCondition: card => card.location === 'play area' && card.name === this.topCard.name,
             onSelect: (p, card) => this.onCardSelected(p, card)
         });
 

--- a/server/game/cards/characters/01/tyrionlannister.js
+++ b/server/game/cards/characters/01/tyrionlannister.js
@@ -12,7 +12,7 @@ class TyrionLannister extends DrawCard {
     }
 
     onChallenge(event, challenge) {
-        if(!this.inPlay || challenge.challengeType !== 'intrigue' || this.abilityUsed >= 2) {
+        if(challenge.challengeType !== 'intrigue' || this.abilityUsed >= 2) {
             return;
         }
 

--- a/server/game/cards/characters/01/tywinlannister.js
+++ b/server/game/cards/characters/01/tywinlannister.js
@@ -10,10 +10,6 @@ class TywinLannister extends DrawCard {
     }
 
     updateStrength() {
-        if(!this.inPlay) {
-            return;
-        }
-
         this.strengthModifier -= this.lastGold;
         this.strengthModifier += this.controller.gold;
 

--- a/server/game/cards/characters/01/wildlinghorde.js
+++ b/server/game/cards/characters/01/wildlinghorde.js
@@ -15,11 +15,11 @@ class WildlingHorde extends DrawCard {
             return false;
         }
 
-        return card.inPlay && card.controller === player && card.hasTrait('Wildling') && currentChallenge.isAttacking(card);
+        return card.location === 'play area' && card.controller === player && card.hasTrait('Wildling') && currentChallenge.isAttacking(card);
     }
 
     kneelFactionCard(player) {
-        if(!this.inPlay || this.controller !== player || player.faction.kneeled) {
+        if(this.controller !== player || player.faction.kneeled) {
             return false;
         }
 
@@ -38,7 +38,7 @@ class WildlingHorde extends DrawCard {
     }
 
     onCardSelected(player, card) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return false;
         }
 

--- a/server/game/cards/characters/02/bronn.js
+++ b/server/game/cards/characters/02/bronn.js
@@ -10,7 +10,7 @@ class Bronn extends DrawCard {
     }
 
     onChallenge(e, challenge) {
-        if(!this.inPlay || this.controller !== challenge.defendingPlayer) {
+        if(this.controller !== challenge.defendingPlayer) {
             return;
         }
 
@@ -20,7 +20,7 @@ class Bronn extends DrawCard {
     }
 
     onChallengeFinished(e, challenge) {
-        if(!this.inPlay || this.controller !== challenge.defendingPlayer) {
+        if(this.controller !== challenge.defendingPlayer) {
             return;
         }
 
@@ -30,7 +30,7 @@ class Bronn extends DrawCard {
     }
 
     takeControl(player) {
-        if(!this.inPlay || player.controller === this.controller || player.gold < 1) {
+        if(player.controller === this.controller || player.gold < 1) {
             return;
         }
 

--- a/server/game/cards/characters/02/hodor.js
+++ b/server/game/cards/characters/02/hodor.js
@@ -9,7 +9,7 @@ class Hodor extends DrawCard {
 
     onAttackerSelected(event, challenge, card) {
         var player = challenge.attackingPlayer;
-        if(!this.inPlay || this.controller !== player || card !== this) {
+        if(this.controller !== player || card !== this) {
             return;
         }
 
@@ -19,7 +19,7 @@ class Hodor extends DrawCard {
     }
 
     modifyDominance(player, strength) {
-        if(!this.inPlay || this.controller !== player || this.kneeled) {
+        if(this.controller !== player || this.kneeled) {
             return strength;
         }
 

--- a/server/game/cards/characters/02/redcloaks.js
+++ b/server/game/cards/characters/02/redcloaks.js
@@ -13,7 +13,7 @@ class RedCloaks extends DrawCard {
     }
 
     addGold(player) {
-        if(!this.inPlay || this.controller !== player || this.usedThisPhase || player.gold <= 0) {
+        if(this.location !== 'play area' || this.controller !== player || this.usedThisPhase || player.gold <= 0) {
             return;
         }
 
@@ -30,7 +30,7 @@ class RedCloaks extends DrawCard {
     }
 
     onAttackersDeclared(e, challenge) {
-        if(!this.inPlay || this.controller !== challenge.attackingPlayer || challenge.challengeType !== 'intrigue') {
+        if(this.location !== 'play area' || this.controller !== challenge.attackingPlayer || challenge.challengeType !== 'intrigue') {
             return;
         }
 

--- a/server/game/cards/characters/02/thehound.js
+++ b/server/game/cards/characters/02/thehound.js
@@ -8,7 +8,7 @@ class TheHound extends DrawCard {
     }
 
     afterChallenge(event, challenge) {
-        if(!this.inPlay || challenge.winner !== this.controller) {
+        if(challenge.winner !== this.controller) {
             return;
         }
 

--- a/server/game/cards/characters/03/catelynstark.js
+++ b/server/game/cards/characters/03/catelynstark.js
@@ -11,7 +11,7 @@ class CatelynStark extends DrawCard {
     }
 
     updateStrength() {
-        if(!this.inPlay || this.isBlank()) {
+        if(this.isBlank()) {
             return;
         }
 
@@ -26,7 +26,7 @@ class CatelynStark extends DrawCard {
     }
 
     onCardSacrificed(event, player, card) {
-        if(!this.inPlay || this.isBlank() || this.controller !== player || this.abilityUsed >= 2) {
+        if(this.isBlank() || this.controller !== player || this.abilityUsed >= 2) {
             return;
         }
 
@@ -53,7 +53,7 @@ class CatelynStark extends DrawCard {
     }
 
     gainPower(player) {
-        if(!this.inPlay || this.isBlank() || this.controller !== player) {
+        if(this.isBlank() || this.controller !== player) {
             return false;
         }
 
@@ -67,7 +67,7 @@ class CatelynStark extends DrawCard {
     }
 
     cancel(player) {
-        if(!this.inPlay || this.isBlank() || this.controller !== player) {
+        if(this.isBlank() || this.controller !== player) {
             return false;
         }
 

--- a/server/game/cards/characters/03/eddardstark.js
+++ b/server/game/cards/characters/03/eddardstark.js
@@ -9,7 +9,7 @@ class EddardStark extends DrawCard {
 
     onRenown(event, challenge, card) {
         var player = challenge.winner;
-        if(!this.inPlay || this.isBlank() || this.controller !== player || card !== this) {
+        if(this.isBlank() || this.controller !== player || card !== this) {
             return;
         }
 
@@ -26,7 +26,7 @@ class EddardStark extends DrawCard {
     }
 
     onCardSelected(player, card) {
-        if(!this.inPlay || this.isBlank() || this.controller !== player) {
+        if(this.isBlank() || this.controller !== player) {
             return;
         }
 

--- a/server/game/cards/characters/03/jonsnow.js
+++ b/server/game/cards/characters/03/jonsnow.js
@@ -10,14 +10,14 @@ class JonSnow extends DrawCard {
     }
 
     sacrifice(player) {
-        if(!this.inPlay || this.controller !== player || this.usedThisRound) {
+        if(this.controller !== player || this.usedThisRound) {
             return;
         }
 
         this.game.promptForSelect(this.controller, {
             activePromptTitle: 'Select a character to sacrifice',
             waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
-            cardCondition: card => card.inPlay && card.controller === this.controller && card.getType() === 'character' && card.getFaction() === this.getFaction(),
+            cardCondition: card => card.location === 'play area' && card.controller === this.controller && card.getType() === 'character' && card.getFaction() === this.getFaction(),
             onSelect: (p, card) => this.onSacrificeSelected(p, card)
         });        
 
@@ -30,7 +30,7 @@ class JonSnow extends DrawCard {
         this.game.promptForSelect(this.controller, {
             activePromptTitle: 'Select a character to stand',
             waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
-            cardCondition: card => card.inPlay && card.controller === this.controller && card.getType() === 'character' && 
+            cardCondition: card => card.location === 'play area' && card.controller === this.controller && card.getType() === 'character' &&
                 card.getFaction() === this.getFaction() && card.isUnique() && card.kneeled,
             onSelect: (p, card) => this.onStandSelected(p, card)
         });

--- a/server/game/cards/characters/03/oldnan.js
+++ b/server/game/cards/characters/03/oldnan.js
@@ -10,7 +10,7 @@ class OldNan extends DrawCard {
     }
 
     onPlotFlip() {
-        if(!this.inPlay || this.kneeled) {
+        if(this.kneeled) {
             return;
         }
 
@@ -36,7 +36,7 @@ class OldNan extends DrawCard {
     }
 
     plotSelected(player, cardId) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return false;
         }
 

--- a/server/game/cards/characters/04/shae.js
+++ b/server/game/cards/characters/04/shae.js
@@ -13,7 +13,7 @@ class Shae extends DrawCard {
     }
 
     stand(player) {
-        if(!this.inPlay || this.controller !== player || this.usedThisPhase >= 2 || player.gold <= 0 || !this.kneeled) {
+        if(this.controller !== player || this.usedThisPhase >= 2 || player.gold <= 0 || !this.kneeled) {
             return;
         }
 

--- a/server/game/cards/characters/05/cerseilannister.js
+++ b/server/game/cards/characters/05/cerseilannister.js
@@ -13,7 +13,7 @@ class CerseiLannister extends DrawCard {
 
     onAttackersDeclared(e, challenge) {
         var player = challenge.attackingPlayer;
-        if(!this.inPlay || this.controller !== player || challenge.challengeType !== 'intrigue') {
+        if(this.controller !== player || challenge.challengeType !== 'intrigue') {
             return;
         }
 
@@ -23,7 +23,7 @@ class CerseiLannister extends DrawCard {
     }
 
     onCardDiscarded(event, player, card) {
-        if(!this.inPlay || this.controller === player || card.location !== 'hand' || this.abilityUsed >= 3 || this.isBlank()) {
+        if(this.controller === player || card.location !== 'hand' || this.abilityUsed >= 3 || this.isBlank()) {
             return;
         }
 

--- a/server/game/cards/events/01/puttothesword.js
+++ b/server/game/cards/events/01/puttothesword.js
@@ -24,7 +24,7 @@ class PutToTheSword extends DrawCard {
         this.game.promptForSelect(player, {
             activePromptTitle: 'Select a character to kill',
             waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
-            cardCondition: card => card.inPlay && card.controller !== player && card.getType() === 'character',
+            cardCondition: card => card.location === 'play area' && card.controller !== player && card.getType() === 'character',
             onSelect: (p, card) => this.onCardSelected(p, card)
         });
     }

--- a/server/game/cards/events/01/puttothetorch.js
+++ b/server/game/cards/events/01/puttothetorch.js
@@ -24,7 +24,7 @@ class PutToTheTorch extends DrawCard {
         this.game.promptForSelect(player, {
             activePromptTitle: 'Select a location to discard',
             waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
-            cardCondition: card => card.inPlay && card.controller !== player && card.getType() === 'location',
+            cardCondition: card => card.location === 'play area' && card.controller !== player && card.getType() === 'location',
             onSelect: (p, card) => this.onCardSelected(p, card)
         });
     }

--- a/server/game/cards/events/01/tearsoflys.js
+++ b/server/game/cards/events/01/tearsoflys.js
@@ -29,7 +29,7 @@ class TearsOfLys extends DrawCard {
         this.game.promptForSelect(player, {
             activePromptTitle: 'Select a character to receive poison token',
             waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
-            cardCondition: card => card.inPlay && card.controller !== player && card.getType() === 'character' && !card.hasIcon('intrigue'),
+            cardCondition: card => card.location === 'play area' && card.controller !== player && card.getType() === 'character' && !card.hasIcon('intrigue'),
             onSelect: (p, card) => this.onCardSelected(p, card)
         });
     }
@@ -45,7 +45,7 @@ class TearsOfLys extends DrawCard {
     }
 
     onEndChallengePhase() {
-        if(this.poisonTarget && this.poisonTarget.inPlay && this.poisonTarget.hasToken('poison')) {
+        if(this.poisonTarget && this.poisonTarget.location === 'play area' && this.poisonTarget.hasToken('poison')) {
             this.poisonTarget.controller.killCharacter(this.poisonTarget);
 
             this.game.addMessage('{0} uses {1} to kill {2} at the end of the phase', this.controller, this, this.poisonTarget);

--- a/server/game/cards/locations/01/casterlyrock.js
+++ b/server/game/cards/locations/01/casterlyrock.js
@@ -8,10 +8,6 @@ class CasterlyRock extends DrawCard {
     }
 
     onPlotFlip() {
-        if(!this.inPlay) {
-            return;
-        }
-
         if(!this.isBlank()) {
             this.controller.addChallenge('intrigue', 1);
         }

--- a/server/game/cards/locations/01/chamberofthepaintedtable.js
+++ b/server/game/cards/locations/01/chamberofthepaintedtable.js
@@ -8,7 +8,7 @@ class ChamberOfThePaintedTable extends DrawCard {
     }
 
     onDominanceDetermined(event, winner) {
-        if(!this.inPlay || this.isBlank() || this.controller !== winner) {
+        if(this.isBlank() || this.controller !== winner) {
             return;
         }
 
@@ -25,7 +25,7 @@ class ChamberOfThePaintedTable extends DrawCard {
     }
 
     gainPower(player) {
-        if(!this.inPlay || this.isBlank() || this.controller !== player) {
+        if(this.isBlank() || this.controller !== player) {
             return false;
         }
 
@@ -41,7 +41,7 @@ class ChamberOfThePaintedTable extends DrawCard {
     }
 
     cancel(player) {
-        if(!this.inPlay || this.isBlank() || this.controller !== player) {
+        if(this.isBlank() || this.controller !== player) {
             return false;
         }
 

--- a/server/game/cards/locations/01/greatkraken.js
+++ b/server/game/cards/locations/01/greatkraken.js
@@ -13,7 +13,7 @@ class GreatKraken extends DrawCard {
 
     onUnopposedWin(event, challenge) {
         var winner = challenge.winner;
-        if(!this.inPlay || this.isBlank() || this.controller !== winner && this.abilityUsed < 2) {
+        if(this.isBlank() || this.controller !== winner && this.abilityUsed < 2) {
             return;
         }
 
@@ -31,7 +31,7 @@ class GreatKraken extends DrawCard {
     }
 
     onCardPlayed(event, player, card) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return;
         }
 
@@ -41,7 +41,7 @@ class GreatKraken extends DrawCard {
     }
 
     gainPower(player) {
-        if(!this.inPlay || this.isBlank() || this.controller !== player) {
+        if(this.isBlank() || this.controller !== player) {
             return false;
         }
 
@@ -55,7 +55,7 @@ class GreatKraken extends DrawCard {
     }
 
     drawCard(player) {
-        if(!this.inPlay || this.isBlank() || this.controller !== player) {
+        if(this.isBlank() || this.controller !== player) {
             return false;
         }
 
@@ -69,7 +69,7 @@ class GreatKraken extends DrawCard {
     }
 
     cancel(player) {
-        if(!this.inPlay || this.isBlank() || this.controller !== player) {
+        if(this.isBlank() || this.controller !== player) {
             return false;
         }
 

--- a/server/game/cards/locations/01/lannisport.js
+++ b/server/game/cards/locations/01/lannisport.js
@@ -12,7 +12,7 @@ class Lannisport extends DrawCard {
     }
 
     afterChallenge(event, challenge) {
-        if(!this.inPlay || this.isBlank()) {
+        if(this.isBlank()) {
             return;
         }
 
@@ -33,7 +33,7 @@ class Lannisport extends DrawCard {
     }
 
     drawCard(player) {
-        if(!this.inPlay || this.isBlank() || this.controller !== player) {
+        if(this.isBlank() || this.controller !== player) {
             return false;
         }
 
@@ -45,7 +45,7 @@ class Lannisport extends DrawCard {
     }
 
     cancel(player) {
-        if(!this.inPlay || this.isBlank() || this.controller !== player) {
+        if(this.isBlank() || this.controller !== player) {
             return false;
         }
 

--- a/server/game/cards/locations/01/theironthrone.js
+++ b/server/game/cards/locations/01/theironthrone.js
@@ -6,7 +6,7 @@ class TheIronThrone extends DrawCard {
     }
 
     modifyDominance(player, strength) {
-        if(this.inPlay && this.controller === player) {
+        if(this.controller === player) {
             return strength + 8;
         }
 

--- a/server/game/cards/locations/01/theredkeep.js
+++ b/server/game/cards/locations/01/theredkeep.js
@@ -8,10 +8,6 @@ class TheRedKeep extends DrawCard {
     }
 
     onAttackersDeclared(event, challenge) {
-        if(!this.inPlay) {
-            return;
-        }
-
         if(challenge.challengeType === 'power' && challenge.attackers.length > 0) {
             challenge.modifyAttackerStrength(2);
 
@@ -20,7 +16,7 @@ class TheRedKeep extends DrawCard {
     }
 
     onEndChallengePhase() {
-        if(!this.inPlay || this.kneeled) {
+        if(this.kneeled) {
             return;
         }
 
@@ -39,7 +35,7 @@ class TheRedKeep extends DrawCard {
     }
 
     drawTwo(player) {
-        if(!this.inPlay || this.isBlank() || this.controller !== player) {
+        if(this.isBlank() || this.controller !== player) {
             return false;
         }
 
@@ -51,7 +47,7 @@ class TheRedKeep extends DrawCard {
     }
 
     cancel(player) {
-        if(!this.inPlay || this.isBlank() || this.controller !== player) {
+        if(this.isBlank() || this.controller !== player) {
             return false;
         }
 

--- a/server/game/cards/locations/01/thewall.js
+++ b/server/game/cards/locations/01/thewall.js
@@ -18,7 +18,7 @@ class TheWall extends DrawCard {
     }
 
     onCardPlayed(e, player, card) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return;
         }
 
@@ -28,10 +28,6 @@ class TheWall extends DrawCard {
     }
 
     onUnopposedWin(e, challenge) {
-        if(!this.inPlay) {
-            return;
-        }
-
         if(this.controller !== challenge.winner && !this.kneeled) {
             this.game.addMessage('{0} is forced to kneel {1} because they lost an unopposed challenge', this.controller, this);
             this.kneeled = true;
@@ -39,7 +35,7 @@ class TheWall extends DrawCard {
     }
 
     onEndChallengePhase() {
-        if(!this.inPlay || this.kneeled) {
+        if(this.kneeled) {
             return;
         }
 
@@ -56,7 +52,7 @@ class TheWall extends DrawCard {
     }
 
     kneel(player) {
-        if(!this.inPlay || this.isBlank() || this.controller !== player) {
+        if(this.isBlank() || this.controller !== player) {
             return false;
         }
 
@@ -68,7 +64,7 @@ class TheWall extends DrawCard {
     }
 
     cancel(player) {
-        if(!this.inPlay || this.isBlank() || this.controller !== player) {
+        if(this.isBlank() || this.controller !== player) {
             return false;
         }
 

--- a/server/game/cards/locations/02/cerseiswheelhouse.js
+++ b/server/game/cards/locations/02/cerseiswheelhouse.js
@@ -8,7 +8,7 @@ class CerseisWheelhouse extends DrawCard {
     }
 
     onFirstPlayerDetermined(event, player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return;
         }
 

--- a/server/game/cards/locations/02/streetofthesisters.js
+++ b/server/game/cards/locations/02/streetofthesisters.js
@@ -8,7 +8,7 @@ class StreetOfTheSisters extends DrawCard {
     }
 
     afterChallenge(event, challenge) {
-        if(!this.inPlay || this.controller.faction.kneeled) {
+        if(this.controller.faction.kneeled) {
             return;
         }
 

--- a/server/game/cards/locations/03/winterfell.js
+++ b/server/game/cards/locations/03/winterfell.js
@@ -18,7 +18,7 @@ class Winterfell extends DrawCard {
     }
 
     onCardPlayed(e, player, card) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return;
         }
 

--- a/server/game/cards/locations/04/bitterbridgeencampment.js
+++ b/server/game/cards/locations/04/bitterbridgeencampment.js
@@ -10,7 +10,7 @@ class BitterbridgeEncampment extends DrawCard {
     }
 
     onPlotRevealed(event, player) {
-        if(!this.inPlay || this.kneeled || !player.activePlot.hasTrait('Summer')) {
+        if(this.kneeled || !player.activePlot.hasTrait('Summer')) {
             return;
         }
 
@@ -33,7 +33,7 @@ class BitterbridgeEncampment extends DrawCard {
     }
 
     kneel(player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return false;
         }
 

--- a/server/game/cards/plots/01/aclashofkings.js
+++ b/server/game/cards/plots/01/aclashofkings.js
@@ -8,10 +8,6 @@ class AClashOfKings extends PlotCard {
     }
 
     afterChallenge(e, challenge) {
-        if(!this.inPlay) {
-            return;
-        }
-
         if(challenge.winner === this.controller && challenge.challengeType === 'power' && challenge.loser.power > 0) {
             this.game.addMessage('{0} uses {1} to move 1 power from {2}\'s faction card to their own', challenge.winner, this, challenge.loser);
 

--- a/server/game/cards/plots/01/afeastforcrows.js
+++ b/server/game/cards/plots/01/afeastforcrows.js
@@ -8,7 +8,7 @@ class AFeastForCrows extends PlotCard {
     }
 
     onDominanceDetermined(event, winner) {
-        if(!this.inPlay || winner !== this.controller) {
+        if(winner !== this.controller) {
             return;
         }
 

--- a/server/game/cards/plots/01/agameofthrones.js
+++ b/server/game/cards/plots/01/agameofthrones.js
@@ -2,7 +2,7 @@ const PlotCard = require('../../../plotcard.js');
 
 class AGameOfThrones extends PlotCard {
     canChallenge(player, challengeType) {
-        if(this.inPlay && (challengeType === 'power' || challengeType === 'military') && player.getNumberOfChallengesWon('intrigue') <= 0) {
+        if((challengeType === 'power' || challengeType === 'military') && player.getNumberOfChallengesWon('intrigue') <= 0) {
             return false;
         }
 

--- a/server/game/cards/plots/01/anoblecause.js
+++ b/server/game/cards/plots/01/anoblecause.js
@@ -8,7 +8,7 @@ class ANobleCause extends PlotCard {
     }
 
     canReduce(player, card) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return false;
         }
 

--- a/server/game/cards/plots/01/buildingorders.js
+++ b/server/game/cards/plots/01/buildingorders.js
@@ -4,7 +4,7 @@ const PlotCard = require('../../../plotcard.js');
 
 class BuildingOrders extends PlotCard {
     onReveal(player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return true;
         }
 

--- a/server/game/cards/plots/01/callingthebanners.js
+++ b/server/game/cards/plots/01/callingthebanners.js
@@ -2,7 +2,7 @@ const PlotCard = require('../../../plotcard.js');
 
 class CallingTheBanners extends PlotCard {
     onReveal(player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return true;
         }
 

--- a/server/game/cards/plots/01/calmoverwesteros.js
+++ b/server/game/cards/plots/01/calmoverwesteros.js
@@ -2,7 +2,7 @@ const PlotCard = require('../../../plotcard.js');
 
 class CalmOverWesteros extends PlotCard {
     onReveal(player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return true;
         }
 
@@ -34,7 +34,7 @@ class CalmOverWesteros extends PlotCard {
     }
 
     modifyClaim(player, challengeType, claim) {
-        if(!this.inPlay || player === this.controller || this.challengeType !== challengeType) {
+        if(player === this.controller || this.challengeType !== challengeType) {
             return claim;
         }
 

--- a/server/game/cards/plots/01/confiscation.js
+++ b/server/game/cards/plots/01/confiscation.js
@@ -2,7 +2,7 @@ const PlotCard = require('../../../plotcard.js');
 
 class Confiscation extends PlotCard {
     onReveal(player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return true;
         }
 
@@ -21,10 +21,6 @@ class Confiscation extends PlotCard {
     }
 
     onCardSelected(player, attachment) {
-        if(!this.inPlay) {
-            return false;
-        }
-
         attachment.owner.discardCard(attachment);
 
         this.game.addMessage('{0} uses {1} to discard {2}', player, this, attachment);

--- a/server/game/cards/plots/01/countingcoppers.js
+++ b/server/game/cards/plots/01/countingcoppers.js
@@ -2,7 +2,7 @@ const PlotCard = require('../../../plotcard.js');
 
 class CountingCoppers extends PlotCard {
     onReveal(player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return true;
         }
 

--- a/server/game/cards/plots/01/filthyaccusations.js
+++ b/server/game/cards/plots/01/filthyaccusations.js
@@ -2,7 +2,7 @@ const PlotCard = require('../../../plotcard.js');
 
 class FilthyAccusations extends PlotCard {
     onReveal(player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return true;
         }
 
@@ -20,10 +20,6 @@ class FilthyAccusations extends PlotCard {
     }
 
     onCardSelected(player, card) {
-        if(!this.inPlay) {
-            return false;
-        }
-
         card.kneeled = true;
 
         this.game.addMessage('{0} uses {1} to kneel {2}', player, this, card);

--- a/server/game/cards/plots/01/headsonspikes.js
+++ b/server/game/cards/plots/01/headsonspikes.js
@@ -4,7 +4,7 @@ const PlotCard = require('../../../plotcard.js');
 
 class HeadsOnSpikes extends PlotCard {
     onReveal(player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return true;
         }
 

--- a/server/game/cards/plots/01/marchedtothewall.js
+++ b/server/game/cards/plots/01/marchedtothewall.js
@@ -4,7 +4,7 @@ const PlotCard = require('../../../plotcard.js');
 
 class MarchedToTheWall extends PlotCard {
     onReveal(player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return true;
         }
 

--- a/server/game/cards/plots/01/marchingorders.js
+++ b/server/game/cards/plots/01/marchingorders.js
@@ -2,7 +2,7 @@ const PlotCard = require('../../../plotcard.js');
 
 class MarchingOrders extends PlotCard {
     canPlay(player, card) {
-        if(!this.inPlay || this.controller !== player || this.controller !== card.controller) {
+        if(this.controller !== player || this.controller !== card.controller) {
             return true;
         }
 

--- a/server/game/cards/plots/01/navalsuperirority.js
+++ b/server/game/cards/plots/01/navalsuperirority.js
@@ -2,10 +2,6 @@ const PlotCard = require('../../../plotcard.js');
 
 class NavalSuperiority extends PlotCard {
     modifyIncome(player, income) {
-        if(!this.inPlay) {
-            return income;
-        }
-
         if(player.activePlot.hasTrait('Kingdom') || player.activePlot.hasTrait('Edict')) {
             this.game.addMessage('{0} uses {1} to treat the gold value of {2} as if it were 0', this.controller, this, player.activePlot);
 

--- a/server/game/cards/plots/01/powerbehindthethrone.js
+++ b/server/game/cards/plots/01/powerbehindthethrone.js
@@ -8,7 +8,7 @@ class PowerBehindTheThrone extends PlotCard {
     }
 
     onReveal(player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return true;
         }
 
@@ -27,7 +27,7 @@ class PowerBehindTheThrone extends PlotCard {
         this.game.promptForSelect(player, {
             activePromptTitle: 'Select a character to stand',
             waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
-            cardCondition: card => card.inPlay && card.controller === player && card.kneeled,
+            cardCondition: card => card.location === 'play area' && card.controller === player && card.kneeled,
             onSelect: (p, card) => this.onCardSelected(p, card)
         });
     }

--- a/server/game/cards/plots/01/rebuilding.js
+++ b/server/game/cards/plots/01/rebuilding.js
@@ -4,7 +4,7 @@ const PlotCard = require('../../../plotcard.js');
 
 class Rebuilding extends PlotCard {
     onReveal(player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return true;
         }
 
@@ -25,10 +25,6 @@ class Rebuilding extends PlotCard {
     }
 
     doneSelect(player, cards) {
-        if(!this.inPlay) {
-            return false;
-        }
-
         var params = '';
         var paramIndex = 2;
 

--- a/server/game/cards/plots/01/reinforcement.js
+++ b/server/game/cards/plots/01/reinforcement.js
@@ -2,7 +2,7 @@ const PlotCard = require('../../../plotcard.js');
 
 class Reinforcements extends PlotCard {
     onReveal(player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return true;
         }
 
@@ -25,10 +25,6 @@ class Reinforcements extends PlotCard {
     }
 
     onCardClicked(player, card) {
-        if(!this.inPlay) {
-            return false;
-        }
-
         var hand = !!player.findCardByUuid(player.hand, card.uuid);
 
         this.game.addMessage('{0} uses {1} to put {2} into play from their {3}', player, this, card, hand ? 'hand' : 'discard pile');

--- a/server/game/cards/plots/01/summons.js
+++ b/server/game/cards/plots/01/summons.js
@@ -4,7 +4,7 @@ const PlotCard = require('../../../plotcard.js');
 
 class Summons extends PlotCard {
     onReveal(player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return true;
         }
 

--- a/server/game/cards/plots/01/wildfireassault.js
+++ b/server/game/cards/plots/01/wildfireassault.js
@@ -4,7 +4,7 @@ const PlotCard = require('../../../plotcard.js');
 
 class WildfireAssault extends PlotCard {
     onReveal(player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return true;
         }
 

--- a/server/game/cards/plots/02/closecall.js
+++ b/server/game/cards/plots/02/closecall.js
@@ -2,7 +2,7 @@ const PlotCard = require('../../../plotcard.js');
 
 class CloseCall extends PlotCard {
     onReveal(player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return true;
         }
 
@@ -21,10 +21,6 @@ class CloseCall extends PlotCard {
     }
 
     onCardSelected(player, card) {
-        if(!this.inPlay) {
-            return false;
-        }
-
         player.moveCard(card, 'discard pile');
 
         this.game.addMessage('{0} uses {1} to move {2} to their discard pile', player, this, card);

--- a/server/game/cards/plots/02/heretoserve.js
+++ b/server/game/cards/plots/02/heretoserve.js
@@ -4,7 +4,7 @@ const PlotCard = require('../../../plotcard.js');
 
 class HereToServe extends PlotCard {
     onReveal(player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return true;
         }
 

--- a/server/game/cards/plots/02/politicaldisaster.js
+++ b/server/game/cards/plots/02/politicaldisaster.js
@@ -4,7 +4,7 @@ const PlotCard = require('../../../plotcard.js');
 
 class PoliticalDisaster extends PlotCard {
     onReveal(player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return true;
         }
 

--- a/server/game/cards/plots/02/riseofthekraken.js
+++ b/server/game/cards/plots/02/riseofthekraken.js
@@ -9,7 +9,7 @@ class RiseOfTheKraken extends PlotCard {
 
     onUnopposedWin(e, challenge) {
         var player = challenge.winner;
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return;
         }
 
@@ -26,7 +26,7 @@ class RiseOfTheKraken extends PlotCard {
     }
 
     gainPower(player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return false;
         }
 
@@ -38,7 +38,7 @@ class RiseOfTheKraken extends PlotCard {
     }
 
     cancel(player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return false;
         }
         

--- a/server/game/cards/plots/02/thelongplan.js
+++ b/server/game/cards/plots/02/thelongplan.js
@@ -8,7 +8,7 @@ class TheLongPlan extends PlotCard {
     }
 
     onBeforeTaxation(event, player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return;
         }
 
@@ -16,7 +16,7 @@ class TheLongPlan extends PlotCard {
     }
 
     afterChallenge(event, challenge) {
-        if(!this.inPlay || this.controller !== challenge.loser) {
+        if(this.controller !== challenge.loser) {
             return;
         }
 
@@ -33,7 +33,7 @@ class TheLongPlan extends PlotCard {
     }
 
     gainGold(player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return false;
         }
 
@@ -45,7 +45,7 @@ class TheLongPlan extends PlotCard {
     }
 
     cancel(player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return false;
         }
         

--- a/server/game/cards/plots/02/tradingwiththepentoshi.js
+++ b/server/game/cards/plots/02/tradingwiththepentoshi.js
@@ -2,7 +2,7 @@ const PlotCard = require('../../../plotcard.js');
 
 class TradingWithThePentoshi extends PlotCard {
     onReveal(player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return true;
         }
 

--- a/server/game/cards/plots/03/asongofsummer.js
+++ b/server/game/cards/plots/03/asongofsummer.js
@@ -38,7 +38,7 @@ class ASongOfSummer extends PlotCard {
     }
 
     onCardPlayed(e, player, card) {
-        if(!this.inPlay || this.owner !== player) {
+        if(this.owner !== player) {
             return;
         }
 

--- a/server/game/cards/plots/03/atimeforwolves.js
+++ b/server/game/cards/plots/03/atimeforwolves.js
@@ -4,7 +4,7 @@ const PlotCard = require('../../../plotcard.js');
 
 class ATimeForWolves extends PlotCard {
     onReveal(player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return true;
         }
 

--- a/server/game/cards/plots/03/thelongwinter.js
+++ b/server/game/cards/plots/03/thelongwinter.js
@@ -4,7 +4,7 @@ const PlotCard = require('../../../plotcard.js');
 
 class TheLongWinter extends PlotCard {
     onReveal(player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return true;
         }
 

--- a/server/game/cards/plots/04/summerharvest.js
+++ b/server/game/cards/plots/04/summerharvest.js
@@ -2,7 +2,7 @@ const PlotCard = require('../../../plotcard.js');
 
 class SummerHarvest extends PlotCard {
     onReveal(player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return true;
         }
 

--- a/server/game/cards/plots/04/valarmorghulis.js
+++ b/server/game/cards/plots/04/valarmorghulis.js
@@ -4,7 +4,7 @@ const PlotCard = require('../../../plotcard.js');
 
 class ValarMorghulis extends PlotCard {
     onReveal(player) {
-        if(!this.inPlay || this.controller !== player) {
+        if(this.controller !== player) {
             return true;
         }
 

--- a/server/game/cards/reducer.js
+++ b/server/game/cards/reducer.js
@@ -12,7 +12,7 @@ class Reducer extends DrawCard {
     }
 
     canReduce(player, card) {
-        if(!this.inPlay || this.controller !== player || !this.kneeled || this.abilityUsed) {
+        if(this.controller !== player || !this.kneeled || this.abilityUsed) {
             return false;
         }
 
@@ -20,7 +20,7 @@ class Reducer extends DrawCard {
     }
 
     onClick(player) {
-        if(!this.inPlay || player.phase !== 'marshal' || this.controller !== player || this.kneeled || this.abilityUsed) {
+        if(player.phase !== 'marshal' || this.controller !== player || this.kneeled || this.abilityUsed) {
             return false;
         }
 

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -1,5 +1,6 @@
 const _ = require('underscore');
 const Player = require('./player.js');
+const EventRegistrar = require('./eventregistrar.js');
 
 class Challenge {
     constructor(game, attackingPlayer, defendingPlayer, challengeType) {
@@ -14,6 +15,7 @@ class Challenge {
         this.defenders = [];
         this.defenderStrength = 0;
         this.defenderStrengthModifier = 0;
+        this.events = new EventRegistrar(game, this);
         this.registerEvents(['onCardLeftPlay']);
     }
 
@@ -145,21 +147,11 @@ class Challenge {
     }
 
     registerEvents(events) {
-        this.events = [];
-
-        _.each(events, event => {
-            this[event] = this[event].bind(this);
-
-            this.game.on(event, this[event]);
-
-            this.events.push(event);
-        });
+        this.events.register(events);
     }
 
     unregisterEvents() {
-        _.each(this.events, event => {
-            this.game.removeListener(event, this[event]);
-        });
+        this.events.unregisterAll();
     }
 }
 

--- a/server/game/deck.js
+++ b/server/game/deck.js
@@ -33,14 +33,14 @@ class Deck {
         } else {
             result.faction = new DrawCard(player, { type_code: 'faction' });
         }
-        result.faction.location = 'faction';
+        result.faction.moveTo('faction');
 
         result.allCards = [result.faction].concat(result.drawCards).concat(result.plotCards);
 
         if(this.data.agenda) {
             result.agenda = this.createCard(AgendaCard, player, this.data.agenda);
             result.agenda.inPlay = true;
-            result.agenda.location = 'agenda';
+            result.agenda.moveTo('agenda');
             result.allCards.push(result.agenda);
         } else {
             result.agenda = undefined;

--- a/server/game/deck.js
+++ b/server/game/deck.js
@@ -39,7 +39,6 @@ class Deck {
 
         if(this.data.agenda) {
             result.agenda = this.createCard(AgendaCard, player, this.data.agenda);
-            result.agenda.inPlay = true;
             result.agenda.moveTo('agenda');
             result.allCards.push(result.agenda);
         } else {

--- a/server/game/eventregistrar.js
+++ b/server/game/eventregistrar.js
@@ -1,0 +1,26 @@
+const _ = require('underscore');
+
+class EventRegistrar {
+    constructor(game, context) {
+        this.game = game;
+        this.context = context;
+        this.events = [];
+    }
+
+    register(eventNames) {
+        _.each(eventNames, eventName => {
+            var boundHandler = this.context[eventName].bind(this.context);
+            this.game.on(eventName, boundHandler);
+            this.events.push({ name: eventName, handler: boundHandler });
+        });
+    }
+
+    unregisterAll() {
+        _.each(this.events, event => {
+            this.game.removeListener(event.name, event.handler);
+        });
+        this.events = [];
+    }
+}
+
+module.exports = EventRegistrar;

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -382,7 +382,7 @@ class Game extends EventEmitter {
             this.promptForSelect(player, {
                 activePromptTitle: 'Select a card to set power for',
                 waitingPromptTitle: 'Waiting for opponent to set power',
-                cardCondition: card => card.inPlay && card.controller === player,
+                cardCondition: card => card.location === 'play area' && card.controller === player,
                 onSelect: (p, card) => {
                     card.power = num;
                     this.addMessage('{0} uses the /power command to set the power of {1} to {2}', p, card, num);
@@ -421,7 +421,7 @@ class Game extends EventEmitter {
             this.promptForSelect(player, {
                 activePromptTitle: 'Select a card to set strength for',
                 waitingPromptTitle: 'Waiting for opponent to set strength',
-                cardCondition: card => card.inPlay && card.controller === player && card.getType() === 'character',
+                cardCondition: card => card.location === 'play area' && card.controller === player && card.getType() === 'character',
                 onSelect: (p, card) => {
                     card.strengthModifier = num - card.cardData.strength;
                     this.addMessage('{0} uses the /strength command to set the strength of {1} to {2}', p, card, num);

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -549,7 +549,6 @@ class Player extends Spectator {
 
         attachment.parent = card;
         attachment.moveTo('play area');
-        attachment.inPlay = true;
 
         card.attachments.push(attachment);
 
@@ -670,7 +669,7 @@ class Player extends Spectator {
             return false;
         }
 
-        if(!card.inPlay) {
+        if(card.location !== 'play area') {
             return false;
         }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -243,7 +243,7 @@ class Player extends Spectator {
 
     initDrawDeck() {
         this.hand.each(card => {
-            card.location = 'draw deck';
+            card.moveTo('draw deck');
             this.drawDeck.push(card);
         });
         this.hand = _([]);
@@ -477,14 +477,19 @@ class Player extends Spectator {
 
         if(this.activePlot) {
             var previousPlot = this.removeActivePlot();
+            previousPlot.moveTo('revealed plots');
             this.plotDiscard.push(previousPlot);
         }
 
+        this.selectedPlot.moveTo('active plot');
         this.activePlot = this.selectedPlot;
         this.plotDeck = this.removeCardByUuid(this.plotDeck, this.selectedPlot.uuid);
 
         if(this.plotDeck.isEmpty()) {
             this.plotDeck = this.plotDiscard;
+            _.each(this.plotDeck, plot => {
+                plot.moveTo('plot deck');
+            });
             this.plotDiscard = _([]);
         }
 
@@ -543,8 +548,7 @@ class Player extends Spectator {
         attachment.owner.removeCardFromPile(attachment);
 
         attachment.parent = card;
-        attachment.facedown = false;
-        attachment.location = 'play area';
+        attachment.moveTo('play area');
         attachment.inPlay = true;
 
         card.attachments.push(attachment);
@@ -841,15 +845,11 @@ class Player extends Spectator {
             this.game.raiseEvent('onCardDiscarded', this, card);
         }
 
-        card.location = targetLocation;
+        card.moveTo(targetLocation);
         if(targetLocation === 'draw deck') {
             targetPile.unshift(card);
         } else {
             targetPile.push(card);
-        }
-
-        if(targetLocation !== 'play area') {
-            card.facedown = false;
         }
     }
 
@@ -862,9 +862,8 @@ class Player extends Spectator {
         if(!dupe) {
             return false;
         }
-        
-        dupe.facedown = false;
-        dupe.location = 'discard pile';
+
+        dupe.moveTo('discard pile');
         dupe.owner.discardPile.push(dupe);
         this.game.raiseEvent('onDupeDiscarded', this, card, dupe);
 

--- a/server/game/plotcard.js
+++ b/server/game/plotcard.js
@@ -41,7 +41,6 @@ class PlotCard extends BaseCard {
     }
 
     flipFaceup() {
-        this.inPlay = true;
         this.facedown = false;
     }
 

--- a/test/server/card/drawcard.moveto.spec.js
+++ b/test/server/card/drawcard.moveto.spec.js
@@ -1,0 +1,120 @@
+/*global describe, it, beforeEach, expect, spyOn*/
+/*eslint camelcase: 0, no-invalid-this: 0 */
+
+const DrawCard = require('../../../server/game/drawcard.js');
+
+describe('DrawCard', function () {
+    beforeEach(function () {
+        this.testCard = { code: '111', label: 'test 1(some pack)', name: 'test 1' };
+        this.card = new DrawCard({}, this.testCard);
+        spyOn(this.card.events, 'register');
+        spyOn(this.card.events, 'unregisterAll');
+    });
+
+    describe('moveTo()', function() {
+        it('should set the location', function() {
+            this.card.moveTo('hand');
+            expect(this.card.location).toBe('hand');
+        });
+
+        describe('when the card is facedown', function() {
+            beforeEach(function() {
+                this.card.facedown = true;
+            });
+
+            describe('when moved to the play area', function() {
+                beforeEach(function() {
+                    this.card.moveTo('play area');
+                });
+
+                it('should not flip the card', function() {
+                    expect(this.card.facedown).toBe(true);
+                });
+            });
+
+            describe('when moved to somewhere other than the play area', function() {
+                beforeEach(function() {
+                    this.card.moveTo('hand');
+                });
+
+                it('should flip the card', function() {
+                    expect(this.card.facedown).toBe(false);
+                });
+            });
+        });
+
+        describe('when the card has events', function() {
+            beforeEach(function() {
+                this.card.registerEvents(['foo', 'bar']);
+            });
+
+            describe('when in a non-event handling area', function() {
+                beforeEach(function() {
+                    this.card.location = 'discard pile';
+                });
+
+                describe('and moving to another non-event handling area', function() {
+                    beforeEach(function() {
+                        this.card.moveTo('dead pile');
+                    });
+
+                    it('should not register events', function() {
+                        expect(this.card.events.register).not.toHaveBeenCalled();
+                    });
+
+                    it('should not unregister events', function() {
+                        expect(this.card.events.unregisterAll).not.toHaveBeenCalled();
+                    });
+                });
+
+                describe('and moving to an event handling area', function() {
+                    beforeEach(function() {
+                        this.card.moveTo('play area');
+                    });
+
+                    it('should register events', function() {
+                        expect(this.card.events.register).toHaveBeenCalledWith(['foo', 'bar']);
+                    });
+
+                    it('should not unregister events', function() {
+                        expect(this.card.events.unregisterAll).not.toHaveBeenCalled();
+                    });
+                });
+            });
+
+            describe('when in an event handling area', function() {
+                beforeEach(function() {
+                    this.card.location = 'play area';
+                });
+
+                describe('and moving to another event handling area', function() {
+                    beforeEach(function() {
+                        this.card.moveTo('play area');
+                    });
+
+                    it('should not register events', function() {
+                        expect(this.card.events.register).not.toHaveBeenCalled();
+                    });
+
+                    it('should not unregister events', function() {
+                        expect(this.card.events.unregisterAll).not.toHaveBeenCalled();
+                    });
+                });
+
+                describe('and moving to a non-event handling area', function() {
+                    beforeEach(function() {
+                        this.card.moveTo('draw deck');
+                    });
+
+                    it('should not register events', function() {
+                        expect(this.card.events.register).not.toHaveBeenCalled();
+                    });
+
+                    it('should unregister events', function() {
+                        expect(this.card.events.unregisterAll).toHaveBeenCalled();
+                    });
+                });
+            });
+        });
+    });
+});

--- a/test/server/card/plotcard.moveto.spec.js
+++ b/test/server/card/plotcard.moveto.spec.js
@@ -1,0 +1,120 @@
+/*global describe, it, beforeEach, expect, spyOn*/
+/*eslint camelcase: 0, no-invalid-this: 0 */
+
+const PlotCard = require('../../../server/game/plotcard.js');
+
+describe('PlotCard', function () {
+    beforeEach(function () {
+        this.testCard = { code: '111', label: 'test 1(some pack)', name: 'test 1' };
+        this.card = new PlotCard({}, this.testCard);
+        spyOn(this.card.events, 'register');
+        spyOn(this.card.events, 'unregisterAll');
+    });
+
+    describe('moveTo()', function() {
+        it('should set the location', function() {
+            this.card.moveTo('revealed plots');
+            expect(this.card.location).toBe('revealed plots');
+        });
+
+        describe('when the card is facedown', function() {
+            beforeEach(function() {
+                this.card.facedown = true;
+            });
+
+            describe('when moved to the play area', function() {
+                beforeEach(function() {
+                    this.card.moveTo('play area');
+                });
+
+                it('should not flip the card', function() {
+                    expect(this.card.facedown).toBe(true);
+                });
+            });
+
+            describe('when moved to somewhere other than the play area', function() {
+                beforeEach(function() {
+                    this.card.moveTo('hand');
+                });
+
+                it('should flip the card', function() {
+                    expect(this.card.facedown).toBe(false);
+                });
+            });
+        });
+
+        describe('when the card has events', function() {
+            beforeEach(function() {
+                this.card.registerEvents(['foo', 'bar']);
+            });
+
+            describe('when in a non-event handling area', function() {
+                beforeEach(function() {
+                    this.card.location = 'plot deck';
+                });
+
+                describe('and moving to another non-event handling area', function() {
+                    beforeEach(function() {
+                        this.card.moveTo('revealed plots');
+                    });
+
+                    it('should not register events', function() {
+                        expect(this.card.events.register).not.toHaveBeenCalled();
+                    });
+
+                    it('should not unregister events', function() {
+                        expect(this.card.events.unregisterAll).not.toHaveBeenCalled();
+                    });
+                });
+
+                describe('and moving to an event handling area', function() {
+                    beforeEach(function() {
+                        this.card.moveTo('active plot');
+                    });
+
+                    it('should register events', function() {
+                        expect(this.card.events.register).toHaveBeenCalledWith(['foo', 'bar']);
+                    });
+
+                    it('should not unregister events', function() {
+                        expect(this.card.events.unregisterAll).not.toHaveBeenCalled();
+                    });
+                });
+            });
+
+            describe('when in an event handling area', function() {
+                beforeEach(function() {
+                    this.card.location = 'active plot';
+                });
+
+                describe('and moving to another event handling area', function() {
+                    beforeEach(function() {
+                        this.card.moveTo('active plot');
+                    });
+
+                    it('should not register events', function() {
+                        expect(this.card.events.register).not.toHaveBeenCalled();
+                    });
+
+                    it('should not unregister events', function() {
+                        expect(this.card.events.unregisterAll).not.toHaveBeenCalled();
+                    });
+                });
+
+                describe('and moving to a non-event handling area', function() {
+                    beforeEach(function() {
+                        this.card.moveTo('revealed plots');
+                    });
+
+                    it('should not register events', function() {
+                        expect(this.card.events.register).not.toHaveBeenCalled();
+                    });
+
+                    it('should unregister events', function() {
+                        expect(this.card.events.unregisterAll).toHaveBeenCalled();
+                    });
+                });
+            });
+        });
+    });
+});

--- a/test/server/cards/agendas/05045 - therainsofcastamere.spec.js
+++ b/test/server/cards/agendas/05045 - therainsofcastamere.spec.js
@@ -7,7 +7,7 @@ const TheRainsOfCastamere = require('../../../../server/game/cards/agendas/thera
 
 describe('The Rains of Castamere', function() {
     function createPlotSpy(uuid, hasTrait) {
-        var plot = jasmine.createSpyObj('plot', ['hasTrait']);
+        var plot = jasmine.createSpyObj('plot', ['hasTrait', 'moveTo']);
         plot.uuid = uuid;
         plot.hasTrait.and.callFake(hasTrait);
         return plot;
@@ -78,6 +78,7 @@ describe('The Rains of Castamere', function() {
 
             it('should not make the plot leave play directly', function() {
                 expect(this.player.removeActivePlot).not.toHaveBeenCalled();
+                expect(this.plot1.moveTo).not.toHaveBeenCalled();
             });
         });
 
@@ -90,6 +91,7 @@ describe('The Rains of Castamere', function() {
 
             it('should remove the active plot from the game', function() {
                 expect(this.player.removeActivePlot).toHaveBeenCalled();
+                expect(this.scheme1.moveTo).toHaveBeenCalledWith('out of game');
             });
         });
     });

--- a/test/server/cards/characters/01/01087 - serjaimelannister.spec.js
+++ b/test/server/cards/characters/01/01087 - serjaimelannister.spec.js
@@ -30,7 +30,6 @@ describe('SerJaimeLannister', function() {
 
         describe('and this card is in play', function() {
             beforeEach(function() {
-                this.character.inPlay = true;
                 this.character.kneeled = true;
             });
 

--- a/test/server/cards/characters/02/02070 - redcloaks.spec.js
+++ b/test/server/cards/characters/02/02070 - redcloaks.spec.js
@@ -15,13 +15,13 @@ describe('RedCloaks', function() {
         this.otherPlayerSpy.game = this.gameSpy;
 
         this.card = new RedCloaks(this.playerSpy, {});
-        this.card.inPlay = true;
+        this.card.location = 'play area';
     });
 
     describe('addGold', function() {
         describe('when called while i am not in play', function() {
             beforeEach(function() {
-                this.card.inPlay = false;
+                this.card.location = 'discard pile';
                 this.playerSpy.gold = 10;
                 this.card.addGold(this.playerSpy);
             });
@@ -115,7 +115,7 @@ describe('RedCloaks', function() {
 
             describe('and this card is not in play', function() {
                 beforeEach(function() {
-                    this.card.inPlay = false;
+                    this.card.location = 'hand';
                     this.card.onAttackersDeclared({}, this.challenge);
                 });
 

--- a/test/server/cards/plots/01/01001-aclashofkings.spec.js
+++ b/test/server/cards/plots/01/01001-aclashofkings.spec.js
@@ -23,7 +23,7 @@ describe('AClashOfKings', function() {
         });
 
         it('should register its afterChallenge handler', function() {
-            expect(this.gameSpy.on).toHaveBeenCalledWith('afterChallenge', this.plot.afterChallenge);
+            expect(this.gameSpy.on).toHaveBeenCalledWith('afterChallenge', jasmine.any(Function));
         });
     });
 
@@ -37,7 +37,7 @@ describe('AClashOfKings', function() {
         });
 
         it('should unregister its afterChallenge handler', function() {
-            expect(this.gameSpy.removeListener).toHaveBeenCalledWith('afterChallenge', this.plot.afterChallenge);
+            expect(this.gameSpy.removeListener).toHaveBeenCalledWith('afterChallenge', jasmine.any(Function));
         });
     });
 

--- a/test/server/cards/plots/01/01001-aclashofkings.spec.js
+++ b/test/server/cards/plots/01/01001-aclashofkings.spec.js
@@ -34,10 +34,6 @@ describe('AClashOfKings', function() {
             this.plot.moveTo('revealed plots');
         });
 
-        it('should be marked as not in play', function() {
-            expect(this.plot.inPlay).toBe(false);
-        });
-
         it('should unregister its afterChallenge handler', function() {
             expect(this.gameSpy.removeListener).toHaveBeenCalledWith('afterChallenge', jasmine.any(Function));
         });
@@ -50,11 +46,9 @@ describe('AClashOfKings', function() {
             this.challenge.loser = this.otherPlayerSpy;
         });
 
-        describe('and this plot is not in play', function() {
+        describe('and the challenge type was not power', function() {
             beforeEach(function() {
-                this.plot.inPlay = false;
-                this.challenge.winner = this.otherPlayerSpy;
-                this.challenge.loser = this.playerSpy;
+                this.challenge.challengeType = 'not power';
                 this.plot.afterChallenge({}, this.challenge);
             });
 
@@ -63,14 +57,11 @@ describe('AClashOfKings', function() {
             });
         });
 
-        describe('and this plot is in play', function() {
-            beforeEach(function() {
-                this.plot.inPlay = true;
-            });
-
-            describe('and the challenge type was not power', function() {
+        describe('and the challenge type was power', function() {
+            describe('and our owner lost', function() {
                 beforeEach(function() {
-                    this.challenge.challengeType = 'not power';
+                    this.challenge.winner = this.otherPlayerSpy;
+                    this.challenge.loser = this.playerSpy;
                     this.plot.afterChallenge({}, this.challenge);
                 });
 
@@ -79,11 +70,9 @@ describe('AClashOfKings', function() {
                 });
             });
 
-            describe('and the challenge type was power', function() {
-                describe('and our owner lost', function() {
+            describe('and our owner won', function() {
+                describe('but the loser did not have any power', function() {
                     beforeEach(function() {
-                        this.challenge.winner = this.otherPlayerSpy;
-                        this.challenge.loser = this.playerSpy;
                         this.plot.afterChallenge({}, this.challenge);
                     });
 
@@ -92,26 +81,14 @@ describe('AClashOfKings', function() {
                     });
                 });
 
-                describe('and our owner won', function() {
-                    describe('but the loser did not have any power', function() {
-                        beforeEach(function() {
-                            this.plot.afterChallenge({}, this.challenge);
-                        });
-
-                        it('should not change any power', function() {
-                            expect(this.gameSpy.transferPower).not.toHaveBeenCalled();
-                        });
+                describe('and the loser had power', function() {
+                    beforeEach(function() {
+                        this.otherPlayerSpy.power = 1;
+                        this.plot.afterChallenge({}, this.challenge);
                     });
 
-                    describe('and the loser had power', function() {
-                        beforeEach(function() {
-                            this.otherPlayerSpy.power = 1;
-                            this.plot.afterChallenge({}, this.challenge);
-                        });
-
-                        it('should transfer one power from the loser to our owner', function() {
-                            expect(this.gameSpy.transferPower).toHaveBeenCalledWith(this.playerSpy, this.otherPlayerSpy, 1);
-                        });
+                    it('should transfer one power from the loser to our owner', function() {
+                        expect(this.gameSpy.transferPower).toHaveBeenCalledWith(this.playerSpy, this.otherPlayerSpy, 1);
                     });
                 });
             });

--- a/test/server/cards/plots/01/01001-aclashofkings.spec.js
+++ b/test/server/cards/plots/01/01001-aclashofkings.spec.js
@@ -15,6 +15,7 @@ describe('AClashOfKings', function() {
         this.otherPlayerSpy.game = this.gameSpy;
 
         this.plot = new AClashOfKings(this.playerSpy, {});
+        this.plot.moveTo('active plot');
     });
 
     describe('when revealed', function() {
@@ -30,6 +31,7 @@ describe('AClashOfKings', function() {
     describe('when card leaves play', function() {
         beforeEach(function() {
             this.plot.leavesPlay();
+            this.plot.moveTo('revealed plots');
         });
 
         it('should be marked as not in play', function() {
@@ -44,7 +46,7 @@ describe('AClashOfKings', function() {
     describe('when a challenge is finished', function() {
         beforeEach(function() {
             this.challenge = new Challenge(this.gameSpy, this.playerSpy, this.otherPlayerSpy, 'power');
-            this.challenge.winner = this.playerSpy
+            this.challenge.winner = this.playerSpy;
             this.challenge.loser = this.otherPlayerSpy;
         });
 
@@ -52,7 +54,7 @@ describe('AClashOfKings', function() {
             beforeEach(function() {
                 this.plot.inPlay = false;
                 this.challenge.winner = this.otherPlayerSpy;
-                this.challenge.loser = this.playerSpy
+                this.challenge.loser = this.playerSpy;
                 this.plot.afterChallenge({}, this.challenge);
             });
 
@@ -81,7 +83,7 @@ describe('AClashOfKings', function() {
                 describe('and our owner lost', function() {
                     beforeEach(function() {
                         this.challenge.winner = this.otherPlayerSpy;
-                        this.challenge.loser = this.playerSpy
+                        this.challenge.loser = this.playerSpy;
                         this.plot.afterChallenge({}, this.challenge);
                     });
 

--- a/test/server/cards/plots/01/01002-afeastforcrows.spec.js
+++ b/test/server/cards/plots/01/01002-afeastforcrows.spec.js
@@ -22,7 +22,7 @@ describe('AFeastForCrows', function() {
         });
 
         it('should register its onDominanceDetermined handler', function() {
-            expect(this.gameSpy.on).toHaveBeenCalledWith('onDominanceDetermined', this.plot.onDominanceDetermined);
+            expect(this.gameSpy.on).toHaveBeenCalledWith('onDominanceDetermined', jasmine.any(Function));
         });
     });
 
@@ -36,7 +36,7 @@ describe('AFeastForCrows', function() {
         });
 
         it('should unregister its onDominanceDetermined handler', function() {
-            expect(this.gameSpy.removeListener).toHaveBeenCalledWith('onDominanceDetermined', this.plot.onDominanceDetermined);
+            expect(this.gameSpy.removeListener).toHaveBeenCalledWith('onDominanceDetermined', jasmine.any(Function));
         });
     });
 

--- a/test/server/cards/plots/01/01002-afeastforcrows.spec.js
+++ b/test/server/cards/plots/01/01002-afeastforcrows.spec.js
@@ -14,6 +14,7 @@ describe('AFeastForCrows', function() {
         this.otherPlayerSpy.game = this.gameSpy;
 
         this.plot = new AFeastForCrows(this.playerSpy, {});
+        this.plot.moveTo('active plot');
     });
 
     describe('when revealed', function() {
@@ -29,6 +30,7 @@ describe('AFeastForCrows', function() {
     describe('when card leaves play', function() {
         beforeEach(function() {
             this.plot.leavesPlay();
+            this.plot.moveTo('revealed plots');
         });
 
         it('should be marked as not in play', function() {

--- a/test/server/cards/plots/01/01002-afeastforcrows.spec.js
+++ b/test/server/cards/plots/01/01002-afeastforcrows.spec.js
@@ -33,49 +33,31 @@ describe('AFeastForCrows', function() {
             this.plot.moveTo('revealed plots');
         });
 
-        it('should be marked as not in play', function() {
-            expect(this.plot.inPlay).toBe(false);
-        });
-
         it('should unregister its onDominanceDetermined handler', function() {
             expect(this.gameSpy.removeListener).toHaveBeenCalledWith('onDominanceDetermined', jasmine.any(Function));
         });
     });
 
     describe('when dominance finished', function() {
-        describe('and this plot is not in play', function() {
-            beforeEach(function() {
-                this.plot.inPlay = false;
-                this.plot.onDominanceDetermined({}, this.playerSpy);
-            });
+        beforeEach(function() {
+            this.plot.onDominanceDetermined({}, this.playerSpy);
+        });
 
-            it('should not change any power', function() {
-                expect(this.gameSpy.addPower).not.toHaveBeenCalled();
+        describe('and our owner won', function() {
+            it('should add 2 power to our owner', function() {
+                expect(this.gameSpy.addPower).toHaveBeenCalledWith(this.playerSpy, 2);
             });
         });
 
-        describe('and this plot is in play', function() {
+        describe('and our owner did not win', function() {
             beforeEach(function() {
-                this.plot.inPlay = true;
-                this.plot.onDominanceDetermined({}, this.playerSpy);
+                this.gameSpy.addPower.calls.reset();
+
+                this.plot.onDominanceDetermined({}, this.otherPlayerSpy);
             });
 
-            describe('and our owner won', function() {
-                it('should add 2 power to our owner', function() {
-                    expect(this.gameSpy.addPower).toHaveBeenCalledWith(this.playerSpy, 2);
-                });
-            });
-
-            describe('and our owner did not win', function() {
-                beforeEach(function() {
-                    this.gameSpy.addPower.calls.reset();
-
-                    this.plot.onDominanceDetermined({}, this.otherPlayerSpy);
-                });
-
-                it('should not add any power', function() {
-                    expect(this.gameSpy.addPower).not.toHaveBeenCalled();
-                });
+            it('should not add any power', function() {
+                expect(this.gameSpy.addPower).not.toHaveBeenCalled();
             });
         });
     });

--- a/test/server/cards/plots/01/01003-agameofthrones.spec.js
+++ b/test/server/cards/plots/01/01003-agameofthrones.spec.js
@@ -19,36 +19,29 @@ describe('AGameOfThrones', function() {
     });
 
     describe('when called for intrigue challenge', function() {
-        describe('and this plot is not in play', function() {
-            beforeEach(function() {
-                this.plot.inPlay = false;
-
-                this.canChallenge = this.plot.canChallenge(this.playerSpy, 'intrigue');
-            });
-
-            it('should return true', function() {
-                expect(this.canChallenge).toBe(true);
-            });
+        beforeEach(function() {
+            this.canChallenge = this.plot.canChallenge(this.playerSpy, 'intrigue');
         });
 
-        describe('and this plot is in play', function() {
-            beforeEach(function() {
-                this.plot.inPlay = true;
-
-                this.canChallenge = this.plot.canChallenge(this.playerSpy, 'intrigue');
-            });
-
-            it('should return true', function() {
-                expect(this.canChallenge).toBe(true);
-            });
+        it('should return true', function() {
+            expect(this.canChallenge).toBe(true);
         });
     });
 
     describe('when called for power challenge', function() {
-        describe('and this plot is not in play', function() {
+        describe('and no intrique challenges have been won yet this round', function() {
             beforeEach(function() {
-                this.plot.inPlay = false;
+                this.canChallenge = this.plot.canChallenge(this.playerSpy, 'power');
+            });
 
+            it('should return false', function() {
+                expect(this.canChallenge).toBe(false);
+            });
+        });
+
+        describe('and at least one intrigue challenge has been won this round', function() {
+            beforeEach(function() {
+                this.playerSpy.getNumberOfChallengesWon.and.returnValue(1);
                 this.canChallenge = this.plot.canChallenge(this.playerSpy, 'power');
             });
 
@@ -56,72 +49,27 @@ describe('AGameOfThrones', function() {
                 expect(this.canChallenge).toBe(true);
             });
         });
-
-        describe('and this plot is in play', function() {
-            beforeEach(function() {
-                this.plot.inPlay = true;
-            });
-
-            describe('and no intrique challenges have been won yet this round', function() {
-                beforeEach(function() {
-                    this.canChallenge = this.plot.canChallenge(this.playerSpy, 'power');
-                });
-
-                it('should return false', function() {
-                    expect(this.canChallenge).toBe(false);
-                });
-            });
-
-            describe('and at least one intrigue challenge has been won this round', function() {
-                beforeEach(function() {
-                    this.playerSpy.getNumberOfChallengesWon.and.returnValue(1);
-                    this.canChallenge = this.plot.canChallenge(this.playerSpy, 'power');
-                });
-
-                it('should return true', function() {
-                    expect(this.canChallenge).toBe(true);
-                });
-            });
-        });
     });
 
     describe('when called for military challenge', function() {
-        describe('and this plot is not in play', function() {
+        describe('and no intrique challenges have been won yet this round', function() {
             beforeEach(function() {
-                this.plot.inPlay = false;
+                this.canChallenge = this.plot.canChallenge(this.playerSpy, 'military');
+            });
 
+            it('should return false', function() {
+                expect(this.canChallenge).toBe(false);
+            });
+        });
+
+        describe('and at least one intrigue challenge has been won this round', function() {
+            beforeEach(function() {
+                this.playerSpy.getNumberOfChallengesWon.and.returnValue(1);
                 this.canChallenge = this.plot.canChallenge(this.playerSpy, 'military');
             });
 
             it('should return true', function() {
                 expect(this.canChallenge).toBe(true);
-            });
-        });
-
-        describe('and this plot is in play', function() {
-            beforeEach(function() {
-                this.plot.inPlay = true;
-            });
-
-            describe('and no intrique challenges have been won yet this round', function() {
-                beforeEach(function() {
-                    this.canChallenge = this.plot.canChallenge(this.playerSpy, 'military');
-                });
-
-                it('should return false', function() {
-                    expect(this.canChallenge).toBe(false);
-                });
-            });
-
-            describe('and at least one intrigue challenge has been won this round', function() {
-                beforeEach(function() {
-                    this.playerSpy.getNumberOfChallengesWon.and.returnValue(1);
-                    this.canChallenge = this.plot.canChallenge(this.playerSpy, 'military');
-                });
-
-                it('should return true', function() {
-                    expect(this.canChallenge).toBe(true);
-                });
             });
         });
     });

--- a/test/server/cards/plots/01/01004-anoblecause.spec.js
+++ b/test/server/cards/plots/01/01004-anoblecause.spec.js
@@ -20,61 +20,51 @@ describe('ANobleCause', function() {
     });
 
     describe('canReduce', function() {
-        describe('when this plot is not active', function() {
-            it('should return false', function() {
-                expect(this.canReduce).toBe(false);
-            });
+        beforeEach(function() {
+            this.canReduce = this.plot.canReduce(this.playerSpy, this.cardSpy);
         });
 
-        describe('when this plot is active', function() {
+        describe('and the card is a lord or lady', function() {
             beforeEach(function() {
-                this.plot.inPlay = true;
+                this.cardSpy.hasTrait.and.returnValue(true);
 
                 this.canReduce = this.plot.canReduce(this.playerSpy, this.cardSpy);
             });
 
-            describe('and the card is a lord or lady', function() {
-                beforeEach(function() {
-                    this.cardSpy.hasTrait.and.returnValue(true);
-
-                    this.canReduce = this.plot.canReduce(this.playerSpy, this.cardSpy);
-                });
-
-                it('should return true', function() {
-                    expect(this.canReduce).toBe(true);
-                });
-
-                describe('and the plot has already been used this round', function() {
-                    beforeEach(function() {
-                        this.plot.abilityUsed = true;
-
-                        this.canReduce = this.plot.canReduce(this.playerSpy, this.cardSpy);
-                    });
-
-                    it('should return false', function() {
-                        expect(this.canReduce).toBe(false);
-                    });
-                });
-
-                describe('and the player is not my owner', function() {
-                    beforeEach(function() {
-                        this.canReduce = this.plot.canReduce(this.otherPlayerSpy, this.cardSpy);
-                    });
-
-                    it('should return false', function() {
-                        expect(this.canReduce).toBe(false);
-                    });
-                });
+            it('should return true', function() {
+                expect(this.canReduce).toBe(true);
             });
 
-            describe('and the card and neither a lord nor lady', function() {
+            describe('and the plot has already been used this round', function() {
                 beforeEach(function() {
+                    this.plot.abilityUsed = true;
+
                     this.canReduce = this.plot.canReduce(this.playerSpy, this.cardSpy);
                 });
 
                 it('should return false', function() {
                     expect(this.canReduce).toBe(false);
                 });
+            });
+
+            describe('and the player is not my owner', function() {
+                beforeEach(function() {
+                    this.canReduce = this.plot.canReduce(this.otherPlayerSpy, this.cardSpy);
+                });
+
+                it('should return false', function() {
+                    expect(this.canReduce).toBe(false);
+                });
+            });
+        });
+
+        describe('and the card and neither a lord nor lady', function() {
+            beforeEach(function() {
+                this.canReduce = this.plot.canReduce(this.playerSpy, this.cardSpy);
+            });
+
+            it('should return false', function() {
+                expect(this.canReduce).toBe(false);
             });
         });
     });

--- a/test/server/cards/plots/02/02039-pentoshi.spec.js
+++ b/test/server/cards/plots/02/02039-pentoshi.spec.js
@@ -22,36 +22,14 @@ describe('Trading With The Pentoshi', function() {
     });
 
     describe('onReveal()', function() {
-        describe('when not in player', function() {
-            beforeEach(function() {
-                this.pentoshi.inPlay = false;
-            });
-
-            it('should not give the player 3 gold', function() {
-                this.pentoshi.onReveal(this.player1);
-                expect(this.player1.gold).toBe(0);
-            });
-
-            it('should not give the opponents 3 gold', function() {
-                this.pentoshi.onReveal(this.player1);
-                expect(this.player2.gold).toBe(0);
-            });
+        it('should not give the player 3 gold', function() {
+            this.pentoshi.onReveal(this.player1);
+            expect(this.player1.gold).toBe(0);
         });
 
-        describe('when in play', function() {
-            beforeEach(function() {
-                this.pentoshi.inPlay = true;
-            });
-
-            it('should not give the player 3 gold', function() {
-                this.pentoshi.onReveal(this.player1);
-                expect(this.player1.gold).toBe(0);
-            });
-
-            it('should give the opponents 3 gold', function() {
-                this.pentoshi.onReveal(this.player1);
-                expect(this.player2.gold).toBe(3);
-            });
+        it('should give the opponents 3 gold', function() {
+            this.pentoshi.onReveal(this.player1);
+            expect(this.player2.gold).toBe(3);
         });
     });
 });

--- a/test/server/eventregistrar.spec.js
+++ b/test/server/eventregistrar.spec.js
@@ -1,0 +1,54 @@
+/* global describe, it, beforeEach, expect, jasmine, spyOn */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+const EventRegistrar = require('../../server/game/eventregistrar.js');
+
+describe('EventRegistrar', function () {
+    beforeEach(function() {
+        this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener']);
+        this.context = {
+            method: function() {},
+            anotherMethod: function() {}
+        };
+        this.boundHandler = {};
+        spyOn(this.context.method, 'bind').and.returnValue(this.boundHandler);
+        this.events = new EventRegistrar(this.gameSpy, this.context);
+    });
+
+    describe('register()', function () {
+        it('should bind the event with the given context', function() {
+            this.events.register(['method']);
+            expect(this.context.method.bind).toHaveBeenCalledWith(this.context);
+        });
+
+        it('should register the event with the game', function() {
+            this.events.register(['method']);
+            expect(this.gameSpy.on).toHaveBeenCalledWith('method', this.boundHandler);
+        });
+
+        it('should handle multiple events', function() {
+            this.events.register(['method', 'anotherMethod']);
+            expect(this.gameSpy.on).toHaveBeenCalledWith('method', this.boundHandler);
+            expect(this.gameSpy.on).toHaveBeenCalledWith('anotherMethod', jasmine.any(Function));
+        });
+    });
+
+    describe('unregisterAll()', function() {
+        beforeEach(function() {
+            this.events.register(['method', 'anotherMethod']);
+        });
+
+        it('should remove the listeners from the game', function() {
+            this.events.unregisterAll();
+            expect(this.gameSpy.removeListener).toHaveBeenCalledWith('method', this.boundHandler);
+            expect(this.gameSpy.removeListener).toHaveBeenCalledWith('anotherMethod', jasmine.any(Function));
+        });
+
+        it('should not unregister multiple times', function() {
+            this.events.unregisterAll();
+            this.gameSpy.removeListener.calls.reset();
+            this.events.unregisterAll();
+            expect(this.gameSpy.removeListener.calls.count()).toBe(0);
+        });
+    });
+});

--- a/test/server/player/drop.spec.js
+++ b/test/server/player/drop.spec.js
@@ -1,4 +1,4 @@
-/* global describe, it, beforeEach, expect, jasmine, spyOn */
+/* global describe, it, beforeEach, expect, jasmine */
 /* eslint camelcase: 0, no-invalid-this: 0 */
 
 const _ = require('underscore');
@@ -15,7 +15,7 @@ describe('Player', () => {
             this.gameSpy.players = [];
             this.gameSpy.players[this.player.name] = this.player;
 
-            this.cardSpy = jasmine.createSpyObj('card', ['getType', 'leavesPlay']);
+            this.cardSpy = jasmine.createSpyObj('card', ['getType', 'leavesPlay', 'moveTo']);
             this.cardSpy.uuid = '1111';
             this.cardSpy.controller = this.cardSpy.owner = this.player;
             this.cardSpy.attachments = _([]);
@@ -300,7 +300,7 @@ describe('Player', () => {
 
             describe('when two cards are dragged to the draw deck', function() {
                 beforeEach(function() {
-                    this.cardSpy2 = jasmine.createSpyObj('card', ['getType']);
+                    this.cardSpy2 = jasmine.createSpyObj('card', ['getType', 'moveTo']);
                     this.cardSpy2.uuid = '2222';
                     this.cardSpy2.controller = this.player;
                     this.player.hand.push(this.cardSpy2);

--- a/test/server/player/playcard.spec.js
+++ b/test/server/player/playcard.spec.js
@@ -13,7 +13,7 @@ describe('Player', function() {
     describe('playCard', function() {
         beforeEach(function() {
             this.canPlaySpy = spyOn(this.player, 'canPlayCard');
-            this.cardSpy = jasmine.createSpyObj('card', ['getType', 'getCost', 'isUnique', 'isLimited', 'play', 'isAmbush']);
+            this.cardSpy = jasmine.createSpyObj('card', ['getType', 'getCost', 'isUnique', 'isLimited', 'play', 'isAmbush', 'moveTo']);
             this.dupeCardSpy = jasmine.createSpyObj('dupecard', ['addDuplicate']);
 
             this.canPlaySpy.and.returnValue(true);


### PR DESCRIPTION
It may be more useful to look at the diff for the [first two commits](https://github.com/cryogen/throneteki/compare/master...ystros:1d162131e82f2bc883c6fa0586ffbd6888c7a4fe?expand=1&w=1) which makes the primary change. Commit 043b444 removes the inPlay flag.

* Fixes a bug where cards that have left play will lose its event handlers even if it re-enters play. This is most noticeable for jump characters (e.g. The Hound)
* Cards now only listen to events if they're in play.
* Since the inPlay flag was being used to prevent cards not-in-play from triggering inappropriately, it is no longer needed and has been removed.
* In a few cases, inPlay was being used as a synonym for the card location being set to 'play area' and has been converted to that check.