### PR TITLE
Fix plot replenishing loop

### DIFF
--- a/server/game/player.js
+++ b/server/game/player.js
@@ -487,7 +487,7 @@ class Player extends Spectator {
 
         if(this.plotDeck.isEmpty()) {
             this.plotDeck = this.plotDiscard;
-            _.each(this.plotDeck, plot => {
+            this.plotDeck.each(plot => {
                 plot.moveTo('plot deck');
             });
             this.plotDiscard = _([]);


### PR DESCRIPTION
Player.plotDeck is already an underscore wrapped array, so the use of
each was causing a crash.

Resolves https://sentry.io/throneteki/throneteki/issues/198219459/