### PR TITLE
Only play cards as ambush during challenge phase

### DIFF
--- a/server/game/player.js
+++ b/server/game/player.js
@@ -372,7 +372,7 @@ class Player extends Spectator {
 
         if(this.phase === 'marshal') {
             this.game.addMessage('{0} {1} {2} costing {3}', this, dupeCard ? 'duplicates' : 'marshals', card, cost);
-        } else if(card.isAmbush()) {
+        } else if(card.isAmbush() && this.phase === 'challenge') {
             this.game.addMessage('{0} ambushes with {1} costing {2}', this, card, cost);
 
             isAmbush = true;

--- a/test/server/player/playcard.spec.js
+++ b/test/server/player/playcard.spec.js
@@ -13,7 +13,7 @@ describe('Player', function() {
     describe('playCard', function() {
         beforeEach(function() {
             this.canPlaySpy = spyOn(this.player, 'canPlayCard');
-            this.cardSpy = jasmine.createSpyObj('card', ['getType', 'getCost', 'isUnique', 'isLimited', 'play', 'isAmbush', 'moveTo']);
+            this.cardSpy = jasmine.createSpyObj('card', ['getType', 'getCost', 'isUnique', 'isLimited', 'play', 'isAmbush', 'moveTo', 'getAmbushCost']);
             this.dupeCardSpy = jasmine.createSpyObj('dupecard', ['addDuplicate']);
 
             this.canPlaySpy.and.returnValue(true);
@@ -66,6 +66,34 @@ describe('Player', function() {
 
                 it('should remove the card from hand', function() {
                     expect(this.player.hand).not.toContain(this.cardSpy);
+                });
+            });
+        });
+
+        describe('when the card has ambush', function() {
+            beforeEach(function() {
+                this.cardSpy.isAmbush.and.returnValue(true);
+            });
+
+            describe('and it is the challenge phase', function() {
+                beforeEach(function() {
+                    this.player.phase = 'challenge';
+                    this.canPlay = this.player.playCard(this.cardSpy, false);
+                });
+
+                it('should play the card as an ambush', function() {
+                    expect(this.cardSpy.play).toHaveBeenCalledWith(this.player, true);
+                });
+            });
+
+            describe('and it is not the challenge phase', function() {
+                beforeEach(function() {
+                    this.player.phase = 'setup';
+                    this.canPlay = this.player.playCard(this.cardSpy, false);
+                });
+
+                it('should not play the card as an ambush', function() {
+                    expect(this.cardSpy.play).toHaveBeenCalledWith(this.player, false);
                 });
             });
         });


### PR DESCRIPTION
Previously, if a card with the Ambush keyword was played normally during
the setup phase, it would play it as an ambushed card at its non-ambush
price, including a message saying that they ambushed it. This would
reveal information about the player's setup to the opponent before the
cards were revealed.