### PR TITLE
Fix cards that react to themselves entering play

### DIFF
--- a/server/game/player.js
+++ b/server/game/player.js
@@ -387,16 +387,16 @@ class Player extends Spectator {
             this.removeCardFromPile(card);
             dupeCard.addDuplicate(card);
         } else {
-            if(this.phase !== 'setup') {
-                this.game.raiseEvent('onCardEntersPlay', card);
-            }
-
             card.facedown = this.phase === 'setup';
             if(!dupeCard) {
                 card.play(this, isAmbush);
             }
             card.new = true;
             this.moveCard(card, 'play area');
+
+            if(this.phase !== 'setup') {
+                this.game.raiseEvent('onCardEntersPlay', card);
+            }
         }
 
         if(card.isLimited() && !forcePlay) {


### PR DESCRIPTION
Previously, cards were listening to their appropriate events at all
times. Commit a1e39969e0d90f93968978f72211e1758fd9a462 changed this so
that they would only listen to events while in play. Due to the order
things were done in the Player.playCard method, this introduced a bug
where cards that had reactions when they entered play (such as Arya
Stark) would not fire correctly. This changes the order to fire the
onCardEntersPlay event after the event listeners have been turned on.