### PR TITLE
Introduce class to manage card actions

### DIFF
--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -1,0 +1,95 @@
+/**
+ * Represents an action ability provided by card text.
+ *
+ * Properties:
+ * title        - string that is used within the card menu associated with this
+ *                action.
+ * method       - string indicating the method on card that should be called
+ *                when the action is executed. If this method returns an
+ *                explicit `false` value then that execution of the action does
+ *                not count toward the limit amount.
+ * phase        - string representing which phases the action may be executed.
+ *                Defaults to 'any' which allows the action to be executed in
+ *                any phase.
+ * limit.amount - integer indicating the number of times an action may be
+ *                executed per period.
+ * limit.period - string indicating how often the action's use count is reset.
+ *                Must be either 'challenge', 'phase', or 'round'.
+ * anyPlayer    - boolean indicating that the action may be executed by a player
+ *                other than the card's controller. Defaults to false.
+ */
+class CardAction {
+    constructor(game, card, properties) {
+        this.game = game;
+        this.card = card;
+        this.title = properties.title;
+        this.limit = properties.limit;
+        this.phase = properties.phase || 'any';
+        this.anyPlayer = properties.anyPlayer || false;
+        this.useCount = 0;
+
+        this.handler = card[properties.method].bind(card);
+    }
+
+    execute(player, arg) {
+        if(this.phase !== 'any' && this.phase !== this.game.currentPhase || this.game.currentPhase === 'setup') {
+            return;
+        }
+
+        if(this.limit && this.useCount >= this.limit.amount) {
+            return;
+        }
+
+        if(player !== this.card.controller && !this.anyPlayer) {
+            return;
+        }
+
+        if(this.card.isBlank()) {
+            return;
+        }
+
+        if(this.handler(player, arg) !== false) {
+            this.useCount += 1;
+        }
+    }
+
+    getMenuItem() {
+        return { text: this.title, method: 'doAction', anyPlayer: !!this.anyPlayer };
+    }
+
+    reset() {
+        this.useCount = 0;
+    }
+
+    registerEvents() {
+        if(this.limit) {
+            this.event = {
+                name: this.getPeriodEventName(),
+                handler: this.reset.bind(this)
+            };
+            this.game.on(this.event.name, this.event.handler);
+        }
+    }
+
+    getPeriodEventName() {
+        switch(this.limit.period) {
+            case 'challenge':
+                return 'onChallengeFinished';
+            case 'phase':
+                return 'onPhaseEnded';
+            case 'round':
+                return 'onRoundEnded';
+        }
+
+        throw new Error('Unknown period"' + this.limit.period + '" for card ' + this.card.name);
+    }
+
+    unregisterEvents() {
+        if(this.event) {
+            this.game.removeListener(this.event.name, this.event.handler);
+            this.event = null;
+        }
+    }
+}
+
+module.exports = CardAction;

--- a/server/game/cards/agendas/fealty.js
+++ b/server/game/cards/agendas/fealty.js
@@ -5,15 +5,16 @@ class Fealty extends Reducer {
         super(owner, cardData, 1, (player, card) => {
             return card.isLoyal();
         });
+    }
 
-        this.menu.push({ text: 'Kneel your faction card', method: 'onClick' });
+    setupCardAbilities() {
+        this.action({
+            title: 'Kneel your faction card',
+            method: 'onClick'
+        });
     }
 
     onClick(player) {
-        if(!this.controller === player) {
-            return;
-        }
-
         player.faction.kneeled = true;
 
         this.game.addMessage('{0} uses {1} to kneel their faction card and reduce the cost of the next loyal card by 1', player, this);

--- a/server/game/cards/attachments/01/sealofthehand.js
+++ b/server/game/cards/attachments/01/sealofthehand.js
@@ -1,15 +1,16 @@
 const DrawCard = require('../../../drawcard.js');
- 
-class SealOfTheHand extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
 
-        this.menu.push({ text: 'Stand attached character', method: 'kneel' });
+class SealOfTheHand extends DrawCard {
+    setupCardAbilities() {
+        this.action({
+            title: 'Stand attached character',
+            method: 'kneel'
+        });
     }
 
     kneel(player) {
         if(!this.parent || !this.parent.kneeled) {
-            return;
+            return false;
         }
 
         this.parent.kneeled = false;

--- a/server/game/cards/characters/01/wildlinghorde.js
+++ b/server/game/cards/characters/01/wildlinghorde.js
@@ -1,12 +1,18 @@
 const DrawCard = require('../../../drawcard.js');
- 
+
 class WildlingHorde extends DrawCard {
     constructor(owner, cardData) {
         super(owner, cardData);
 
-        this.menu.push({ text: 'Kneel your faction card', command: 'card', method: 'kneelFactionCard' });
-
         this.registerEvents(['afterChallenge']);
+    }
+
+    setupCardAbilities() {
+      this.action({
+          title: 'Kneel your faction card',
+          method: 'kneelFactionCard',
+          phase: 'challenge'
+      });
     }
 
     cardCondition(player, card) {
@@ -19,11 +25,11 @@ class WildlingHorde extends DrawCard {
     }
 
     kneelFactionCard(player) {
-        if(this.controller !== player || player.faction.kneeled) {
+        if(player.faction.kneeled) {
             return false;
         }
 
-        if(player.phase !== 'challenge' || !this.game.currentChallenge) {
+        if(!this.game.currentChallenge) {
             return false;
         }
 

--- a/server/game/cards/characters/02/bronn.js
+++ b/server/game/cards/characters/02/bronn.js
@@ -4,9 +4,16 @@ class Bronn extends DrawCard {
     constructor(owner, cardData) {
         super(owner, cardData);
 
-        this.menu.push({ text: 'Pay 1 gold to take control of Bronn', command: 'menuItem', method: 'takeControl', anyPlayer: true });
-
         this.registerEvents(['onChallenge', 'onChallengeFinished']);
+    }
+
+    setupCardAbilities() {
+        this.action({
+            title: 'Pay 1 gold to take control of Bronn',
+            method: 'takeControl',
+            phase: 'marshal',
+            anyPlayer: true
+        });
     }
 
     onChallenge(e, challenge) {
@@ -30,8 +37,8 @@ class Bronn extends DrawCard {
     }
 
     takeControl(player) {
-        if(player.controller === this.controller || player.gold < 1) {
-            return;
+        if(player === this.controller || player.gold < 1) {
+            return false;
         }
 
         this.game.addMessage('{0} pays 1 gold to take control of {1}', player, this);

--- a/server/game/cards/characters/02/redcloaks.js
+++ b/server/game/cards/characters/02/redcloaks.js
@@ -4,29 +4,28 @@ class RedCloaks extends DrawCard {
     constructor(owner, cardData) {
         super(owner, cardData);
 
-        this.registerEvents(['onAttackersDeclared', 'onPhaseEnded']);
-
-        this.menu.push({ text: 'Move 1 gold from your gold pool to this card', command: 'card', method: 'addGold' });
+        this.registerEvents(['onAttackersDeclared']);
 
         this.tokens['gold'] = 0;
-        this.usedThisPhase = false;
+    }
+
+    setupCardAbilities() {
+        this.action({
+            title: 'Move 1 gold from your gold pool to this card',
+            method: 'addGold',
+            limit: { amount: 1, period: 'phase' }
+        });
     }
 
     addGold(player) {
-        if(this.location !== 'play area' || this.controller !== player || this.usedThisPhase || player.gold <= 0) {
-            return;
+        if(this.location !== 'play area' || player.gold <= 0) {
+            return false;
         }
 
         this.addToken('gold', 1);
         this.controller.gold--;
 
         this.game.addMessage('{0} moves 1 gold from their gold pool to {1}', this.controller, this);
-
-        this.usedThisPhase = true;
-    }
-
-    onPhaseEnded() {
-        this.usedThisPhase = false;
     }
 
     onAttackersDeclared(e, challenge) {

--- a/server/game/cards/characters/03/jonsnow.js
+++ b/server/game/cards/characters/03/jonsnow.js
@@ -1,19 +1,15 @@
 const DrawCard = require('../../../drawcard.js');
 
 class JonSnow extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['onBeginRound']);
-
-        this.menu.push({ text: 'Sacrifice character', command: 'card', method: 'sacrifice' });
+    setupCardAbilities() {
+        this.action({
+            title: 'Sacrifice character',
+            method: 'sacrifice',
+            limit: { amount: 1, period: 'round' }
+        });
     }
 
-    sacrifice(player) {
-        if(this.controller !== player || this.usedThisRound) {
-            return;
-        }
-
+    sacrifice() {
         this.game.promptForSelect(this.controller, {
             activePromptTitle: 'Select a character to sacrifice',
             waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
@@ -45,13 +41,7 @@ class JonSnow extends DrawCard {
         player.sacrificeCard(this.toSacrifice);
         this.toSacrifice.selected = false;
 
-        this.usedThisRound = true;
-
         return true;
-    }
-
-    onBeginRound() {
-        this.usedThisRound = false;
     }
 }
 

--- a/server/game/cards/characters/04/shae.js
+++ b/server/game/cards/characters/04/shae.js
@@ -4,29 +4,26 @@ class Shae extends DrawCard {
     constructor(owner, cardData) {
         super(owner, cardData);
 
-        this.registerEvents(['onPhaseEnded']);
-
-        this.menu.push({ text: 'Pay 1 gold to stand Shae', command: 'card', method: 'stand' });
-
         this.tokens['gold'] = 0;
-        this.usedThisPhase = 0;
+    }
+
+    setupCardAbilities() {
+        this.action({
+            title: 'Pay 1 gold to stand Shae',
+            method: 'stand',
+            phase: 'challenge'
+        });
     }
 
     stand(player) {
-        if(this.controller !== player || this.usedThisPhase >= 2 || player.gold <= 0 || !this.kneeled) {
-            return;
+        if(player.gold <= 0 || !this.kneeled) {
+            return false;
         }
 
         this.controller.gold--;
         this.kneeled = false;
 
         this.game.addMessage('{0} pays 1 gold to stand {1}', this.controller, this);
-
-        this.usedThisPhase++;
-    }
-
-    onPhaseEnded() {
-        this.usedThisPhase = 0;
     }
 }
 

--- a/server/game/cards/plots/01/powerbehindthethrone.js
+++ b/server/game/cards/plots/01/powerbehindthethrone.js
@@ -1,10 +1,11 @@
 const PlotCard = require('../../../plotcard.js');
 
 class PowerBehindTheThrone extends PlotCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.menu.push({ text: 'Discard a stand token', command: 'plot', method: 'discardToken' });
+    setupCardAbilities() {
+        this.action({
+            title: 'Discard a stand token',
+            method: 'discardToken'
+        });
     }
 
     onReveal(player) {
@@ -21,7 +22,7 @@ class PowerBehindTheThrone extends PlotCard {
 
     discardToken(player) {
         if(!this.hasToken('stand')) {
-            return;
+            return false;
         }
 
         this.game.promptForSelect(player, {
@@ -40,10 +41,6 @@ class PowerBehindTheThrone extends PlotCard {
         this.removeToken('stand', 1);
 
         return true;
-    }
-
-    leavesPlay() {
-        super.leavesPlay();
     }
 }
 

--- a/server/game/gamesteps/taxationphase.js
+++ b/server/game/gamesteps/taxationphase.js
@@ -10,7 +10,8 @@ class TaxationPhase extends Phase {
         this.initialise([
             new SimpleStep(game, () => this.returnGold()),
             new DiscardToReservePrompt(game),
-            new EndRoundPrompt(game)
+            new EndRoundPrompt(game),
+            new SimpleStep(game, () => this.roundEnded())
         ]);
     }
 
@@ -20,9 +21,13 @@ class TaxationPhase extends Phase {
             if(!event.cancel) {
                 player.taxation();
             }
-            
+
             this.game.raiseEvent('onAfterTaxation', player);
         });
+    }
+
+    roundEnded() {
+        this.game.raiseEvent('onRoundEnded');
     }
 }
 

--- a/test/server/card/cardaction.spec.js
+++ b/test/server/card/cardaction.spec.js
@@ -1,0 +1,445 @@
+/*global describe, it, beforeEach, expect, jasmine, spyOn */
+/*eslint camelcase: 0, no-invalid-this: 0 */
+
+const EventEmitter = require('events');
+
+const CardAction = require('../../../server/game/cardaction.js');
+
+describe('CardAction', function () {
+    beforeEach(function () {
+        this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener']);
+        this.gameSpy.currentPhase = 'marshal';
+
+        this.cardSpy = jasmine.createSpyObj('card', ['isBlank']);
+        this.cardSpy.handler = function() {};
+        spyOn(this.cardSpy, 'handler').and.returnValue(true);
+
+        this.properties = {
+            title: 'Do the thing',
+            method: 'handler'
+        };
+    });
+
+    describe('execute()', function() {
+        beforeEach(function() {
+            this.player = {};
+            this.cardSpy.controller = this.player;
+        });
+
+        describe('when the action has limited uses', function() {
+            beforeEach(function() {
+                this.properties.limit = {
+                    amount: 2,
+                    period: 'round'
+                };
+                this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+            });
+
+            describe('and the use count has reached the limit', function() {
+                beforeEach(function() {
+                    // Use twice
+                    this.action.execute(this.player, 'arg');
+                    this.action.execute(this.player, 'arg');
+
+                    this.cardSpy.handler.calls.reset();
+
+                    this.action.execute(this.player, 'arg');
+                });
+
+                it('should not call the handler', function() {
+                    expect(this.cardSpy.handler).not.toHaveBeenCalled();
+                });
+            });
+
+            describe('and the use count is below the limit', function() {
+                describe('and the handler returns false', function() {
+                    beforeEach(function() {
+                        this.cardSpy.handler.and.returnValue(false);
+
+                        // Theoretically reach the limit
+                        this.action.execute(this.player, 'arg');
+                        this.action.execute(this.player, 'arg');
+
+                        // Call past the limit
+                        this.action.execute(this.player, 'arg');
+                    });
+
+                    it('should call the handler', function() {
+                        expect(this.cardSpy.handler).toHaveBeenCalledWith(this.player, 'arg');
+                    });
+
+                    it('should not count towards the limit', function() {
+                        expect(this.cardSpy.handler.calls.count()).toBe(3);
+                    });
+                });
+
+                describe('and the handler returns undefined or a non-false value', function() {
+                    beforeEach(function() {
+                        this.cardSpy.handler.and.returnValue(undefined);
+
+                        // Theoretically reach the limit
+                        this.action.execute(this.player, 'arg');
+                        this.action.execute(this.player, 'arg');
+
+                        // Call past the limit
+                        this.action.execute(this.player, 'arg');
+                    });
+
+                    it('should call the handler', function() {
+                        expect(this.cardSpy.handler).toHaveBeenCalledWith(this.player, 'arg');
+                    });
+
+                    it('should count towards the limit', function() {
+                        expect(this.cardSpy.handler.calls.count()).toBe(2);
+                    });
+                });
+            });
+        });
+
+        describe('when executed with a player other than the card controller', function() {
+            beforeEach(function() {
+                this.otherPlayer = {};
+            });
+
+            describe('and the anyPlayer property is not set', function() {
+                beforeEach(function() {
+                    this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+                    this.action.execute(this.otherPlayer, 'arg');
+                });
+
+                it('should not call the handler', function() {
+                    expect(this.cardSpy.handler).not.toHaveBeenCalled();
+                });
+            });
+
+            describe('and the anyPlayer property is set', function() {
+                beforeEach(function() {
+                    this.properties.anyPlayer = true;
+                    this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+                    this.action.execute(this.otherPlayer, 'arg');
+                });
+
+                it('should call the handler', function() {
+                    expect(this.cardSpy.handler).toHaveBeenCalledWith(this.otherPlayer, 'arg');
+                });
+            });
+        });
+
+        describe('when the card is blank', function() {
+            beforeEach(function() {
+                this.cardSpy.isBlank.and.returnValue(true);
+                this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+                this.action.execute(this.player, 'arg');
+            });
+
+            it('should not call the handler', function() {
+                expect(this.cardSpy.handler).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('when only allowed in a certain phase', function() {
+            beforeEach(function() {
+                this.properties.phase = 'challenge';
+                this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+            });
+
+            describe('and it is not that phase', function() {
+                beforeEach(function() {
+                    this.gameSpy.currentPhase = 'dominance';
+                    this.action.execute(this.player, 'arg');
+                });
+
+                it('should not call the handler', function() {
+                    expect(this.cardSpy.handler).not.toHaveBeenCalled();
+                });
+            });
+
+            describe('and it is the phase', function() {
+                beforeEach(function() {
+                    this.gameSpy.currentPhase = 'challenge';
+                    this.action.execute(this.player, 'arg');
+                });
+
+                it('should call the handler', function() {
+                    expect(this.cardSpy.handler).toHaveBeenCalledWith(this.player, 'arg');
+                });
+            });
+        });
+
+        describe('when the current phase is setup', function() {
+            beforeEach(function() {
+                this.gameSpy.currentPhase = 'setup';
+                this.properties.phase = 'any';
+                this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+                this.action.execute(this.player, 'arg');
+            });
+
+            it('should not call the handler', function() {
+                expect(this.cardSpy.handler).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('when all conditions met', function() {
+            beforeEach(function() {
+                this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+                this.action.execute(this.player, 'arg');
+            });
+
+            it('should call the handler', function() {
+                expect(this.cardSpy.handler).toHaveBeenCalledWith(this.player, 'arg');
+            });
+        });
+    });
+
+    describe('registerEvents()', function() {
+        describe('when there is no limit', function() {
+            beforeEach(function() {
+                this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+                this.action.registerEvents();
+            });
+
+            it('should not register an event', function() {
+                expect(this.gameSpy.on).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('when the period is challenge', function() {
+            beforeEach(function() {
+                this.properties.limit = {
+                    amount: 1,
+                    period: 'challenge'
+                };
+                this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+                this.action.registerEvents();
+            });
+
+            it('should register a listener for the onChallengeFinished event', function() {
+                expect(this.gameSpy.on).toHaveBeenCalledWith('onChallengeFinished', jasmine.any(Function));
+            });
+        });
+
+        describe('when the period is phase', function() {
+            beforeEach(function() {
+                this.properties.limit = {
+                    amount: 1,
+                    period: 'phase'
+                };
+                this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+                this.action.registerEvents();
+            });
+
+            it('should register a listener for the onPhaseEnded event', function() {
+                expect(this.gameSpy.on).toHaveBeenCalledWith('onPhaseEnded', jasmine.any(Function));
+            });
+        });
+
+        describe('when the period is round', function() {
+            beforeEach(function() {
+                this.properties.limit = {
+                    amount: 1,
+                    period: 'round'
+                };
+                this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+                this.action.registerEvents();
+            });
+
+            it('should register a listener for the onRoundEnded event', function() {
+                expect(this.gameSpy.on).toHaveBeenCalledWith('onRoundEnded', jasmine.any(Function));
+            });
+        });
+    });
+
+    describe('unregisterEvents()', function() {
+        describe('when there is no limit', function() {
+            beforeEach(function() {
+                this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+                this.action.registerEvents();
+
+                this.action.unregisterEvents();
+            });
+
+            it('should not remove a listener', function() {
+                expect(this.gameSpy.removeListener).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('when the period is challenge', function() {
+            beforeEach(function() {
+                this.properties.limit = {
+                    amount: 1,
+                    period: 'challenge'
+                };
+                this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+                this.action.registerEvents();
+
+                this.action.unregisterEvents();
+            });
+
+            it('should remove a listener for the onChallengeFinished event', function() {
+                expect(this.gameSpy.removeListener).toHaveBeenCalledWith('onChallengeFinished', jasmine.any(Function));
+            });
+        });
+
+        describe('when the period is phase', function() {
+            beforeEach(function() {
+                this.properties.limit = {
+                    amount: 1,
+                    period: 'phase'
+                };
+                this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+                this.action.registerEvents();
+
+                this.action.unregisterEvents();
+            });
+
+            it('should remove a listener for the onPhaseEnded event', function() {
+                expect(this.gameSpy.removeListener).toHaveBeenCalledWith('onPhaseEnded', jasmine.any(Function));
+            });
+        });
+
+        describe('when the period is round', function() {
+            beforeEach(function() {
+                this.properties.limit = {
+                    amount: 1,
+                    period: 'round'
+                };
+                this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+                this.action.registerEvents();
+                this.action.unregisterEvents();
+            });
+
+            it('should remove a listener for the onRoundEnded event', function() {
+                expect(this.gameSpy.removeListener).toHaveBeenCalledWith('onRoundEnded', jasmine.any(Function));
+            });
+        });
+
+        describe('when unregistering multiple times', function() {
+            beforeEach(function() {
+                this.properties.limit = {
+                    amount: 1,
+                    period: 'round'
+                };
+                this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+                this.action.registerEvents();
+                this.action.unregisterEvents();
+
+                this.action.unregisterEvents();
+            });
+
+            it('should only remove the listener once', function() {
+                expect(this.gameSpy.removeListener.calls.count()).toBe(1);
+            });
+        });
+    });
+
+    describe('getMenuItem()', function() {
+        beforeEach(function() {
+            this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+            this.menuItem = this.action.getMenuItem();
+        });
+
+        it('returns the menu item format', function() {
+            expect(this.menuItem).toEqual({ text: 'Do the thing', method: 'doAction', anyPlayer: false });
+        });
+    });
+
+    describe('resetting the use count', function() {
+        beforeEach(function() {
+            this.game = new EventEmitter();
+            this.game.currentPhase = 'marshal';
+        });
+
+        describe('when the period is challenge', function() {
+            beforeEach(function() {
+                this.properties.limit = {
+                    amount: 1,
+                    period: 'challenge'
+                };
+                this.action = new CardAction(this.game, this.cardSpy, this.properties);
+                this.action.registerEvents();
+                this.action.execute(this.player, 'arg');
+                this.cardSpy.handler.calls.reset();
+            });
+
+            it('should reset on challenge end', function() {
+                this.game.emit('onChallengeFinished');
+                this.action.execute(this.player, 'arg');
+                expect(this.cardSpy.handler.calls.count()).toBe(1);
+            });
+
+            it('should not reset on phase end', function() {
+                this.game.emit('onPhaseEnded');
+                this.action.execute(this.player, 'arg');
+                expect(this.cardSpy.handler.calls.count()).toBe(0);
+            });
+
+            it('should not reset on round end', function() {
+                this.game.emit('onRoundEnded');
+                this.action.execute(this.player, 'arg');
+                expect(this.cardSpy.handler.calls.count()).toBe(0);
+            });
+        });
+
+        describe('when the period is phase', function() {
+            beforeEach(function() {
+                this.properties.limit = {
+                    amount: 1,
+                    period: 'phase'
+                };
+                this.action = new CardAction(this.game, this.cardSpy, this.properties);
+                this.action.registerEvents();
+                this.action.execute(this.player, 'arg');
+                this.cardSpy.handler.calls.reset();
+            });
+
+            it('should not reset on challenge end', function() {
+                this.game.emit('onChallengeFinished');
+                this.action.execute(this.player, 'arg');
+                expect(this.cardSpy.handler.calls.count()).toBe(0);
+            });
+
+            it('should reset on phase end', function() {
+                this.game.emit('onPhaseEnded');
+                this.action.execute(this.player, 'arg');
+                expect(this.cardSpy.handler.calls.count()).toBe(1);
+            });
+
+            it('should not reset on round end', function() {
+                this.game.emit('onRoundEnded');
+                this.action.execute(this.player, 'arg');
+                expect(this.cardSpy.handler.calls.count()).toBe(0);
+            });
+        });
+
+        describe('when the period is round', function() {
+            beforeEach(function() {
+                this.properties.limit = {
+                    amount: 1,
+                    period: 'round'
+                };
+                this.action = new CardAction(this.game, this.cardSpy, this.properties);
+                this.action.registerEvents();
+                this.action.execute(this.player, 'arg');
+                this.cardSpy.handler.calls.reset();
+            });
+
+            it('should not reset on challenge end', function() {
+                this.game.emit('onChallengeFinished');
+                this.action.execute(this.player, 'arg');
+                expect(this.cardSpy.handler.calls.count()).toBe(0);
+            });
+
+            it('should not reset on phase end', function() {
+                this.game.emit('onPhaseEnded');
+                this.action.execute(this.player, 'arg');
+                expect(this.cardSpy.handler.calls.count()).toBe(0);
+            });
+
+            it('should reset on round end', function() {
+                this.game.emit('onRoundEnded');
+                this.action.execute(this.player, 'arg');
+                expect(this.cardSpy.handler.calls.count()).toBe(1);
+            });
+        });
+    });
+});

--- a/test/server/cards/characters/02/02070 - redcloaks.spec.js
+++ b/test/server/cards/characters/02/02070 - redcloaks.spec.js
@@ -9,10 +9,8 @@ describe('RedCloaks', function() {
     beforeEach(function() {
         this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener', 'addPower', 'addMessage']);
         this.playerSpy = jasmine.createSpyObj('player', ['']);
-        this.otherPlayerSpy = jasmine.createSpyObj('player2', ['']);
 
         this.playerSpy.game = this.gameSpy;
-        this.otherPlayerSpy.game = this.gameSpy;
 
         this.card = new RedCloaks(this.playerSpy, {});
         this.card.location = 'play area';
@@ -24,16 +22,6 @@ describe('RedCloaks', function() {
                 this.card.location = 'discard pile';
                 this.playerSpy.gold = 10;
                 this.card.addGold(this.playerSpy);
-            });
-
-            it('should not add any gold to the card', function() {
-                expect(this.card.tokens['gold']).toBe(0);
-            });
-        });
-
-        describe('when not called for my owner', function() {
-            beforeEach(function() {
-                this.card.addGold(this.otherPlayerSpy);
             });
 
             it('should not add any gold to the card', function() {
@@ -65,27 +53,6 @@ describe('RedCloaks', function() {
 
                 it('should reduce my owner\'s gold count by 1', function() {
                     expect(this.playerSpy.gold).toBe(9);
-                });
-
-                describe('and then called again in the same round', function() {
-                    beforeEach(function() {
-                        this.card.addGold(this.playerSpy);
-                    });
-
-                    it('should not add another gold token to the card', function() {
-                        expect(this.card.tokens['gold']).toBe(1);
-                    });
-                });
-
-                describe('and then called again in a new phase', function() {
-                    beforeEach(function() {
-                        this.card.onPhaseEnded();
-                        this.card.addGold(this.playerSpy);
-                    });
-
-                    it('should add another gold token to the card', function() {
-                        expect(this.card.tokens['gold']).toBe(2);
-                    });
                 });
             });
         });


### PR DESCRIPTION
Wraps card actions in a class that manages the following:
* Ensures the action can be executed in the current phase.
* Ensures the action is being executed by the appropriate player (the card controller by default, any player if the anyPlayer flag is set)
* Ensures the card is not blank before executing the action
* Allows an optional limit that is enforced. Limits can be per 'challenge', per 'phase' or per 'round'. (the format of this option will likely change once a similar class is introduced for reactions)