### PR TITLE
Use once events to clean up lasting effects

### DIFF
--- a/server/game/cards/characters/01/edricdayne.js
+++ b/server/game/cards/characters/01/edricdayne.js
@@ -4,8 +4,6 @@ class EdricDayne extends DrawCard {
     constructor(owner, cardData) {
         super(owner, cardData);
 
-        this.registerEvents(['onPhaseEnded']);
-
         this.icons = [];
     }
 
@@ -33,7 +31,7 @@ class EdricDayne extends DrawCard {
             waitingPromptTitle: 'Waiting for opponent to use ' + this.name
         });
 
-        return true;        
+        return true;
     }
 
     iconSelected(player, icon) {
@@ -43,6 +41,10 @@ class EdricDayne extends DrawCard {
         this.game.addMessage('{0} uses {1} to give {1} an {2} icon', player, this, icon);
 
         this.controller.gold--;
+
+        this.game.once('onPhaseEnded', () => {
+            this.onPhaseEnded();
+        });
 
         return true;
     }

--- a/server/game/cards/characters/01/selysebaratheon.js
+++ b/server/game/cards/characters/01/selysebaratheon.js
@@ -1,12 +1,6 @@
 const DrawCard = require('../../../drawcard.js');
 
 class SelyseBaratheon extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['onPhaseEnded']);
-    }
-
     setupCardAbilities() {
         this.action({
             title: 'Pay 1 gold to give an intrigue icon to a character',
@@ -37,6 +31,10 @@ class SelyseBaratheon extends DrawCard {
         this.game.addMessage('{0} uses {1} to give {2} an {3} icon', player, this, card, 'intrigue');
 
         this.controller.gold--;
+
+        this.game.once('onPhaseEnded', () => {
+            this.onPhaseEnded();
+        });
 
         return true;
     }

--- a/server/game/cards/characters/01/serjaimelannister.js
+++ b/server/game/cards/characters/01/serjaimelannister.js
@@ -4,7 +4,7 @@ class SerJaimeLannister extends DrawCard {
     constructor(owner, cardData) {
         super(owner, cardData);
 
-        this.registerEvents(['onAttackersDeclared', 'onChallengeFinished']);
+        this.registerEvents(['onAttackersDeclared']);
     }
 
     onAttackersDeclared(event, challenge) {
@@ -24,6 +24,10 @@ class SerJaimeLannister extends DrawCard {
         if(!this.isBlank() && challenge.isAttacking(this)) {
             this.kneeled = false;
         }
+
+        this.game.once('onChallengeFinished', (event, challenge) => {
+            this.onChallengeFinished(event, challenge);
+        });
     }
 
     onChallengeFinished(event, challenge) {

--- a/server/game/cards/characters/01/wildlinghorde.js
+++ b/server/game/cards/characters/01/wildlinghorde.js
@@ -1,12 +1,6 @@
 const DrawCard = require('../../../drawcard.js');
 
 class WildlingHorde extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['afterChallenge']);
-    }
-
     setupCardAbilities() {
       this.action({
           title: 'Kneel your faction card',
@@ -53,6 +47,10 @@ class WildlingHorde extends DrawCard {
         card.strengthModifier += 2;
 
         this.game.addMessage('{0} uses {1} to kneel their faction card and increase the strength of {2} by 2 until the end of the challenge', player, this, card);
+
+        this.game.once('afterChallenge', () => {
+            this.afterChallenge();
+        });
 
         return true;
     }

--- a/server/game/cards/characters/02/bronn.js
+++ b/server/game/cards/characters/02/bronn.js
@@ -4,7 +4,7 @@ class Bronn extends DrawCard {
     constructor(owner, cardData) {
         super(owner, cardData);
 
-        this.registerEvents(['onChallenge', 'onChallengeFinished']);
+        this.registerEvents(['onChallenge']);
     }
 
     setupCardAbilities() {
@@ -24,6 +24,10 @@ class Bronn extends DrawCard {
         this.addIcon('military');
         this.addIcon('intrigue');
         this.addIcon('power');
+
+        this.game.once('onChallengeFinished', (e, challenge) => {
+            this.onChallengeFinished(e, challenge);
+        });
     }
 
     onChallengeFinished(e, challenge) {

--- a/server/game/cards/characters/02/nymeriasand.js
+++ b/server/game/cards/characters/02/nymeriasand.js
@@ -3,12 +3,6 @@ const _ = require('underscore');
 const DrawCard = require('../../../drawcard.js');
 
 class NymeriaSand extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['onPhaseEnded']);
-    }
-
     setupCardAbilities() {
         this.action({
             title: 'Remove icon from opponent\'s character',
@@ -79,6 +73,10 @@ class NymeriaSand extends DrawCard {
 
                 this.cardsAffected.push(card);
             }
+        });
+
+        this.game.once('onPhaseEnded', () => {
+            this.onPhaseEnded();
         });
 
         return true;

--- a/server/game/cards/characters/02/redcloaks.js
+++ b/server/game/cards/characters/02/redcloaks.js
@@ -34,6 +34,10 @@ class RedCloaks extends DrawCard {
         }
 
         this.strengthModifier += this.tokens['gold'];
+
+        this.game.once('onChallengeFinished', (e, challenge) => {
+            this.onChallengeFinished(e, challenge);
+        });
     }
 
     onChallengeFinished(e, challenge) {

--- a/server/game/cards/characters/02/wildlingscout.js
+++ b/server/game/cards/characters/02/wildlingscout.js
@@ -1,12 +1,6 @@
 const DrawCard = require('../../../drawcard.js');
- 
+
 class WildlingScout extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['onPhaseEnded']);
-    }
-
     setupCardAbilities() {
         this.action({
             title: 'Sacrifice this character to give another character stealth',
@@ -39,6 +33,10 @@ class WildlingScout extends DrawCard {
         this.modifiedCard = card;
 
         this.game.addMessage('{0} sacrifices {1} to make {2} gain stealth', player, this, card);
+
+        this.game.once('onPhaseEnded', () => {
+            this.onPhaseEnded();
+        });
 
         return true;
     }

--- a/server/game/cards/characters/03/oldnan.js
+++ b/server/game/cards/characters/03/oldnan.js
@@ -6,7 +6,7 @@ class OldNan extends DrawCard {
     constructor(owner, cardData) {
         super(owner, cardData);
 
-        this.registerEvents(['onPlotFlip', 'onAfterTaxation']);
+        this.registerEvents(['onPlotFlip']);
     }
 
     onPlotFlip() {
@@ -76,6 +76,10 @@ class OldNan extends DrawCard {
         this.modifiedPlot = plotCard;
         this.trait = trait;
         this.kneeled = true;
+
+        this.game.once('onAfterTaxation', () => {
+            this.onAfterTaxation();
+        });
 
         return true;
     }

--- a/server/game/cards/events/01/tearsoflys.js
+++ b/server/game/cards/events/01/tearsoflys.js
@@ -1,12 +1,6 @@
 const DrawCard = require('../../../drawcard.js');
 
 class TearsOfLys extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['onEndChallengePhase']);
-    }
-
     canPlay(player, card) {
         if(player !== this.controller || this !== card) {
             return false;
@@ -40,6 +34,10 @@ class TearsOfLys extends DrawCard {
         this.game.addMessage('{0} uses {1} to place 1 poison token on {2}', player, this, card);
 
         this.poisonTarget = card;
+
+        this.game.once('onEndChallengePhase', () => {
+            this.onEndChallengePhase();
+        });
 
         return true;
     }

--- a/server/game/cards/locations/01/ironfleetscout.js
+++ b/server/game/cards/locations/01/ironfleetscout.js
@@ -1,12 +1,6 @@
 const DrawCard = require('../../../drawcard.js');
- 
+
 class IronFleetScout extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['onAfterChallenge']);
-    }
-
     setupCardAbilities() {
         this.action({
             title: 'Kneel this card to give a character +1 STR',
@@ -40,6 +34,10 @@ class IronFleetScout extends DrawCard {
         this.modifiedCard = card;
 
         this.game.addMessage('{0} kneels {1} to give {2} +{3} STR until the end of the challenge', player, this, card, this.strength);
+
+        this.game.once('afterChallenge', () => {
+            this.onAfterChallenge();
+        });
 
         return true;
     }

--- a/server/game/cards/locations/04/pyke.js
+++ b/server/game/cards/locations/04/pyke.js
@@ -1,12 +1,6 @@
 const DrawCard = require('../../../drawcard.js');
- 
+
 class Pyke extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['onPhaseEnded']);
-    }
-
     setupCardAbilities() {
         this.action({
             title: 'Kneel Pyke to give a character stealth',
@@ -38,6 +32,10 @@ class Pyke extends DrawCard {
         this.modifiedCard = card;
 
         this.game.addMessage('{0} kneeled {1} to make {2} gain stealth', player, this, card);
+
+        this.game.once('onPhaseEnded', () => {
+            this.onPhaseEnded();
+        });
 
         return true;
     }

--- a/test/server/cards/characters/01/01087 - serjaimelannister.spec.js
+++ b/test/server/cards/characters/01/01087 - serjaimelannister.spec.js
@@ -7,7 +7,7 @@ const SerJaimeLannister = require('../../../../../server/game/cards/characters/0
 
 describe('SerJaimeLannister', function() {
     beforeEach(function() {
-        this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener', 'addPower', 'addMessage']);
+        this.gameSpy = jasmine.createSpyObj('game', ['on', 'once', 'removeListener', 'addPower', 'addMessage']);
         this.playerSpy = jasmine.createSpyObj('player', ['']);
         this.otherPlayerSpy = jasmine.createSpyObj('player2', ['']);
 

--- a/test/server/cards/characters/02/02070 - redcloaks.spec.js
+++ b/test/server/cards/characters/02/02070 - redcloaks.spec.js
@@ -7,7 +7,7 @@ const RedCloaks = require('../../../../../server/game/cards/characters/02/redclo
 
 describe('RedCloaks', function() {
     beforeEach(function() {
-        this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener', 'addPower', 'addMessage']);
+        this.gameSpy = jasmine.createSpyObj('game', ['on', 'once', 'removeListener', 'addPower', 'addMessage']);
         this.playerSpy = jasmine.createSpyObj('player', ['']);
 
         this.playerSpy.game = this.gameSpy;


### PR DESCRIPTION
Previously, cards listened to end of phase and end of challenge events
to remove any lasting effects they may have applied. However, since
cards only listen to events while in play now, cards that left play
before the end of challenge / phase would not properly clean up after
themselves.

This change attaches a one-time event listener each time a lasting
effect is applied. Because the event is registered through game directly
and not the underlying event registrar, it won't be unregistered should
the card leave play prematurely.