### PR TITLE
Allow event self handlers when leaving play

### DIFF
--- a/test/server/player/drop.spec.js
+++ b/test/server/player/drop.spec.js
@@ -346,5 +346,24 @@ describe('Player', () => {
                 });
             });
         });
+
+        describe('event order', function() {
+            beforeEach(function() {
+                this.player.cardsInPlay.push(this.cardSpy);
+                this.cardSpy.location = 'play area';
+                this.cardSpy.getType.and.returnValue('character');
+            });
+
+            it('should fire onCharacterKilled before onCardLeftPlay', function() {
+                var events = [];
+                this.gameSpy.raiseEvent.and.callFake((name) => {
+                    events.push(name);
+                });
+
+                var result = this.player.drop(this.cardSpy.uuid, 'play area', 'dead pile');
+                expect(result).toBe(true);
+                expect(events.indexOf('onCharacterKilled')).toBeLessThan(events.indexOf('onCardLeftPlay'));
+            });
+        });
     });
 });


### PR DESCRIPTION
Some cards need to react to being killed, sacrificed or discarded.
Because event listeners are removed when a card leaves play, these
events must be fired prior to the card being moved to an out-of-play
game location.

This change ensures that the onCharacterKilled and onSacrificed events
are raised prior to the onCardLeftPlay event.