### PR TITLE
Modify Drowned Men strength instead of recalculate

### DIFF
--- a/server/game/cards/characters/01/drownedmen.js
+++ b/server/game/cards/characters/01/drownedmen.js
@@ -5,16 +5,19 @@ class DrownedMen extends DrawCard {
         super(owner, cardData);
 
         this.registerEvents(['onCardPlayed', 'onCardLeftPlay']);
+        this.warshipStrength = 0;
     }
 
     calculateStrength() {
-        this.strengthModifier = this.controller.cardsInPlay.reduce((counter, card) => {
+        this.strengthModifier -= this.warshipStrength;
+        this.warshipStrength = this.controller.cardsInPlay.reduce((counter, card) => {
             if(this.isBlank() || card.getType() !== 'location' || !card.hasTrait('Warship')) {
                 return counter;
             }
 
             return counter + 1;
         }, 0);
+        this.strengthModifier += this.warshipStrength;
     }
 
     play(player) {


### PR DESCRIPTION
Previously the Drowned Men was recalculating its strength as cards
entered and left play. This meant that if its strength should be
modified via another card, such as Priest of the Drowned God, that
modification would be lost when strength when Drowned Men strength was
recalculated.

Fixes #190 