### PR TITLE
Introduce effects wrapper + persistent effects

### DIFF
--- a/server/game/abilitydsl.js
+++ b/server/game/abilitydsl.js
@@ -1,0 +1,9 @@
+const AbilityLimit = require('./abilitylimit.js');
+const Effects = require('./effects.js');
+
+const AbilityDsl = {
+    limit: AbilityLimit,
+    effects: Effects
+}
+
+module.exports = AbilityDsl;

--- a/server/game/abilitydsl.js
+++ b/server/game/abilitydsl.js
@@ -4,6 +4,6 @@ const Effects = require('./effects.js');
 const AbilityDsl = {
     limit: AbilityLimit,
     effects: Effects
-}
+};
 
 module.exports = AbilityDsl;

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -1,6 +1,7 @@
 const uuid = require('node-uuid');
 const _ = require('underscore');
 
+const AbilityDsl = require('./abilitydsl.js');
 const CardAction = require('./cardaction.js');
 const CardForcedReaction = require('./cardforcedreaction.js');
 const CardReaction = require('./cardreaction.js');
@@ -39,8 +40,8 @@ class BaseCard {
 
         this.events = new EventRegistrar(this.game, this);
 
-        this.abilities = { reactions: [] };
-        this.setupCardAbilities();
+        this.abilities = { reactions: [], persistentEffects: [] };
+        this.setupCardAbilities(AbilityDsl);
     }
 
     parseKeywords(text) {
@@ -81,7 +82,7 @@ class BaseCard {
         this.eventsForRegistration = events;
     }
 
-    setupCardAbilities() {
+    setupCardAbilities(dsl) {
     }
 
     action(properties) {
@@ -110,6 +111,29 @@ class BaseCard {
         this.forcedReaction(properties);
     }
 
+    /**
+     * Applies an effect that continues as long as the card providing the effect
+     * is both in play and not blank.
+     */
+    persistentEffect(properties) {
+        this.abilities.persistentEffects.push(_.extend({ duration: 'persistent' }, properties));
+    }
+
+    /**
+     * Applies an effect with the specified properties while the current card is
+     * attached to another card. By default the effect will target the parent
+     * card, but you can provide a match function to narrow down whether the
+     * effect is applied (for cases where the effect only applies to specific
+     * characters).
+     */
+    whileAttached(properties) {
+        this.persistentEffect({
+            match: (card, context) => card === this.parent && (!properties.match || properties.match(card, context)),
+            targetController: 'any',
+            effect: properties.effect
+        });
+    }
+
     doAction(player, arg) {
         if(!this.abilities.action) {
             return;
@@ -133,6 +157,9 @@ class BaseCard {
     }
 
     play() {
+        _.each(this.abilities.persistentEffects, effect => {
+            this.game.addEffect(this, effect);
+        });
     }
 
     leavesPlay() {

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -227,7 +227,12 @@ class BaseCard {
     }
 
     setBlank() {
+        var before = this.isBlank();
         this.blankCount++;
+        var after = this.isBlank();
+        if(!before && after) {
+            this.game.raiseEvent('onCardBlankToggled', this, after);
+        }
     }
 
     addKeyword(keyword) {
@@ -263,7 +268,12 @@ class BaseCard {
     }
 
     clearBlank() {
+        var before = this.isBlank();
         this.blankCount--;
+        var after = this.isBlank();
+        if(before && !after) {
+            this.game.raiseEvent('onCardBlankToggled', this, after);
+        }
     }
 
     addToken(type, number) {

--- a/server/game/cards/attachments/01/drogosarakh.js
+++ b/server/game/cards/attachments/01/drogosarakh.js
@@ -7,6 +7,12 @@ class DrogosArakh extends DrawCard {
         this.registerEvents(['onAttackersDeclared']);
     }
 
+    setupCardAbilities(dsl) {
+        this.whileAttached({
+            effect: dsl.effects.modifyStrength(2)
+        });
+    }
+
     onAttackersDeclared(event, challenge) {
         if(challenge.challengeType !== 'military' || !challenge.isAttacking(this.parent) || this.parent.name !== 'Khal Drogo' || this.controller.getNumberOfChallengesInitiated() > 1) {
             return;
@@ -21,18 +27,6 @@ class DrogosArakh extends DrawCard {
         }
 
         return super.canAttach(player, card);
-    }
-
-    attach(player, card) {
-        card.strengthModifier += 2;
-
-        super.attach(player, card);
-    }
-
-    leavesPlay() {
-        super.leavesPlay();
-
-        this.parent.strengthModifier--;
     }
 }
 

--- a/server/game/cards/attachments/01/littlebird.js
+++ b/server/game/cards/attachments/01/littlebird.js
@@ -1,14 +1,10 @@
 const DrawCard = require('../../../drawcard.js');
 
 class LittleBird extends DrawCard {
-    attach(player, card) {
-        card.addIcon('intrigue');
-    }
-
-    leavesPlay() {
-        super.leavesPlay();
-        
-        this.parent.addIcon('intrigue');
+    setupCardAbilities(dsl) {
+        this.whileAttached({
+            effect: dsl.effects.addIcon('intrigue')
+        });
     }
 }
 

--- a/server/game/cards/attachments/01/milkofthepoppy.js
+++ b/server/game/cards/attachments/01/milkofthepoppy.js
@@ -1,14 +1,10 @@
 const DrawCard = require('../../../drawcard.js');
 
 class MilkOfThePoppy extends DrawCard {
-    attach(player, card) {
-        card.setBlank();
-    }
-
-    leavesPlay() {
-        super.leavesPlay();
-        
-        this.parent.clearBlank();
+    setupCardAbilities(dsl) {
+        this.whileAttached({
+            effect: dsl.effects.blank
+        });
     }
 }
 

--- a/server/game/cards/attachments/01/noblelineage.js
+++ b/server/game/cards/attachments/01/noblelineage.js
@@ -1,14 +1,10 @@
 const DrawCard = require('../../../drawcard.js');
 
 class NobleLineage extends DrawCard {
-    attach(player, card) {
-        card.addIcon('power');
-    }
-
-    leavesPlay() {
-        super.leavesPlay();
-        
-        this.parent.addIcon('power');
+    setupCardAbilities(dsl) {
+        this.whileAttached({
+            effect: dsl.effects.addIcon('power')
+        });
     }
 }
 

--- a/server/game/cards/attachments/01/syriostraining.js
+++ b/server/game/cards/attachments/01/syriostraining.js
@@ -1,14 +1,10 @@
 const DrawCard = require('../../../drawcard.js');
 
 class SyriosTraining extends DrawCard {
-    attach(player, card) {
-        card.addIcon('military');
-    }
-
-    leavesPlay() {
-        super.leavesPlay();
-        
-        this.parent.addIcon('military');
+    setupCardAbilities(dsl) {
+        this.whileAttached({
+            effect: dsl.effects.addIcon('military')
+        });
     }
 }
 

--- a/server/game/cards/attachments/01/widowswail.js
+++ b/server/game/cards/attachments/01/widowswail.js
@@ -1,22 +1,14 @@
 const DrawCard = require('../../../drawcard.js');
 
 class WidowsWail extends DrawCard {
-    attach(player, card) {
-        card.strengthModifier += 2;
-
-        if(card.name === 'Joffrey Baratheon') {
-            card.addIcon('military');
-        }
-    }
-
-    leavesPlay() {
-        super.leavesPlay();
-
-        this.parent.strengthModifier -= 2;
-
-        if(this.parent.name === 'Joffrey Baratheon') {
-            this.parent.removeIcon('military');
-        }
+    setupCardAbilities(dsl) {
+        this.whileAttached({
+            effect: dsl.effects.modifyStrength(2)
+        });
+        this.whileAttached({
+            match: (card) => card.name === 'Joffrey Baratheon',
+            effect: dsl.effects.addIcon('military')
+        });
     }
 }
 

--- a/server/game/cards/attachments/02/knighted.js
+++ b/server/game/cards/attachments/02/knighted.js
@@ -1,16 +1,13 @@
 const DrawCard = require('../../../drawcard.js');
- 
-class Knighted extends DrawCard {
-    attach(player, card) {
-        card.strengthModifier++;
-        card.addTrait('Knight');
-    }
 
-    leavesPlay() {
-        super.leavesPlay();
-        
-        this.parent.strengthModifier--;
-        this.parent.removeTrait('Knight');
+class Knighted extends DrawCard {
+    setupCardAbilities(dsl) {
+        this.whileAttached({
+            effect: dsl.effects.modifyStrength(1)
+        });
+        this.whileAttached({
+            effect: dsl.effects.addTrait('Knight')
+        });
     }
 }
 

--- a/server/game/cards/attachments/02/practiceblade.js
+++ b/server/game/cards/attachments/02/practiceblade.js
@@ -1,24 +1,21 @@
 const DrawCard = require('../../../drawcard.js');
 
 class PracticeBlade extends DrawCard {
+    setupCardAbilities(dsl) {
+        this.whileAttached({
+            effect: dsl.effects.modifyStrength(1)
+        });
+        this.whileAttached({
+            effect: dsl.effects.addIcon('military')
+        });
+    }
+
     canAttach(player, card) {
         if(card.getType() !== 'character' || card.getFaction() !== this.getFaction()) {
             return false;
         }
 
         return super.canAttach(player, card);
-    }
-
-    attach(player, card) {
-        card.strengthModifier += 1;
-        card.addIcon('military');
-    }
-
-    leavesPlay() {
-        super.leavesPlay();
-
-        this.parent.strengthModifier -= 1;
-        this.parent.removeIcon('military');
     }
 }
 

--- a/server/game/cards/characters/01/direwolfpup.js
+++ b/server/game/cards/characters/01/direwolfpup.js
@@ -1,54 +1,21 @@
 const DrawCard = require('../../../drawcard.js');
 
 class DirewolfPup extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['onCardPlayed', 'onCardLeftPlay']);
+    setupCardAbilities(dsl) {
+        this.persistentEffect({
+            match: card => card === this,
+            effect: dsl.effects.dynamicStrength(() => this.calculateStrength())
+        });
     }
 
     calculateStrength() {
-        this.strengthModifier = this.controller.cardsInPlay.reduce((counter, card) => {
-            if(this.isBlank() || card.uuid === this.uuid || !card.hasTrait('Direwolf')) {
+        return this.controller.cardsInPlay.reduce((counter, card) => {
+            if(card.uuid === this.uuid || !card.hasTrait('Direwolf')) {
                 return counter;
             }
 
             return counter + 1;
         }, 0);
-    }
-
-    play(player) {
-        super.play(player);
-
-        this.calculateStrength();
-    }
-
-    onCardPlayed(e, player) {
-        if(this.controller !== player) {
-            return;
-        }
-
-        this.calculateStrength();
-    }
-
-    onCardLeftPlay(e, player) {
-        if(this.controller !== player) {
-            return;
-        }
-
-        this.calculateStrength();
-    }
-
-    setBlank() {
-        super.setBlank();
-
-        this.calculateStrength();
-    }
-
-    clearBlank() {
-        super.clearBlank();
-
-        this.calculateStrength();
     }
 }
 

--- a/server/game/cards/characters/01/drogon.js
+++ b/server/game/cards/characters/01/drogon.js
@@ -1,51 +1,12 @@
 const DrawCard = require('../../../drawcard.js');
- 
+
 class Drogon extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['onCardPlayed', 'onCardLeftPlay']);
-    }
-
-    play() {
-        super.play();
-
-        this.controller.cardsInPlay.each(card => {
-            if(card.hasTrait('Stormborn')) {
-                card.addKeyword('Renown');
-            }
+    setupCardAbilities(dsl) {
+        this.persistentEffect({
+            match: (card) => card.hasTrait('Stormborn'),
+            effect: dsl.effects.addKeyword('Renown')
         });
     }
-    
-    leavesPlay() {
-        super.leavesPlay();
-
-        this.controller.cardsInPlay.each(card => {
-            if(card.hasTrait('Stormborn')) {
-                card.removeKeyword('Renown');
-            }
-        });
-    }
-
-    onCardPlayed(event, player, card) {
-        if(this.controller !== player || this.isBlank()) {
-            return;
-        }
-
-        if(card.hasTrait('Stormborn')) {
-            card.addKeyword('Renown');
-        }
-    }
-
-    onCardLeftPlay(event, player, card) {
-        if(this.controller !== player || this.isBlank()) {
-            return;
-        }
-    
-        if(card.hasTrait('Stormborn')) {
-            card.removeKeyword('Renown');
-        }
-    }    
 }
 
 Drogon.code = '01161';

--- a/server/game/cards/characters/01/drownedmen.js
+++ b/server/game/cards/characters/01/drownedmen.js
@@ -1,57 +1,19 @@
 const DrawCard = require('../../../drawcard.js');
 
 class DrownedMen extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['onCardPlayed', 'onCardLeftPlay']);
-        this.warshipStrength = 0;
+    setupCardAbilities(dsl) {
+        this.persistentEffect({
+            match: card => card === this,
+            effect: dsl.effects.dynamicStrength(() => this.calculateStrength())
+        });
     }
 
     calculateStrength() {
-        this.strengthModifier -= this.warshipStrength;
-        this.warshipStrength = this.controller.cardsInPlay.reduce((counter, card) => {
-            if(this.isBlank() || card.getType() !== 'location' || !card.hasTrait('Warship')) {
-                return counter;
-            }
+        var cards = this.controller.cardsInPlay.filter(card => {
+            return card.getType() === 'location' && card.hasTrait('Warship');
+        });
 
-            return counter + 1;
-        }, 0);
-        this.strengthModifier += this.warshipStrength;
-    }
-
-    play(player) {
-        super.play(player);
-
-        this.calculateStrength();
-    }
-
-    onCardPlayed(e, player) {
-        if(this.controller !== player) {
-            return;
-        }
-
-        this.calculateStrength();
-    }
-
-    onCardLeftPlay(e, player) {
-        if(this.controller !== player) {
-            return;
-        }
-
-        this.calculateStrength();
-    }
-
-    setBlank() {
-        super.setBlank();
-
-        this.calculateStrength();
-    }
-
-    clearBlank() {
-        super.clearBlank();
-
-        this.calculateStrength();
+        return cards.length;
     }
 }
 

--- a/server/game/cards/characters/01/robertbaratheon.js
+++ b/server/game/cards/characters/01/robertbaratheon.js
@@ -1,73 +1,21 @@
-const _ = require('underscore');
-
 const DrawCard = require('../../../drawcard.js');
 
 class RobertBaratheon extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['onCardPlayed', 'onCardLeftPlay', 'onCardKneeled', 'onCardStood']);
+    setupCardAbilities(dsl) {
+        this.persistentEffect({
+            match: card => card === this,
+            effect: dsl.effects.dynamicStrength(() => this.calculateStrength())
+        });
     }
 
     calculateStrength() {
-        var otherPlayer = this.game.getOtherPlayer(this.controller);
-        var cardsInPlay = [];
-
-        if(!otherPlayer) {
-            cardsInPlay = this.controller.cardsInPlay.value();
-        } else {
-            cardsInPlay = this.controller.cardsInPlay.union(otherPlayer.cardsInPlay.value());
-        }
-
-        this.strengthModifier = _.reduce(cardsInPlay, (counter, card) => {
-            if(this.isBlank() || card === this || card.getType() !== 'character' || !card.kneeled) {
+        return this.game.allCards.reduce((counter, card) => {
+            if(card === this || card.location !== 'play area' || card.getType() !== 'character' || !card.kneeled) {
                 return counter;
             }
 
             return counter + 1;
         }, 0);
-    }
-
-    play(player) {
-        super.play(player);
-
-        this.calculateStrength();
-    }
-
-    onCardPlayed() {
-        this.calculateStrength();
-    }
-
-    onCardLeftPlay() {
-        this.calculateStrength();
-    }
-
-    onCardKneeled(event, player, card) {
-        if(card.getType() !== 'character') {
-            return;
-        }
-
-        this.calculateStrength();
-    }
-
-    onCardStood(event, player, card) {
-        if(card.getType() !== 'character') {
-            return;
-        }
-
-        this.calculateStrength();
-    }
-
-    setBlank() {
-        super.setBlank();
-
-        this.calculateStrength();
-    }
-
-    clearBlank() {
-        super.clearBlank();
-
-        this.calculateStrength();
     }
 }
 

--- a/server/game/cards/characters/01/unsullied.js
+++ b/server/game/cards/characters/01/unsullied.js
@@ -1,41 +1,12 @@
-const _ = require('underscore');
-
 const DrawCard = require('../../../drawcard.js');
 
 class Unsullied extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['onDefendersDeclared', 'afterChallenge']);
-    }
-
-    onDefendersDeclared(event, challenge) {
-        if(challenge.defendingPlayer === this.controller || !challenge.isAttacking(this) || this.isBlank()) {
-            return;
-        }
-
-        var opponentCards = challenge.getOpponentCards(this.controller);
-
-        _.each(opponentCards, card => {
-            card.strengthModifier--;
-        });
-
-        challenge.calculateStrength();
-    
-        this.game.addMessage('{0} uses {1} to add -1 to the strength of each opponent\'s defending characters for this challenge', this.controller, this);
-
-        this.strengthModified = true;
-    }    
-
-    afterChallenge(event, challenge) {
-        if(!this.strengthModified) {
-            return;
-        }
-
-        var opponentCards = challenge.getOpponentCards(this.controller);
-
-        _.each(opponentCards, card => {
-            card.strengthModifier++;
+    setupCardAbilities(dsl) {
+        this.persistentEffect({
+            condition: () => this.game.currentChallenge && this.game.currentChallenge.isAttacking(this),
+            match: (card) => this.game.currentChallenge && this.game.currentChallenge.isDefending(card),
+            targetController: 'opponent',
+            effect: dsl.effects.modifyStrength(-1)
         });
     }
 }

--- a/server/game/cards/characters/01/viserion.js
+++ b/server/game/cards/characters/01/viserion.js
@@ -1,51 +1,12 @@
 const DrawCard = require('../../../drawcard.js');
- 
+
 class Viserion extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['onCardPlayed', 'onCardLeftPlay']);
-    }
-
-    play() {
-        super.play();
-
-        this.controller.cardsInPlay.each(card => {
-            if(card.hasTrait('Stormborn')) {
-                card.addKeyword('Stealth');
-            }
+    setupCardAbilities(dsl) {
+        this.persistentEffect({
+            match: (card) => card.hasTrait('Stormborn'),
+            effect: dsl.effects.addKeyword('Stealth')
         });
     }
-    
-    leavesPlay() {
-        super.leavesPlay();
-
-        this.controller.cardsInPlay.each(card => {
-            if(card.hasTrait('Stormborn')) {
-                card.removeKeyword('Stealth');
-            }
-        });
-    }
-
-    onCardPlayed(event, player, card) {
-        if(this.controller !== player || this.isBlank()) {
-            return;
-        }
-
-        if(card.hasTrait('Stormborn')) {
-            card.addKeyword('Stealth');
-        }
-    }
-
-    onCardLeftPlay(event, player, card) {
-        if(this.controller !== player || this.isBlank()) {
-            return;
-        }
-    
-        if(card.hasTrait('Stormborn')) {
-            card.removeKeyword('Stealth');
-        }
-    }    
 }
 
 Viserion.code = '01166';

--- a/server/game/cards/characters/01/wardensofthereach.js
+++ b/server/game/cards/characters/01/wardensofthereach.js
@@ -1,54 +1,21 @@
 const DrawCard = require('../../../drawcard.js');
 
 class WardensOfTheReach extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['onCardPlayed', 'onCardLeftPlay']);
+    setupCardAbilities(dsl) {
+        this.persistentEffect({
+            match: card => card === this,
+            effect: dsl.effects.dynamicStrength(() => this.calculateStrength())
+        });
     }
 
     calculateStrength() {
-        this.strengthModifier = this.controller.cardsInPlay.reduce((counter, card) => {
-            if(this.isBlank() || card.getType() !== 'location' || !card.hasTrait('The Reach')) {
+        return this.controller.cardsInPlay.reduce((counter, card) => {
+            if(card.getType() !== 'location' || !card.hasTrait('The Reach')) {
                 return counter;
             }
 
             return counter + 1;
         }, 0);
-    }
-
-    play(player) {
-        super.play(player);
-
-        this.calculateStrength();
-    }
-
-    onCardPlayed(e, player) {
-        if(this.controller !== player) {
-            return;
-        }
-
-        this.calculateStrength();
-    }
-
-    onCardLeftPlay(e, player) {
-        if(this.controller !== player) {
-            return;
-        }
-
-        this.calculateStrength();
-    }
-
-    setBlank() {
-        super.setBlank();
-
-        this.calculateStrength();
-    }
-
-    clearBlank() {
-        super.clearBlank();
-
-        this.calculateStrength();
     }
 }
 

--- a/server/game/cards/characters/02/priestofthedrownedgod.js
+++ b/server/game/cards/characters/02/priestofthedrownedgod.js
@@ -1,43 +1,10 @@
 const DrawCard = require('../../../drawcard.js');
 
 class PriestOfTheDrownedGod extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['onCardPlayed']);
-    }
-
-    play(player) {
-        super.play(player);
-
-        player.cardsInPlay.each(card => {
-            if(card.getType() === 'character' && card.hasTrait('Drowned God')) {
-                card.strengthModifier++;
-            }
-        });
-    }
-
-    onCardPlayed(e, player, card) {
-        if(this.controller !== player || this.isBlank()) {
-            return;
-        }
-
-        if(card.getType() === 'character' && card.hasTrait('Drowned God')) {
-            card.strengthModifier++;
-        }
-    }
-
-    leavesPlay() {
-        super.leavesPlay();
-        
-        if(this.isBlank()) {
-            return;
-        }
-
-        this.controller.cardsInPlay.each(card => {
-            if(card.getType() === 'character' && card.hasTrait('Drowned God')) {
-                card.strengthModifier--;
-            }
+    setupCardAbilities(dsl) {
+        this.persistentEffect({
+            match: card => card.getType() === 'character' && card.hasTrait('Drowned God'),
+            effect: dsl.effects.modifyStrength(1)
         });
     }
 }

--- a/server/game/cards/characters/03/sansastark.js
+++ b/server/game/cards/characters/03/sansastark.js
@@ -1,66 +1,26 @@
 const DrawCard = require('../../../drawcard.js');
 
 class SansaStark extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['onBeginMarshal', 'onCardPlayed', 'onCharacterKilled']);
-
-        this.lastGold = 0;
+    setupCardAbilities(dsl) {
+        this.persistentEffect({
+            match: card => card === this,
+            effect: dsl.effects.dynamicStrength(() => this.calculateStrength())
+        });
+        this.persistentEffect({
+            condition: () => this.getStrength() === 0,
+            match: card => card === this,
+            effect: dsl.effects.addKeyword('Insight')
+        });
     }
 
-    updateStrength(card) {
-        this.strengthModifier = this.controller.deadPile.reduce((count, card) => {
-            if(!this.isBlank() && card.getFaction() === 'stark') {
+    calculateStrength() {
+        return this.controller.deadPile.reduce((count, card) => {
+            if(card.getFaction() === 'stark') {
                 return count - 1;
             }
 
             return count;
         }, 0);
-
-        if(card && card.getFaction() === 'stark') {
-            this.strengthModifier--;
-        }
-
-        if(this.getStrength() === 0) {
-            if(!this.addedInsight) {
-                this.addKeyword('Insight');
-            }
-        } else if(this.addedInsight) {
-            this.removeKeyword('Insight');
-        }
-    }
-
-    onBeginMarshal(event, player) {
-        if(this.controller !== player) {
-            return;
-        }
-
-        this.updateStrength();
-    }
-
-    onCardPlayed(event, player) {
-        if(this.controller !== player) {
-            return;
-        }
-
-        this.updateStrength();
-    }
-
-    onCharacterKilled(event, player, card) {
-        if(this.controller !== player) {
-            return;
-        }
-
-        this.updateStrength(card);
-    }
-
-    leavesPlay() {
-        super.leavesPlay();
-
-        if(this.addedInsight) {
-            this.removeKeyword('Insight');
-        }
     }
 }
 

--- a/server/game/cards/locations/01/thewall.js
+++ b/server/game/cards/locations/01/thewall.js
@@ -1,13 +1,7 @@
 const DrawCard = require('../../../drawcard.js');
 
 class TheWall extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['onCardEntersPlay']);
-    }
-
-    setupCardAbilities() {
+    setupCardAbilities(dsl) {
         this.forcedReaction({
             when: {
                 onUnopposedWin: (e, challenge) => this.controller !== challenge.winner && !this.kneeled
@@ -27,43 +21,9 @@ class TheWall extends DrawCard {
                 this.game.addMessage('{0} kneels {1} to gain 2 power for their faction', this.controller, this);
             }
         });
-    }
-
-    isBoostableCard(card) {
-        return card.getFaction() === this.getFaction() && card.getType() === 'character';
-    }
-
-    play(player) {
-        super.play(player);
-
-        player.cardsInPlay.each(card => {
-            if(this.isBoostableCard(card)) {
-                card.strengthModifier++;
-            }
-        });
-    }
-
-    onCardEntersPlay(event, card) {
-        if(this.controller !== card.controller) {
-            return;
-        }
-
-        if(this.isBoostableCard(card)) {
-            card.strengthModifier++;
-        }
-    }
-
-    leavesPlay() {
-        super.leavesPlay();
-
-        if(this.isBlank()) {
-            return;
-        }
-
-        this.controller.cardsInPlay.each(card => {
-            if(this.isBoostableCard(card)) {
-                card.strengthModifier--;
-            }
+        this.persistentEffect({
+            match: (card) => this.getFaction() === card.getFaction() && card.getType() === 'character',
+            effect: dsl.effects.modifyStrength(1)
         });
     }
 }

--- a/server/game/cards/locations/03/winterfell.js
+++ b/server/game/cards/locations/03/winterfell.js
@@ -1,40 +1,12 @@
 const DrawCard = require('../../../drawcard.js');
 
 class Winterfell extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['onCardPlayed']);
-    }
-
-    play(player) {
-        super.play(player);
-
-        player.cardsInPlay.each(card => {
-            if(card.getFaction() === this.getFaction() && card.getType() === 'character') {
-                card.strengthModifier++;
-            }
+    setupCardAbilities(dsl) {
+        this.persistentEffect({
+            match: card => card.getFaction() === this.getFaction() && card.getType() === 'character',
+            effect: dsl.effects.modifyStrength(1)
         });
-    }
-
-    onCardPlayed(e, player, card) {
-        if(this.controller !== player || this.isBlank()) {
-            return;
-        }
-
-        if(card.getFaction() === this.getFaction() && card.getType() === 'character') {
-            card.strengthModifier++;
-        }
-    }
-
-    leavesPlay() {
-        super.leavesPlay();
-
-        this.controller.cardsInPlay.each(card => {
-            if(card.getFaction() === this.getFaction() && card.getType() === 'character') {
-                card.strengthModifier--;
-            }
-        });
+        // TODO: Reaction for preventing card abilities.
     }
 }
 

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -200,6 +200,9 @@ class DrawCard extends BaseCard {
     }
 
     attach() {
+        _.each(this.abilities.persistentEffects, effect => {
+            this.game.addEffect(this, effect);
+        });
     }
 
     play(player, isAmbush) {
@@ -214,7 +217,6 @@ class DrawCard extends BaseCard {
 
     leavesPlay() {
         this.kneeled = false;
-        this.strengthModifier = 0;
         this.power = 0;
         this.wasAmbush = false;
         this.inChallenge = false;

--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -8,6 +8,11 @@ const _ = require('underscore');
  *                    a boolean about whether the passed card should have the
  *                    effect applied.
  * duration         - string representing how long the effect lasts.
+ * condition        - function that returns a boolean determining whether the
+ *                    effect can be applied. Use with cards that have a
+ *                    condition that must be met before applying a persistent
+ *                    effect (e.g. "when there are more Summer plots revealed
+ *                    than Winter plots").
  * targetController - string that determines which player's cards are targeted.
  *                    Can be 'current' (default), 'opponent' or 'any'.
  * effect.apply     - function that takes a card and a context object and modifies
@@ -21,14 +26,20 @@ class Effect {
         this.source = source;
         this.match = properties.match;
         this.duration = properties.duration;
+        this.condition = properties.condition || (() => true);
         this.targetController = properties.targetController || 'current';
         this.effect = properties.effect;
         this.targets = [];
         this.context = { game: game, source: source };
         this.active = true;
+        this.isStateDependent = properties.condition || properties.effect.isStateDependent;
     }
 
     addTargets(cards) {
+        if(!this.condition()) {
+            return;
+        }
+
         _.each(cards, card => {
             if(this.isValidTarget(card)) {
                 this.targets.push(card);

--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -1,0 +1,94 @@
+const _ = require('underscore');
+
+/**
+ * Represents a card based effect applied to one or more targets.
+ *
+ * Properties:
+ * match            - function that takes a card and context object and returns
+ *                    a boolean about whether the passed card should have the
+ *                    effect applied.
+ * duration         - string representing how long the effect lasts.
+ * targetController - string that determines which player's cards are targeted.
+ *                    Can be 'current' (default), 'opponent' or 'any'.
+ * effect.apply     - function that takes a card and a context object and modifies
+ *                    the card to apply the effect.
+ * effect.unapply   - function that takes a card and a context object and modifies
+ *                    the card to remove the previously applied effect.
+ */
+class Effect {
+    constructor(game, source, properties) {
+        this.game = game;
+        this.source = source;
+        this.match = properties.match;
+        this.duration = properties.duration;
+        this.targetController = properties.targetController || 'current';
+        this.effect = properties.effect;
+        this.targets = [];
+        this.context = { game: game, source: source };
+        this.active = true;
+    }
+
+    addTargets(cards) {
+        _.each(cards, card => {
+            if(this.isValidTarget(card)) {
+                this.targets.push(card);
+                if(this.active) {
+                    this.effect.apply(card, this.context);
+                }
+            }
+        });
+    }
+
+    isValidTarget(card) {
+        if(!this.match(card, this.context)) {
+            return false;
+        }
+
+        if(this.targetController === 'current') {
+            return card.controller === this.source.controller;
+        }
+
+        if(this.targetController === 'opponent') {
+            return card.controller !== this.source.controller;
+        }
+
+        return true;
+    }
+
+    removeTarget(card) {
+        if(!_.contains(this.targets, card)) {
+            return;
+        }
+
+        if(this.active) {
+            this.effect.unapply(card, this.context);
+        }
+
+        this.targets = _.reject(this.targets, target => target === card);
+    }
+
+    hasTarget(card) {
+        return this.targets.includes(card);
+    }
+
+    setActive(newActive) {
+        if(this.active && !newActive) {
+            _.each(this.targets, target => this.effect.unapply(target, this.context));
+        }
+
+        if(!this.active && newActive) {
+            _.each(this.targets, target => this.effect.apply(target, this.context));
+        }
+
+        this.active = newActive;
+    }
+
+    cancel() {
+        if(this.active) {
+            _.each(this.targets, target => this.effect.unapply(target, this.context));
+        }
+        this.targets = [];
+    }
+}
+
+module.exports = Effect;

--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -12,8 +12,21 @@ class EffectEngine {
 
     add(effect) {
         this.effects.push(effect);
+        this.applyEffect(effect);
+    }
+
+    applyEffect(effect) {
         var validTargets = this.game.allCards.filter(card => card.location === 'play area');
         effect.addTargets(validTargets);
+    }
+
+    reapplyStateDependentEffects() {
+        _.each(this.effects, effect => {
+            if(effect.isStateDependent) {
+                effect.cancel();
+                this.applyEffect(effect);
+            }
+        });
     }
 
     onCardEntersPlay(e, card) {

--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -1,0 +1,51 @@
+const _ = require('underscore');
+
+const EventRegistrar = require('./eventregistrar.js');
+
+class EffectEngine {
+    constructor(game) {
+        this.game = game;
+        this.events = new EventRegistrar(game, this);
+        this.events.register(['onCardEntersPlay', 'onCardLeftPlay', 'onCardBlankToggled']);
+        this.effects = [];
+    }
+
+    add(effect) {
+        this.effects.push(effect);
+        var validTargets = this.game.allCards.filter(card => card.location === 'play area');
+        effect.addTargets(validTargets);
+    }
+
+    onCardEntersPlay(e, card) {
+        _.each(this.effects, effect => {
+            if(effect.duration === 'persistent') {
+                effect.addTargets([card]);
+            }
+        });
+    }
+
+    onCardLeftPlay(e, player, card) {
+        _.each(this.effects, effect => {
+            effect.removeTarget(card);
+        });
+
+        this.unapplyAndRemove(effect => effect.duration === 'persistent' && effect.source === card);
+    }
+
+    onCardBlankToggled(event, card, isBlank) {
+        var matchingEffects = _.filter(this.effects, effect => effect.duration === 'persistent' && effect.source === card);
+        _.each(matchingEffects, effect => {
+            effect.setActive(!isBlank);
+        });
+    }
+
+    unapplyAndRemove(match) {
+        var [matchingEffects, remainingEffects] = _.partition(this.effects, match);
+        _.each(matchingEffects, effect => {
+            effect.cancel();
+        });
+        this.effects = remainingEffects;
+    }
+}
+
+module.exports = EffectEngine;

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -9,6 +9,20 @@ const Effects = {
             }
         };
     },
+    dynamicStrength: function(calculate) {
+        return {
+            apply: function(card, context) {
+                context.dynamicStrength = context.dynamicStrength || {};
+                context.dynamicStrength[card] = calculate(card, context);
+                card.strengthModifier += context.dynamicStrength[card];
+            },
+            unapply: function(card, context) {
+                card.strengthModifier -= context.dynamicStrength[card];
+                delete context.dynamicStrength[card];
+            },
+            isStateDependent: true
+        };
+    },
     addIcon: function(icon) {
         return {
             apply: function(card) {

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -43,18 +43,13 @@ const Effects = {
             }
         };
     },
-    poison: function() {
+    addTrait: function(trait) {
         return {
-            apply: function(card, context) {
-                context.game.addMessage('{0} uses {1} to place 1 poison token on {2}', context.source.controller, context.source, card);
-                card.addToken('poison', 1);
+            apply: function(card) {
+                card.addTrait(trait);
             },
-            unapply: function(card, context) {
-                if(card.hasToken('poison', 1)) {
-                    context.game.addMessage('{0} uses {1} to kill {2} at the end of the phase', context.source.controller, context.source, card);
-                    card.removeToken('poison');
-                    card.controller.killCharacter(card);
-                }
+            unapply: function(card) {
+                card.removeTrait(trait);
             }
         };
     },

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -1,0 +1,57 @@
+const Effects = {
+    modifyStrength: function(value) {
+        return {
+            apply: function(card) {
+                card.strengthModifier += value;
+            },
+            unapply: function(card) {
+                card.strengthModifier -= value;
+            }
+        };
+    },
+    addIcon: function(icon) {
+        return {
+            apply: function(card) {
+                card.setIcon(icon);
+            },
+            unapply: function(card) {
+                card.clearIcon(card);
+            }
+        };
+    },
+    addKeyword: function(keyword) {
+        return {
+            apply: function(card) {
+                card.addKeyword(keyword);
+            },
+            unapply: function(card) {
+                card.removeKeyword(keyword);
+            }
+        };
+    },
+    poison: function() {
+        return {
+            apply: function(card, context) {
+                context.game.addMessage('{0} uses {1} to place 1 poison token on {2}', context.source.controller, context.source, card);
+                card.addToken('poison', 1);
+            },
+            unapply: function(card, context) {
+                if(card.hasToken('poison', 1)) {
+                    context.game.addMessage('{0} uses {1} to kill {2} at the end of the phase', context.source.controller, context.source, card);
+                    card.removeToken('poison');
+                    card.controller.killCharacter(card);
+                }
+            }
+        };
+    },
+    blank: {
+        apply: function(card) {
+            card.setBlank();
+        },
+        unapply: function(card) {
+            card.clearBlank();
+        }
+    }
+};
+
+module.exports = Effects;

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -4,6 +4,8 @@ const uuid = require('node-uuid');
 
 const Event = require('./event.js');
 const GameChat = require('./gamechat.js');
+const EffectEngine = require('./effectengine.js');
+const Effect = require('./effect.js');
 const Spectator = require('./spectator.js');
 const GamePipeline = require('./gamepipeline.js');
 const SetupPhase = require('./gamesteps/setupphase.js');
@@ -23,6 +25,7 @@ class Game extends EventEmitter {
     constructor(owner, details) {
         super();
 
+        this.effectEngine = new EffectEngine(this);
         this.players = {};
         this.playerPlots = {};
         this.playerCards = {};
@@ -123,6 +126,10 @@ class Game extends EventEmitter {
             }
             return player.findCardByUuidInAnyList(cardId);
         }, null);
+    }
+
+    addEffect(source, properties) {
+        this.effectEngine.add(new Effect(this, source, properties));
     }
 
     playCard(playerName, cardId, isDrop, sourceList) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -698,6 +698,7 @@ class Game extends EventEmitter {
 
     continue() {
         this.pipeline.continue();
+        this.effectEngine.reapplyStateDependentEffects();
     }
 
     getSaveState() {

--- a/test/server/effect.spec.js
+++ b/test/server/effect.spec.js
@@ -29,6 +29,48 @@ describe('Effect', function () {
             this.properties.match.and.callFake((card) => card === this.matchingCard);
         });
 
+        describe('when the effect has a condition', function() {
+            beforeEach(function() {
+                this.effect.active = true;
+                this.properties.condition = jasmine.createSpy('condition');
+                this.effect = new Effect(this.gameSpy, this.sourceSpy, this.properties);
+            });
+
+            describe('and the condition returns true', function() {
+                beforeEach(function() {
+                    this.properties.condition.and.returnValue(true);
+                    this.effect.addTargets([this.nonMatchingCard, this.matchingCard]);
+                });
+
+                it('should add the matching cards to the target list', function() {
+                    expect(this.effect.targets).toContain(this.matchingCard);
+                    expect(this.effect.targets).not.toContain(this.nonMatchingCard);
+                });
+
+                it('should apply the effect to the matching card', function() {
+                    expect(this.properties.effect.apply).toHaveBeenCalledWith(this.matchingCard, { game: this.gameSpy, source: this.sourceSpy });
+                    expect(this.properties.effect.apply).not.toHaveBeenCalledWith(this.nonMatchingCard, jasmine.any(Object));
+                });
+            });
+
+            describe('and the condition returns false', function() {
+                beforeEach(function() {
+                    this.properties.condition.and.returnValue(false);
+                    this.effect.addTargets([this.nonMatchingCard, this.matchingCard]);
+                });
+
+                it('should not add the matching cards to the target list', function() {
+                    expect(this.effect.targets).not.toContain(this.matchingCard);
+                    expect(this.effect.targets).not.toContain(this.nonMatchingCard);
+                });
+
+                it('should not apply the effect to the matching card', function() {
+                    expect(this.properties.effect.apply).not.toHaveBeenCalledWith(this.matchingCard, jasmine.any(Object));
+                    expect(this.properties.effect.apply).not.toHaveBeenCalledWith(this.nonMatchingCard, jasmine.any(Object));
+                });
+            });
+        });
+
         describe('when the effect is active', function() {
             beforeEach(function() {
                 this.effect.active = true;

--- a/test/server/effect.spec.js
+++ b/test/server/effect.spec.js
@@ -1,0 +1,224 @@
+/*global describe, it, beforeEach, expect, jasmine */
+/*eslint camelcase: 0, no-invalid-this: 0 */
+
+const Effect = require('../../server/game/effect.js');
+
+describe('Effect', function () {
+    beforeEach(function () {
+        this.gameSpy = jasmine.createSpyObj('game', ['']);
+        this.sourceSpy = jasmine.createSpyObj('source', ['isBlank']);
+        this.properties = {
+            match: jasmine.createSpy('match'),
+            duration: 'persistent',
+            effect: {
+                apply: jasmine.createSpy('apply'),
+                unapply: jasmine.createSpy('unapply')
+            }
+        };
+
+        this.properties.match.and.returnValue(true);
+
+        this.effect = new Effect(this.gameSpy, this.sourceSpy, this.properties);
+    });
+
+    describe('addTargets()', function() {
+        beforeEach(function() {
+            this.matchingCard = { good: true };
+            this.nonMatchingCard = { bad: true };
+
+            this.properties.match.and.callFake((card) => card === this.matchingCard);
+        });
+
+        describe('when the effect is active', function() {
+            beforeEach(function() {
+                this.effect.active = true;
+                this.effect.addTargets([this.nonMatchingCard, this.matchingCard]);
+            });
+
+            it('should add the matching cards to the target list', function() {
+                expect(this.effect.targets).toContain(this.matchingCard);
+                expect(this.effect.targets).not.toContain(this.nonMatchingCard);
+            });
+
+            it('should apply the effect to the matching card', function() {
+                expect(this.properties.effect.apply).toHaveBeenCalledWith(this.matchingCard, { game: this.gameSpy, source: this.sourceSpy });
+                expect(this.properties.effect.apply).not.toHaveBeenCalledWith(this.nonMatchingCard, jasmine.any(Object));
+            });
+        });
+
+        describe('when the effect is inactive', function() {
+            beforeEach(function() {
+                this.effect.active = false;
+                this.effect.addTargets([this.nonMatchingCard, this.matchingCard]);
+            });
+
+            it('should add the matching cards to the target list', function() {
+                expect(this.effect.targets).toContain(this.matchingCard);
+            });
+
+            it('should not apply the effect to the matching card', function() {
+                expect(this.properties.effect.apply).not.toHaveBeenCalledWith(this.matchingCard, jasmine.any(Object));
+            });
+        });
+    });
+
+    describe('removeTarget()', function() {
+        beforeEach(function() {
+            this.target = { good: true };
+
+            this.effect.addTargets([this.target]);
+        });
+
+        describe('when the card is not an existing target', function() {
+            beforeEach(function() {
+                this.effect.removeTarget({});
+            });
+
+            it('should not unapply the effect', function() {
+                expect(this.properties.effect.unapply).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('when the effect is inactive', function() {
+            beforeEach(function() {
+                this.effect.active = false;
+                this.effect.removeTarget(this.target);
+            });
+
+            it('should remove the card from the target list', function() {
+                expect(this.effect.targets).not.toContain(this.target);
+            });
+
+            it('should not unapply the effect', function() {
+                expect(this.properties.effect.unapply).not.toHaveBeenCalledWith(this.target, jasmine.any(Object));
+            });
+        });
+
+        describe('when the effect is active', function() {
+            beforeEach(function() {
+                this.effect.setActive(true);
+                this.effect.removeTarget(this.target);
+            });
+
+            it('should remove the card from the target list', function() {
+                expect(this.effect.targets).not.toContain(this.target);
+            });
+
+            it('should unapply the effect', function() {
+                expect(this.properties.effect.unapply).toHaveBeenCalledWith(this.target, { game: this.gameSpy, source: this.sourceSpy });
+            });
+        });
+    });
+
+    describe('setActive()', function() {
+        beforeEach(function() {
+            this.target = {};
+            this.effect.targets =[this.target];
+        });
+
+        describe('when the effect is active', function() {
+            beforeEach(function() {
+                this.effect.active = true;
+            });
+
+            describe('and is set to inactive', function() {
+                beforeEach(function() {
+                    this.effect.setActive(false);
+                });
+
+                it('should unapply the effect from existing targets', function() {
+                    expect(this.properties.effect.unapply).toHaveBeenCalledWith(this.target, { game: this.gameSpy, source: this.sourceSpy });
+                });
+
+                it('should not apply the effect to anything', function() {
+                    expect(this.properties.effect.apply).not.toHaveBeenCalled();
+                });
+            });
+
+            describe('and is set to active', function() {
+                beforeEach(function() {
+                    this.effect.setActive(true);
+                });
+
+                it('should not unapply the effect from existing targets', function() {
+                    expect(this.properties.effect.unapply).not.toHaveBeenCalled();
+                });
+
+                it('should not apply the effect to anything', function() {
+                    expect(this.properties.effect.apply).not.toHaveBeenCalled();
+                });
+            });
+        });
+
+        describe('when the effect is inactive', function() {
+            beforeEach(function() {
+                this.effect.active = false;
+            });
+
+            describe('and is set to inactive', function() {
+                beforeEach(function() {
+                    this.effect.setActive(false);
+                });
+
+                it('should not unapply the effect', function() {
+                    expect(this.properties.effect.unapply).not.toHaveBeenCalled();
+                });
+
+                it('should not apply the effect', function() {
+                    expect(this.properties.effect.apply).not.toHaveBeenCalled();
+                });
+            });
+
+            describe('and is set to active', function() {
+                beforeEach(function() {
+                    this.effect.setActive(true);
+                });
+
+                it('should not unapply the effect', function() {
+                    expect(this.properties.effect.unapply).not.toHaveBeenCalled();
+                });
+
+                it('should apply the effect to existing targets', function() {
+                    expect(this.properties.effect.apply).toHaveBeenCalledWith(this.target, { game: this.gameSpy, source: this.sourceSpy });
+                });
+            });
+        });
+    });
+
+    describe('cancel()', function() {
+        beforeEach(function() {
+            this.target = {};
+            this.effect.targets = [this.target];
+        });
+
+        describe('when the effect is active', function() {
+            beforeEach(function() {
+                this.effect.active = true;
+                this.effect.cancel();
+            });
+
+            it('should unapply the effect from existing targets', function() {
+                expect(this.properties.effect.unapply).toHaveBeenCalledWith(this.target, { game: this.gameSpy, source: this.sourceSpy });
+            });
+
+            it('should remove all targets', function() {
+                expect(this.effect.targets.length).toBe(0);
+            });
+        });
+
+        describe('when the effect is inactive', function() {
+            beforeEach(function() {
+                this.effect.active = false;
+                this.effect.cancel();
+            });
+
+            it('should not unapply the effect from existing targets', function() {
+                expect(this.properties.effect.unapply).not.toHaveBeenCalled();
+            });
+
+            it('should remove all targets', function() {
+                expect(this.effect.targets.length).toBe(0);
+            });
+        });
+    });
+});

--- a/test/server/effectengine.spec.js
+++ b/test/server/effectengine.spec.js
@@ -33,6 +33,42 @@ describe('EffectEngine', function () {
         });
     });
 
+    describe('reapplyStateDependentEffects()', function() {
+        beforeEach(function() {
+            this.engine.effects = [this.effectSpy];
+        });
+
+        describe('when an effect is state dependent', function() {
+            beforeEach(function() {
+                this.effectSpy.isStateDependent = true;
+                this.engine.reapplyStateDependentEffects();
+            });
+
+            it('should cancel the effect', function() {
+                expect(this.effectSpy.cancel).toHaveBeenCalled();
+            });
+
+            it('should add existing valid targets back to the effect', function() {
+                expect(this.effectSpy.addTargets).toHaveBeenCalledWith([this.playAreaCard]);
+            });
+        });
+
+        describe('when an effect is not state dependent', function() {
+            beforeEach(function() {
+                this.effectSpy.isStateDependent = false;
+                this.engine.reapplyStateDependentEffects();
+            });
+
+            it('should not cancel the effect', function() {
+                expect(this.effectSpy.cancel).not.toHaveBeenCalled();
+            });
+
+            it('should not add existing valid targets back to the effect', function() {
+                expect(this.effectSpy.addTargets).not.toHaveBeenCalled();
+            });
+        });
+    });
+
     describe('onCardEntersPlay()', function() {
         beforeEach(function() {
             this.engine.effects = [this.effectSpy];

--- a/test/server/effectengine.spec.js
+++ b/test/server/effectengine.spec.js
@@ -1,0 +1,223 @@
+/*global describe, it, beforeEach, expect, jasmine */
+/*eslint camelcase: 0, no-invalid-this: 0 */
+
+const _ = require('underscore');
+
+const EffectEngine = require('../../server/game/effectengine.js');
+
+describe('EffectEngine', function () {
+    beforeEach(function () {
+        this.playAreaCard = { location: 'play area' };
+        this.handCard = { location: 'hand' };
+        this.discardedCard = { location: 'discard pile' };
+
+        this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener']);
+        this.gameSpy.allCards = _([this.handCard, this.playAreaCard, this.discardedCard]);
+
+        this.effectSpy = jasmine.createSpyObj('effect', ['addTargets', 'removeTarget', 'cancel', 'setActive']);
+
+        this.engine = new EffectEngine(this.gameSpy);
+    });
+
+    describe('add()', function() {
+        beforeEach(function() {
+            this.engine.add(this.effectSpy);
+        });
+
+        it('should adds the effect to the list', function() {
+            expect(this.engine.effects).toContain(this.effectSpy);
+        });
+
+        it('should add existing valid targets to the effect', function() {
+            expect(this.effectSpy.addTargets).toHaveBeenCalledWith([this.playAreaCard]);
+        });
+    });
+
+    describe('onCardEntersPlay()', function() {
+        beforeEach(function() {
+            this.engine.effects = [this.effectSpy];
+        });
+
+        describe('when an effect has persistent duration', function() {
+            beforeEach(function() {
+                this.effectSpy.duration = 'persistent';
+                this.cardEnteringPlay = {};
+                this.engine.onCardEntersPlay({}, this.cardEnteringPlay);
+            });
+
+            it('should add the card entering play as a target', function() {
+                expect(this.effectSpy.addTargets).toHaveBeenCalledWith([this.cardEnteringPlay]);
+            });
+        });
+
+        describe('when an effect has a non-persistent duration', function() {
+            beforeEach(function() {
+                this.effectSpy.duration = 'untilEndOfChallenge';
+                this.cardEnteringPlay = {};
+                this.engine.onCardEntersPlay({}, this.cardEnteringPlay);
+            });
+
+            it('should not add the card entering play as a target', function() {
+                expect(this.effectSpy.addTargets).not.toHaveBeenCalled();
+            });
+        });
+    });
+
+    describe('onCardLeftPlay()', function() {
+        beforeEach(function() {
+            this.engine.effects = [this.effectSpy];
+            this.cardLeavingPlay = {};
+        });
+
+        describe('when an effect has persistent duration', function() {
+            beforeEach(function() {
+                this.effectSpy.duration = 'persistent';
+            });
+
+            describe('and the card leaving play is the source for an effect', function() {
+                beforeEach(function() {
+                    this.effectSpy.source = this.cardLeavingPlay;
+                    this.engine.onCardLeftPlay({}, {}, this.cardLeavingPlay);
+                });
+
+                it('should remove the target from all effects', function() {
+                    expect(this.effectSpy.removeTarget).toHaveBeenCalledWith(this.cardLeavingPlay);
+                });
+
+                it('should cancel the effect', function() {
+                    expect(this.effectSpy.cancel).toHaveBeenCalled();
+                });
+
+                it('should remove the effect from the list', function() {
+                    expect(this.engine.effects).not.toContain(this.effectSpy);
+                });
+            });
+
+            describe('and the card leaving play is not the source for an effect', function() {
+                beforeEach(function() {
+                    this.effectSpy.source = {};
+                    this.engine.onCardLeftPlay({}, {}, this.cardLeavingPlay);
+                });
+
+                it('should remove the target from all effects', function() {
+                    expect(this.effectSpy.removeTarget).toHaveBeenCalledWith(this.cardLeavingPlay);
+                });
+
+                it('should not cancel the effect', function() {
+                    expect(this.effectSpy.cancel).not.toHaveBeenCalled();
+                });
+
+                it('should not remove the effect from the list', function() {
+                    expect(this.engine.effects).toContain(this.effectSpy);
+                });
+            });
+        });
+
+        describe('when an effect has a non-persistent duration', function() {
+            beforeEach(function() {
+                this.effectSpy.duration = 'untilEndOfChallenge';
+            });
+
+            describe('and the card leaving play is the source for an effect', function() {
+                beforeEach(function() {
+                    this.effectSpy.source = this.cardLeavingPlay;
+                    this.engine.onCardLeftPlay({}, {}, this.cardLeavingPlay);
+                });
+
+                it('should remove the target from all effects', function() {
+                    expect(this.effectSpy.removeTarget).toHaveBeenCalledWith(this.cardLeavingPlay);
+                });
+
+                it('should not cancel the effect', function() {
+                    expect(this.effectSpy.cancel).not.toHaveBeenCalled();
+                });
+
+                it('should not remove the effect from the list', function() {
+                    expect(this.engine.effects).toContain(this.effectSpy);
+                });
+            });
+
+            describe('and the card leaving play is not the source for an effect', function() {
+                beforeEach(function() {
+                    this.effectSpy.source = {};
+                    this.engine.onCardLeftPlay({}, {}, this.cardLeavingPlay);
+                });
+
+                it('should remove the target from all effects', function() {
+                    expect(this.effectSpy.removeTarget).toHaveBeenCalledWith(this.cardLeavingPlay);
+                });
+
+                it('should not cancel the effect', function() {
+                    expect(this.effectSpy.cancel).not.toHaveBeenCalled();
+                });
+
+                it('should not remove the effect from the list', function() {
+                    expect(this.engine.effects).toContain(this.effectSpy);
+                });
+            });
+        });
+    });
+
+    describe('onCardBlankToggled()', function() {
+        beforeEach(function() {
+            this.engine.effects = [this.effectSpy];
+            this.cardBeingToggled = {};
+        });
+
+        describe('when an effect has persistent duration', function() {
+            beforeEach(function() {
+                this.effectSpy.duration = 'persistent';
+            });
+
+            describe('and the card being blanked is the source for an effect', function() {
+                beforeEach(function() {
+                    this.effectSpy.source = this.cardBeingToggled;
+                    this.engine.onCardBlankToggled({}, this.cardBeingToggled, false);
+                });
+
+                it('should set the active value for the effect', function() {
+                    expect(this.effectSpy.setActive).toHaveBeenCalledWith(true);
+                });
+            });
+
+            describe('and the card being blanked is not the source for an effect', function() {
+                beforeEach(function() {
+                    this.effectSpy.source = {};
+                    this.engine.onCardBlankToggled({}, this.cardBeingToggled, false);
+                });
+
+                it('should not set the active value for the effect', function() {
+                    expect(this.effectSpy.setActive).not.toHaveBeenCalled();
+                });
+            });
+        });
+
+        describe('when an effect has a non-persistent duration', function() {
+            beforeEach(function() {
+                this.effectSpy.duration = 'untilEndOfChallenge';
+            });
+
+            describe('and the card being blanked is the source for an effect', function() {
+                beforeEach(function() {
+                    this.effectSpy.source = this.cardBeingToggled;
+                    this.engine.onCardBlankToggled({}, this.cardBeingToggled, false);
+                });
+
+                it('should not set the active value for the effect', function() {
+                    expect(this.effectSpy.setActive).not.toHaveBeenCalled();
+                });
+            });
+
+            describe('and the card being blanked is not the source for an effect', function() {
+                beforeEach(function() {
+                    this.effectSpy.source = {};
+                    this.engine.onCardBlankToggled({}, this.cardBeingToggled, false);
+                });
+
+                it('should not set the active value for the effect', function() {
+                    expect(this.effectSpy.setActive).not.toHaveBeenCalled();
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
* Adds an Effect class that manages applying and unapplying effects to targeted cards.
* Adds an EffectEngine class that manages lifecycle for effects (adding targets as they come into play, removing them as they leave play, removing effects as their source leave play, etc)
* Adds BaseCard.persistentEffect for defining any given effect that continues while a card is in play, and BaseCard.whileAttached which reduces some of the boilerplate for attachment effects.
* Converts several cards to use the new declaration syntax.

There's probably some problems around timing of when conditional effects are refreshed (e.g. Unsullied applies its -1 correctly but the game announces the defense strength incorrectly initially), but want to keep things rolling forward.
