### PR TITLE
Implement lasting effects

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -160,6 +160,14 @@ class BaseCard {
         this.game.addEffect(this, _.extend({ duration: 'atEndOfPhase' }, properties));
     }
 
+    /**
+     * Applies an immediate effect which lasts until the end of the round.
+     */
+    untilEndOfRound(propertyFactory) {
+        var properties = propertyFactory(AbilityDsl);
+        this.game.addEffect(this, _.extend({ duration: 'untilEndOfRound' }, properties));
+    }
+
     doAction(player, arg) {
         if(!this.abilities.action) {
             return;

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -134,6 +134,32 @@ class BaseCard {
         });
     }
 
+    /**
+     * Applies an immediate effect which lasts until the end of the current
+     * challenge.
+     */
+    untilEndOfChallenge(propertyFactory) {
+        var properties = propertyFactory(AbilityDsl);
+        this.game.addEffect(this, _.extend({ duration: 'untilEndOfChallenge' }, properties));
+    }
+
+    /**
+     * Applies an immediate effect which lasts until the end of the phase.
+     */
+    untilEndOfPhase(propertyFactory) {
+        var properties = propertyFactory(AbilityDsl);
+        this.game.addEffect(this, _.extend({ duration: 'untilEndOfPhase' }, properties));
+    }
+
+    /**
+     * Applies an immediate effect which expires at the end of the phase. Per
+     * game rules this duration is outside of the phase.
+     */
+    atEndOfPhase(propertyFactory) {
+        var properties = propertyFactory(AbilityDsl);
+        this.game.addEffect(this, _.extend({ duration: 'atEndOfPhase' }, properties));
+    }
+
     doAction(player, arg) {
         if(!this.abilities.action) {
             return;

--- a/server/game/cards/attachments/01/heartsbane.js
+++ b/server/game/cards/attachments/01/heartsbane.js
@@ -13,10 +13,11 @@ class Heartsbane extends DrawCard {
             return false;
         }
 
-        this.triggered = true;
-        this.parent.strengthModifier += 3;
-
-        this.game.once('onChallengeFinished', this.onChallengeFinished.bind(this));
+        this.controller.kneelCard(this);
+        this.untilEndOfChallenge(ability => ({
+            match: card => card === this.parent,
+            effect: ability.effects.modifyStrength(3)
+        }));
 
         this.game.addMessage('{0} kneels {1} to give {2} +3 STR until the end of the challenge', player, this, this.parent);
 
@@ -29,14 +30,6 @@ class Heartsbane extends DrawCard {
         }
 
         return super.canAttach(player, card);
-    }
-
-    onChallengeFinished() {
-        if(this.triggered && this.parent) {
-            this.parent.strengthModifier -= 3;
-
-            this.triggered = false;
-        }
     }
 }
 

--- a/server/game/cards/attachments/04/crownofgoldenroses.js
+++ b/server/game/cards/attachments/04/crownofgoldenroses.js
@@ -1,12 +1,14 @@
 const DrawCard = require('../../../drawcard.js');
-const AbilityLimit = require('../../../abilitylimit.js');
 
 class CrownOfGoldenRoses extends DrawCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.action({
             title: 'Discard a card to give attached character STR',
             method: 'boost',
-            limit: AbilityLimit.perRound(2)
+            limit: ability.limit.perRound(2)
+        });
+        this.whileAttached({
+            effect: ability.effects.addTrait('King')
         });
     }
 
@@ -42,14 +44,10 @@ class CrownOfGoldenRoses extends DrawCard {
             icons++;
         }
 
-        this.parent.strengthModifier += icons;
-
-        this.modifiedStr += icons;
-
-        if(!this.eventRegistered) {
-            this.game.once('onPhaseEnded', this.onPhaseEnded.bind(this));
-            this.eventRegistered = true;
-        }
+        this.untilEndOfPhase(ability => ({
+            match: card => card === this.parent,
+            effect: ability.effects.modifyStrength(icons)
+        }));
 
         this.game.addMessage('{0} uses {1} to discard {2} to give {3} +{4} STR', player, this, card, this.parent, icons);
 
@@ -62,28 +60,6 @@ class CrownOfGoldenRoses extends DrawCard {
         }
 
         return super.canAttach(player, card);
-    }
-
-    attach(player, card) {
-        card.addTrait('King');
-
-        super.attach(player, card);
-
-        this.modifiedStr = 0;
-    }
-
-    leavesPlay(player) {
-        super.leavesPlay(player);
-
-        this.parent.removeTrait('King');
-    }
-
-    onPhaseEnded() {
-        if(this.modifiedStr) {
-            this.parent.strengthModifier -= this.modifiedStr;
-
-            this.modifiedStr = 0;
-        }
     }
 }
 

--- a/server/game/cards/characters/01/edricdayne.js
+++ b/server/game/cards/characters/01/edricdayne.js
@@ -3,12 +3,6 @@ const _ = require('underscore');
 const DrawCard = require('../../../drawcard.js');
 
 class EdricDayne extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.icons = [];
-    }
-
     setupCardAbilities() {
         this.action({
             title: 'Pay 1 gold to give this character a challenge icon',
@@ -37,26 +31,16 @@ class EdricDayne extends DrawCard {
     }
 
     iconSelected(player, icon) {
-        this.addIcon(icon);
-        this.icons.push(icon);
-
         this.game.addMessage('{0} uses {1} to give {1} an {2} icon', player, this, icon);
 
         this.game.addGold(this.controller, -1);
 
-        this.game.once('onPhaseEnded', () => {
-            this.onPhaseEnded();
-        });
+        this.untilEndOfPhase(ability => ({
+            match: card => card === this,
+            effects: ability.effects.addIcon(icon)
+        }));
 
         return true;
-    }
-
-    onPhaseEnded() {
-        _.each(this.icons, icon => {
-            this.removeIcon(icon);
-        });
-        
-        this.icons = [];
     }
 }
 

--- a/server/game/cards/characters/01/margaerytyrell.js
+++ b/server/game/cards/characters/01/margaerytyrell.js
@@ -27,7 +27,7 @@ class MargaeryTyrell extends DrawCard {
         this.game.addMessage('{0} kneels {1} to give {2} +3 STR until the end of the phase', player, this, card);
         this.controller.kneelCard(this);
         this.untilEndOfChallenge(ability => ({
-            match: c => c === card,
+            match: card,
             effect: ability.effects.modifyStrength(3)
         }));
 

--- a/server/game/cards/characters/01/margaerytyrell.js
+++ b/server/game/cards/characters/01/margaerytyrell.js
@@ -20,26 +20,18 @@ class MargaeryTyrell extends DrawCard {
             onSelect: (p, card) => this.onCardSelected(p, card)
         });
 
-        this.game.once('onChallengeFinished', this.onChallengeFinished.bind(this));
-
         return true;
     }
 
     onCardSelected(player, card) {
         this.game.addMessage('{0} kneels {1} to give {2} +3 STR until the end of the phase', player, this, card);
-
-        card.strengthModifier += 3;
-
-        this.selectedCard = card;
+        this.controller.kneelCard(this);
+        this.untilEndOfChallenge(ability => ({
+            match: c => c === card,
+            effect: ability.effects.modifyStrength(3)
+        }));
 
         return true;
-    }
-
-    onChallengeFinished() {
-        if(this.selectedCard) {
-            this.selectedCard.strengthModifier -= 3;
-            this.selcetedCard = undefined;
-        }
     }
 }
 

--- a/server/game/cards/characters/01/selysebaratheon.js
+++ b/server/game/cards/characters/01/selysebaratheon.js
@@ -24,26 +24,15 @@ class SelyseBaratheon extends DrawCard {
     }
 
     onCardSelected(player, card) {
-        card.addIcon('intrigue');
-
-        this.cardModified = card;
-
         this.game.addMessage('{0} uses {1} to give {2} an {3} icon', player, this, card, 'intrigue');
 
         this.game.addGold(this.controller, -1);
-
-        this.game.once('onPhaseEnded', () => {
-            this.onPhaseEnded();
-        });
+        this.untilEndOfPhase(ability => ({
+            match: c => c === card,
+            effect: ability.effects.addIcon('intrigue')
+        }));
 
         return true;
-    }
-
-    onPhaseEnded() {
-        if(this.cardModified) {
-            this.cardModified.removeIcon('intrigue');
-            this.cardModified = undefined;
-        }
     }
 }
 

--- a/server/game/cards/characters/01/selysebaratheon.js
+++ b/server/game/cards/characters/01/selysebaratheon.js
@@ -28,7 +28,7 @@ class SelyseBaratheon extends DrawCard {
 
         this.game.addGold(this.controller, -1);
         this.untilEndOfPhase(ability => ({
-            match: c => c === card,
+            match: card,
             effect: ability.effects.addIcon('intrigue')
         }));
 

--- a/server/game/cards/characters/01/serjaimelannister.js
+++ b/server/game/cards/characters/01/serjaimelannister.js
@@ -13,9 +13,10 @@ class SerJaimeLannister extends DrawCard {
             return;
         }
 
-        if(!this.isBlank()) {
-            this.addKeyword('renown');
-        }
+        this.untilEndOfChallenge(ability => ({
+            match: c => c === this,
+            effect: ability.effects.addKeyword('renown')
+        }));
 
         if(this.controller !== player) {
             return;
@@ -23,16 +24,6 @@ class SerJaimeLannister extends DrawCard {
 
         if(!this.isBlank() && challenge.isAttacking(this)) {
             player.standCard(this);
-        }
-
-        this.game.once('onChallengeFinished', (event, challenge) => {
-            this.onChallengeFinished(event, challenge);
-        });
-    }
-
-    onChallengeFinished(event, challenge) {
-        if(challenge.challengeType === 'military') {
-            this.removeKeyword('renown');
         }
     }
 }

--- a/server/game/cards/characters/01/serjaimelannister.js
+++ b/server/game/cards/characters/01/serjaimelannister.js
@@ -14,7 +14,7 @@ class SerJaimeLannister extends DrawCard {
         }
 
         this.untilEndOfChallenge(ability => ({
-            match: c => c === this,
+            match: this,
             effect: ability.effects.addKeyword('renown')
         }));
 

--- a/server/game/cards/characters/01/wildlinghorde.js
+++ b/server/game/cards/characters/01/wildlinghorde.js
@@ -46,7 +46,7 @@ class WildlingHorde extends DrawCard {
 
         this.game.addMessage('{0} uses {1} to kneel their faction card and increase the strength of {2} by 2 until the end of the challenge', player, this, card);
         this.untilEndOfChallenge(ability => ({
-            match: c => c === card,
+            match: card,
             effect: ability.effects.modifyStrength(2)
         }));
 

--- a/server/game/cards/characters/01/wildlinghorde.js
+++ b/server/game/cards/characters/01/wildlinghorde.js
@@ -44,25 +44,13 @@ class WildlingHorde extends DrawCard {
 
         player.kneelCard(player.faction);
 
-        this.cardInEffect = card;
-        card.strengthModifier += 2;
-
         this.game.addMessage('{0} uses {1} to kneel their faction card and increase the strength of {2} by 2 until the end of the challenge', player, this, card);
-
-        this.game.once('afterChallenge', () => {
-            this.afterChallenge();
-        });
+        this.untilEndOfChallenge(ability => ({
+            match: c => c === card,
+            effect: ability.effects.modifyStrength(2)
+        }));
 
         return true;
-    }
-
-    afterChallenge() {
-        if(!this.cardInEffect) {
-            return;
-        }
-
-        this.cardInEffect.strengthModifier -= 2;
-        this.cardInEffect = undefined;
     }
 }
 

--- a/server/game/cards/characters/02/arborknight.js
+++ b/server/game/cards/characters/02/arborknight.js
@@ -4,12 +4,6 @@ const DrawCard = require('../../../drawcard.js');
 const AbilityLimit = require('../../../abilitylimit.js');
 
 class ArborKnight extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.cardsAffected = [];
-    }
-
     setupCardAbilities() {
         this.action({
             title: 'Pay 1 gold to give a character +1 STR',
@@ -30,35 +24,19 @@ class ArborKnight extends DrawCard {
             onSelect: (p, card) => this.onCardSelected(p, card)
         });
 
-        if(!this.registeredEvent) {
-            this.game.once('onChallengeFinished', this.onChallengeFinished.bind(this));
-
-            this.registeredEvent = true;
-        }
-
         return true;
     }
 
     onCardSelected(player, card) {
         this.game.addMessage('{0} uses {1} to pay 1 gold and give {2} +1 STR until the end of the challenge', player, this, card);
+        this.untilEndOfChallenge(ability => ({
+            match: c => c === card,
+            effect: ability.effects.modifyStrength(1)
+        }));
 
-        card.strengthModifier++;
-
-        this.cardsAffected.push(card);
-        
         player.gold -= 1;
 
         return true;
-    }
-
-    onChallengeFinished() {
-        this.registeredEvent = false;
-        
-        _.each(this.cardsAffected, card => {
-            card.strengthModifier--;
-        });
-
-        this.cardsAffected = [];
     }
 }
 

--- a/server/game/cards/characters/02/arborknight.js
+++ b/server/game/cards/characters/02/arborknight.js
@@ -30,7 +30,7 @@ class ArborKnight extends DrawCard {
     onCardSelected(player, card) {
         this.game.addMessage('{0} uses {1} to pay 1 gold and give {2} +1 STR until the end of the challenge', player, this, card);
         this.untilEndOfChallenge(ability => ({
-            match: c => c === card,
+            match: card,
             effect: ability.effects.modifyStrength(1)
         }));
 

--- a/server/game/cards/characters/02/bronn.js
+++ b/server/game/cards/characters/02/bronn.js
@@ -21,23 +21,14 @@ class Bronn extends DrawCard {
             return;
         }
 
-        this.addIcon('military');
-        this.addIcon('intrigue');
-        this.addIcon('power');
-
-        this.game.once('onChallengeFinished', (e, challenge) => {
-            this.onChallengeFinished(e, challenge);
-        });
-    }
-
-    onChallengeFinished(e, challenge) {
-        if(this.controller !== challenge.defendingPlayer) {
-            return;
-        }
-
-        this.removeIcon('military');
-        this.removeIcon('intrigue');
-        this.removeIcon('power');
+        this.untilEndOfChallenge(ability => ({
+            match: c => c === this,
+            effect: [
+                ability.effects.addIcon('military'),
+                ability.effects.addIcon('intrigue'),
+                ability.effects.addIcon('power')
+            ]
+        }));
     }
 
     takeControl(player) {

--- a/server/game/cards/characters/02/bronn.js
+++ b/server/game/cards/characters/02/bronn.js
@@ -22,7 +22,7 @@ class Bronn extends DrawCard {
         }
 
         this.untilEndOfChallenge(ability => ({
-            match: c => c === this,
+            match: this,
             effect: [
                 ability.effects.addIcon('military'),
                 ability.effects.addIcon('intrigue'),

--- a/server/game/cards/characters/02/halder.js
+++ b/server/game/cards/characters/02/halder.js
@@ -39,7 +39,7 @@ class Halder extends DrawCard {
 
         this.kneelingCard.controller.kneelCard(this.kneelingCard);
         this.untilEndOfPhase(ability => ({
-            match: c => c === card,
+            match: card,
             effect: ability.effects.modifyStrength(1)
         }));
 

--- a/server/game/cards/characters/02/halder.js
+++ b/server/game/cards/characters/02/halder.js
@@ -8,9 +8,7 @@ class Halder extends DrawCard {
             title: 'Kneel a location or attachment',
             method: 'kneel'
         });
-
-        this.cardsAffected = [];
-    }    
+    }
 
     kneel(player) {
         this.game.promptForSelect(player, {
@@ -39,25 +37,13 @@ class Halder extends DrawCard {
     onStrCardSelected(player, card) {
         this.game.addMessage('{0} uses {1} to kneels {2} to give {3} +1 STR until the end of the phase', player, this, this.kneelingCard, card);
 
-        if(!this.eventRegistered) {
-            this.game.once('onPhaseEnded', this.onPhaseEnded.bind(this));
-
-            this.eventRegistered = true;
-        }
-
-        card.strengthModifier++;
-
-        this.cardsAffected.push(card);
+        this.kneelingCard.controller.kneelCard(this.kneelingCard);
+        this.untilEndOfPhase(ability => ({
+            match: c => c === card,
+            effect: ability.effects.modifyStrength(1)
+        }));
 
         return true;
-    }
-
-    onPhaseEnded() {
-        _.each(this.cardsAffected, card => {
-            card.strengthModifier--;
-        });
-
-        this.cardsAffected = [];
     }
 }
 

--- a/server/game/cards/characters/02/redcloaks.js
+++ b/server/game/cards/characters/02/redcloaks.js
@@ -27,7 +27,7 @@ class RedCloaks extends DrawCard {
         }
 
         this.untilEndOfChallenge(ability => ({
-            match: c => c === this,
+            match: this,
             effect: ability.effects.modifyStrength(this.tokens['gold'] || 0)
         }));
     }

--- a/server/game/cards/characters/02/redcloaks.js
+++ b/server/game/cards/characters/02/redcloaks.js
@@ -2,12 +2,6 @@ const DrawCard = require('../../../drawcard.js');
 const AbilityLimit = require('../../../abilitylimit.js');
 
 class RedCloaks extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['onAttackersDeclared', 'onChallengeFinished']);
-    }
-
     setupCardAbilities() {
         this.action({
             title: 'Move 1 gold from your gold pool to this card',
@@ -32,19 +26,10 @@ class RedCloaks extends DrawCard {
             return;
         }
 
-        if(this.tokens['gold']) {
-            this.strengthModifier += this.tokens['gold'];
-        }
-
-        this.game.once('onChallengeFinished', (e, challenge) => {
-            this.onChallengeFinished(e, challenge);
-        });
-    }
-
-    onChallengeFinished(e, challenge) {
-        if(challenge.challengeType === 'intrigue' && this.tokens['gold']) {
-            this.strengthModifier -= this.tokens['gold'];
-        }
+        this.untilEndOfChallenge(ability => ({
+            match: c => c === this,
+            effect: ability.effects.modifyStrength(this.tokens['gold'] || 0)
+        }));
     }
 }
 

--- a/server/game/cards/characters/02/syrioforel.js
+++ b/server/game/cards/characters/02/syrioforel.js
@@ -1,12 +1,11 @@
 const DrawCard = require('../../../drawcard.js');
-const AbilityLimit = require('../../../abilitylimit.js');
 
 class SyrioForel extends DrawCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.action({
             title: 'Give a character military icon and stealth',
             method: 'giveIcon',
-            limit: AbilityLimit.perPhase(1)
+            limit: ability.limit.perPhase(1)
         });
     }
 
@@ -30,26 +29,16 @@ class SyrioForel extends DrawCard {
     }
 
     onCardSelected(player, card) {
-        this.selectedCard = card;
-
-        card.addIcon('military');
-        card.addKeyword('Stealth');
-
         this.game.addMessage('{0} uses {1} to give {2} a {3} icon and stealth until the end of the phase', player, this, card, 'military');
-
-        this.game.once('onPhaseEnded', () => {
-            this.onPhaseEnded();
-        });
+        this.untilEndOfPhase(ability => ({
+            match: c => c === card,
+            effect: [
+                ability.effects.addIcon('military'),
+                ability.effects.addKeyword('Stealth')
+            ]
+        }));
 
         return true;
-    }
-
-    onPhaseEnded() {
-        if(this.selectedCard) {
-            this.selectedCard.removeIcon('military');
-            this.selectedCard.removeKeyword('Stealth');
-            this.selectedCard = undefined;
-        }
     }
 }
 

--- a/server/game/cards/characters/02/syrioforel.js
+++ b/server/game/cards/characters/02/syrioforel.js
@@ -31,7 +31,7 @@ class SyrioForel extends DrawCard {
     onCardSelected(player, card) {
         this.game.addMessage('{0} uses {1} to give {2} a {3} icon and stealth until the end of the phase', player, this, card, 'military');
         this.untilEndOfPhase(ability => ({
-            match: c => c === card,
+            match: card,
             effect: [
                 ability.effects.addIcon('military'),
                 ability.effects.addKeyword('Stealth')

--- a/server/game/cards/characters/02/tyenesand.js
+++ b/server/game/cards/characters/02/tyenesand.js
@@ -17,7 +17,7 @@ class TyeneSand extends DrawCard {
                     cardCondition: card => card.location === 'play area' && card.getType() === 'character' && !card.hasIcon('intrigue'),
                     onSelect: (p, card) => {
                         this.atEndOfPhase(ability => ({
-                            match: c => c === card,
+                            match: card,
                             effect: ability.effects.poison
                         }));
                         return true;

--- a/server/game/cards/characters/02/tyenesand.js
+++ b/server/game/cards/characters/02/tyenesand.js
@@ -1,73 +1,30 @@
 const DrawCard = require('../../../drawcard.js');
 
 class TyeneSand extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['afterChallenge']);
-    }
-
-    afterChallenge(event, challenge) {
-        if(challenge.winner !== this.controller || !challenge.isAttacking(this) || challenge.challengeType !== 'intrigue' || this.isBlank()) {
-            return;
-        }
-
-        this.game.promptWithMenu(this.controller, this, {
-            activePrompt: {
-                menuTitle: 'Trigger ' + this.name + '?',
-                buttons: [
-                    { text: 'Yes', method: 'poison' },
-                    { text: 'No', method: 'cancel' }
-                ]
+    setupCardAbilities(ability) {
+        this.reaction({
+            when: {
+                afterChallenge: (event, challenge) => (
+                    challenge.challengeType === 'intrigue' &&
+                    challenge.winner === this.controller &&
+                    challenge.isAttacking(this)
+                )
             },
-            waitingPromptTitle: 'Waiting for opponent to use ' + this.name
-        });         
-
-        return true;        
-    }
-
-    poison(player) {
-        this.game.promptForSelect(player, {
-            activePromptTitle: 'Select a character',
-            waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
-            cardCondition: card => card.location === 'play area' && card.getType() === 'character' && !card.hasIcon('intrigue'),
-            onSelect: (p, card) => this.onCardSelected(p, card)
-        });
-
-        return true;        
-    }
-
-    cancel(player) {
-        this.game.addMessage('{0} declines to trigger {1}', player, this);
-
-        return true;
-    }
-
-    onCardSelected(player, card) {
-        card.addToken('poison', 1);
-
-        this.selectedCard = card;
-
-        this.game.addMessage('{0} uses {1} to add a poison token to {2}', player, this, card);
-
-        this.game.once('onPhaseEnded', () => {
-            this.onPhaseEnded();
-        });
-
-        return true;
-    }
-
-    onPhaseEnded() {
-        if(this.selectedCard) {
-            if(this.selectedCard.hasToken('poison')) {
-                this.selectedCard.removeToken('poison', 1);
-                this.selectedCard.controller.killCharacter(this.selectedCard);
-
-                this.game.addMessage('{0} uses {1} to kill {2} as it still has a poison token at the end of the phase', this.controller, this, this.selectedCard);
+            handler: () => {
+                this.game.promptForSelect(this.controller, {
+                    activePromptTitle: 'Select a character',
+                    waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
+                    cardCondition: card => card.location === 'play area' && card.getType() === 'character' && !card.hasIcon('intrigue'),
+                    onSelect: (p, card) => {
+                        this.atEndOfPhase(ability => ({
+                            match: c => c === card,
+                            effect: ability.effects.poison
+                        }));
+                        return true;
+                    }
+                });
             }
-
-            this.selectedCard = undefined;
-        }
+        })
     }
 }
 

--- a/server/game/cards/characters/02/wildlingscout.js
+++ b/server/game/cards/characters/02/wildlingscout.js
@@ -31,7 +31,7 @@ class WildlingScout extends DrawCard {
 
         this.game.addMessage('{0} sacrifices {1} to make {2} gain stealth', player, this, card);
         this.untilEndOfPhase(ability => ({
-            match: c => c === card,
+            match: card,
             effect: ability.effects.addKeyword('Stealth')
         }));
 

--- a/server/game/cards/characters/02/wildlingscout.js
+++ b/server/game/cards/characters/02/wildlingscout.js
@@ -1,14 +1,13 @@
 const DrawCard = require('../../../drawcard.js');
-const AbilityLimit = require('../../../abilitylimit.js');
 
 class WildlingScout extends DrawCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.action({
             title: 'Sacrifice this character to give another character stealth',
             method: 'sacrifice',
-            limit: AbilityLimit.perPhase(1)
+            limit: ability.limit.perPhase(1)
         });
-    }    
+    }
 
     sacrifice(player) {
         if(this.location !== 'play area') {
@@ -30,25 +29,14 @@ class WildlingScout extends DrawCard {
     onCardSelected(player, card) {
         player.sacrificeCard(this);
 
-        card.addKeyword('Stealth');
-        this.modifiedCard = card;
-
         this.game.addMessage('{0} sacrifices {1} to make {2} gain stealth', player, this, card);
-
-        this.game.once('onPhaseEnded', () => {
-            this.onPhaseEnded();
-        });
+        this.untilEndOfPhase(ability => ({
+            match: c => c === card,
+            effect: ability.effects.addKeyword('Stealth')
+        }));
 
         return true;
     }
-
-    onPhaseEnded() {
-        if(this.modifiedCard) {
-            this.modifiedCard.removeKeyword('Stealth');
-
-            this.modifiedCard = undefined;
-        }
-    }   
 }
 
 WildlingScout.code = '02078';

--- a/server/game/cards/characters/03/oldnan.js
+++ b/server/game/cards/characters/03/oldnan.js
@@ -72,8 +72,7 @@ class OldNan extends DrawCard {
         this.game.addMessage('{0} uses {1} to add the {2} trait to {3}', player, this, trait, plotCard);
         player.kneelCard(this);
         this.untilEndOfRound(ability => ({
-            match: c => c === plotCard,
-            targetController: 'any',
+            match: plotCard,
             effect: ability.effects.addTrait(trait)
         }));
 

--- a/server/game/cards/characters/03/oldnan.js
+++ b/server/game/cards/characters/03/oldnan.js
@@ -69,27 +69,15 @@ class OldNan extends DrawCard {
             return false;
         }
 
-        plotCard.addTrait(trait);
-
         this.game.addMessage('{0} uses {1} to add the {2} trait to {3}', player, this, trait, plotCard);
-
-        this.modifiedPlot = plotCard;
-        this.trait = trait;
         player.kneelCard(this);
-
-        this.game.once('onAfterTaxation', () => {
-            this.onAfterTaxation();
-        });
+        this.untilEndOfRound(ability => ({
+            match: c => c === plotCard,
+            targetController: 'any',
+            effect: ability.effects.addTrait(trait)
+        }));
 
         return true;
-    }
-
-    onAfterTaxation() {
-        if(this.modifiedPlot) {
-            this.modifiedPlot.removeTrait(this.trait);
-
-            this.modifiedPlot = undefined;
-        }
     }
 }
 

--- a/server/game/cards/characters/04/eliasand.js
+++ b/server/game/cards/characters/04/eliasand.js
@@ -1,64 +1,31 @@
 const DrawCard = require('../../../drawcard.js');
 
 class EliaSand extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['afterChallenge']);
-
-        this.abilityUsed = 0;
-    }
-
-    afterChallenge(event, challenge) {
-        if(challenge.winner === this.controller || this.abilityUsed >= 2 || this.isBlank()) {
-            return;
-        }
-
-        this.game.promptWithMenu(this.controller, this, {
-            activePrompt: {
-                menuTitle: 'Trigger ' + this.name + '?',
-                buttons: [
-                    { text: 'Yes', method: 'giveStealth' },
-                    { text: 'No', method: 'cancel' }
-                ]
+    setupCardAbilities(ability) {
+        this.reaction({
+            when: {
+                afterChallenge: (event, challenge) => this.controller === challenge.loser
             },
-            waitingPromptTitle: 'Waiting for opponent to use ' + this.name
-        });   
-    }
-
-    giveStealth(player) {      
-        this.game.promptForSelect(player, {
-            activePromptTitle: 'Select character',
-            waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
-            cardCondition: card => card.location === 'play area' && card.getType() === 'character',
-            onSelect: (p, card) => this.onCardSelected(p, card)
-        });
-
-        return true;        
+            limit: ability.limit.perPhase(2),
+            handler: () => {
+                this.game.promptForSelect(this.controller, {
+                    activePromptTitle: 'Select character',
+                    waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
+                    cardCondition: card => card.location === 'play area' && card.getType() === 'character',
+                    onSelect: (p, card) => this.onCardSelected(p, card)
+                });
+            }
+        })
     }
 
     onCardSelected(player, card) {
-        card.addKeyword('Stealth');
-        this.selectedCard = card;
-
         this.game.addMessage('{0} uses {1} to give {2} Stealth', player, this, card);
-
-        this.abilityUsed++;
-
-        this.game.once('onPhaseEnded', () => {
-            this.onPhaseEnded();
-        });
+        this.untilEndOfPhase(ability => ({
+            match: c => c === card,
+            effect: ability.effects.addKeyword('Stealth')
+        }));
 
         return true;
-    }
-
-    onPhaseEnded() {
-        if(this.selectedCard) {
-            this.selectedCard.removeKeyword('Stealth');
-            this.selectedCard = undefined;
-        }
-
-        this.abilityUsed = 0;
     }
 }
 

--- a/server/game/cards/characters/04/eliasand.js
+++ b/server/game/cards/characters/04/eliasand.js
@@ -21,7 +21,7 @@ class EliaSand extends DrawCard {
     onCardSelected(player, card) {
         this.game.addMessage('{0} uses {1} to give {2} Stealth', player, this, card);
         this.untilEndOfPhase(ability => ({
-            match: c => c === card,
+            match: card,
             effect: ability.effects.addKeyword('Stealth')
         }));
 

--- a/server/game/cards/events/01/confinement.js
+++ b/server/game/cards/events/01/confinement.js
@@ -17,25 +17,16 @@ class Confinement extends DrawCard {
     }
 
     onCardSelected(player, card) {
-        card.removeIcon('military');
-        card.removeIcon('intrigue');
-        card.removeIcon('power');
-
-        this.cardSelected = card;
-
-        this.game.once('onPhaseEnded', this.onPhaseEnded.bind(this));
+        this.untilEndOfPhase(ability => ({
+            match: c => c === card,
+            effect: [
+                ability.effects.removeIcon('military'),
+                ability.effects.removeIcon('intrigue'),
+                ability.effects.removeIcon('power')
+            ]
+        }));
 
         return true;
-    }
-
-    onPhaseEnded() {
-        if(this.cardSelected) {
-            this.cardSelected.addIcon('military');
-            this.cardSelected.addIcon('intrigue');
-            this.cardSelected.addIcon('power');
-
-            this.cardSelected = undefined;
-        }
     }
 }
 

--- a/server/game/cards/events/01/confinement.js
+++ b/server/game/cards/events/01/confinement.js
@@ -18,7 +18,7 @@ class Confinement extends DrawCard {
 
     onCardSelected(player, card) {
         this.untilEndOfPhase(ability => ({
-            match: c => c === card,
+            match: card,
             effect: [
                 ability.effects.removeIcon('military'),
                 ability.effects.removeIcon('intrigue'),

--- a/server/game/cards/events/01/dracarys.js
+++ b/server/game/cards/events/01/dracarys.js
@@ -39,7 +39,7 @@ class Dracarys extends DrawCard {
         this.game.addMessage('{0} uses {1} to kneel {2} and give {3} -4 STR until the end of the phase', player, this, this.selectedCard, card);
         player.kneelCard(this.selectedCard);
         this.untilEndOfPhase(ability => ({
-            match: c => c === card,
+            match: card,
             effect: [
                 ability.effects.modifyStrength(-4),
                 ability.effects.killByStrength

--- a/server/game/cards/events/01/dracarys.js
+++ b/server/game/cards/events/01/dracarys.js
@@ -36,33 +36,17 @@ class Dracarys extends DrawCard {
     }
 
     onStrSelected(player, card) {
-        player.kneelCard(this.selectedCard);
-
-        card.strengthModifier -= 4;
-
         this.game.addMessage('{0} uses {1} to kneel {2} and give {3} -4 STR until the end of the phase', player, this, this.selectedCard, card);
-
-        if(card.getStrength() <= 0) {
-            card.controller.killCharacter(card, false);
-            
-            this.game.addMessage('{0} is killed as its STR is 0', card);
-        } else {
-            this.game.once('onPhaseEnded', () => {
-                this.onPhaseEnded();
-            });
-
-            this.strCard = card;
-        }
+        player.kneelCard(this.selectedCard);
+        this.untilEndOfPhase(ability => ({
+            match: c => c === card,
+            effect: [
+                ability.effects.modifyStrength(-4),
+                ability.effects.killByStrength
+            ]
+        }));
 
         return true;
-    }
-
-    onPhaseEnded() {
-        if(this.strCard) {
-            this.strCard.strengthModifier += 4;
-
-            this.strCard = undefined;
-        }
     }
 }
 

--- a/server/game/cards/events/01/hearmeroar.js
+++ b/server/game/cards/events/01/hearmeroar.js
@@ -21,23 +21,14 @@ class HearMeRoar extends DrawCard {
     onCardSelected(player, card) {
         player.playCard(card, true);
 
-        this.selectedCard = card;
+        this.atEndOfPhase(ability => ({
+            match: c => c === card,
+            effect: ability.effects.discardIfStillInPlay(false)
+        }));
 
         this.game.addMessage('{0} uses {1} to put {2} into play from their hand', player, this, card);
 
-        this.game.once('onPhaseEnded', this.onPhaseEnded.bind(this));
-
         return true;
-    }
-
-    onPhaseEnded() {
-        if(this.selectedCard) {
-            this.selectedCard.controller.discardCard(this.selectedCard, false);
-
-            this.game.addMessage('{0} discards {1} at the end of the phase because of {2}', this.controller, this.selectedCard, this);
-
-            this.selectedCard = undefined;
-        }
     }
 }
 

--- a/server/game/cards/events/01/hearmeroar.js
+++ b/server/game/cards/events/01/hearmeroar.js
@@ -22,7 +22,7 @@ class HearMeRoar extends DrawCard {
         player.playCard(card, true);
 
         this.atEndOfPhase(ability => ({
-            match: c => c === card,
+            match: card,
             effect: ability.effects.discardIfStillInPlay(false)
         }));
 

--- a/server/game/cards/events/01/tearsoflys.js
+++ b/server/game/cards/events/01/tearsoflys.js
@@ -26,7 +26,7 @@ class TearsOfLys extends DrawCard {
             cardCondition: card => card.location === 'play area' && card.controller !== player && card.getType() === 'character' && !card.hasIcon('intrigue'),
             onSelect: (p, card) => {
                 this.atEndOfPhase(ability => ({
-                    match: c => c === card,
+                    match: card,
                     effect: ability.effects.poison
                 }));
                 return true;

--- a/server/game/cards/events/01/tearsoflys.js
+++ b/server/game/cards/events/01/tearsoflys.js
@@ -24,36 +24,14 @@ class TearsOfLys extends DrawCard {
             activePromptTitle: 'Select a character to receive poison token',
             waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
             cardCondition: card => card.location === 'play area' && card.controller !== player && card.getType() === 'character' && !card.hasIcon('intrigue'),
-            onSelect: (p, card) => this.onCardSelected(p, card)
-        });
-    }
-
-    onCardSelected(player, card) {
-        card.addToken('poison', 1);
-
-        this.game.addMessage('{0} uses {1} to place 1 poison token on {2}', player, this, card);
-
-        this.poisonTarget = card;
-
-        this.game.once('onPhaseEnded', (event, phase) => {
-            if(phase === 'challenge') {
-                this.onPhaseEnded();
+            onSelect: (p, card) => {
+                this.atEndOfPhase(ability => ({
+                    match: c => c === card,
+                    effect: ability.effects.poison
+                }));
+                return true;
             }
         });
-
-        return true;
-    }
-
-    onPhaseEnded() {
-        if(this.poisonTarget && this.poisonTarget.location === 'play area' && this.poisonTarget.hasToken('poison')) {
-            this.poisonTarget.controller.killCharacter(this.poisonTarget);
-
-            this.poisonTarget.removeToken('poision', 1);
-
-            this.game.addMessage('{0} uses {1} to kill {2} at the end of the phase', this.controller, this, this.poisonTarget);
-
-            this.poisonTarget = undefined;
-        }
     }
 }
 

--- a/server/game/cards/events/02/nightmares.js
+++ b/server/game/cards/events/02/nightmares.js
@@ -12,7 +12,7 @@ class Nightmares extends DrawCard {
 
     onCardSelected(player, card) {
         this.untilEndOfPhase(ability => ({
-            match: c => c === card,
+            match: card,
             effect: ability.effects.blank
         }));
 

--- a/server/game/cards/events/02/nightmares.js
+++ b/server/game/cards/events/02/nightmares.js
@@ -11,25 +11,14 @@ class Nightmares extends DrawCard {
     }
 
     onCardSelected(player, card) {
-        this.selectedCard = card;
-
-        card.setBlank();
+        this.untilEndOfPhase(ability => ({
+            match: c => c === card,
+            effect: ability.effects.blank
+        }));
 
         this.game.addMessage('{0} uses {1} to treat the text box of {2} as blank until the end of the phase', player, this, card);
 
-        this.game.once('onPhaseEnded', () => {
-            this.onPhaseEnded();
-        });
-
         return true;
-    }
-
-    onPhaseEnded() {
-        if(this.selectedCard) {
-            this.selectedCard.clearBlank();
-
-            this.selectedCard = undefined;
-        }
     }
 }
 

--- a/server/game/cards/locations/01/ironfleetscout.js
+++ b/server/game/cards/locations/01/ironfleetscout.js
@@ -30,7 +30,7 @@ class IronFleetScout extends DrawCard {
         player.kneelCard(this);
         this.game.addMessage('{0} kneels {1} to give {2} +{3} STR until the end of the challenge', player, this, card, strength);
         this.untilEndOfPhase(ability => ({
-            match: c => c === card,
+            match: card,
             effect: ability.effects.modifyStrength(strength)
         }));
 

--- a/server/game/cards/locations/01/ironfleetscout.js
+++ b/server/game/cards/locations/01/ironfleetscout.js
@@ -26,29 +26,16 @@ class IronFleetScout extends DrawCard {
     }
 
     onCardSelected(player, card) {
+        var strength = player.firstPlayer ? 2 : 1;
         player.kneelCard(this);
-
-        this.strength = player.firstPlayer ? 2 : 1;
-
-        card.strengthModifier += this.strength;
-        this.modifiedCard = card;
-
-        this.game.addMessage('{0} kneels {1} to give {2} +{3} STR until the end of the challenge', player, this, card, this.strength);
-
-        this.game.once('afterChallenge', () => {
-            this.onAfterChallenge();
-        });
+        this.game.addMessage('{0} kneels {1} to give {2} +{3} STR until the end of the challenge', player, this, card, strength);
+        this.untilEndOfPhase(ability => ({
+            match: c => c === card,
+            effect: ability.effects.modifyStrength(strength)
+        }));
 
         return true;
     }
-
-    onAfterChallenge() {
-        if(this.modifiedCard) {
-            this.modifiedCard.strengthModifier -= this.strength;
-
-            this.modifiedCard = undefined;
-        }
-    }   
 }
 
 IronFleetScout.code = '01079';

--- a/server/game/cards/locations/01/plazaofpunishment.js
+++ b/server/game/cards/locations/01/plazaofpunishment.js
@@ -39,7 +39,7 @@ class PlazaOfPunishment extends DrawCard {
         this.game.addMessage('{0} uses {1} to give {2} -2 STR', player, this, card);
         player.kneelCard(this);
         this.untilEndOfPhase(ability => ({
-            match: c => c === card,
+            match: card,
             effect: [
                 ability.effects.modifyStrength(-2),
                 ability.effects.killByStrength

--- a/server/game/cards/locations/01/plazaofpunishment.js
+++ b/server/game/cards/locations/01/plazaofpunishment.js
@@ -36,33 +36,17 @@ class PlazaOfPunishment extends DrawCard {
     }
 
     onCardSelected(player, card) {
-        card.strengthModifier -= 2;
-
-        player.kneelCard(this);
-
         this.game.addMessage('{0} uses {1} to give {2} -2 STR', player, this, card);
-
-        if(card.getStrength() <= 0) {
-            card.controller.killCharacter(card, false);
-
-            this.game.addMessage('{0} is killed as its STR is 0', card);
-        } else {
-            this.cardSelected = card;
-
-            this.game.once('onPhaseEnded', () => {
-                this.onPhaseEnded();
-            });
-        }
+        player.kneelCard(this);
+        this.untilEndOfPhase(ability => ({
+            match: c => c === card,
+            effect: [
+                ability.effects.modifyStrength(-2),
+                ability.effects.killByStrength
+            ]
+        }));
 
         return true;
-    }
-
-    onPhaseEnded() {
-        if(this.cardSelected) {
-            this.cardSelected.strengthModifier += 2;
-
-            this.cardSelected = undefined;
-        }
     }
 }
 

--- a/server/game/cards/locations/04/pyke.js
+++ b/server/game/cards/locations/04/pyke.js
@@ -29,7 +29,7 @@ class Pyke extends DrawCard {
         this.game.addMessage('{0} kneeled {1} to make {2} gain stealth', player, this, card);
         player.kneelCard(this);
         this.untilEndOfPhase(ability => ({
-            match: c => c === card,
+            match: card,
             effect: ability.effects.addKeyword('Stealth')
         }));
 

--- a/server/game/cards/locations/04/pyke.js
+++ b/server/game/cards/locations/04/pyke.js
@@ -26,27 +26,15 @@ class Pyke extends DrawCard {
     }
 
     onCardSelected(player, card) {
-        player.kneelCard(this);
-
-        card.addKeyword('Stealth');
-        this.modifiedCard = card;
-
         this.game.addMessage('{0} kneeled {1} to make {2} gain stealth', player, this, card);
-
-        this.game.once('onPhaseEnded', () => {
-            this.onPhaseEnded();
-        });
+        player.kneelCard(this);
+        this.untilEndOfPhase(ability => ({
+            match: c => c === card,
+            effect: ability.effects.addKeyword('Stealth')
+        }));
 
         return true;
     }
-
-    onPhaseEnded() {
-        if(this.modifiedCard) {
-            this.modifiedCard.removeKeyword('Stealth');
-
-            this.modifiedCard = undefined;
-        }
-    }   
 }
 
 Pyke.code = '04013';

--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -1,5 +1,7 @@
 const _ = require('underscore');
 
+const Effects = require('./effects.js');
+
 /**
  * Represents a card based effect applied to one or more targets.
  *
@@ -15,6 +17,9 @@ const _ = require('underscore');
  *                    than Winter plots").
  * targetController - string that determines which player's cards are targeted.
  *                    Can be 'current' (default), 'opponent' or 'any'.
+ * effect           - object representing the effect to be applied. If passed an
+ *                    array instead of an object, it will apply / unapply all of
+ *                    the sub objects in the array instead.
  * effect.apply     - function that takes a card and a context object and modifies
  *                    the card to apply the effect.
  * effect.unapply   - function that takes a card and a context object and modifies
@@ -28,11 +33,19 @@ class Effect {
         this.duration = properties.duration;
         this.condition = properties.condition || (() => true);
         this.targetController = properties.targetController || 'current';
-        this.effect = properties.effect;
+        this.effect = this.buildEffect(properties.effect);
         this.targets = [];
         this.context = { game: game, source: source };
         this.active = true;
-        this.isStateDependent = properties.condition || properties.effect.isStateDependent;
+        this.isStateDependent = properties.condition || this.effect.isStateDependent;
+    }
+
+    buildEffect(effect) {
+        if(_.isArray(effect)) {
+            return Effects.all(effect);
+        }
+
+        return effect;
     }
 
     addTargets(cards) {

--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -8,7 +8,8 @@ const Effects = require('./effects.js');
  * Properties:
  * match            - function that takes a card and context object and returns
  *                    a boolean about whether the passed card should have the
- *                    effect applied.
+ *                    effect applied. Alternatively, a card can be passed as the
+ *                    match property to match that single card.
  * duration         - string representing how long the effect lasts.
  * condition        - function that returns a boolean determining whether the
  *                    effect can be applied. Use with cards that have a
@@ -64,6 +65,10 @@ class Effect {
     }
 
     isValidTarget(card) {
+        if(!_.isFunction(this.match)) {
+            return card === this.match;
+        }
+
         if(!this.match(card, this.context)) {
             return false;
         }

--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -6,7 +6,7 @@ class EffectEngine {
     constructor(game) {
         this.game = game;
         this.events = new EventRegistrar(game, this);
-        this.events.register(['onCardEntersPlay', 'onCardLeftPlay', 'onCardBlankToggled']);
+        this.events.register(['onCardEntersPlay', 'onCardLeftPlay', 'onCardBlankToggled', 'onChallengeFinished', 'onPhaseEnded', 'onAtEndOfPhase']);
         this.effects = [];
     }
 
@@ -50,6 +50,18 @@ class EffectEngine {
         _.each(matchingEffects, effect => {
             effect.setActive(!isBlank);
         });
+    }
+
+    onChallengeFinished() {
+        this.unapplyAndRemove(effect => effect.duration === 'untilEndOfChallenge');
+    }
+
+    onPhaseEnded() {
+        this.unapplyAndRemove(effect => effect.duration === 'untilEndOfPhase');
+    }
+
+    onAtEndOfPhase() {
+        this.unapplyAndRemove(effect => effect.duration === 'atEndOfPhase');
     }
 
     unapplyAndRemove(match) {

--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -6,7 +6,7 @@ class EffectEngine {
     constructor(game) {
         this.game = game;
         this.events = new EventRegistrar(game, this);
-        this.events.register(['onCardEntersPlay', 'onCardLeftPlay', 'onCardBlankToggled', 'onChallengeFinished', 'onPhaseEnded', 'onAtEndOfPhase']);
+        this.events.register(['onCardEntersPlay', 'onCardLeftPlay', 'onCardBlankToggled', 'onChallengeFinished', 'onPhaseEnded', 'onAtEndOfPhase', 'onRoundEnded']);
         this.effects = [];
     }
 
@@ -62,6 +62,10 @@ class EffectEngine {
 
     onAtEndOfPhase() {
         this.unapplyAndRemove(effect => effect.duration === 'atEndOfPhase');
+    }
+
+    onRoundEnded() {
+        this.unapplyAndRemove(effect => effect.duration === 'untilEndOfRound');
     }
 
     unapplyAndRemove(match) {

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -76,6 +76,18 @@ const Effects = {
             }
         };
     },
+    killByStrength: {
+        apply: function(card, context) {
+            if(card.getStrength() <= 0) {
+                card.controller.killCharacter(card);
+                context.game.addMessage('{0} is killed as its STR is 0', card);
+            }
+        },
+        unapply: function() {
+            // nothing happens when this effect expires.
+        },
+        isStateDependent: true
+    },
     blank: {
         apply: function(card) {
             card.setBlank();
@@ -83,6 +95,31 @@ const Effects = {
         unapply: function(card) {
             card.clearBlank();
         }
+    },
+    poison: {
+        apply: function(card, context) {
+            card.addToken('poison', 1);
+            context.game.addMessage('{0} uses {1} to place 1 poison token on {2}', context.source.controller, context.source, card);
+        },
+        unapply: function(card, context) {
+            if(card.location === 'play area' && card.hasToken('poison')) {
+                card.removeToken('poison', 1);
+                card.controller.killCharacter(card);
+                context.game.addMessage('{0} uses {1} to kill {2} at the end of the phase', context.source.controller, context.source, card);
+            }
+        }
+    },
+    discardIfStillInPlay: function(allowSave = false) {
+        return {
+            apply: function() {
+            },
+            unapply: function(card, context) {
+                if(card.location === 'play area') {
+                    card.controller.discardCard(card, allowSave);
+                    context.game.addMessage('{0} discards {1} at the end of the phase because of {2}', context.source.controller, card, context.source);
+                }
+            }
+        };
     }
 };
 

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -1,4 +1,17 @@
+const _ = require('underscore');
+
 const Effects = {
+    all: function(effects) {
+        return {
+            apply: function(card, context) {
+                _.each(effects, effect => effect.apply(card, context));
+            },
+            unapply: function(card, context) {
+                _.each(effects, effect => effect.unapply(card, context));
+            },
+            isStateDependent: _.any(effects, effect => !!effect.isStateDependent)
+        }
+    },
     modifyStrength: function(value) {
         return {
             apply: function(card) {

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -39,10 +39,20 @@ const Effects = {
     addIcon: function(icon) {
         return {
             apply: function(card) {
-                card.setIcon(icon);
+                card.addIcon(icon);
             },
             unapply: function(card) {
-                card.clearIcon(card);
+                card.removeIcon(icon);
+            }
+        };
+    },
+    removeIcon: function(icon) {
+        return {
+            apply: function(card) {
+                card.removeIcon(icon);
+            },
+            unapply: function(card) {
+                card.addIcon(icon);
             }
         };
     },

--- a/test/server/cards/characters/01/01087 - serjaimelannister.spec.js
+++ b/test/server/cards/characters/01/01087 - serjaimelannister.spec.js
@@ -7,7 +7,7 @@ const SerJaimeLannister = require('../../../../../server/game/cards/characters/0
 
 describe('SerJaimeLannister', function() {
     beforeEach(function() {
-        this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener', 'addPower', 'addMessage', 'raiseEvent', 'once']);
+        this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener', 'addPower', 'addMessage', 'raiseEvent', 'once', 'addEffect']);
         this.playerSpy = jasmine.createSpyObj('player', ['standCard']);
         this.otherPlayerSpy = jasmine.createSpyObj('player2', ['standCard']);
 
@@ -22,12 +22,6 @@ describe('SerJaimeLannister', function() {
     });
 
     describe('when attackers are declared', function() {
-        describe('and this card is not in play', function() {
-            it('should not set renown on this card', function() {
-                expect(this.character.isRenown()).toBe(false);
-            });
-        });
-
         describe('and this card is in play', function() {
             beforeEach(function() {
                 this.character.kneeled = true;
@@ -39,16 +33,8 @@ describe('SerJaimeLannister', function() {
                     this.character.onAttackersDeclared({}, this.challenge);
                 });
 
-                afterEach(function() {
-                    this.character.removeKeyword('renown');
-                });
-
                 it('should not stand the card', function() {
                     expect(this.playerSpy.standCard).not.toHaveBeenCalled();
-                });
-
-                it('should set renown', function() {
-                    expect(this.character.isRenown()).toBe(true);
                 });
             });
 
@@ -56,11 +42,6 @@ describe('SerJaimeLannister', function() {
                 beforeEach(function() {
                     this.character.onAttackersDeclared({}, this.challenge);
                 });
-
-                afterEach(function() {
-                    this.character.removeKeyword('renown');
-                });
-
 
                 describe('and this card is blank', function() {
                     beforeEach(function() {
@@ -75,19 +56,11 @@ describe('SerJaimeLannister', function() {
                     it('should not stand the card', function() {
                         expect(this.character.kneeled).toBe(true);
                     });
-
-                    it('should not set renown', function() {
-                        expect(this.character.isRenown()).toBe(false);
-                    });
                 });
 
                 describe('and this card is not in the challenge', function() {
                     beforeEach(function() {
                         this.challenge.isAttacking.and.returnValue(false);
-                    });
-
-                    it('should set renown', function() {
-                        expect(this.character.isRenown()).toBe(true);
                     });
 
                     it('should not stand the card', function() {
@@ -102,10 +75,6 @@ describe('SerJaimeLannister', function() {
                         this.character.onAttackersDeclared({}, this.challenge);
                     });
 
-                    afterEach(function() {
-                        this.character.removeKeyword('renown');
-                    });
-
                     it('should stand the card', function() {
                         expect(this.playerSpy.standCard).toHaveBeenCalled();
                     });
@@ -116,10 +85,6 @@ describe('SerJaimeLannister', function() {
                             this.character.keywords['renown'] = 0;
                             this.challenge = 'intrigue';
                             this.character.onAttackersDeclared({}, this.challenge);
-                        });
-
-                        it('should set not renown', function() {
-                            expect(this.character.isRenown()).toBe(false);
                         });
 
                         it('should not stand the card', function() {

--- a/test/server/cards/characters/02/02070 - redcloaks.spec.js
+++ b/test/server/cards/characters/02/02070 - redcloaks.spec.js
@@ -7,7 +7,7 @@ const RedCloaks = require('../../../../../server/game/cards/characters/02/redclo
 
 describe('RedCloaks', function() {
     beforeEach(function() {
-        this.gameSpy = jasmine.createSpyObj('game', ['on', 'once', 'removeListener', 'addPower', 'addMessage', 'addGold']);
+        this.gameSpy = jasmine.createSpyObj('game', ['on', 'once', 'removeListener', 'addPower', 'addMessage', 'addGold', 'addEffect']);
         this.playerSpy = jasmine.createSpyObj('player', ['']);
 
         this.playerSpy.game = this.gameSpy;
@@ -76,7 +76,7 @@ describe('RedCloaks', function() {
                 });
 
                 it('should not increase the strength modifier', function() {
-                    expect(this.card.strengthModifier).toBe(0);
+                    expect(this.gameSpy.addEffect).not.toHaveBeenCalled()
                 });
             });
 
@@ -87,7 +87,7 @@ describe('RedCloaks', function() {
                 });
 
                 it('should not increase the strength modifier', function() {
-                    expect(this.card.strengthModifier).toBe(0);
+                    expect(this.gameSpy.addEffect).not.toHaveBeenCalled()
                 });
             });
 
@@ -97,7 +97,7 @@ describe('RedCloaks', function() {
                 });
 
                 it('should increase the strength modifier', function() {
-                    expect(this.card.strengthModifier).toBe(1);
+                    expect(this.gameSpy.addEffect).toHaveBeenCalled()
                 });
             });
         });

--- a/test/server/effectengine.spec.js
+++ b/test/server/effectengine.spec.js
@@ -367,4 +367,41 @@ describe('EffectEngine', function () {
             });
         });
     });
+
+    describe('onRoundEnded()', function() {
+        beforeEach(function() {
+            this.engine.effects = [this.effectSpy];
+        });
+
+        describe('when an effect has untilEndOfRound duration', function() {
+            beforeEach(function() {
+                this.effectSpy.duration = 'untilEndOfRound';
+                this.engine.onRoundEnded({});
+            });
+
+            it('should cancel the effect', function() {
+                expect(this.effectSpy.cancel).toHaveBeenCalled();
+            });
+
+            it('should remove the effect from the list', function() {
+                expect(this.engine.effects).not.toContain(this.effectSpy);
+            });
+        });
+
+
+        describe('when an effect has a non-untilEndOfRound duration', function() {
+            beforeEach(function() {
+                this.effectSpy.duration = 'persistent';
+                this.engine.onRoundEnded({});
+            });
+
+            it('should not cancel the effect', function() {
+                expect(this.effectSpy.cancel).not.toHaveBeenCalled();
+            });
+
+            it('should not remove the effect from the list', function() {
+                expect(this.engine.effects).toContain(this.effectSpy);
+            });
+        });
+    });
 });

--- a/test/server/effectengine.spec.js
+++ b/test/server/effectengine.spec.js
@@ -256,4 +256,115 @@ describe('EffectEngine', function () {
             });
         });
     });
+
+    describe('onChallengeFinished()', function() {
+        beforeEach(function() {
+            this.engine.effects = [this.effectSpy];
+        });
+
+        describe('when an effect has untilEndOfChallenge duration', function() {
+            beforeEach(function() {
+                this.effectSpy.duration = 'untilEndOfChallenge';
+                this.engine.onChallengeFinished({}, {});
+            });
+
+            it('should cancel the effect', function() {
+                expect(this.effectSpy.cancel).toHaveBeenCalled();
+            });
+
+            it('should remove the effect from the list', function() {
+                expect(this.engine.effects).not.toContain(this.effectSpy);
+            });
+        });
+
+
+        describe('when an effect has a non-untilEndOfChallenge duration', function() {
+            beforeEach(function() {
+                this.effectSpy.duration = 'persistent';
+                this.engine.onChallengeFinished({}, {});
+            });
+
+            it('should not cancel the effect', function() {
+                expect(this.effectSpy.cancel).not.toHaveBeenCalled();
+            });
+
+            it('should not remove the effect from the list', function() {
+                expect(this.engine.effects).toContain(this.effectSpy);
+            });
+        });
+    });
+
+    describe('onPhaseEnded()', function() {
+        beforeEach(function() {
+            this.engine.effects = [this.effectSpy];
+        });
+
+        describe('when an effect has untilEndOfPhase duration', function() {
+            beforeEach(function() {
+                this.effectSpy.duration = 'untilEndOfPhase';
+                this.engine.onPhaseEnded({}, 'marshal');
+            });
+
+            it('should cancel the effect', function() {
+                expect(this.effectSpy.cancel).toHaveBeenCalled();
+            });
+
+            it('should remove the effect from the list', function() {
+                expect(this.engine.effects).not.toContain(this.effectSpy);
+            });
+        });
+
+
+        describe('when an effect has a non-untilEndOfPhase duration', function() {
+            beforeEach(function() {
+                this.effectSpy.duration = 'persistent';
+                this.engine.onPhaseEnded({}, 'marshal');
+            });
+
+            it('should not cancel the effect', function() {
+                expect(this.effectSpy.cancel).not.toHaveBeenCalled();
+            });
+
+            it('should not remove the effect from the list', function() {
+                expect(this.engine.effects).toContain(this.effectSpy);
+            });
+        });
+    });
+
+    describe('onAtEndOfPhase()', function() {
+        beforeEach(function() {
+            this.engine.effects = [this.effectSpy];
+        });
+
+        describe('when an effect has atEndOfPhase duration', function() {
+            beforeEach(function() {
+                this.effectSpy.duration = 'atEndOfPhase';
+                this.engine.onAtEndOfPhase({});
+            });
+
+            it('should cancel the effect', function() {
+                expect(this.effectSpy.cancel).toHaveBeenCalled();
+            });
+
+            it('should remove the effect from the list', function() {
+                expect(this.engine.effects).not.toContain(this.effectSpy);
+            });
+        });
+
+
+        describe('when an effect has a non-atEndOfPhase duration', function() {
+            beforeEach(function() {
+                this.effectSpy.duration = 'persistent';
+                this.engine.onAtEndOfPhase({});
+            });
+
+            it('should not cancel the effect', function() {
+                expect(this.effectSpy.cancel).not.toHaveBeenCalled();
+            });
+
+            it('should not remove the effect from the list', function() {
+                expect(this.engine.effects).toContain(this.effectSpy);
+            });
+        });
+    });
 });


### PR DESCRIPTION
* Adds helpers to immediately apply an effect until the end of the challenge / phase / round and 'at the end of the phase'.
* Gets rid of most (though not quite all) `once` clean up handlers.
* Adds short-hand for applying multiple effects to the same set of cards using an array of effects.
* Adds short-hand for targeting a single card with an effect (most useful for lasting effects)
* Fixes serious issue w/ previous add icon effect implementation.
* Adds effect implementations for removing icons, killing characters with 0 strength, poison tokens, and discarding cards while they're still in play when the effect ends.