### PR TITLE
Remove unused PlotCard.onReveal method.

### DIFF
--- a/server/game/cards/plots/01/powerbehindthethrone.js
+++ b/server/game/cards/plots/01/powerbehindthethrone.js
@@ -2,22 +2,16 @@ const PlotCard = require('../../../plotcard.js');
 
 class PowerBehindTheThrone extends PlotCard {
     setupCardAbilities() {
+        this.whenRevealed({
+            handler: () => {
+              this.game.addMessage('{0} adds 1 stand token to {1}', this.controller, this);
+              this.addToken('stand', 1);
+            }
+        });
         this.action({
             title: 'Discard a stand token',
             method: 'discardToken'
         });
-    }
-
-    onReveal(player) {
-        if(this.controller !== player) {
-            return true;
-        }
-
-        this.game.addMessage('{0} adds 1 stand token to {1}', player, this);
-
-        this.addToken('stand', 1);
-
-        return true;
     }
 
     discardToken(player) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -505,7 +505,6 @@ class Player extends Spectator {
     }
 
     revealPlot() {
-        this.activePlot.onReveal(this);
         this.reserve = this.getTotalReserve();
         this.claim = this.activePlot.getClaim();
     }

--- a/server/game/plotcard.js
+++ b/server/game/plotcard.js
@@ -44,10 +44,6 @@ class PlotCard extends BaseCard {
         this.facedown = false;
     }
 
-    onReveal() {
-        return true;
-    }
-
     onBeginChallengePhase() {
     }
 }

--- a/test/server/gamesteps/plot/resolveplots.spec.js
+++ b/test/server/gamesteps/plot/resolveplots.spec.js
@@ -97,7 +97,7 @@ describe('the ResolvePlots', function() {
                 this.game.getPlayerByName.and.returnValue(this.otherPlayer);
             });
 
-            it('should call onReveal', function() {
+            it('should reveal the plot', function() {
                 this.prompt.resolvePlayer(this.player, this.otherPlayer.name);
                 expect(this.otherPlayer.revealPlot).toHaveBeenCalled();
             });


### PR DESCRIPTION
Previously, PlotCard.onReveal was used to implement 'when revealed'
abilities. These abilities are now defined using BaseCard.whenRevealed
instead.