### PR TITLE
Fix restore of card selection on prompt completion

### DIFF
--- a/server/game/gamesteps/selectcardprompt.js
+++ b/server/game/gamesteps/selectcardprompt.js
@@ -48,13 +48,17 @@ class SelectCardPrompt extends UiPrompt {
     }
 
     savePreviouslySelectedCards() {
-        this.previouslySelectedCards = this.game.allCards.filter(card => card.selected || card.opponentSelected);
-        _.each(this.previouslySelectedCards, card => {
-            if(card.controller !== this.choosingPlayer) {
-                card.opponentSelected = false;
-            } else {
-                card.selected = false;
-            }
+        this.previouslySelectedCards = _.map(
+            this.game.allCards.filter(card => card.selected || card.opponentSelected),
+            card => ({
+                card: card,
+                selected: card.selected,
+                opponentSelected: card.opponentSelected
+            })
+        );
+        _.each(this.previouslySelectedCards, selection => {
+            selection.card.selected = false;
+            selection.card.opponentSelected = false;
         });
     }
 
@@ -161,14 +165,11 @@ class SelectCardPrompt extends UiPrompt {
             card.selected = false;
             card.opponentSelected = false;
         });
-        
+
         // Restore previous selections.
-        _.each(this.previouslySelectedCards, card => {
-            if(card.controller !== this.choosingPlayer) {
-                card.opponentSelected = true;
-            } else {
-                card.selected = true;
-            }
+        _.each(this.previouslySelectedCards, selection => {
+            selection.card.selected = selection.selected;
+            selection.card.opponentSelected = selection.opponentSelected;
         });
     }
 }

--- a/test/server/gamesteps/selectcardprompt.spec.js
+++ b/test/server/gamesteps/selectcardprompt.spec.js
@@ -216,20 +216,61 @@ describe('the SelectCardPrompt', function() {
                     this.properties.cardCondition.and.returnValue(true);
                 });
 
-                it('should select the card if it is not selected', function() {
-                    this.prompt.onCardClicked(this.player, this.card);
-                    expect(this.card.selected).toBe(true);
+                describe('selecting a card owned by the prompted player', function() {
+                    beforeEach(function() {
+                        this.card.controller = this.player;
+                    });
+
+                    it('should select the card if it is not selected', function() {
+                        this.prompt.onCardClicked(this.player, this.card);
+                        expect(this.card.selected).toBe(true);
+                        expect(this.prompt.selectedCards).toContain(this.card);
+                        expect(this.prompt.selectedCards.length).toBe(1);
+                    });
+
+                    it('should unselect the card if it is selected', function() {
+                        this.card.selected = true;
+                        this.prompt.onCardClicked(this.player, this.card);
+                        expect(this.card.selected).toBe(false);
+                        expect(this.prompt.selectedCards).not.toContain(this.card);
+                        expect(this.prompt.selectedCards.length).toBe(0);
+                    });
+
+                    it('should not opponent select the card if it is not selected', function() {
+                        this.prompt.onCardClicked(this.player, this.card);
+                        expect(this.card.opponentSelected).toBeFalsy();
+                    });
+
+                    it('should not call onSelect', function() {
+                        this.prompt.onCardClicked(this.player, this.card);
+                        expect(this.properties.onSelect).not.toHaveBeenCalled();
+                    });
                 });
 
-                it('should unselect the card if it is selected', function() {
-                    this.card.selected = true;
-                    this.prompt.onCardClicked(this.player, this.card);
-                    expect(this.card.selected).toBe(false);
-                });
+                describe('selecting a card owned by another player', function() {
+                    beforeEach(function() {
+                        this.card.controller = this.otherPlayer;
+                    });
 
-                it('should not call onSelect', function() {
-                    this.prompt.onCardClicked(this.player, this.card);
-                    expect(this.properties.onSelect).not.toHaveBeenCalled();
+                    it('should select the card if it is not selected', function() {
+                        this.prompt.onCardClicked(this.player, this.card);
+                        expect(this.card.opponentSelected).toBe(true);
+                        expect(this.prompt.selectedCards).toContain(this.card);
+                        expect(this.prompt.selectedCards.length).toBe(1);
+                    });
+
+                    it('should unselect the card if it is selected', function() {
+                        this.prompt.onCardClicked(this.player, this.card);
+                        this.prompt.onCardClicked(this.player, this.card);
+                        expect(this.card.opponentSelected).toBeFalsy();
+                        expect(this.prompt.selectedCards).not.toContain(this.card);
+                        expect(this.prompt.selectedCards.length).toBe(0);
+                    });
+
+                    it('should not call onSelect', function() {
+                        this.prompt.onCardClicked(this.player, this.card);
+                        expect(this.properties.onSelect).not.toHaveBeenCalled();
+                    });
                 });
             });
 
@@ -348,6 +389,60 @@ describe('the SelectCardPrompt', function() {
                 it('should call the onSelect event with only the cards still selected', function() {
                     this.prompt.onMenuCommand(this.player, 'done');
                     expect(this.properties.onSelect).toHaveBeenCalledWith(this.player, [this.card2]);
+                });
+            });
+        });
+    });
+
+    describe('multiple prompts', function() {
+        beforeEach(function() {
+            this.card2 = { controller: this.player };
+            this.card3 = { controller: this.player };
+            this.game.allCards = _([this.card, this.card2, this.card3]);
+            this.properties = {
+                cardCondition: () => true,
+                onSelect: () => true,
+                onMenuCommand: () => true,
+                onCancel: () => true,
+                numCards: 3
+            };
+            this.prompt = new SelectCardPrompt(this.game, this.player, this.properties);
+        });
+
+        describe('creating a new prompt in the middle of an existing prompt', function() {
+            beforeEach(function() {
+                this.prompt.onCardClicked(this.player, this.card);
+                this.prompt.onCardClicked(this.player, this.card2);
+                this.prompt2 = new SelectCardPrompt(this.game, this.otherPlayer, this.properties);
+            });
+
+            it('should clear existing selection', function() {
+                expect(this.prompt2.selectedCards.length).toBe(0);
+                expect(this.card.selected).toBe(false);
+                expect(this.card2.selected).toBe(false);
+            });
+
+            describe('when the new prompt is completed', function() {
+                beforeEach(function() {
+                    this.prompt2.onCardClicked(this.otherPlayer, this.card);
+                    this.prompt2.onCardClicked(this.otherPlayer, this.card2);
+                    this.prompt2.onCardClicked(this.otherPlayer, this.card3);
+                    this.prompt2.onMenuCommand(this.otherPlayer, 'done');
+                });
+
+                it('should restore selection for original prompt', function() {
+                    expect(this.prompt.selectedCards.length).toBe(2);
+                    expect(this.card.selected).toBe(true);
+                    expect(this.card2.selected).toBe(true);
+                    expect(this.card3.selected).toBe(false);
+                });
+
+                it('should handle clicking after restoration properly', function() {
+                    this.prompt.onCardClicked(this.player, this.card);
+                    expect(this.prompt.selectedCards.length).toBe(1);
+                    expect(this.card.selected).toBe(false);
+                    expect(this.card2.selected).toBe(true);
+                    expect(this.card3.selected).toBe(false);
                 });
             });
         });


### PR DESCRIPTION
Previously, the previous card selection was being recalculated based on
the current prompt's player. However, the selection for the prior prompt
may have been for a different player. This led to a bug where when
returning to the original prompt, the card selected property would be
false, but the card would be in the internal list, allowing the player
to add the character to the selection multiple times.

This change saves the exact values for card.selected and
card.opponentSelected and restores them directly rather than attempt to
recalculate which type of selection was used.