### PR TITLE
Treat printed keywords like a persistent effect

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -45,14 +45,14 @@ class BaseCard {
     parseKeywords(text) {
         var firstLine = text.split('\n')[0];
         var potentialKeywords = _.map(firstLine.split('.'), k => k.toLowerCase().trim());
+        var keywords = [];
 
         this.keywords = {};
-        this.cardData.keywords = [];
         this.allowedAttachmentTrait = 'any';
 
         _.each(potentialKeywords, keyword => {
             if(_.contains(ValidKeywords, keyword)) {
-                this.cardData.keywords.push(keyword);
+                keywords.push(keyword);
             } else if(keyword.indexOf('no attachment') === 0) {
                 var match = keyword.match(/no attachments except <[bi]>(.*)<\/[bi]>/);
                 if(match) {
@@ -68,10 +68,10 @@ class BaseCard {
             }
         });
 
-        if(this.cardData.keywords.length > 0) {
+        if(keywords.length > 0) {
             this.persistentEffect({
                 match: this,
-                effect: AbilityDsl.effects.addMultipleKeywords(this.cardData.keywords)
+                effect: AbilityDsl.effects.addMultipleKeywords(keywords)
             });
         }
     }

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -33,14 +33,12 @@ class BaseCard {
         this.blankCount = 0;
 
         this.tokens = {};
-
         this.menu = _([]);
-        this.parseKeywords(cardData.text || '');
-        this.parseTraits(cardData.traits || '');
-
         this.events = new EventRegistrar(this.game, this);
 
         this.abilities = { reactions: [], persistentEffects: [] };
+        this.parseKeywords(cardData.text || '');
+        this.parseTraits(cardData.traits || '');
         this.setupCardAbilities(AbilityDsl);
     }
 
@@ -49,11 +47,12 @@ class BaseCard {
         var potentialKeywords = _.map(firstLine.split('.'), k => k.toLowerCase().trim());
 
         this.keywords = {};
+        this.cardData.keywords = [];
         this.allowedAttachmentTrait = 'any';
 
         _.each(potentialKeywords, keyword => {
             if(_.contains(ValidKeywords, keyword)) {
-                this.addKeyword(keyword);
+                this.cardData.keywords.push(keyword);
             } else if(keyword.indexOf('no attachment') === 0) {
                 var match = keyword.match(/no attachments except <[bi]>(.*)<\/[bi]>/);
                 if(match) {
@@ -68,6 +67,13 @@ class BaseCard {
                 }
             }
         });
+
+        if(this.cardData.keywords.length > 0) {
+            this.persistentEffect({
+                match: this,
+                effect: AbilityDsl.effects.addMultipleKeywords(this.cardData.keywords)
+            });
+        }
     }
 
     parseTraits(traits) {
@@ -188,13 +194,8 @@ class BaseCard {
     }
 
     hasKeyword(keyword) {
-        if(this.isBlank()) {
-            return false;
-        }
-
-        var keywordEntry = this.keywords[keyword.toLowerCase()];
-
-        return !!keywordEntry;
+        var keywordCount = this.keywords[keyword.toLowerCase()] || 0;
+        return keywordCount > 0;
     }
 
     hasTrait(trait) {
@@ -309,12 +310,8 @@ class BaseCard {
 
     addKeyword(keyword) {
         var lowerCaseKeyword = keyword.toLowerCase();
-
-        if(!this.keywords[lowerCaseKeyword]) {
-            this.keywords[lowerCaseKeyword] = 1;
-        } else {
-            this.keywords[lowerCaseKeyword]++;
-        }
+        this.keywords[lowerCaseKeyword] = this.keywords[lowerCaseKeyword] || 0;
+        this.keywords[lowerCaseKeyword]++;
     }
 
     addTrait(trait) {
@@ -332,7 +329,9 @@ class BaseCard {
     }
 
     removeKeyword(keyword) {
-        this.keywords[keyword.toLowerCase()]--;
+        var lowerCaseKeyword = keyword.toLowerCase();
+        this.keywords[lowerCaseKeyword] = this.keywords[lowerCaseKeyword] || 0;
+        this.keywords[lowerCaseKeyword]--;
     }
 
     removeTrait(trait) {

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -66,6 +66,16 @@ const Effects = {
             }
         };
     },
+    addMultipleKeywords: function(keywords) {
+        return {
+            apply: function(card) {
+                _.each(keywords, keyword => card.addKeyword(keyword));
+            },
+            unapply: function(card) {
+                _.each(keywords, keyword => card.removeKeyword(keyword));
+            }
+        };
+    },
     addTrait: function(trait) {
         return {
             apply: function(card) {

--- a/test/server/card/drawcard.usestealthtobypass.spec.js
+++ b/test/server/card/drawcard.usestealthtobypass.spec.js
@@ -2,63 +2,61 @@
 
 const DrawCard = require('../../../server/game/drawcard.js');
 
-describe('the DrawCard', () => {
-    var cardDataWithStealth = { text: 'Stealth.' };
-    var cardDataWithoutStealth = { text: '' };
-    var source;
-    var target;
-
-    describe('the useStealthToBypass() function', () => {
-        describe('when the card does not have stealth', () => {
-            beforeEach(() => {
-                source = new DrawCard({}, cardDataWithoutStealth);
-                target = new DrawCard({}, cardDataWithoutStealth);
+describe('the DrawCard', function() {
+    describe('the useStealthToBypass() function', function() {
+        describe('when the card does not have stealth', function() {
+            beforeEach(function() {
+                this.source = new DrawCard({}, {});
+                this.target = new DrawCard({}, {});
             });
 
-            it('should return false.', () => {
-                expect(source.useStealthToBypass(target)).toBe(false);
+            it('should return false.', function() {
+                expect(this.source.useStealthToBypass(this.target)).toBe(false);
             });
         });
 
-        describe('when the card has stealth and the target does not', () => {
-            beforeEach(() => {
-                source = new DrawCard({}, cardDataWithStealth);
-                target = new DrawCard({}, cardDataWithoutStealth);
+        describe('when the card has stealth and the target does not', function() {
+            beforeEach(function() {
+                this.source = new DrawCard({}, {});
+                this.source.addKeyword('Stealth');
+                this.target = new DrawCard({}, {});
             });
 
-            it('should return true.', () => {
-                expect(source.useStealthToBypass(target)).toBe(true);
+            it('should return true.', function() {
+                expect(this.source.useStealthToBypass(this.target)).toBe(true);
             });
 
-            it('should mark the target card as being bypassed', () => {
-                source.useStealthToBypass(target);
-                expect(target.stealth).toBe(true);
+            it('should mark the target card as being bypassed', function() {
+                this.source.useStealthToBypass(this.target);
+                expect(this.target.stealth).toBe(true);
             });
 
-            it('should set the stealth target on the source card', () => {
-                source.useStealthToBypass(target);
-                expect(source.stealthTarget).toBe(target);
+            it('should set the stealth target on the source card', function() {
+                this.source.useStealthToBypass(this.target);
+                expect(this.source.stealthTarget).toBe(this.target);
             });
         });
 
-        describe('when both cards have stealth', () => {
-            beforeEach(() => {
-                source = new DrawCard({}, cardDataWithStealth);
-                target = new DrawCard({}, cardDataWithStealth);
+        describe('when both cards have stealth', function() {
+            beforeEach(function() {
+                this.source = new DrawCard({}, {});
+                this.source.addKeyword('Stealth');
+                this.target = new DrawCard({}, {});
+                this.target.addKeyword('Stealth');
             });
 
-            it('should return false', () => {
-                expect(source.useStealthToBypass(target)).toBe(false);
+            it('should return false', function() {
+                expect(this.source.useStealthToBypass(this.target)).toBe(false);
             });
 
-            it('should not mark the target card as being bypassed', () => {
-                source.useStealthToBypass(target);
-                expect(target.stealth).toBeFalsy();
+            it('should not mark the target card as being bypassed', function() {
+                this.source.useStealthToBypass(this.target);
+                expect(this.target.stealth).toBeFalsy();
             });
 
-            it('should not set the stealth target on the source card', () => {
-                source.useStealthToBypass(target);
-                expect(source.stealthTarget).toBeUndefined();
+            it('should not set the stealth target on the source card', function() {
+                this.source.useStealthToBypass(this.target);
+                expect(this.source.stealthTarget).toBeUndefined();
             });
         });
     });


### PR DESCRIPTION
Previously, if a card was blanked it would lose all of its keywords,
even those provided by non-blanked cards. This change makes keywords in
the card text into a persistent effect, which means it will only lose
those keywords when blanked instead of all keywords.

Fixes #214.