### PR TITLE
Effects that target the player instead of cards

### DIFF
--- a/server/game/cards/attachments/02/thesilversteed.js
+++ b/server/game/cards/attachments/02/thesilversteed.js
@@ -17,9 +17,13 @@ class TheSilverSteed extends DrawCard {
             handler: () => {
                 this.controller.sacrificeCard(this);
 
-                this.controller.addChallenge('power', 1);
+                this.untilEndOfPhase(ability => ({
+                    targetType: 'player',
+                    targetController: 'current',
+                    effect: ability.effects.modifyChallengeTypeLimit('power', 1)
+                }));
 
-                this.game.addMessage('{0} sacrifices {1} to be able to initiate an additional {2} challenge this round', this.controller, this, 'power');
+                this.game.addMessage('{0} sacrifices {1} to be able to initiate an additional {2} challenge this phase', this.controller, this, 'power');
             }
         });
     }

--- a/server/game/cards/characters/01/khaldrogo.js
+++ b/server/game/cards/characters/01/khaldrogo.js
@@ -1,25 +1,12 @@
 const DrawCard = require('../../../drawcard.js');
 
 class KhalDrogo extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['onPlotFlip']);
-    }
-
-    onPlotFlip() {
-        if(!this.isBlank()) {
-            this.challengeAdded = true;
-            this.controller.addChallenge('military', 1);
-        }
-    }
-
-    leavesPlay() {
-        super.leavesPlay();
-        
-        if(this.challengeAdded) {
-            this.controller.addChallenge('military', -1);
-        }
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            targetType: 'player',
+            targetController: 'current',
+            effect: ability.effects.modifyChallengeTypeLimit('military', 1)
+        });
     }
 }
 

--- a/server/game/cards/characters/01/olennasinformant.js
+++ b/server/game/cards/characters/01/olennasinformant.js
@@ -1,7 +1,7 @@
 const DrawCard = require('../../../drawcard.js');
 
 class OlennasInformant extends DrawCard {
-    setupCardAbilities(ability) {
+    setupCardAbilities() {
         this.reaction({
             when: {
                 onCardEntersPlay: (e, card) => card === this && this.game.currentPhase === 'challenge'
@@ -32,7 +32,7 @@ class OlennasInformant extends DrawCard {
         this.game.addMessage('{0} uses {1} to be able to initiate an additional {2} challenge this phase', player, this, challenge);
 
         return true;
-    } 
+    }
 }
 
 OlennasInformant.code = '01189';

--- a/server/game/cards/characters/01/olennasinformant.js
+++ b/server/game/cards/characters/01/olennasinformant.js
@@ -1,49 +1,33 @@
 const DrawCard = require('../../../drawcard.js');
 
 class OlennasInformant extends DrawCard {
-    play(player) {
-        super.play(player);
-
-        if(player.phase !== 'challenge') {
-            return;
-        }
-
-        this.game.promptWithMenu(player, this, {
-            activePrompt: {
-                menuTitle: 'Trigger ' + this.name + '?',
-                buttons: [
-                    { text: 'Yes', method: 'trigger' },
-                    { text: 'No', method: 'cancel' }
-                ]
+    setupCardAbilities(ability) {
+        this.reaction({
+            when: {
+                onCardEntersPlay: (e, card) => card === this && this.game.currentPhase === 'challenge'
             },
-            waitingPromptTitle: 'Waiting for opponent to use ' + this.name
+            handler: () => {
+                this.game.promptWithMenu(this.controller, this, {
+                    activePrompt: {
+                        menuTitle: 'Name a challenge type',
+                        buttons: [
+                            { text: 'Military', method: 'challengeSelected', arg: 'military' },
+                            { text: 'Intrigue', method: 'challengeSelected', arg: 'intrigue' },
+                            { text: 'Power', method: 'challengeSelected', arg: 'power' }
+                        ]
+                    },
+                    waitingPromptTitle: 'Waiting for opponent to use ' + this.name
+                });
+            }
         });
-    }
-
-    trigger(player) {
-        this.game.promptWithMenu(player, this, {
-            activePrompt: {
-                menuTitle: 'Name a challenge type',
-                buttons: [
-                    { text: 'Military', method: 'challengeSelected', arg: 'military' },
-                    { text: 'Intrigue', method: 'challengeSelected', arg: 'intrigue' },
-                    { text: 'Power', method: 'challengeSelected', arg: 'power' }
-                ]
-            },
-            waitingPromptTitle: 'Waiting for opponent to use ' + this.name
-        });
-
-        return true;
-    }
-
-    cancel(player) {
-        this.game.addMessage('{0} declines to trigger {1}', player, this);
-
-        return true;
     }
 
     challengeSelected(player, challenge) {
-        this.controller.addChallenge(challenge, 1);
+        this.untilEndOfPhase(ability => ({
+            targetType: 'player',
+            targetController: 'current',
+            effect: ability.effects.modifyChallengeTypeLimit(challenge, 1)
+        }));
 
         this.game.addMessage('{0} uses {1} to be able to initiate an additional {2} challenge this phase', player, this, challenge);
 

--- a/server/game/cards/locations/01/casterlyrock.js
+++ b/server/game/cards/locations/01/casterlyrock.js
@@ -1,24 +1,12 @@
 const DrawCard = require('../../../drawcard.js');
 
 class CasterlyRock extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['onPlotFlip']);
-    }
-
-    onPlotFlip() {
-        if(!this.isBlank()) {
-            this.controller.addChallenge('intrigue', 1);
-        }
-    }
-
-    leavesPlay() {
-        super.leavesPlay();
-        
-        if(!this.isBlank()) {
-            this.controller.addChallenge('intrigue', -1);
-        }
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            targetType: 'player',
+            targetController: 'current',
+            effect: ability.effects.modifyChallengeTypeLimit('intrigue', 1)
+        });
     }
 }
 

--- a/server/game/cards/plots/01/astormofswords.js
+++ b/server/game/cards/plots/01/astormofswords.js
@@ -1,14 +1,12 @@
 const PlotCard = require('../../../plotcard.js');
 
 class AStormOfSwords extends PlotCard {
-    flipFaceup() {
-        super.flipFaceup();
-
-        this.controller.addChallenge('military', 1);
-
-        this.game.addMessage('{0} uses {1} to gain an additional military challenge this round', this.controller, this);
-
-        return true;
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            targetType: 'player',
+            targetController: 'current',
+            effect: ability.effects.modifyChallengeTypeLimit('military', 1)
+        });
     }
 }
 

--- a/server/game/cards/plots/01/sneakattack.js
+++ b/server/game/cards/plots/01/sneakattack.js
@@ -1,10 +1,12 @@
 const PlotCard = require('../../../plotcard.js');
 
 class SneakAttack extends PlotCard {
-    flipFaceup() {
-        super.flipFaceup();
-
-        this.controller.setMaxChallenge(1);
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            targetType: 'player',
+            targetController: 'current',
+            effect: ability.effects.setMaxChallenge(1)
+        });
     }
 }
 

--- a/server/game/cards/plots/02/wraithsintheirmidst.js
+++ b/server/game/cards/plots/02/wraithsintheirmidst.js
@@ -21,6 +21,11 @@ class WraithsInTheirMidst extends PlotCard {
             match: otherPlayer.activePlot,
             effect: ability.effects.modifyReserve(-2)
         }));
+        this.untilEndOfRound(ability => ({
+            targetType: 'player',
+            targetController: 'opponent',
+            effect: ability.effects.setMinReserve(2)
+        }));
     }
 }
 

--- a/server/game/challengetracker.js
+++ b/server/game/challengetracker.js
@@ -1,0 +1,83 @@
+const _ = require('underscore');
+
+class ChallengeTracker {
+    constructor() {
+        this.complete = 0;
+        this.challengeTypes = {
+            military: {
+                performed: 0,
+                max: 1,
+                won: 0,
+                lost: 0
+            },
+            intrigue: {
+                performed: 0,
+                max: 1,
+                won: 0,
+                lost: 0
+            },
+            power: {
+                performed: 0,
+                max: 1,
+                won: 0,
+                lost: 0
+            }
+        };
+    }
+
+    reset() {
+        this.complete = 0;
+        this.resetForType('military');
+        this.resetForType('intrigue');
+        this.resetForType('power');
+    }
+
+    resetForType(challengeType) {
+        this.challengeTypes[challengeType].performed = 0;
+        this.challengeTypes[challengeType].won = 0;
+        this.challengeTypes[challengeType].lost = 0;
+    }
+
+    isAtMax(challengeType) {
+        if(!_.isUndefined(this.maxTotal) && this.complete >= this.maxTotal) {
+            return true;
+        }
+
+        return this.challengeTypes[challengeType].performed >= this.challengeTypes[challengeType].max;
+    }
+
+    getWon(challengeType) {
+        return this.challengeTypes[challengeType].won;
+    }
+
+    getLost(challengeType) {
+        return this.challengeTypes[challengeType].lost;
+    }
+
+    setMax(max) {
+        this.maxTotal = max;
+    }
+
+    clearMax() {
+        delete this.maxTotal;
+    }
+
+    perform(challengeType) {
+        this.challengeTypes[challengeType].performed++;
+        this.complete++;
+    }
+
+    won(challengeType) {
+        this.challengeTypes[challengeType].won++;
+    }
+
+    lost(challengeType) {
+        this.challengeTypes[challengeType].lost++;
+    }
+
+    modifyMaxForType(challengeType, number) {
+        this.challengeTypes[challengeType].max += number;
+    }
+}
+
+module.exports = ChallengeTracker;

--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -18,6 +18,7 @@ class EffectEngine {
     applyEffect(effect) {
         var validTargets = this.game.allCards.filter(card => card.location === 'play area' || card.location === 'active plot');
         effect.addTargets(validTargets);
+        effect.addTargets(this.game.getPlayers());
     }
 
     reapplyStateDependentEffects() {

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -170,11 +170,23 @@ const Effects = {
     },
     setMaxChallenge: function(max) {
         return {
-            apply: function(player, context) {
+            apply: function(player) {
                 player.setMaxChallenge(max);
             },
             unapply: function(player) {
                 player.clearMaxChallenge();
+            }
+        };
+    },
+    setMinReserve: function(min) {
+        return {
+            apply: function(player, context) {
+                context.setMinReserve = context.setMinReserve || {};
+                context.setMinReserve[player] = player.minReserve;
+                player.minReserve = min;
+            },
+            unapply: function(player, context) {
+                player.minReserve = context.setMinReserve[player];
             }
         }
     }

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -157,6 +157,26 @@ const Effects = {
                 delete context.takeControl[card];
             }
         };
+    },
+    modifyChallengeTypeLimit: function(challengeType, value) {
+        return {
+            apply: function(player) {
+                player.addChallenge(challengeType, value);
+            },
+            unapply: function(player) {
+                player.addChallenge(challengeType, -value);
+            }
+        };
+    },
+    setMaxChallenge: function(max) {
+        return {
+            apply: function(player, context) {
+                player.setMaxChallenge(max);
+            },
+            unapply: function(player) {
+                player.clearMaxChallenge();
+            }
+        }
     }
 };
 

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -30,7 +30,7 @@ const Effects = {
             unapply: function(card) {
                 card.reserveModifier -= value;
             }
-        };        
+        };
     },
     dynamicStrength: function(calculate) {
         return {
@@ -188,7 +188,7 @@ const Effects = {
             unapply: function(player, context) {
                 player.minReserve = context.setMinReserve[player];
             }
-        }
+        };
     }
 };
 

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -582,13 +582,19 @@ class Game extends EventEmitter {
                     onSelect: (p, card) => {
                         card.removeIcon(icon);
                         this.addMessage('{0} uses the /take-icon command to remove a {1} icon from {2}', p, icon, card);
-                        
+
                         return true;
                     }
                 });
 
-                return;       
+                return;
             }
+        }
+
+        if(message.indexOf('/reset-challenges-count') === 0) {
+            player.challenges.reset();
+            this.addMessage('{0} uses /reset-challenges-count to reset the number of challenges performed', player);
+            return;
         }
 
         if(message.indexOf('/cancel-prompt') === 0) {

--- a/server/game/gamesteps/challengephase.js
+++ b/server/game/gamesteps/challengephase.js
@@ -45,11 +45,7 @@ class ChallengePhase extends Phase {
     }
 
     initiateChallenge(attackingPlayer, challengeType) {
-        if(attackingPlayer.challenges.complete >= attackingPlayer.challenges.maxTotal) {
-            return;
-        }
-
-        if(attackingPlayer.challenges[challengeType].performed >= attackingPlayer.challenges[challengeType].max) {
+        if(!attackingPlayer.canInitiateChallenge(challengeType)) {
             return;
         }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -29,6 +29,7 @@ class Player extends Spectator {
 
         this.deck = {};
         this.challenges = new ChallengeTracker();
+        this.minReserve = 0;
     }
 
     isCardUuidInList(list, card) {
@@ -980,9 +981,11 @@ class Player extends Spectator {
     }
 
     getTotalReserve() {
-        return this.getTotalPlotStat(card => {
+        var reserve = this.getTotalPlotStat(card => {
             return card.getReserve();
         });
+
+        return Math.max(reserve, this.minReserve);
     }
 
     isBelowReserve() {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -4,6 +4,7 @@ const Spectator = require('./spectator.js');
 const DrawCard = require('./drawcard.js');
 const Deck = require('./deck.js');
 const AttachmentPrompt = require('./gamesteps/attachmentprompt.js');
+const ChallengeTracker = require('./challengetracker.js');
 
 const StartingHandSize = 7;
 const DrawPhaseCards = 2;
@@ -27,6 +28,7 @@ class Player extends Spectator {
         this.game = game;
 
         this.deck = {};
+        this.challenges = new ChallengeTracker();
     }
 
     isCardUuidInList(list, card) {
@@ -100,11 +102,11 @@ class Player extends Spectator {
     }
 
     getNumberOfChallengesWon(challengeType) {
-        return this.challenges[challengeType].won;
+        return this.challenges.getWon(challengeType);
     }
 
     getNumberOfChallengesLost(challengeType) {
-        return this.challenges[challengeType].lost;
+        return this.challenges.getLost(challengeType);
     }
 
     getNumberOfChallengesInitiated() {
@@ -236,13 +238,20 @@ class Player extends Spectator {
         }
     }
 
+    canInitiateChallenge(challengeType) {
+        return !this.challenges.isAtMax(challengeType);
+    }
+
     addChallenge(type, number) {
-        this.challenges[type].max += number;
-        this.challenges.maxTotal += number;
+        this.challenges.modifyMaxForType(type, number);
     }
 
     setMaxChallenge(number) {
-        this.challenges.maxTotal = number;
+        this.challenges.setMax(number);
+    }
+
+    clearMaxChallenge() {
+        this.challenges.clearMax();
     }
 
     initDrawDeck() {
@@ -442,28 +451,8 @@ class Player extends Spectator {
         this.firstPlayer = false;
         this.selectedPlot = undefined;
         this.roundDone = false;
-        this.challenges = {
-            complete: 0,
-            maxTotal: 3,
-            military: {
-                performed: 0,
-                max: 1,
-                won: 0,
-                lost: 0
-            },
-            intrigue: {
-                performed: 0,
-                max: 1,
-                won: 0,
-                lost: 0
-            },
-            power: {
-                performed: 0,
-                max: 1,
-                won: 0,
-                lost: 0
-            }
-        };
+
+        this.challenges.reset();
 
         this.challengerLimit = 0;
         this.drawPhaseCards = DrawPhaseCards;
@@ -720,16 +709,15 @@ class Player extends Spectator {
     }
 
     initiateChallenge(challengeType) {
-        this.challenges[challengeType].performed++;
-        this.challenges.complete++;
+        this.challenges.perform(challengeType);
     }
 
     winChallenge(challengeType) {
-        this.challenges[challengeType].won++;
+        this.challenges.won(challengeType);
     }
 
     loseChallenge(challengeType) {
-        this.challenges[challengeType].lost++;
+        this.challenges.lost(challengeType);
     }
 
     resetForChallenge() {

--- a/test/server/effect.spec.js
+++ b/test/server/effect.spec.js
@@ -2,6 +2,7 @@
 /*eslint camelcase: 0, no-invalid-this: 0 */
 
 const Effect = require('../../server/game/effect.js');
+const Player = require('../../server/game/player.js');
 
 describe('Effect', function () {
     beforeEach(function () {
@@ -100,6 +101,128 @@ describe('Effect', function () {
 
             it('should not apply the effect to the matching card', function() {
                 expect(this.properties.effect.apply).not.toHaveBeenCalledWith(this.matchingCard, jasmine.any(Object));
+            });
+        });
+
+        describe('when the effect target type is card', function() {
+            beforeEach(function() {
+                this.effect.active = true;
+                this.player = {};
+                this.anotherPlayer = {};
+                this.sourceSpy.controller = this.player;
+            });
+
+            describe('when the target controller is current', function() {
+                beforeEach(function() {
+                    this.effect.targetController = 'current';
+                });
+
+                it('should add targets controlled by source card controller', function() {
+                    this.matchingCard.controller = this.player;
+                    this.effect.addTargets([this.matchingCard]);
+                    expect(this.effect.targets).toContain(this.matchingCard);
+                });
+
+                it('should reject targets controlled by an opponent', function() {
+                    this.matchingCard.controller = this.anotherPlayer;
+                    this.effect.addTargets([this.matchingCard]);
+                    expect(this.effect.targets).not.toContain(this.matchingCard);
+                });
+            });
+
+            describe('when the target controller is opponent', function() {
+                beforeEach(function() {
+                    this.effect.targetController = 'opponent';
+                });
+
+                it('should reject targets controlled by source card controller', function() {
+                    this.matchingCard.controller = this.player;
+                    this.effect.addTargets([this.matchingCard]);
+                    expect(this.effect.targets).not.toContain(this.matchingCard);
+                });
+
+                it('should add targets controlled by a different controller', function() {
+                    this.matchingCard.controller = this.anotherPlayer;
+                    this.effect.addTargets([this.matchingCard]);
+                    expect(this.effect.targets).toContain(this.matchingCard);
+                });
+            });
+
+            describe('when the target controller is any', function() {
+                beforeEach(function() {
+                    this.effect.targetController = 'any';
+                });
+
+                it('should add targets controlled by source card controller', function() {
+                    this.matchingCard.controller = this.player;
+                    this.effect.addTargets([this.matchingCard]);
+                    expect(this.effect.targets).toContain(this.matchingCard);
+                });
+
+                it('should add targets controlled by a different controller', function() {
+                    this.matchingCard.controller = this.anotherPlayer;
+                    this.effect.addTargets([this.matchingCard]);
+                    expect(this.effect.targets).toContain(this.matchingCard);
+                });
+            });
+        });
+
+        describe('when the effect target type is player', function() {
+            beforeEach(function() {
+                this.properties.match.and.returnValue(true);
+                this.effect.targetType = 'player';
+                this.effect.active = true;
+                this.player = new Player(1, {}, true, {});
+                this.anotherPlayer = new Player(2, {}, false, {});
+                this.sourceSpy.controller = this.player;
+            });
+
+            describe('when the target controller is current', function() {
+                beforeEach(function() {
+                    this.effect.targetController = 'current';
+                });
+
+                it('should add the current player as a target', function() {
+                    this.effect.addTargets([this.player]);
+                    expect(this.effect.targets).toContain(this.player);
+                });
+
+                it('should reject opponents as a target', function() {
+                    this.effect.addTargets([this.anotherPlayer]);
+                    expect(this.effect.targets).not.toContain(this.anotherPlayer);
+                });
+            });
+
+            describe('when the target controller is opponent', function() {
+                beforeEach(function() {
+                    this.effect.targetController = 'opponent';
+                });
+
+                it('should reject the current player as a target', function() {
+                    this.effect.addTargets([this.player]);
+                    expect(this.effect.targets).not.toContain(this.player);
+                });
+
+                it('should add opponents as a target', function() {
+                    this.effect.addTargets([this.anotherPlayer]);
+                    expect(this.effect.targets).toContain(this.anotherPlayer);
+                });
+            });
+
+            describe('when the target controller is any', function() {
+                beforeEach(function() {
+                    this.effect.targetController = 'any';
+                });
+
+                it('should add the current player as a target', function() {
+                    this.effect.addTargets([this.player]);
+                    expect(this.effect.targets).toContain(this.player);
+                });
+
+                it('should add opponents as a target', function() {
+                    this.effect.addTargets([this.anotherPlayer]);
+                    expect(this.effect.targets).toContain(this.anotherPlayer);
+                });
             });
         });
     });

--- a/test/server/effectengine.spec.js
+++ b/test/server/effectengine.spec.js
@@ -11,7 +11,8 @@ describe('EffectEngine', function () {
         this.handCard = { location: 'hand' };
         this.discardedCard = { location: 'discard pile' };
 
-        this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener']);
+        this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener', 'getPlayers']);
+        this.gameSpy.getPlayers.and.returnValue([]);
         this.gameSpy.allCards = _([this.handCard, this.playAreaCard, this.discardedCard]);
 
         this.effectSpy = jasmine.createSpyObj('effect', ['addTargets', 'removeTarget', 'cancel', 'setActive']);


### PR DESCRIPTION
* Converts the "additional challenge" and "only X challenge" cards to use effects targeting the appropriate player.
* Extracts the tracking of challenge limits, initiation, win and lose counts into a separate class as it was necessary to change how the maximum challenge limits were reset.
* Implements the reserve limit for Wraiths in their Midst.