### PR TITLE
Fix Nymeria Sand

### DIFF
--- a/server/game/cards/characters/02/nymeriasand.js
+++ b/server/game/cards/characters/02/nymeriasand.js
@@ -31,19 +31,7 @@ class NymeriaSand extends DrawCard {
     }
 
     onCardSelected(player, card) {
-        var icons = [];
-
-        if(card.hasIcon('military')) {
-            icons.push('Military');
-        }
-
-        if(card.hasIcon('intrigue')) {
-            icons.push('Intrigue');
-        }
-
-        if(card.hasIcon('power')) {
-            icons.push('Power');
-        }
+        var icons = ['Military', 'Intrigue', 'Power'];
 
         this.selectedCard = card;
 
@@ -64,7 +52,7 @@ class NymeriaSand extends DrawCard {
 
     iconSelected(player, icon) {
         this.untilEndOfPhase(ability => ({
-            match: card => card === this.selectedCard,
+            match: this.selectedCard,
             effect: ability.effects.removeIcon(icon)
         }));
         this.untilEndOfPhase(ability => ({


### PR DESCRIPTION
Previously, when the player used Nymeria's ability it would not remove
the icon from the opponents card. This is because the effect wasn't
specifically targetting opponent controlled cards. This change makes it
target a specific card, which skips the controller checks.

Additionally, Nymeria should now be able to remove an icon even if the
target card does not have that icon. This should be more in line with
the card text.