### PR TITLE
Duplicates shouldn't be considering in play area.

### DIFF
--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -35,7 +35,7 @@ class DrawCard extends BaseCard {
 
     addDuplicate(card) {
         this.dupes.push(card);
-        card.location = 'play area';
+        card.location = 'duplicate';
     }
 
     removeDuplicate() {


### PR DESCRIPTION
In order to make searching all cards safer for effects being applied,
duplicates are no longer considering to have a location of 'play area'.
Previously, this caused the Shadow Tower Mason to grant its ability by
counting duplicated location cards as in play.

Fixes #231.