### PR TITLE
Fix timing of "after plot revealed" reactions.

### DIFF
--- a/server/game/cards/attachments/04/beggarking.js
+++ b/server/game/cards/attachments/04/beggarking.js
@@ -1,3 +1,5 @@
+const _ = require('underscore');
+
 const DrawCard = require('../../../drawcard.js');
 
 class BeggarKing extends DrawCard {
@@ -7,10 +9,12 @@ class BeggarKing extends DrawCard {
         });
         this.reaction({
             when: {
-                onPlotRevealed: (event, player) => (
+                onPlotRevealCompleted: () => (
                     !this.kneeled &&
-                    player !== this.controller &&
-                    this.controller.activePlot.getIncome(true) < player.activePlot.getIncome(true)
+                    _.any(this.game.getPlayers(), player => (
+                        player !== this.controller &&
+                        this.controller.activePlot.getIncome(true) < player.activePlot.getIncome(true)
+                    ))
                 )
             },
             handler: () => {

--- a/server/game/cards/locations/04/bitterbridgeencampment.js
+++ b/server/game/cards/locations/04/bitterbridgeencampment.js
@@ -3,47 +3,19 @@ const _ = require('underscore');
 const DrawCard = require('../../../drawcard.js');
 
 class BitterbridgeEncampment extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['onPlotRevealed']);
-    }
-
-    onPlotRevealed(event, player) {
-        if(this.kneeled || !player.activePlot.hasTrait('Summer') || this.isBlank()) {
-            return;
-        }
-
-        this.game.promptWithMenu(this.controller, this, {
-            activePrompt: {
-                menuTitle: 'Trigger ' + this.name + '?',
-                buttons: [
-                    { text: 'Yes', method: 'kneel' },
-                    { text: 'No', method: 'cancel' }
-                ]
+    setupCardAbilities() {
+        this.reaction({
+            when: {
+                onPlotRevealCompleted: () => _.any(this.game.getPlayers(), player => player.activePlot.hasTrait('Summer'))
             },
-            waitingPromptTitle: 'Waiting for opponent to trigger ' + this.name
+            handler: () => {
+                this.controller.kneelCard(this);
+
+                this.remainingPlayers = this.game.getPlayersInFirstPlayerOrder();
+                this.selections = [];
+                this.proceedToNextStep();
+            }
         });
-    }
-
-    cancel(player) {
-        this.game.addMessage('{0} declines to trigger {1}', player, this);
-
-        return true;
-    }
-
-    kneel(player) {
-        if(this.controller !== player) {
-            return false;
-        }
-
-        player.kneelCard(this);
-
-        this.remainingPlayers = this.game.getPlayersInFirstPlayerOrder();
-        this.selections = [];
-        this.proceedToNextStep();
-
-        return true;
     }
 
     cancelSelection(player) {

--- a/server/game/gamesteps/plotphase.js
+++ b/server/game/gamesteps/plotphase.js
@@ -15,7 +15,8 @@ class PlotPhase extends Phase {
             new SimpleStep(game, () => this.determineInitiative()),
             () => new FirstPlayerPrompt(game, this.initiativeWinner),
             () => new ResolvePlots(game, this.getPlayersWithRevealEffects()),
-            new SimpleStep(game, () => this.resolveRemainingPlots())
+            new SimpleStep(game, () => this.resolveRemainingPlots()),
+            new SimpleStep(game, () => this.completePlotReveal())
         ]);
     }
 
@@ -79,6 +80,10 @@ class PlotPhase extends Phase {
         _.each(playersWithoutRevealEffects, player => {
             this.game.raiseEvent('onPlotRevealed', player);
         });
+    }
+
+    completePlotReveal() {
+        this.game.raiseEvent('onPlotRevealCompleted');
     }
 }
 

--- a/test/server/cards/agendas/05045 - therainsofcastamere.spec.js
+++ b/test/server/cards/agendas/05045 - therainsofcastamere.spec.js
@@ -29,7 +29,7 @@ describe('The Rains of Castamere', function() {
         this.scheme1 = scheme('3333');
         this.scheme2 = scheme('4444');
 
-        this.player = jasmine.createSpyObj('player', ['flipPlotFaceup', 'removeActivePlot', 'revealPlot', 'kneelCard']);
+        this.player = jasmine.createSpyObj('player', ['flipPlotFaceup', 'removeActivePlot', 'kneelCard']);
         this.player.game = this.gameSpy;
         this.player.faction = {};
 
@@ -173,7 +173,7 @@ describe('The Rains of Castamere', function() {
             });
 
             it('should not reveal a plot', function() {
-                expect(this.player.revealPlot).not.toHaveBeenCalled();
+                expect(this.gameSpy.raiseEvent).not.toHaveBeenCalledWith('onPlotRevealed', jasmine.any(Object));
             });
 
             it('should return false', function() {
@@ -202,7 +202,7 @@ describe('The Rains of Castamere', function() {
                 });
 
                 it('should reveal the plot', function() {
-                    expect(this.player.revealPlot).toHaveBeenCalled();
+                    expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onPlotRevealed', this.player);
                 });
 
                 it('should return true', function() {
@@ -230,7 +230,7 @@ describe('The Rains of Castamere', function() {
                 });
 
                 it('should reveal the plot', function() {
-                    expect(this.player.revealPlot).toHaveBeenCalled();
+                    expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onPlotRevealed', this.player);
                 });
 
                 it('should return true', function() {
@@ -262,7 +262,7 @@ describe('The Rains of Castamere', function() {
                 });
 
                 it('should reveal the plot', function() {
-                    expect(this.player.revealPlot).toHaveBeenCalled();
+                    expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onPlotRevealed', this.player);
                 });
 
                 it('should return true', function() {

--- a/test/server/gamesteps/plot/resolveplots.spec.js
+++ b/test/server/gamesteps/plot/resolveplots.spec.js
@@ -6,8 +6,8 @@ const ResolvePlots = require('../../../../server/game/gamesteps/plot/resolveplot
 describe('the ResolvePlots', function() {
     beforeEach(function() {
         this.game = jasmine.createSpyObj('game', ['getPlayerByName', 'getFirstPlayer', 'promptWithMenu', 'raiseEvent']);
-        this.player = jasmine.createSpyObj('player', ['setPrompt', 'cancelPrompt', 'revealPlot']);
-        this.otherPlayer = jasmine.createSpyObj('player', ['setPrompt', 'cancelPrompt', 'revealPlot']);
+        this.player = jasmine.createSpyObj('player', ['setPrompt', 'cancelPrompt']);
+        this.otherPlayer = jasmine.createSpyObj('player', ['setPrompt', 'cancelPrompt']);
 
         this.game.getFirstPlayer.and.returnValue(this.otherPlayer);
     });
@@ -40,7 +40,7 @@ describe('the ResolvePlots', function() {
 
             it('should reveal the plot', function() {
                 this.prompt.continue();
-                expect(this.player.revealPlot).toHaveBeenCalled();
+                expect(this.game.raiseEvent).toHaveBeenCalledWith('onPlotRevealed', this.player);
             });
 
             it('should return true', function() {
@@ -60,8 +60,8 @@ describe('the ResolvePlots', function() {
 
             it('should not reveal any plot', function() {
                 this.prompt.continue();
-                expect(this.player.revealPlot).not.toHaveBeenCalled();
-                expect(this.otherPlayer.revealPlot).not.toHaveBeenCalled();
+                expect(this.game.raiseEvent).not.toHaveBeenCalledWith('onPlotRevealed', this.player);
+                expect(this.game.raiseEvent).not.toHaveBeenCalledWith('onPlotRevealed', this.otherPlayer);
             });
 
             it('should return false', function() {
@@ -82,8 +82,8 @@ describe('the ResolvePlots', function() {
 
             it('should not reveal a plot', function() {
                 this.prompt.resolvePlayer(this.player, 54321);
-                expect(this.player.revealPlot).not.toHaveBeenCalled();
-                expect(this.otherPlayer.revealPlot).not.toHaveBeenCalled();
+                expect(this.game.raiseEvent).not.toHaveBeenCalledWith('onPlotRevealed', this.player);
+                expect(this.game.raiseEvent).not.toHaveBeenCalledWith('onPlotRevealed', this.otherPlayer);
             });
 
             it('should not modify the resolution list', function() {
@@ -99,7 +99,7 @@ describe('the ResolvePlots', function() {
 
             it('should reveal the plot', function() {
                 this.prompt.resolvePlayer(this.player, this.otherPlayer.name);
-                expect(this.otherPlayer.revealPlot).toHaveBeenCalled();
+                expect(this.game.raiseEvent).toHaveBeenCalledWith('onPlotRevealed', this.otherPlayer);
             });
 
             it('should remove the resolved player from the list', function() {


### PR DESCRIPTION
Previously, card abilities that had a reaction to "after a X plot card
is revealed" were executing right when the plot was revealed but before
the "when revealed" text was resolved. Per the rules, these reactions
should happen after all of the "when revealed" abilities have resolved.

Fixes #219.