### PR TITLE
Allow event reactions to play at challenge prompt.

### DIFF
--- a/server/game/gamesteps/challengephase.js
+++ b/server/game/gamesteps/challengephase.js
@@ -68,7 +68,6 @@ class ChallengePhase extends Phase {
 
     cleanupChallenge() {
         this.game.currentChallenge.unregisterEvents();
-        this.game.currentChallenge = null;
     }
 
     chooseOpponent(attackingPlayer) {
@@ -76,6 +75,7 @@ class ChallengePhase extends Phase {
     }
 
     completeChallenges(player) {
+        this.game.currentChallenge = null;
         this.game.addMessage('{0} has finished their challenges', player);
 
         this.remainingPlayers.shift();


### PR DESCRIPTION
Previously, event-based reactions were only playable if there was a
pause in the DUCK phase (e.g. another reaction fires, then the player
could play the event reaction card before completing the original
reaction). This made several cards hard to play.

This change allows such event cards to be played after the challenge has
been completed but before the next challenge has been initiated. It does
so by not immediately clearing the Game.currentChallenge property when a
challenge has been completed.