### PR TITLE
Prevent challenge participation as an effect

### DIFF
--- a/server/game/cards/characters/02/hodor.js
+++ b/server/game/cards/characters/02/hodor.js
@@ -1,21 +1,12 @@
 const DrawCard = require('../../../drawcard.js');
 
 class Hodor extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['onAttackerSelected']);
-    }
-
-    onAttackerSelected(event, challenge, card) {
-        var player = challenge.attackingPlayer;
-        if(this.controller !== player || card !== this || this.isBlank()) {
-            return;
-        }
-
-        if(!player.findCardByName(player.cardsInPlay, 'Bran Stark')) {
-            event.cancel = true;
-        }
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            condition: () => !this.controller.findCardByName(this.controller.cardsInPlay, 'Bran Stark'),
+            match: this,
+            effect: ability.effects.allowAsAttacker(false)
+        });
     }
 
     modifyDominance(player, strength) {

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -31,6 +31,10 @@ class DrawCard extends BaseCard {
         this.kneeled = false;
         this.inChallenge = false;
         this.wasAmbush = false;
+        this.challengeOptions = {
+            allowAsAttacker: true,
+            allowAsDefender: true
+        };
     }
 
     addDuplicate(card) {
@@ -215,6 +219,30 @@ class DrawCard extends BaseCard {
         this.stealth = false;
         this.stealthTarget = undefined;
         this.inChallenge = false;
+    }
+
+    canAddAsAttacker(challengeType) {
+        if(this.location !== 'play area' || this.stealth || this.kneeled) {
+            return false;
+        }
+
+        if(!this.hasIcon(challengeType)) {
+            return false;
+        }
+
+        return this.challengeOptions.allowAsAttacker;
+    }
+
+    canAddAsDefender(challengeType) {
+        if(this.location !== 'play area' || this.stealth || this.kneeled) {
+            return false;
+        }
+
+        if(!this.hasIcon(challengeType)) {
+            return false;
+        }
+
+        return this.challengeOptions.allowAsDefender;
     }
 
     getSummary(isActivePlayer, hideWhenFaceup) {

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -12,6 +12,30 @@ const Effects = {
             isStateDependent: _.any(effects, effect => !!effect.isStateDependent)
         };
     },
+    allowAsAttacker: function(value) {
+        return {
+            apply: function(card, context) {
+                context.allowAsAttacker = context.allowAsAttacker || {};
+                context.allowAsAttacker[card] = card.challengeOptions.allowAsAttacker;
+                card.challengeOptions.allowAsAttacker = value;
+            },
+            unapply: function(card, context) {
+                card.challengeOptions.allowAsAttacker = context.allowAsAttacker[card];
+            }
+        };
+    },
+    allowAsDefender: function(value) {
+        return {
+            apply: function(card, context) {
+                context.allowAsDefender = context.allowAsDefender || {};
+                context.allowAsDefender[card] = card.challengeOptions.allowAsDefender;
+                card.challengeOptions.allowAsDefender = value;
+            },
+            unapply: function(card, context) {
+                card.challengeOptions.allowAsDefender = context.allowAsDefender[card];
+            }
+        };
+    },
     modifyStrength: function(value) {
         return {
             apply: function(card) {
@@ -198,7 +222,7 @@ const Effects = {
                 }
             }
         };
-    },    
+    },
     takeControl: function(newController) {
         return {
             apply: function(card, context) {

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -48,13 +48,7 @@ class ChallengeFlow extends BaseStep {
     }
 
     allowAsAttacker(card) {
-        var event = this.game.raiseEvent('onAttackerSelected', this.challenge, card);
-
-        if(event.cancel) {
-            return false;
-        }
-
-        return this.challenge.attackingPlayer.canAddToChallenge(card, this.challenge.challengeType);
+        return this.challenge.attackingPlayer === card.controller && card.canAddAsAttacker(this.challenge.challengeType);
     }
 
     chooseAttackers(player, attackers) {
@@ -87,7 +81,7 @@ class ChallengeFlow extends BaseStep {
     }
 
     allowAsDefender(card) {
-        return this.challenge.defendingPlayer.canAddToChallenge(card, this.challenge.challengeType);
+        return this.challenge.defendingPlayer === card.controller && card.canAddAsDefender(this.challenge.challengeType);
     }
 
     chooseDefenders(defenders) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -692,18 +692,6 @@ class Player extends Spectator {
         this.selectCard = false;
     }
 
-    canAddToChallenge(card, challengeType) {
-        if(!card || card.location !== 'play area' || card.stealth || card.kneeled) {
-            return false;
-        }
-
-        if(card.controller !== this || !card.hasIcon(challengeType)) {
-            return false;
-        }
-
-        return card;
-    }
-
     initiateChallenge(challengeType) {
         this.challenges.perform(challengeType);
     }


### PR DESCRIPTION
Cards can now be prevented from being declared as attackers or defenders using an effect now. It should be possible to implement these cards now: https://thronesdb.com/find?q=x%3Acannot+x%3Adeclared&sort=set&view=card

Hodor has been converted to use the effect. Doing so removed the need for the onAttackerSelected event.