### PR TITLE
Do not declare a winner if cannot be won.

### DIFF
--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -120,7 +120,7 @@ class Challenge {
 
         this.calculateStrength();
 
-        if(this.attackerStrength === 0 && this.defenderStrength === 0) {
+        if(this.attackerStrength === 0 && this.defenderStrength === 0 || this.attackerStrength >= this.defenderStrength && this.attackerCannotWin) {
             this.loser = undefined;
             this.winner = undefined;
             this.loserStrength = this.winnerStrength = 0;

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -106,9 +106,11 @@ class ChallengeFlow extends BaseStep {
         this.challenge.determineWinner();
 
         if(!this.challenge.winner && !this.challenge.loser) {
-            this.game.addMessage('Attacking strength is 0, there is no winner for this challenge');
-        } else if(this.challenge.isAttackerTheWinner() && this.challenge.attackerCannotWin) {
-            this.game.addMessage('There is no winner or loser for this challenge');
+            if(this.challenge.attackerStrength === 0) {
+                this.game.addMessage('Attacking strength is 0, there is no winner for this challenge');
+            } else {
+                this.game.addMessage('There is no winner or loser for this challenge');
+            }
         } else {
             this.game.addMessage('{0} won a {1} challenge {2} vs {3}',
                 this.challenge.winner, this.challenge.challengeType, this.challenge.winnerStrength, this.challenge.loserStrength);


### PR DESCRIPTION
Previously, if the "cannot win a challenge" effect was in play, the
challenge would still declare a winner but skip over applying claim. Now
when the effect is in play, the attacking player is not named the
winner. If the defending player wins, they are still declared the
winner.

Fixes #247.