### PR TITLE
Fix Jousting Contest crash

### DIFF
--- a/server/game/cards/plots/01/joustingcontest.js
+++ b/server/game/cards/plots/01/joustingcontest.js
@@ -1,15 +1,12 @@
 const PlotCard = require('../../../plotcard.js');
 
 class JoustingContest extends PlotCard {
-    flipFaceup() {
-        super.flipFaceup();
-
-        this.controller.challengerLimit = 1;
-        var otherPlayer = this.game.getOtherPlayer(this.controller);
-
-        if(otherPlayer) {
-            otherPlayer.challengerLimit = 1;
-        }
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            targetType: 'player',
+            targetController: 'any',
+            effect: ability.effects.setChallengerLimit(1)
+        });
     }
 }
 

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -269,6 +269,18 @@ const Effects = {
             }
         };
     },
+    setChallengerLimit: function(value) {
+        return {
+            apply: function(player, context) {
+                context.setChallengerLimit = context.setChallengerLimit || {};
+                context.setChallengerLimit[player] = player.challengerLimit;
+                player.challengerLimit = value;
+            },
+            unapply: function(player, context) {
+                player.challengerLimit = context.setChallengerLimit[player];
+            }
+        };
+    },
     /**
      * Effects specifically for Old Wyk.
      */

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -37,10 +37,14 @@ class ChallengeFlow extends BaseStep {
     }
 
     promptForAttackers() {
+        var title = 'Select challenge attackers';
+        if(this.challenge.attackingPlayer.challengerLimit !== 0) {
+            title += ' (limit ' + this.challenge.attackingPlayer.challengerLimit + ')'
+        }
         this.game.promptForSelect(this.challenge.attackingPlayer, {
             numCards: this.challenge.attackingPlayer.challengerLimit,
             multiSelect: true,
-            activePromptTitle: 'Select challenge attackers',
+            activePromptTitle: title,
             waitingPromptTitle: 'Waiting for opponent to select attackers',
             cardCondition: card => this.allowAsAttacker(card),
             onSelect: (player, attackers) => this.chooseAttackers(player, attackers),
@@ -71,10 +75,15 @@ class ChallengeFlow extends BaseStep {
             return;
         }
 
+        var title = 'Select defenders';
+        if(this.challenge.defendingPlayer.challengerLimit !== 0) {
+            title += ' (limit ' + this.challenge.defendingPlayer.challengerLimit + ')'
+        }
+
         this.game.promptForSelect(this.challenge.defendingPlayer, {
             numCards: this.challenge.defendingPlayer.challengerLimit,
             multiSelect: true,
-            activePromptTitle: 'Select defenders',
+            activePromptTitle: title,
             waitingPromptTitle: 'Waiting for opponent to defend',
             cardCondition: card => this.allowAsDefender(card),
             onSelect: (player, defenders) => this.chooseDefenders(defenders),

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -39,6 +39,7 @@ class ChallengeFlow extends BaseStep {
     promptForAttackers() {
         this.game.promptForSelect(this.challenge.attackingPlayer, {
             numCards: this.challenge.attackingPlayer.challengerLimit,
+            multiSelect: true,
             activePromptTitle: 'Select challenge attackers',
             waitingPromptTitle: 'Waiting for opponent to select attackers',
             cardCondition: card => this.allowAsAttacker(card),
@@ -72,6 +73,7 @@ class ChallengeFlow extends BaseStep {
 
         this.game.promptForSelect(this.challenge.defendingPlayer, {
             numCards: this.challenge.defendingPlayer.challengerLimit,
+            multiSelect: true,
             activePromptTitle: 'Select defenders',
             waitingPromptTitle: 'Waiting for opponent to defend',
             cardCondition: card => this.allowAsDefender(card),

--- a/server/game/gamesteps/selectcardprompt.js
+++ b/server/game/gamesteps/selectcardprompt.js
@@ -8,6 +8,8 @@ const UiPrompt = require('./uiprompt.js');
  * numCards           - an integer specifying the number of cards the player
  *                      must select. Set to 0 if there is no limit on the num
  *                      of cards that can be selected.
+ * multiSelect        - boolean that ensures that the selected cards are sent as
+ *                      an array, even if the numCards limit is 1.
  * additionalButtons  - array of additional buttons for the prompt.
  * activePromptTitle  - the title that should be used in the prompt for the
  *                      choosing player.
@@ -97,7 +99,7 @@ class SelectCardPrompt extends UiPrompt {
             return false;
         }
 
-        if(this.properties.numCards === 1 && this.selectedCards.length === 1) {
+        if(this.properties.numCards === 1 && this.selectedCards.length === 1 && !this.properties.multiSelect) {
             this.fireOnSelect();
         }
     }
@@ -127,7 +129,7 @@ class SelectCardPrompt extends UiPrompt {
     }
 
     fireOnSelect() {
-        var cardParam = (this.properties.numCards === 1) ? this.selectedCards[0] : this.selectedCards;
+        var cardParam = (this.properties.numCards === 1 && !this.properties.multiSelect) ? this.selectedCards[0] : this.selectedCards;
         if(this.properties.onSelect(this.choosingPlayer, cardParam)) {
             this.complete();
         } else {


### PR DESCRIPTION
* Makes select card prompt always pass an array instead of a single card when selecting attackers / defenders in a challenge. It was passing a single card when Jousting Contest was out since the limit was 1.
* Adds the challenger limit to the attacker/defender prompts (if there is a limit in effect).
* Converts Jousting Contest to use a persistent effect.

Resolves https://sentry.io/throneteki/throneteki/issues/203294158/