### PR TITLE
Ensure onBeginRound event is fired.

### DIFF
--- a/server/game/game.js
+++ b/server/game/game.js
@@ -790,6 +790,7 @@ class Game extends EventEmitter {
     }
 
     beginRound() {
+        this.raiseEvent('onBeginRound');
         this.queueStep(new PlotPhase(this));
         this.queueStep(new DrawPhase(this));
         this.queueStep(new MarshalingPhase(this));
@@ -798,8 +799,6 @@ class Game extends EventEmitter {
         this.queueStep(new StandingPhase(this));
         this.queueStep(new TaxationPhase(this));
         this.queueStep(new SimpleStep(this, () => this.beginRound()));
-
-        this.raiseEvent('onBeginRound');
     }
 
     queueStep(step) {


### PR DESCRIPTION
The previous change introducing event ordering did so by queuing an
event resolver onto the game pipeline. Therefore the order of queuing
the onBeginRound event and the rest of the game steps matters now.
Previous to this change, reducers were no longer reseting because the
onBeginRound event was being queued after all of the round steps,
thereby never executing.