### PR TITLE
Fix and convert agendas

### DIFF
--- a/server/game/cards/agendas/kingsofsummer.js
+++ b/server/game/cards/agendas/kingsofsummer.js
@@ -3,38 +3,17 @@ const _ = require('underscore');
 const AgendaCard = require('../../agendacard.js');
 
 class KingsOfSummer extends AgendaCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['onPlotFlip']);
-    }
-
-    onPlotFlip() {
-        var wasWinter = false;
-
-        _.each(this.game.getPlayers(), player => {
-            if(player.activePlot) {
-                player.activePlot.reserveModifier--;
-
-                if(player.activePlot.hasTrait('Winter')) {
-                    wasWinter = true;
-                }
-            }
-
-            player.selectedPlot.reserveModifier++;
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            targetController: 'any',
+            match: card => card === card.controller.activePlot,
+            effect: ability.effects.modifyReserve(1)
         });
-
-        if(!wasWinter && this.controller.activePlot && this.controller.activePlot.hasTrait('Summer')) {
-            this.controller.activePlot.goldModifier--;
-        }
-
-        if(!_.any(this.game.getPlayers(), player => {
-            return player.selectedPlot.hasTrait('Winter');
-        }) && this.controller.selectedPlot.hasTrait('Summer')) {
-            this.controller.selectedPlot.goldModifier++;
-
-            this.game.addMessage('{0} uses {1} to add 1 gold to their revealed plot as there are no Winter plot cards revealed', this.controller, this);
-        }
+        this.persistentEffect({
+            condition: () => _.all(this.game.getPlayers(), player => player.activePlot && !player.activePlot.hasTrait('Winter')),
+            match: card => card === card.controller.activePlot && card.hasTrait('Summer'),
+            effect: ability.effects.modifyGold(1)
+        });
     }
 }
 

--- a/server/game/cards/agendas/kingsofwinter.js
+++ b/server/game/cards/agendas/kingsofwinter.js
@@ -3,37 +3,18 @@ const _ = require('underscore');
 const AgendaCard = require('../../agendacard.js');
 
 class KingsOfWinter extends AgendaCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['onPlotFlip']);
-    }
-
-    onPlotFlip() {
-        _.each(this.game.getPlayers(), player => {
-            if(player.activePlot) {
-                player.activePlot.reserveModifier++;
-            }
-
-            player.selectedPlot.reserveModifier--;
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            targetController: 'any',
+            match: card => card === card.controller.activePlot,
+            effect: ability.effects.modifyReserve(-1)
         });
-
-        var otherPlayer = this.game.getOtherPlayer(this.controller);
-
-        if(!otherPlayer) {
-            return;
-        }
-
-        if(this.controller.activePlot && this.controller.activePlot.hasTrait('Winter')) {
-            if(otherPlayer.activePlot && !otherPlayer.activePlot.hasTrait('Summer')) {
-                otherPlayer.activePlot.goldModifier++;
-            }
-        }
-
-        if(this.controller.selectedPlot.hasTrait('Winter') && !otherPlayer.selectedPlot.hasTrait('Summer')) {
-            this.game.addMessage('{0} uses {1} to reduce the gold value of {2}\'s revealed non-Summer plot', this.controller, this, otherPlayer);
-            otherPlayer.selectedPlot.goldModifier--;
-        }
+        this.persistentEffect({
+            condition: () => this.controller.activePlot && this.controller.activePlot.hasTrait('Winter'),
+            targetController: 'opponent',
+            match: card => card === card.controller.activePlot && !card.hasTrait('Summer'),
+            effect: ability.effects.modifyGold(-1)
+        });
     }
 }
 

--- a/server/game/cards/agendas/thelordofthecrossing.js
+++ b/server/game/cards/agendas/thelordofthecrossing.js
@@ -6,23 +6,28 @@ class TheLordOfTheCrossing extends AgendaCard {
     constructor(owner, cardData) {
         super(owner, cardData);
 
-        this.registerEvents(['onChallenge', 'afterChallenge']);
+        this.registerEvents(['afterChallenge']);
     }
 
-    onChallenge(e, challenge) {
-        var player = challenge.attackingPlayer;
-        if(this.controller !== player) {
-            return;
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            condition: () => this.game.currentChallenge && this.game.currentChallenge.attackingPlayer === this.controller,
+            match: card => this.game.currentChallenge.isAttacking(card),
+            effect: ability.effects.dynamicStrength(() => this.challengeBonus())
+        });
+    }
+
+    challengeBonus() {
+        var numChallenges = this.controller.getNumberOfChallengesInitiated();
+        if(numChallenges === 1) {
+            return -1;
         }
 
-        _.each(challenge.attackers, card => {
-            var numChallenges = player.getNumberOfChallengesInitiated();
-            if(numChallenges === 0) {
-                card.strengthModifier--;
-            } else if(numChallenges === 2) {
-                card.strengthModifier += 2;
-            }
-        });
+        if(numChallenges === 3) {
+            return 2;
+        }
+
+        return 0;
     }
 
     afterChallenge(e, challenge) {
@@ -35,14 +40,6 @@ class TheLordOfTheCrossing extends AgendaCard {
             this.game.addMessage('{0} gains 1 power from {1}', challenge.winner, this);
             this.game.addPower(challenge.winner, 1);
         }
-
-        _.each(challenge.attackers, card => {
-            if(currentChallenge === 1) {
-                card.strengthModifier++;
-            } else if(currentChallenge === 3) {
-                card.strengthModifier -= 2;
-            }
-        });
     }
 }
 

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -775,7 +775,6 @@ class Game extends EventEmitter {
             return cards.concat(player.allCards.toArray());
         }, []));
 
-        this.raiseEvent('onDecksPrepared');
         this.pipeline.initialise([
             new SetupPhase(this),
             new SimpleStep(this, () => this.beginRound())

--- a/server/game/gamesteps/setupphase.js
+++ b/server/game/gamesteps/setupphase.js
@@ -20,6 +20,11 @@ class SetupPhase extends Phase {
 
     prepareDecks() {
         this.game.raiseEvent('onDecksPrepared');
+        _.each(this.game.getPlayers(), player => {
+            if(player.agenda) {
+                player.agenda.play();
+            }
+        });
     }
 
     startGame() {

--- a/server/game/gamesteps/setupphase.js
+++ b/server/game/gamesteps/setupphase.js
@@ -9,12 +9,17 @@ class SetupPhase extends Phase {
     constructor(game) {
         super(game, 'setup');
         this.initialise([
+            new SimpleStep(game, () => this.prepareDecks()),
             new KeepOrMulliganPrompt(game),
             new SimpleStep(game, () => this.startGame()),
             new SetupCardsPrompt(game),
             new SimpleStep(game, () => this.setupDone()),
             new CheckAttachmentsPrompt(game)
         ]);
+    }
+
+    prepareDecks() {
+        this.game.raiseEvent('onDecksPrepared');
     }
 
     startGame() {


### PR DESCRIPTION
* Fixes Rains of Castamere by ensuring the onDecksPrepared event is properly fired.
* Adds support for persistent effects on agendas.
* Converts Kings of Winter, Kings of Summer and Lord of the Crossing to use persistent effects.

Note: because Lord of the Crossing now uses a dynamic effect, the strength announced for a challenge will be incorrect. The strength used to determine winners should be fine. Same issue as #236.