### PR TITLE
Prevent infinite loop on plot duplicators

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -165,7 +165,7 @@ class BaseCard {
                 onPlotRevealed: (e, player) => player === this.controller
             }
         };
-        this.forcedReaction(_.extend(whenClause, properties));
+        this.forcedInterrupt(_.extend(whenClause, properties));
     }
 
     /**

--- a/server/game/cards/plots/02/pullingthestrings.js
+++ b/server/game/cards/plots/02/pullingthestrings.js
@@ -28,11 +28,12 @@ class PullingTheStrings extends PlotCard {
 
         this.game.addMessage('{0} uses {1} to initiate the when resolved effect of {2}', player, this, card);
         card.controller = this.controller;
-        this.game.raiseEvent('onPlotRevealed', this.controller);
-        card.controller = card.owner;
-        card.moveTo('revealed plots');
+        this.game.raiseEvent('onPlotRevealed', this.controller, () => {
+            card.controller = card.owner;
+            card.moveTo('revealed plots');
 
-        this.resolving = false;
+            this.resolving = false;
+        });
 
         return true;
     }

--- a/server/game/cards/plots/04/varyssriddle.js
+++ b/server/game/cards/plots/04/varyssriddle.js
@@ -17,9 +17,11 @@ class VaryssRiddle extends PlotCard {
                 this.game.addMessage('{0} uses {1} to initiate the when resolved effect of {2}', this.controller, this, plot);
                 plot.controller = this.controller;
                 this.resolving = true;
-                this.game.raiseEvent('onPlotRevealed', this.controller);
-                this.resolving = false;
-                plot.controller = plot.owner;
+
+                this.game.raiseEvent('onPlotRevealed', this.controller, () => {
+                    this.resolving = false;
+                    plot.controller = plot.owner;
+                });
             }
         });
     }


### PR DESCRIPTION
Varys' Riddle and Pulling the Strings could put the players in an
infinite loop because events are pipeline-based and no longer 100%
synchronous.