### PR TITLE
Cleanup old ability code

### DIFF
--- a/server/game/cards/attachments/01/throwingaxe.js
+++ b/server/game/cards/attachments/01/throwingaxe.js
@@ -1,13 +1,12 @@
 const DrawCard = require('../../../drawcard.js');
-const AbilityLimit = require('../../../abilitylimit.js');
 
 class ThrowingAxe extends DrawCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.reaction({
             when: {
                 afterChallenge: (event, challenge) => challenge.winner === this.controller && challenge.isAttacking(this.parent)
             },
-            limit: AbilityLimit.perPhase(1),
+            limit: ability.limit.perPhase(1),
             handler: () => {
                 this.game.promptForSelect(this.controller, {
                     activePromptTitle: 'Select a character to kill',

--- a/server/game/cards/characters/01/ariannemartell.js
+++ b/server/game/cards/characters/01/ariannemartell.js
@@ -1,12 +1,11 @@
 const DrawCard = require('../../../drawcard.js');
-const AbilityLimit = require('../../../abilitylimit.js');
 
 class ArianneMartell extends DrawCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.action({
             title: 'Put a card with printed cost of 5 or lower in play',
             method: 'putInPlay',
-            limit: AbilityLimit.perPhase(1)
+            limit: ability.limit.perPhase(1)
         });
     }
 

--- a/server/game/cards/characters/01/direwolfpup.js
+++ b/server/game/cards/characters/01/direwolfpup.js
@@ -1,10 +1,10 @@
 const DrawCard = require('../../../drawcard.js');
 
 class DirewolfPup extends DrawCard {
-    setupCardAbilities(dsl) {
+    setupCardAbilities(ability) {
         this.persistentEffect({
             match: card => card === this,
-            effect: dsl.effects.dynamicStrength(() => this.calculateStrength())
+            effect: ability.effects.dynamicStrength(() => this.calculateStrength())
         });
     }
 

--- a/server/game/cards/characters/01/drogon.js
+++ b/server/game/cards/characters/01/drogon.js
@@ -1,10 +1,10 @@
 const DrawCard = require('../../../drawcard.js');
 
 class Drogon extends DrawCard {
-    setupCardAbilities(dsl) {
+    setupCardAbilities(ability) {
         this.persistentEffect({
             match: (card) => card.hasTrait('Stormborn'),
-            effect: dsl.effects.addKeyword('Renown')
+            effect: ability.effects.addKeyword('Renown')
         });
     }
 }

--- a/server/game/cards/characters/01/drownedmen.js
+++ b/server/game/cards/characters/01/drownedmen.js
@@ -1,10 +1,10 @@
 const DrawCard = require('../../../drawcard.js');
 
 class DrownedMen extends DrawCard {
-    setupCardAbilities(dsl) {
+    setupCardAbilities(ability) {
         this.persistentEffect({
             match: card => card === this,
-            effect: dsl.effects.dynamicStrength(() => this.calculateStrength())
+            effect: ability.effects.dynamicStrength(() => this.calculateStrength())
         });
     }
 

--- a/server/game/cards/characters/01/magisterillyrio.js
+++ b/server/game/cards/characters/01/magisterillyrio.js
@@ -1,12 +1,11 @@
 const DrawCard = require('../../../drawcard.js');
-const AbilityLimit = require('../../../abilitylimit.js');
 
 class MagisterIllyrio extends DrawCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.action({
             title: 'Pay 2 gold to stand a character',
             method: 'stand',
-            limit: AbilityLimit.perPhase(1)
+            limit: ability.limit.perPhase(1)
         });
     }
 

--- a/server/game/cards/characters/01/oldforesthunter.js
+++ b/server/game/cards/characters/01/oldforesthunter.js
@@ -1,12 +1,11 @@
 const DrawCard = require('../../../drawcard.js');
-const AbilityLimit = require('../../../abilitylimit.js');
 
 class OldForestHunter extends DrawCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.action({
             title: 'Discard a card to gain 1 gold',
             method: 'discard',
-            limit: AbilityLimit.perPhase(1)
+            limit: ability.limit.perPhase(1)
         });
     }
 

--- a/server/game/cards/characters/01/robertbaratheon.js
+++ b/server/game/cards/characters/01/robertbaratheon.js
@@ -1,10 +1,10 @@
 const DrawCard = require('../../../drawcard.js');
 
 class RobertBaratheon extends DrawCard {
-    setupCardAbilities(dsl) {
+    setupCardAbilities(ability) {
         this.persistentEffect({
             match: card => card === this,
-            effect: dsl.effects.dynamicStrength(() => this.calculateStrength())
+            effect: ability.effects.dynamicStrength(() => this.calculateStrength())
         });
     }
 

--- a/server/game/cards/characters/01/tyrionlannister.js
+++ b/server/game/cards/characters/01/tyrionlannister.js
@@ -1,13 +1,12 @@
 const DrawCard = require('../../../drawcard.js');
-const AbilityLimit = require('../../../abilitylimit.js');
 
 class TyrionLannister extends DrawCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.reaction({
             when: {
                 onChallenge: (event, challenge) => challenge.challengeType === 'intrigue'
             },
-            limit: AbilityLimit.perRound(2),
+            limit: ability.limit.perRound(2),
             handler: () => {
                 this.game.addGold(this.controller, 2);
                 this.game.addMessage('{0} uses {1} to gain 2 gold as an intrigue challenge has been declared', this.controller, this);

--- a/server/game/cards/characters/01/unsullied.js
+++ b/server/game/cards/characters/01/unsullied.js
@@ -1,12 +1,12 @@
 const DrawCard = require('../../../drawcard.js');
 
 class Unsullied extends DrawCard {
-    setupCardAbilities(dsl) {
+    setupCardAbilities(ability) {
         this.persistentEffect({
             condition: () => this.game.currentChallenge && this.game.currentChallenge.isAttacking(this),
             match: (card) => this.game.currentChallenge && this.game.currentChallenge.isDefending(card),
             targetController: 'opponent',
-            effect: dsl.effects.modifyStrength(-1)
+            effect: ability.effects.modifyStrength(-1)
         });
     }
 }

--- a/server/game/cards/characters/01/viserion.js
+++ b/server/game/cards/characters/01/viserion.js
@@ -1,10 +1,10 @@
 const DrawCard = require('../../../drawcard.js');
 
 class Viserion extends DrawCard {
-    setupCardAbilities(dsl) {
+    setupCardAbilities(ability) {
         this.persistentEffect({
             match: (card) => card.hasTrait('Stormborn'),
-            effect: dsl.effects.addKeyword('Stealth')
+            effect: ability.effects.addKeyword('Stealth')
         });
     }
 }

--- a/server/game/cards/characters/01/wardensofthereach.js
+++ b/server/game/cards/characters/01/wardensofthereach.js
@@ -1,10 +1,10 @@
 const DrawCard = require('../../../drawcard.js');
 
 class WardensOfTheReach extends DrawCard {
-    setupCardAbilities(dsl) {
+    setupCardAbilities(ability) {
         this.persistentEffect({
             match: card => card === this,
-            effect: dsl.effects.dynamicStrength(() => this.calculateStrength())
+            effect: ability.effects.dynamicStrength(() => this.calculateStrength())
         });
     }
 

--- a/server/game/cards/characters/02/arborknight.js
+++ b/server/game/cards/characters/02/arborknight.js
@@ -1,12 +1,11 @@
 const DrawCard = require('../../../drawcard.js');
-const AbilityLimit = require('../../../abilitylimit.js');
 
 class ArborKnight extends DrawCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.action({
             title: 'Pay 1 gold to give a character +1 STR',
             method: 'payGold',
-            limit: AbilityLimit.perPhase(3)
+            limit: ability.limit.perPhase(3)
         });
     }
 

--- a/server/game/cards/characters/02/priestofthedrownedgod.js
+++ b/server/game/cards/characters/02/priestofthedrownedgod.js
@@ -1,10 +1,10 @@
 const DrawCard = require('../../../drawcard.js');
 
 class PriestOfTheDrownedGod extends DrawCard {
-    setupCardAbilities(dsl) {
+    setupCardAbilities(ability) {
         this.persistentEffect({
             match: card => card.getType() === 'character' && card.hasTrait('Drowned God'),
-            effect: dsl.effects.modifyStrength(1)
+            effect: ability.effects.modifyStrength(1)
         });
     }
 }

--- a/server/game/cards/characters/03/jonsnow.js
+++ b/server/game/cards/characters/03/jonsnow.js
@@ -1,12 +1,11 @@
 const DrawCard = require('../../../drawcard.js');
-const AbilityLimit = require('../../../abilitylimit.js');
 
 class JonSnow extends DrawCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.action({
             title: 'Sacrifice character',
             method: 'sacrifice',
-            limit: AbilityLimit.perRound(1)
+            limit: ability.limit.perRound(1)
         });
     }
 

--- a/server/game/cards/characters/03/sansastark.js
+++ b/server/game/cards/characters/03/sansastark.js
@@ -1,15 +1,15 @@
 const DrawCard = require('../../../drawcard.js');
 
 class SansaStark extends DrawCard {
-    setupCardAbilities(dsl) {
+    setupCardAbilities(ability) {
         this.persistentEffect({
             match: card => card === this,
-            effect: dsl.effects.dynamicStrength(() => this.calculateStrength())
+            effect: ability.effects.dynamicStrength(() => this.calculateStrength())
         });
         this.persistentEffect({
             condition: () => this.getStrength() === 0,
             match: card => card === this,
-            effect: dsl.effects.addKeyword('Insight')
+            effect: ability.effects.addKeyword('Insight')
         });
     }
 

--- a/server/game/cards/characters/04/shae.js
+++ b/server/game/cards/characters/04/shae.js
@@ -1,13 +1,12 @@
 const DrawCard = require('../../../drawcard.js');
-const AbilityLimit = require('../../../abilitylimit.js');
 
 class Shae extends DrawCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.action({
             title: 'Pay 1 gold to stand Shae',
             method: 'stand',
             phase: 'challenge',
-            limit: AbilityLimit.perPhase(2)
+            limit: ability.limit.perPhase(2)
         });
     }
 

--- a/server/game/cards/locations/01/greatkraken.js
+++ b/server/game/cards/locations/01/greatkraken.js
@@ -1,5 +1,4 @@
 const DrawCard = require('../../../drawcard.js');
-const AbilityLimit = require('../../../abilitylimit.js');
 
 class GreatKraken extends DrawCard {
     constructor(owner, cardData) {
@@ -8,12 +7,12 @@ class GreatKraken extends DrawCard {
         this.registerEvents(['onCardPlayed']);
     }
 
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.reaction({
             when: {
                 onUnopposedWin: (event, challenge) => this.controller === challenge.winner
             },
-            limit: AbilityLimit.perRound(2),
+            limit: ability.limit.perRound(2),
             choices: {
                 'Draw 1 card': () => {
                     this.controller.drawCardsToHand(1);

--- a/server/game/cards/locations/01/thewall.js
+++ b/server/game/cards/locations/01/thewall.js
@@ -1,7 +1,7 @@
 const DrawCard = require('../../../drawcard.js');
 
 class TheWall extends DrawCard {
-    setupCardAbilities(dsl) {
+    setupCardAbilities(ability) {
         this.forcedReaction({
             when: {
                 onUnopposedWin: (e, challenge) => this.controller !== challenge.winner && !this.kneeled
@@ -23,7 +23,7 @@ class TheWall extends DrawCard {
         });
         this.persistentEffect({
             match: (card) => this.getFaction() === card.getFaction() && card.getType() === 'character',
-            effect: dsl.effects.modifyStrength(1)
+            effect: ability.effects.modifyStrength(1)
         });
     }
 }

--- a/server/game/cards/locations/03/winterfell.js
+++ b/server/game/cards/locations/03/winterfell.js
@@ -1,10 +1,10 @@
 const DrawCard = require('../../../drawcard.js');
 
 class Winterfell extends DrawCard {
-    setupCardAbilities(dsl) {
+    setupCardAbilities(ability) {
         this.persistentEffect({
             match: card => card.getFaction() === this.getFaction() && card.getType() === 'character',
-            effect: dsl.effects.modifyStrength(1)
+            effect: ability.effects.modifyStrength(1)
         });
         // TODO: Reaction for preventing card abilities.
     }

--- a/server/game/cards/plots/02/wardensofthenorth.js
+++ b/server/game/cards/plots/02/wardensofthenorth.js
@@ -1,13 +1,12 @@
 const PlotCard = require('../../../plotcard.js');
-const AbilityLimit = require('../../../abilitylimit.js');
 
 class WardensOfTheNorth extends PlotCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.action({
             title: 'Kneel a character to have it participate in the current challenge',
             method: 'onClick',
             phase: 'challenge',
-            limit: AbilityLimit.perRound(2)
+            limit: ability.limit.perRound(2)
         });
     }
 


### PR DESCRIPTION
* Replaces old references to `dsl` to the now standard `ability`.
* Uses `ability.limit` for ability limits instead of explicitly requiring `AbilityLimit` each time.