### PR TITLE
Allow event-based recalculation of effects

### DIFF
--- a/docs/implementing-cards.md
+++ b/docs/implementing-cards.md
@@ -149,6 +149,18 @@ this.persistentEffect({
 });
 ```
 
+Certain cards may apply effects that need to be recalculated mid-challenge. For example, Robert Baratheon's strength is based on how many other characters are kneeling, so declaring him in a challenge along with other characters will change his strength. For such scenarios, pass the optional `recalculateWhen` property as an array of event names for which the effect should be recalculated. **Note:** this mechanism should be used sparingly if possible and only with problematic cards.
+
+```javascript
+// Robert Baratheon gets +1 STR for each other kneeling character in play.
+this.persistentEffect({
+    match: this,
+    // Recalculate the effect whenever a card stands or kneels.
+    recalculateWhen: ['onCardStood', 'onCardKneeled'],
+    effect: ability.effects.dynamicStrength(() => this.calculateStrength())
+});
+```
+
 #### Attachment-based effects
 
 A `whileAttached` method is provided to define persistent effects that are applied to the card an attachment is attached. These effects remain as long as the card is attached to its parent and the attachment has not been blanked.

--- a/server/game/cards/agendas/thelordofthecrossing.js
+++ b/server/game/cards/agendas/thelordofthecrossing.js
@@ -13,6 +13,7 @@ class TheLordOfTheCrossing extends AgendaCard {
         this.persistentEffect({
             condition: () => this.game.currentChallenge && this.game.currentChallenge.attackingPlayer === this.controller,
             match: card => this.game.currentChallenge.isAttacking(card),
+            recalculateWhen: ['onAttackersDeclared'],
             effect: ability.effects.dynamicStrength(() => this.challengeBonus())
         });
     }

--- a/server/game/cards/characters/01/robertbaratheon.js
+++ b/server/game/cards/characters/01/robertbaratheon.js
@@ -3,7 +3,8 @@ const DrawCard = require('../../../drawcard.js');
 class RobertBaratheon extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            match: card => card === this,
+            match: this,
+            recalculateWhen: ['onCardStood', 'onCardKneeled'],
             effect: ability.effects.dynamicStrength(() => this.calculateStrength())
         });
     }

--- a/server/game/cards/characters/01/unsullied.js
+++ b/server/game/cards/characters/01/unsullied.js
@@ -6,6 +6,7 @@ class Unsullied extends DrawCard {
             condition: () => this.game.currentChallenge && this.game.currentChallenge.isAttacking(this),
             match: (card) => this.game.currentChallenge && this.game.currentChallenge.isDefending(card),
             targetController: 'opponent',
+            recalculateWhen: ['onDefendersDeclared'],
             effect: ability.effects.modifyStrength(-1)
         });
     }

--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -28,6 +28,8 @@ const Player = require('./player.js');
  *                    the card to apply the effect.
  * effect.unapply   - function that takes a card and a context object and modifies
  *                    the card to remove the previously applied effect.
+ * recalculateWhen  - optional array of event names that indicate when an effect
+ *                    should be recalculated by the engine.
  */
 class Effect {
     constructor(game, source, properties) {
@@ -42,6 +44,7 @@ class Effect {
         this.targets = [];
         this.context = { game: game, source: source };
         this.active = true;
+        this.recalculateWhen = properties.recalculateWhen || [];
         this.isStateDependent = properties.condition || this.effect.isStateDependent;
     }
 

--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -136,6 +136,11 @@ class Effect {
         }
         this.targets = [];
     }
+
+    resetTargets(newTargets) {
+        this.cancel();
+        this.addTargets(newTargets);
+    }
 }
 
 module.exports = Effect;

--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -8,11 +8,13 @@ class EffectEngine {
         this.events = new EventRegistrar(game, this);
         this.events.register(['onCardEntersPlay', 'onCardLeftPlay', 'onCardBlankToggled', 'onChallengeFinished', 'onPhaseEnded', 'onAtEndOfPhase', 'onRoundEnded']);
         this.effects = [];
+        this.recalculateEvents = {};
     }
 
     add(effect) {
         this.effects.push(effect);
         effect.addTargets(this.getTargets());
+        this.registerRecalculateEvents(effect.recalculateWhen);
     }
 
     getTargets() {
@@ -67,10 +69,47 @@ class EffectEngine {
         this.unapplyAndRemove(effect => effect.duration === 'untilEndOfRound');
     }
 
+    registerRecalculateEvents(eventNames) {
+        _.each(eventNames, eventName => {
+            if(!this.recalculateEvents[eventName]) {
+                var handler = this.recalculateEvent.bind(this);
+                this.recalculateEvents[eventName] = {
+                    name: eventName,
+                    handler: handler,
+                    count: 1
+                };
+                this.game.on(eventName, handler);
+            } else {
+                this.recalculateEvents[eventName].count++;
+            }
+        });
+    }
+
+    unregisterRecalculateEvents(eventNames) {
+        _.each(eventNames, eventName => {
+            var event = this.recalculateEvents[eventName];
+            if(event && event.count <= 1) {
+                this.game.removeListener(event.name, event.handler);
+                delete this.recalculateEvents[eventName];
+            } else if(event) {
+                event.count--;
+            }
+        });
+    }
+
+    recalculateEvent(event) {
+        _.each(this.effects, effect => {
+            if(effect.isStateDependent && effect.recalculateWhen.includes(event.name)) {
+                effect.resetTargets(this.getTargets());
+            }
+        })
+    }
+
     unapplyAndRemove(match) {
         var [matchingEffects, remainingEffects] = _.partition(this.effects, match);
         _.each(matchingEffects, effect => {
             effect.cancel();
+            this.unregisterRecalculateEvents(effect.recalculateWhen);
         });
         this.effects = remainingEffects;
     }

--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -12,20 +12,18 @@ class EffectEngine {
 
     add(effect) {
         this.effects.push(effect);
-        this.applyEffect(effect);
+        effect.addTargets(this.getTargets());
     }
 
-    applyEffect(effect) {
+    getTargets() {
         var validTargets = this.game.allCards.filter(card => card.location === 'play area' || card.location === 'active plot');
-        effect.addTargets(validTargets);
-        effect.addTargets(this.game.getPlayers());
+        return validTargets.concat(_.values(this.game.getPlayers()));
     }
 
     reapplyStateDependentEffects() {
         _.each(this.effects, effect => {
             if(effect.isStateDependent) {
-                effect.cancel();
-                this.applyEffect(effect);
+                effect.resetTargets(this.getTargets());
             }
         });
     }

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -19,6 +19,7 @@ class ChallengeFlow extends BaseStep {
             new SimpleStep(this.game, () => this.announceAttackerStrength()),
             new ActionWindow(this.game),
             new SimpleStep(this.game, () => this.promptForDefenders()),
+            new SimpleStep(this.game, () => this.announceDefenderStrength()),
             new ActionWindow(this.game),
             new SimpleStep(this.game, () => this.determineWinner()),
             new SimpleStep(this.game, () => this.unopposedPower()),
@@ -67,6 +68,8 @@ class ChallengeFlow extends BaseStep {
     }
 
     announceAttackerStrength() {
+        // Explicitly recalculate strength in case an effect has modified character strength.
+        this.challenge.calculateStrength();
         this.game.addMessage('{0} has initiated a {1} challenge with strength {2}', this.challenge.attackingPlayer, this.challenge.challengeType, this.challenge.attackerStrength);
     }
 
@@ -100,11 +103,15 @@ class ChallengeFlow extends BaseStep {
 
         this.game.raiseEvent('onDefendersDeclared', this.challenge);
 
+        return true;
+    }
+
+    announceDefenderStrength() {
+        // Explicitly recalculate strength in case an effect has modified character strength.
+        this.challenge.calculateStrength();
         if(!this.challenge.isUnopposed()) {
             this.game.addMessage('{0} has defended with strength {1}', this.challenge.defendingPlayer, this.challenge.defenderStrength);
         }
-
-        return true;
     }
 
     determineWinner() {

--- a/test/server/effectengine.spec.js
+++ b/test/server/effectengine.spec.js
@@ -15,7 +15,7 @@ describe('EffectEngine', function () {
         this.gameSpy.getPlayers.and.returnValue([]);
         this.gameSpy.allCards = _([this.handCard, this.playAreaCard, this.discardedCard]);
 
-        this.effectSpy = jasmine.createSpyObj('effect', ['addTargets', 'removeTarget', 'cancel', 'setActive']);
+        this.effectSpy = jasmine.createSpyObj('effect', ['addTargets', 'resetTargets', 'removeTarget', 'cancel', 'setActive']);
 
         this.engine = new EffectEngine(this.gameSpy);
     });
@@ -34,6 +34,17 @@ describe('EffectEngine', function () {
         });
     });
 
+    describe('getTargets()', function() {
+        beforeEach(function() {
+            this.player = {};
+            this.gameSpy.getPlayers.and.returnValue([this.player]);
+        });
+
+        it('should return all play area cards and players', function() {
+            expect(this.engine.getTargets()).toEqual([this.playAreaCard, this.player]);
+        });
+    });
+
     describe('reapplyStateDependentEffects()', function() {
         beforeEach(function() {
             this.engine.effects = [this.effectSpy];
@@ -45,12 +56,8 @@ describe('EffectEngine', function () {
                 this.engine.reapplyStateDependentEffects();
             });
 
-            it('should cancel the effect', function() {
-                expect(this.effectSpy.cancel).toHaveBeenCalled();
-            });
-
-            it('should add existing valid targets back to the effect', function() {
-                expect(this.effectSpy.addTargets).toHaveBeenCalledWith([this.playAreaCard]);
+            it('should reset valid targets', function() {
+                expect(this.effectSpy.resetTargets).toHaveBeenCalledWith([this.playAreaCard]);
             });
         });
 
@@ -60,12 +67,8 @@ describe('EffectEngine', function () {
                 this.engine.reapplyStateDependentEffects();
             });
 
-            it('should not cancel the effect', function() {
-                expect(this.effectSpy.cancel).not.toHaveBeenCalled();
-            });
-
-            it('should not add existing valid targets back to the effect', function() {
-                expect(this.effectSpy.addTargets).not.toHaveBeenCalled();
+            it('should not reset valid targets', function() {
+                expect(this.effectSpy.resetTargets).not.toHaveBeenCalled();
             });
         });
     });


### PR DESCRIPTION
* Fixes display bugs when an effect needs to be calculated immediately after challenge participants are declared including: Lord of the Crossing, Robert Baratheon, and Unsullied.

Fixes #236.