### PR TITLE
Fix dynamic and state restoring effects.

### DIFF
--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -16,11 +16,12 @@ const Effects = {
         return {
             apply: function(card, context) {
                 context.allowAsAttacker = context.allowAsAttacker || {};
-                context.allowAsAttacker[card] = card.challengeOptions.allowAsAttacker;
+                context.allowAsAttacker[card.uuid] = card.challengeOptions.allowAsAttacker;
                 card.challengeOptions.allowAsAttacker = value;
             },
             unapply: function(card, context) {
-                card.challengeOptions.allowAsAttacker = context.allowAsAttacker[card];
+                card.challengeOptions.allowAsAttacker = context.allowAsAttacker[card.uuid];
+                delete context.allowAsAttacker[card.uuid];
             }
         };
     },
@@ -28,11 +29,12 @@ const Effects = {
         return {
             apply: function(card, context) {
                 context.allowAsDefender = context.allowAsDefender || {};
-                context.allowAsDefender[card] = card.challengeOptions.allowAsDefender;
+                context.allowAsDefender[card.uuid] = card.challengeOptions.allowAsDefender;
                 card.challengeOptions.allowAsDefender = value;
             },
             unapply: function(card, context) {
-                card.challengeOptions.allowAsDefender = context.allowAsDefender[card];
+                card.challengeOptions.allowAsDefender = context.allowAsDefender[card.uuid];
+                delete context.allowAsDefender[card.uuid];
             }
         };
     },
@@ -100,12 +102,12 @@ const Effects = {
         return {
             apply: function(card, context) {
                 context.dynamicStrength = context.dynamicStrength || {};
-                context.dynamicStrength[card] = calculate(card, context);
-                card.strengthModifier += context.dynamicStrength[card];
+                context.dynamicStrength[card.uuid] = calculate(card, context);
+                card.strengthModifier += context.dynamicStrength[card.uuid];
             },
             unapply: function(card, context) {
-                card.strengthModifier -= context.dynamicStrength[card];
-                delete context.dynamicStrength[card];
+                card.strengthModifier -= context.dynamicStrength[card.uuid];
+                delete context.dynamicStrength[card.uuid];
             },
             isStateDependent: true
         };
@@ -227,13 +229,13 @@ const Effects = {
         return {
             apply: function(card, context) {
                 context.takeControl = context.takeControl || {};
-                context.takeControl[card] = { originalController: card.controller };
+                context.takeControl[card.uuid] = { originalController: card.controller };
                 context.game.takeControl(newController, card);
                 context.game.addMessage('{0} uses {1} to take control of {2}', context.source.controller, context.source, card);
             },
             unapply: function(card, context) {
-                context.game.takeControl(context.takeControl[card].originalController, card);
-                delete context.takeControl[card];
+                context.game.takeControl(context.takeControl[card.uuid].originalController, card);
+                delete context.takeControl[card.uuid];
             }
         };
     },
@@ -261,11 +263,12 @@ const Effects = {
         return {
             apply: function(player, context) {
                 context.setMinReserve = context.setMinReserve || {};
-                context.setMinReserve[player] = player.minReserve;
+                context.setMinReserve[player.id] = player.minReserve;
                 player.minReserve = min;
             },
             unapply: function(player, context) {
-                player.minReserve = context.setMinReserve[player];
+                player.minReserve = context.setMinReserve[player.id];
+                delete context.setMinReserve[player.id];
             }
         };
     },
@@ -273,11 +276,12 @@ const Effects = {
         return {
             apply: function(player, context) {
                 context.setChallengerLimit = context.setChallengerLimit || {};
-                context.setChallengerLimit[player] = player.challengerLimit;
+                context.setChallengerLimit[player.id] = player.challengerLimit;
                 player.challengerLimit = value;
             },
             unapply: function(player, context) {
-                player.challengerLimit = context.setChallengerLimit[player];
+                player.challengerLimit = context.setChallengerLimit[player.id];
+                delete context.setChallengerLimit[player.id];
             }
         };
     },

--- a/test/server/effects/dynamicstrength.spec.js
+++ b/test/server/effects/dynamicstrength.spec.js
@@ -1,0 +1,52 @@
+/*global describe, it, beforeEach, expect, jasmine*/
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+const _ = require('underscore');
+
+const Effects = require('../../../server/game/effects.js');
+
+describe('Effects.dynamicStrength', function() {
+    beforeEach(function() {
+        this.context = {};
+        this.calculateMethod = jasmine.createSpy('calculateMethod');
+
+        this.card1 = { uuid: '1111', strengthModifier: 0 };
+        this.card2 = { uuid: '2222', strengthModifier: 0 };
+
+        this.effect = Effects.dynamicStrength(this.calculateMethod);
+    });
+
+    describe('apply()', function() {
+        beforeEach(function() {
+            this.calculateMethod.and.returnValue(3);
+            this.effect.apply(this.card1, this.context);
+            this.calculateMethod.and.returnValue(4);
+            this.effect.apply(this.card2, this.context);
+        });
+
+        it('should add the result of the calculate method', function() {
+            expect(this.card1.strengthModifier).toBe(3);
+            expect(this.card2.strengthModifier).toBe(4);
+        });
+
+        it('should store the modifier for each card on context', function() {
+            expect(_.keys(this.context.dynamicStrength).length).toBe(2);
+        });
+    });
+
+    describe('unapply()', function() {
+        beforeEach(function() {
+            this.calculateMethod.and.returnValue(3);
+            this.effect.apply(this.card1, this.context);
+            this.calculateMethod.and.returnValue(4);
+            this.effect.apply(this.card2, this.context);
+        });
+
+        it('should reduce the previously applied value', function() {
+            this.effect.unapply(this.card1, this.context);
+            this.effect.unapply(this.card2, this.context);
+            expect(this.card1.strengthModifier).toBe(0);
+            expect(this.card2.strengthModifier).toBe(0);
+        });
+    });
+});


### PR DESCRIPTION
Previously, effects that were dynamicly calculated or restored original
state upon being unapplied were using the card object as the key on the
context object. Javascript silently converts these to strings using
`toString`, meaning if such an effect were applied to multiple cards,
they would all use the same key and overwrite each others state.

As a result, cards like Lord of the Crossing which apply their effect to
multiple cards were setting the strength properly, then when unapplied
would correctly reduce the strength of the first card, delete the state
from the context object, and then apply an undefined strength modifier to
the remainder of the cards. Since the remaining cards had `NaN` as a
strength, the resulting challenge strength would be 0.