### PR TITLE
Implement card ambushers

### DIFF
--- a/docs/implementing-cards.md
+++ b/docs/implementing-cards.md
@@ -197,6 +197,20 @@ this.persistentEffect({
 });
 ```
 
+#### Applying effects to cards in hand
+
+By default, effects will only be applied to cards in the play area.  Certain cards effects refer to cards in your hand, such as reducing their cost or providing ambush to matching cards. In these cases, set the `targetLocation` property to `'hand'`.
+
+```javascript
+// Each Direwolf card in your hand gains ambush (X). X is that card's printed cost.
+this.persistentEffect({
+    // Explicitly target the effect to cards in hand.
+    targetLocation: 'hand',
+    match: card => card.hasTrait('Direwolf'),
+    effect: ability.effects.gainAmbush()
+});
+```
+
 #### Player modifying effects
 
 Certain cards provide bonuses or restrictions on the player itself instead of on any specific cards. These can be implemented setting the `targetType` to `'player'` and using the appropriate effect.

--- a/server/game/cards/characters/02/raiderfrompyke.js
+++ b/server/game/cards/characters/02/raiderfrompyke.js
@@ -1,0 +1,15 @@
+const DrawCard = require('../../../drawcard.js');
+
+class RaiderFromPyke extends DrawCard {
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            targetLocation: 'hand',
+            match: card => card.hasTrait('Weapon'),
+            effect: ability.effects.gainAmbush()
+        });
+    }
+}
+
+RaiderFromPyke.code = '02091';
+
+module.exports = RaiderFromPyke;

--- a/server/game/cards/characters/03/mancerayder.js
+++ b/server/game/cards/characters/03/mancerayder.js
@@ -1,0 +1,24 @@
+const _ = require('underscore');
+
+const DrawCard = require('../../../drawcard.js');
+
+class ManceRayder extends DrawCard {
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            targetLocation: 'hand',
+            condition: () => _.all(this.game.getPlayers(), player => !player.activePlot || !player.activePlot.hasTrait('Winter')),
+            match: card => card.hasTrait('Wildling'),
+            effect: ability.effects.gainAmbush()
+        });
+        this.persistentEffect({
+            targetLocation: 'hand',
+            condition: () => _.any(this.game.getPlayers(), player => player.activePlot && player.activePlot.hasTrait('Winter')),
+            match: card => card.hasTrait('Wildling'),
+            effect: ability.effects.gainAmbush(-1)
+        });
+    }
+}
+
+ManceRayder.code = '03039';
+
+module.exports = ManceRayder;

--- a/server/game/cards/characters/04/harmenuller.js
+++ b/server/game/cards/characters/04/harmenuller.js
@@ -1,0 +1,15 @@
+const DrawCard = require('../../../drawcard.js');
+
+class HarmenUller extends DrawCard {
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            targetLocation: 'hand',
+            match: card => card.hasTrait('Sand Snake'),
+            effect: ability.effects.gainAmbush(-1)
+        });
+    }
+}
+
+HarmenUller.code = '04016';
+
+module.exports = HarmenUller;

--- a/server/game/cards/locations/01/thewolfswood.js
+++ b/server/game/cards/locations/01/thewolfswood.js
@@ -1,0 +1,15 @@
+const DrawCard = require('../../../drawcard.js');
+
+class TheWolfswood extends DrawCard {
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            targetLocation: 'hand',
+            match: card => card.hasTrait('Direwolf'),
+            effect: ability.effects.gainAmbush()
+        });
+    }
+}
+
+TheWolfswood.code = '01155';
+
+module.exports = TheWolfswood;

--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -3,6 +3,8 @@ const _ = require('underscore');
 const Effects = require('./effects.js');
 const Player = require('./player.js');
 
+const PlayAreaLocations = ['play area', 'active plot'];
+
 /**
  * Represents a card based effect applied to one or more targets.
  *
@@ -21,6 +23,9 @@ const Player = require('./player.js');
  *                    Can be 'current' (default), 'opponent' or 'any'.
  * targetType       - string that determines whether cards or players are the
  *                    target for the effect. Can be 'card' (default) or 'player'
+ * targetLocation   - string that determines the location of cards that can be
+ *                    applied by the effect. Can be 'play area' (default) or
+ *                    'hand'.
  * effect           - object representing the effect to be applied. If passed an
  *                    array instead of an object, it will apply / unapply all of
  *                    the sub objects in the array instead.
@@ -40,6 +45,7 @@ class Effect {
         this.condition = properties.condition || (() => true);
         this.targetController = properties.targetController || 'current';
         this.targetType = properties.targetType || 'card';
+        this.targetLocation = properties.targetLocation || 'play area';
         this.effect = this.buildEffect(properties.effect);
         this.targets = [];
         this.context = { game: game, source: source };
@@ -85,6 +91,14 @@ class Effect {
         }
 
         if(this.targetType === 'card') {
+            if(this.targetLocation === 'play area' && !PlayAreaLocations.includes(target.location)) {
+                return false;
+            }
+
+            if(this.targetLocation === 'hand' && target.location !== 'hand') {
+                return false;
+            }
+
             if(this.targetController === 'current') {
                 return target.controller === this.source.controller;
             }

--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -6,7 +6,7 @@ class EffectEngine {
     constructor(game) {
         this.game = game;
         this.events = new EventRegistrar(game, this);
-        this.events.register(['onCardEntersPlay', 'onCardLeftPlay', 'onCardBlankToggled', 'onChallengeFinished', 'onPhaseEnded', 'onAtEndOfPhase', 'onRoundEnded']);
+        this.events.register(['onCardEntersPlay', 'onCardLeftPlay', 'onCardEntersHand', 'onCardLeftHand', 'onCardBlankToggled', 'onChallengeFinished', 'onPhaseEnded', 'onAtEndOfPhase', 'onRoundEnded']);
         this.effects = [];
         this.recalculateEvents = {};
     }
@@ -31,19 +31,36 @@ class EffectEngine {
     }
 
     onCardEntersPlay(e, card) {
+        this.addTargetForPersistentEffects(card, 'play area');
+    }
+
+    onCardLeftPlay(e, player, card) {
+        this.removeTargetFromPersistentEffects(card, 'play area');
+        this.unapplyAndRemove(effect => effect.duration === 'persistent' && effect.source === card);
+    }
+
+    onCardEntersHand(e, card) {
+        this.addTargetForPersistentEffects(card, 'hand');
+    }
+
+    onCardLeftHand(e, player, card) {
+        this.removeTargetFromPersistentEffects(card, 'hand');
+    }
+
+    addTargetForPersistentEffects(card, targetLocation) {
         _.each(this.effects, effect => {
-            if(effect.duration === 'persistent') {
+            if(effect.duration === 'persistent' && effect.targetLocation === targetLocation) {
                 effect.addTargets([card]);
             }
         });
     }
 
-    onCardLeftPlay(e, player, card) {
+    removeTargetFromPersistentEffects(card, targetLocation) {
         _.each(this.effects, effect => {
-            effect.removeTarget(card);
+            if(effect.targetLocation === targetLocation) {
+                effect.removeTarget(card);
+            }
         });
-
-        this.unapplyAndRemove(effect => effect.duration === 'persistent' && effect.source === card);
     }
 
     onCardBlankToggled(event, card, isBlank) {

--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -18,7 +18,7 @@ class EffectEngine {
     }
 
     getTargets() {
-        var validTargets = this.game.allCards.filter(card => card.location === 'play area' || card.location === 'active plot');
+        var validTargets = this.game.allCards.filter(card => card.location === 'play area' || card.location === 'active plot' || card.location === 'hand');
         return validTargets.concat(_.values(this.game.getPlayers()));
     }
 

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -195,6 +195,19 @@ const Effects = {
             }
         }
     },
+    gainAmbush: function(costModifier = 0) {
+        return {
+            apply: function(card, context) {
+                context.gainAmbush = context.gainAmbush || {};
+                context.gainAmbush[card.uuid] = card.ambushCost;
+                card.ambushCost = card.cardData.cost + costModifier;
+            },
+            unapply: function(card, context) {
+                card.ambushCost = context.gainAmbush[card.uuid];
+                delete context.gainAmbush[card.uuid];
+            }
+        };
+    },
     discardIfStillInPlay: function(allowSave = false) {
         return {
             apply: function(card, context) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -863,6 +863,10 @@ class Player extends Spectator {
             }
         }
 
+        if(card.location === 'hand') {
+            this.game.raiseEvent('onCardLeftHand', card);
+        }
+
         if(!options.isDupe) {
             card.moveTo(targetLocation);
         } else {
@@ -873,6 +877,10 @@ class Player extends Spectator {
             targetPile.unshift(card);
         } else {
             targetPile.push(card);
+        }
+
+        if(targetLocation === 'hand') {
+            this.game.raiseEvent('onCardEntersHand', card);
         }
     }
 

--- a/test/server/effect.spec.js
+++ b/test/server/effect.spec.js
@@ -24,8 +24,8 @@ describe('Effect', function () {
 
     describe('addTargets()', function() {
         beforeEach(function() {
-            this.matchingCard = { good: true };
-            this.nonMatchingCard = { bad: true };
+            this.matchingCard = { good: true, location: 'play area' };
+            this.nonMatchingCard = { bad: true, location: 'play area' };
 
             this.properties.match.and.callFake((card) => card === this.matchingCard);
         });
@@ -229,7 +229,7 @@ describe('Effect', function () {
 
     describe('removeTarget()', function() {
         beforeEach(function() {
-            this.target = { good: true };
+            this.target = { good: true, location: 'play area' };
 
             this.effect.addTargets([this.target]);
         });

--- a/test/server/effectengine.spec.js
+++ b/test/server/effectengine.spec.js
@@ -16,6 +16,7 @@ describe('EffectEngine', function () {
         this.gameSpy.allCards = _([this.handCard, this.playAreaCard, this.discardedCard]);
 
         this.effectSpy = jasmine.createSpyObj('effect', ['addTargets', 'resetTargets', 'removeTarget', 'cancel', 'setActive']);
+        this.effectSpy.targetLocation = 'play area';
 
         this.engine = new EffectEngine(this.gameSpy);
     });
@@ -81,7 +82,7 @@ describe('EffectEngine', function () {
         describe('when an effect has persistent duration', function() {
             beforeEach(function() {
                 this.effectSpy.duration = 'persistent';
-                this.cardEnteringPlay = {};
+                this.cardEnteringPlay = { location: 'play area' };
                 this.engine.onCardEntersPlay({}, this.cardEnteringPlay);
             });
 
@@ -93,7 +94,7 @@ describe('EffectEngine', function () {
         describe('when an effect has a non-persistent duration', function() {
             beforeEach(function() {
                 this.effectSpy.duration = 'untilEndOfChallenge';
-                this.cardEnteringPlay = {};
+                this.cardEnteringPlay = { location: 'play area' };
                 this.engine.onCardEntersPlay({}, this.cardEnteringPlay);
             });
 
@@ -106,7 +107,7 @@ describe('EffectEngine', function () {
     describe('onCardLeftPlay()', function() {
         beforeEach(function() {
             this.engine.effects = [this.effectSpy];
-            this.cardLeavingPlay = {};
+            this.cardLeavingPlay = { location: 'play area' };
         });
 
         describe('when an effect has persistent duration', function() {

--- a/test/server/effectengine.spec.js
+++ b/test/server/effectengine.spec.js
@@ -30,7 +30,7 @@ describe('EffectEngine', function () {
         });
 
         it('should add existing valid targets to the effect', function() {
-            expect(this.effectSpy.addTargets).toHaveBeenCalledWith([this.playAreaCard]);
+            expect(this.effectSpy.addTargets).toHaveBeenCalledWith([this.handCard, this.playAreaCard]);
         });
     });
 
@@ -41,7 +41,7 @@ describe('EffectEngine', function () {
         });
 
         it('should return all play area cards and players', function() {
-            expect(this.engine.getTargets()).toEqual([this.playAreaCard, this.player]);
+            expect(this.engine.getTargets()).toEqual([this.handCard, this.playAreaCard, this.player]);
         });
     });
 
@@ -57,7 +57,7 @@ describe('EffectEngine', function () {
             });
 
             it('should reset valid targets', function() {
-                expect(this.effectSpy.resetTargets).toHaveBeenCalledWith([this.playAreaCard]);
+                expect(this.effectSpy.resetTargets).toHaveBeenCalledWith([this.handCard, this.playAreaCard]);
             });
         });
 

--- a/test/server/player/movecard.spec.js
+++ b/test/server/player/movecard.spec.js
@@ -68,7 +68,7 @@ describe('Player', function() {
             });
 
             it('should not to raise the left play event', function() {
-                expect(this.gameSpy.raiseEvent).not.toHaveBeenCalled();
+                expect(this.gameSpy.raiseEvent).not.toHaveBeenCalledWith('onCardLeftPlay', jasmine.any(Object), jasmine.any(Object));
             });
         });
 


### PR DESCRIPTION
* Adds the ability for an effect to target cards in hand (reducers can be converted to this next)
* Implements all the "Each X card in your hand gains ambush" persistent effects. Does not implement [Shagga Son of Dolf](https://thronesdb.com/card/05009) which requires cards in hand to provide effects while they are in hand.