### PR TITLE
Fix cards with self-matching persistent effects

### DIFF
--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -78,6 +78,16 @@ class Effect {
     }
 
     isValidTarget(target) {
+        if(this.targetType === 'card') {
+            if(this.targetLocation === 'play area' && !PlayAreaLocations.includes(target.location)) {
+                return false;
+            }
+
+            if(this.targetLocation === 'hand' && target.location !== 'hand') {
+                return false;
+            }
+        }
+
         if(!_.isFunction(this.match)) {
             return target === this.match;
         }
@@ -91,14 +101,6 @@ class Effect {
         }
 
         if(this.targetType === 'card') {
-            if(this.targetLocation === 'play area' && !PlayAreaLocations.includes(target.location)) {
-                return false;
-            }
-
-            if(this.targetLocation === 'hand' && target.location !== 'hand') {
-                return false;
-            }
-
             if(this.targetController === 'current') {
                 return target.controller === this.source.controller;
             }

--- a/test/server/effect.spec.js
+++ b/test/server/effect.spec.js
@@ -110,6 +110,7 @@ describe('Effect', function () {
                 this.player = {};
                 this.anotherPlayer = {};
                 this.sourceSpy.controller = this.player;
+                this.matchingCard.controller = this.player;
             });
 
             describe('when the target controller is current', function() {
@@ -163,6 +164,108 @@ describe('Effect', function () {
                     this.matchingCard.controller = this.anotherPlayer;
                     this.effect.addTargets([this.matchingCard]);
                     expect(this.effect.targets).toContain(this.matchingCard);
+                });
+            });
+
+            describe('when the target location is play area', function() {
+                beforeEach(function() {
+                    this.effect.targetLocation = 'play area';
+                });
+
+                it('should add targets from play area', function() {
+                    this.matchingCard.location = 'play area';
+                    this.effect.addTargets([this.matchingCard]);
+                    expect(this.effect.targets).toContain(this.matchingCard);
+                });
+
+                it('should add targets from active plot', function() {
+                    this.matchingCard.location = 'active plot';
+                    this.effect.addTargets([this.matchingCard]);
+                    expect(this.effect.targets).toContain(this.matchingCard);
+                });
+
+                it('should reject targets from hand', function() {
+                    this.matchingCard.location = 'hand';
+                    this.effect.addTargets([this.matchingCard]);
+                    expect(this.effect.targets).not.toContain(this.matchingCard);
+                });
+            });
+
+            describe('when the target location is hand', function() {
+                beforeEach(function() {
+                    this.effect.targetLocation = 'hand';
+                });
+
+                it('should reject targets from play area', function() {
+                    this.matchingCard.location = 'play area';
+                    this.effect.addTargets([this.matchingCard]);
+                    expect(this.effect.targets).not.toContain(this.matchingCard);
+                });
+
+                it('should reject targets from active plot', function() {
+                    this.matchingCard.location = 'active plot';
+                    this.effect.addTargets([this.matchingCard]);
+                    expect(this.effect.targets).not.toContain(this.matchingCard);
+                });
+
+                it('should add targets from hand', function() {
+                    this.matchingCard.location = 'hand';
+                    this.effect.addTargets([this.matchingCard]);
+                    expect(this.effect.targets).toContain(this.matchingCard);
+                });
+            });
+
+            describe('when the match is a specific card', function() {
+                beforeEach(function() {
+                    this.effect.match = this.matchingCard;
+                });
+
+                describe('when the target location is play area', function() {
+                    beforeEach(function() {
+                        this.effect.targetLocation = 'play area';
+                    });
+
+                    it('should add targets from play area', function() {
+                        this.matchingCard.location = 'play area';
+                        this.effect.addTargets([this.matchingCard]);
+                        expect(this.effect.targets).toContain(this.matchingCard);
+                    });
+
+                    it('should add targets from active plot', function() {
+                        this.matchingCard.location = 'active plot';
+                        this.effect.addTargets([this.matchingCard]);
+                        expect(this.effect.targets).toContain(this.matchingCard);
+                    });
+
+                    it('should reject targets from hand', function() {
+                        this.matchingCard.location = 'hand';
+                        this.effect.addTargets([this.matchingCard]);
+                        expect(this.effect.targets).not.toContain(this.matchingCard);
+                    });
+                });
+
+                describe('when the target location is hand', function() {
+                    beforeEach(function() {
+                        this.effect.targetLocation = 'hand';
+                    });
+
+                    it('should reject targets from play area', function() {
+                        this.matchingCard.location = 'play area';
+                        this.effect.addTargets([this.matchingCard]);
+                        expect(this.effect.targets).not.toContain(this.matchingCard);
+                    });
+
+                    it('should reject targets from active plot', function() {
+                        this.matchingCard.location = 'active plot';
+                        this.effect.addTargets([this.matchingCard]);
+                        expect(this.effect.targets).not.toContain(this.matchingCard);
+                    });
+
+                    it('should add targets from hand', function() {
+                        this.matchingCard.location = 'hand';
+                        this.effect.addTargets([this.matchingCard]);
+                        expect(this.effect.targets).toContain(this.matchingCard);
+                    });
                 });
             });
         });


### PR DESCRIPTION
Previously the ability to match cards in hand was implemented. This
introduced a bug where cards that did not use a matching function (i.e.
they targetted themselves or another specific card) could have their
effect applied multiple times because the target location was not
enforced. In the case of Robert Baratheon, the effect was applied just
before he entered play (while still in hand), then again when the
onCardEnterPlay event was fired. Then when strength was recalculated for
the card, it was unapplied twice, leading to a NaN strength modifier.