### PR TITLE
Fix Maester Caleotte

### DIFF
--- a/server/game/cards/characters/01/maestercaleotte.js
+++ b/server/game/cards/characters/01/maestercaleotte.js
@@ -38,7 +38,7 @@ class MaesterCaleotte extends DrawCard {
     iconSelected(player, icon) {
         this.game.addMessage('{0} uses {1} to remove a {2} icon from {3}', player, this, icon, this.selectedCard);
         this.untilEndOfPhase(ability => ({
-            match: card => card === this.selectedCard,
+            match: this.selectedCard,
             effect: ability.effects.removeIcon(icon)
         }));
 


### PR DESCRIPTION
The match property should have been targeting a specific card.
Because it was a matching function, it was searching only cards in the
targetController - your own cards by default - and not matching on
opponent cards.