### PR TITLE
Only fire kneel/stand events when state changes.

### DIFF
--- a/server/game/player.js
+++ b/server/game/player.js
@@ -885,15 +885,19 @@ class Player extends Spectator {
     }
 
     kneelCard(card) {
-        card.kneeled = true;
+        if(!card.kneeled) {
+            card.kneeled = true;
 
-        this.game.raiseEvent('onCardKneeled', this, card);
+            this.game.raiseEvent('onCardKneeled', this, card);
+        }
     }
 
     standCard(card) {
-        card.kneeled = false;
+        if(card.kneeled) {
+            card.kneeled = false;
 
-        this.game.raiseEvent('onCardStood', this, card);
+            this.game.raiseEvent('onCardStood', this, card);
+        }
     }
 
     removeDuplicate(card) {


### PR DESCRIPTION
Previously, the onCardStood and onCardKneeled events were being fired
even if the card was already standing or kneeling. This lead to a
problem where Stinking Drunk would activate during the stand phase
even if the card was already standing.