### PR TITLE
Ensure nested events are not cancelled

### DIFF
--- a/server/game/gamesteps/eventwindow.js
+++ b/server/game/gamesteps/eventwindow.js
@@ -44,7 +44,7 @@ class EventWindow extends BaseStep {
     }
 
     continue() {
-        return this.event.cancelled || this.pipeline.continue();
+        return this.pipeline.continue();
     }
 
     cancelInterrupts() {
@@ -52,14 +52,26 @@ class EventWindow extends BaseStep {
     }
 
     forcedInterrupts() {
+        if(this.event.cancelled) {
+            return;
+        }
+
         this.game.emit(this.eventName + ':forcedinterrupt', this.event, ...this.params);
     }
 
     interrupts() {
+        if(this.event.cancelled) {
+            return;
+        }
+
         this.game.emit(this.eventName + ':interrupt', this.event, ...this.params);
     }
 
     executeHandler() {
+        if(this.event.cancelled) {
+            return;
+        }
+
         if(!this.event.shouldSkipHandler) {
             this.handler();
         }
@@ -67,10 +79,18 @@ class EventWindow extends BaseStep {
     }
 
     forcedReactions() {
+        if(this.event.cancelled) {
+            return;
+        }
+
         this.game.emit(this.eventName + ':forcedreaction', this.event, ...this.params);
     }
 
     reactions() {
+        if(this.event.cancelled) {
+            return;
+        }
+
         this.game.emit(this.eventName + ':reaction', this.event, ...this.params);
     }
 }

--- a/test/server/gamesteps/eventwindow.spec.js
+++ b/test/server/gamesteps/eventwindow.spec.js
@@ -1,0 +1,87 @@
+/*global describe, it, beforeEach, expect, jasmine*/
+/* eslint no-invalid-this: 0 */
+
+const EventWindow = require('../../../server/game/gamesteps/eventwindow.js');
+const Event = require('../../../server/game/event.js');
+
+describe('EventWindow', function() {
+    beforeEach(function() {
+        this.gameSpy = jasmine.createSpyObj('game', ['emit']);
+        this.params = ['foo', 'bar'];
+        this.handler = jasmine.createSpy('handler');
+        this.eventWindow = new EventWindow(this.gameSpy, 'myevent', this.params, this.handler);
+    });
+
+    describe('continue()', function() {
+        describe('during the normal flow', function() {
+            beforeEach(function() {
+                this.eventWindow.continue();
+            });
+
+            it('should emit all of the interrupt/reaction events', function() {
+                expect(this.gameSpy.emit).toHaveBeenCalledWith('myevent:cancelinterrupt', jasmine.any(Event), 'foo', 'bar');
+                expect(this.gameSpy.emit).toHaveBeenCalledWith('myevent:forcedinterrupt', jasmine.any(Event), 'foo', 'bar');
+                expect(this.gameSpy.emit).toHaveBeenCalledWith('myevent:interrupt', jasmine.any(Event), 'foo', 'bar');
+                expect(this.gameSpy.emit).toHaveBeenCalledWith('myevent', jasmine.any(Event), 'foo', 'bar');
+                expect(this.gameSpy.emit).toHaveBeenCalledWith('myevent:forcedreaction', jasmine.any(Event), 'foo', 'bar');
+                expect(this.gameSpy.emit).toHaveBeenCalledWith('myevent:reaction', jasmine.any(Event), 'foo', 'bar');
+            });
+
+            it('should call the handler', function() {
+                expect(this.handler).toHaveBeenCalled();
+            });
+        });
+
+        describe('when the event is cancelled', function() {
+            beforeEach(function() {
+                this.eventWindow.event.cancel();
+            });
+
+            it('should not emit the post-cancel interrupt/reaction events', function() {
+                this.eventWindow.continue();
+                expect(this.gameSpy.emit).not.toHaveBeenCalledWith('myevent:forcedinterrupt', jasmine.any(Event), jasmine.any(String), jasmine.any(String));
+                expect(this.gameSpy.emit).not.toHaveBeenCalledWith('myevent:interrupt', jasmine.any(Event), jasmine.any(String), jasmine.any(String));
+                expect(this.gameSpy.emit).not.toHaveBeenCalledWith('myevent', jasmine.any(Event), jasmine.any(String), jasmine.any(String));
+                expect(this.gameSpy.emit).not.toHaveBeenCalledWith('myevent:forcedreaction', jasmine.any(Event), jasmine.any(String), jasmine.any(String));
+                expect(this.gameSpy.emit).not.toHaveBeenCalledWith('myevent:reaction', jasmine.any(Event), jasmine.any(String), jasmine.any(String));
+            });
+
+            it('should not call the handler', function() {
+                this.eventWindow.continue();
+                expect(this.handler).not.toHaveBeenCalled();
+            });
+
+            describe('and another step has been queued on the event', function() {
+                beforeEach(function() {
+                    this.anotherStep = jasmine.createSpyObj('step', ['continue']);
+                    this.eventWindow.queueStep(this.anotherStep);
+                });
+
+                it('should still call the step', function() {
+                    this.eventWindow.continue();
+                    expect(this.anotherStep.continue).toHaveBeenCalled();
+                });
+            });
+        });
+
+        describe('when an event has its handler skipped', function() {
+            beforeEach(function() {
+                this.eventWindow.event.skipHandler();
+                this.eventWindow.continue();
+            });
+
+            it('should emit all of the interrupt/reaction events', function() {
+                expect(this.gameSpy.emit).toHaveBeenCalledWith('myevent:cancelinterrupt', jasmine.any(Event), 'foo', 'bar');
+                expect(this.gameSpy.emit).toHaveBeenCalledWith('myevent:forcedinterrupt', jasmine.any(Event), 'foo', 'bar');
+                expect(this.gameSpy.emit).toHaveBeenCalledWith('myevent:interrupt', jasmine.any(Event), 'foo', 'bar');
+                expect(this.gameSpy.emit).toHaveBeenCalledWith('myevent', jasmine.any(Event), 'foo', 'bar');
+                expect(this.gameSpy.emit).toHaveBeenCalledWith('myevent:forcedreaction', jasmine.any(Event), 'foo', 'bar');
+                expect(this.gameSpy.emit).toHaveBeenCalledWith('myevent:reaction', jasmine.any(Event), 'foo', 'bar');
+            });
+
+            it('should not call the handler', function() {
+                expect(this.handler).not.toHaveBeenCalled();
+            });
+        });
+    });
+});


### PR DESCRIPTION
Previously, if an interrupt ended up cancelling an event, any events
that may have been triggered during that cancellation would be skipped
because they are queued onto the EventWindow's pipeline.

For example, if Jory Cassel's ability activated when a character would
be killed, the sacrifice and left play events for Jory would not be
emitted. Thus, any cards that react to Jory's sacrifice (e.g. WotN
Catelyn) would not trigger.