### PR TITLE
Fix For the Watch!

### DIFF
--- a/server/game/cards/plots/02/forthewatch.js
+++ b/server/game/cards/plots/02/forthewatch.js
@@ -8,12 +8,12 @@ class ForTheWatch extends PlotCard {
     }
 
     onChallenge(event, challenge) {
-        if(challenge.attackingPlayer === this.controller || challenge.attackingPlayer.challenges.complete >= 1) {
+        if(challenge.attackingPlayer === this.controller || challenge.attackingPlayer.getNumberOfChallengesInitiated() > 1) {
             return;
         }
 
         challenge.attackerCannotWin = true;
-    } 
+    }
 }
 
 ForTheWatch.code = '02067';

--- a/server/game/cards/plots/02/forthewatch.js
+++ b/server/game/cards/plots/02/forthewatch.js
@@ -1,18 +1,17 @@
 const PlotCard = require('../../../plotcard.js');
 
 class ForTheWatch extends PlotCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['onChallenge']);
-    }
-
-    onChallenge(event, challenge) {
-        if(challenge.attackingPlayer === this.controller || challenge.attackingPlayer.getNumberOfChallengesInitiated() > 1) {
-            return;
-        }
-
-        challenge.attackerCannotWin = true;
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            condition: () => (
+                this.game.currentChallenge &&
+                this.game.currentChallenge.defendingPlayer === this.controller &&
+                this.game.currentChallenge.attackingPlayer.getNumberOfChallengesInitiated() <= 1
+            ),
+            targetType: 'player',
+            targetController: 'opponent',
+            effect: ability.effects.cannotWinChallenge()
+        });
     }
 }
 

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -120,7 +120,7 @@ class Challenge {
 
         this.calculateStrength();
 
-        if(this.attackerStrength === 0 && this.defenderStrength === 0 || this.attackerStrength >= this.defenderStrength && this.attackerCannotWin) {
+        if(this.attackerStrength === 0 && this.defenderStrength === 0 || this.attackerStrength >= this.defenderStrength && this.attackingPlayer.cannotWinChallenge) {
             this.loser = undefined;
             this.winner = undefined;
             this.loserStrength = this.winnerStrength = 0;

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -313,6 +313,16 @@ const Effects = {
             }
         };
     },
+    cannotWinChallenge: function() {
+        return {
+            apply: function(player) {
+                player.cannotWinChallenge = true;
+            },
+            unapply: function(player) {
+                player.cannotWinChallenge = false;
+            }
+        }
+    },
     /**
      * Effects specifically for Old Wyk.
      */

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -110,8 +110,10 @@ class ChallengeFlow extends BaseStep {
     announceDefenderStrength() {
         // Explicitly recalculate strength in case an effect has modified character strength.
         this.challenge.calculateStrength();
-        if(!this.challenge.isUnopposed()) {
+        if(this.challenge.defenderStrength > 0) {
             this.game.addMessage('{0} has defended with strength {1}', this.challenge.defendingPlayer, this.challenge.defenderStrength);
+        } else {
+            this.game.addMessage('{0} does not defend the challenge', this.challenge.defendingPlayer);
         }
     }
 

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -60,9 +60,10 @@ class ChallengeFlow extends BaseStep {
     chooseAttackers(player, attackers) {
         this.challenge.addAttackers(attackers);
 
-        this.game.raiseEvent('onChallenge', this.challenge);
-        this.challenge.initiateChallenge();
-        this.game.raiseEvent('onAttackersDeclared', this.challenge);
+        this.game.raiseEvent('onChallenge', this.challenge, () => {
+            this.challenge.initiateChallenge();
+            this.game.raiseEvent('onAttackersDeclared', this.challenge);
+        });
 
         return true;
     }

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -133,7 +133,7 @@ class ChallengeFlow extends BaseStep {
     }
 
     unopposedPower() {
-        if(this.challenge.isUnopposed() && this.challenge.isAttackerTheWinner() && !this.challenge.attackerCannotWin) {
+        if(this.challenge.isUnopposed() && this.challenge.isAttackerTheWinner()) {
             this.game.addMessage('{0} has gained 1 power from an unopposed challenge', this.challenge.winner);
             this.game.addPower(this.challenge.winner, 1);
 
@@ -142,7 +142,7 @@ class ChallengeFlow extends BaseStep {
     }
 
     beforeClaim() {
-        if(!this.challenge.isAttackerTheWinner() || this.challenge.attackerCannotWin) {
+        if(!this.challenge.isAttackerTheWinner()) {
             return;
         }
 


### PR DESCRIPTION
* Converts For the Watch! to use an effect so that it can be blanked by Forgotten Plans in the future.
* Nests the onAttackersDeclared event inside of the onChallenge event to ensure proper resolution order.
* Misc: adds a message when a player does not defend against a challenge.

Fixes #301.