### PR TITLE
Fix action window ordering

### DIFF
--- a/server/game/gamesteps/playerorderprompt.js
+++ b/server/game/gamesteps/playerorderprompt.js
@@ -8,16 +8,19 @@ const UiPrompt = require('./uiprompt.js');
  * any matching players from the prompt.
  */
 class PlayerOrderPrompt extends UiPrompt {
-    constructor(game) {
-        super(game);
-        this.players = game.getPlayersInFirstPlayerOrder();
-    }
-
     get currentPlayer() {
+        this.lazyFetchPlayers();
         return this.players[0];
     }
 
+    lazyFetchPlayers() {
+        if(!this.players) {
+            this.players = this.game.getPlayersInFirstPlayerOrder();
+        }
+    }
+
     skipPlayers() {
+        this.lazyFetchPlayers();
         this.players = _.reject(this.players, p => this.skipCondition(p));
     }
 
@@ -26,6 +29,7 @@ class PlayerOrderPrompt extends UiPrompt {
     }
 
     completePlayer() {
+        this.lazyFetchPlayers();
         this.players.shift();
     }
 
@@ -34,6 +38,7 @@ class PlayerOrderPrompt extends UiPrompt {
     }
 
     isComplete() {
+        this.lazyFetchPlayers();
         return this.players.length === 0;
     }
 

--- a/test/server/gamesteps/playerorderprompt.spec.js
+++ b/test/server/gamesteps/playerorderprompt.spec.js
@@ -77,5 +77,31 @@ describe('the PlayerOrderPrompt', () => {
                 expect(prompt.continue()).toBe(true);
             });
         });
+
+        describe('when the first player order changes after construction', function() {
+            beforeEach(function() {
+                player2.firstPlayer = false;
+                player1.firstPlayer = true;
+            });
+
+            it('should prompt players in the current first-player order', () => {
+                prompt.continue();
+                expect(prompt.currentPlayer).toBe(player1);
+            });
+
+            it('should give the active prompt to the current player', () => {
+                prompt.continue();
+                expect(player1.setPrompt).toHaveBeenCalledWith(activePrompt);
+            });
+
+            it('should give the waiting prompt to the remaining players', () => {
+                prompt.continue();
+                expect(player2.setPrompt).toHaveBeenCalledWith(waitingPrompt);
+            });
+
+            it('should return false', () => {
+                expect(prompt.continue()).toBe(false);
+            });
+        });
     });
 });

--- a/test/server/gamesteps/playerorderprompt.spec.js
+++ b/test/server/gamesteps/playerorderprompt.spec.js
@@ -2,27 +2,22 @@
 /* eslint camelcase: 0, no-invalid-this: 0 */
 
 const PlayerOrderPrompt = require('../../../server/game/gamesteps/playerorderprompt.js');
-const Game = require('../../../server/game/game.js');
-const Player = require('../../../server/game/player.js');
 
 describe('the PlayerOrderPrompt', function() {
     beforeEach(function() {
         this.activePrompt = { active: true };
         this.waitingPrompt = { active: false };
 
-        this.game = new Game('1', 'Test Game');
-        this.player1 = new Player('1', { username: 'Player 1' }, true, this.game);
-        this.player2 = new Player('2', { username: 'Player 2' }, false, this.game);
-        this.player2.firstPlayer = true;
-        this.game.playersAndSpectators[0] = this.player1;
-        this.game.playersAndSpectators[1] = this.player2;
+        this.game = jasmine.createSpyObj('game', ['getPlayers', 'getPlayersInFirstPlayerOrder']);
+        this.player1 = jasmine.createSpyObj('player1', ['setPrompt', 'cancelPrompt']);
+        this.player2 = jasmine.createSpyObj('player1', ['setPrompt', 'cancelPrompt']);
+
+        this.game.getPlayers.and.returnValue([this.player1, this.player2]);
+        this.game.getPlayersInFirstPlayerOrder.and.returnValue([this.player2, this.player1]);
+
         this.prompt = new PlayerOrderPrompt(this.game);
         spyOn(this.prompt, 'activePrompt').and.returnValue(this.activePrompt);
         spyOn(this.prompt, 'waitingPrompt').and.returnValue(this.waitingPrompt);
-        spyOn(this.player1, 'setPrompt');
-        spyOn(this.player2, 'setPrompt');
-        spyOn(this.player1, 'cancelPrompt');
-        spyOn(this.player2, 'cancelPrompt');
     });
 
     describe('the continue() function', function() {
@@ -77,8 +72,7 @@ describe('the PlayerOrderPrompt', function() {
 
         describe('when the first player order changes after construction', function() {
             beforeEach(function() {
-                this.player2.firstPlayer = false;
-                this.player1.firstPlayer = true;
+                this.game.getPlayersInFirstPlayerOrder.and.returnValue([this.player1, this.player2]);
             });
 
             it('should prompt players in the current first-player order', function() {

--- a/test/server/gamesteps/playerorderprompt.spec.js
+++ b/test/server/gamesteps/playerorderprompt.spec.js
@@ -1,106 +1,103 @@
 /*global describe, it, beforeEach, expect, spyOn*/
+/* eslint camelcase: 0, no-invalid-this: 0 */
 
 const PlayerOrderPrompt = require('../../../server/game/gamesteps/playerorderprompt.js');
 const Game = require('../../../server/game/game.js');
 const Player = require('../../../server/game/player.js');
 
-describe('the PlayerOrderPrompt', () => {
-    var prompt;
-    var game = {};
-    var player1;
-    var player2;
-    var activePrompt = {};
-    var waitingPrompt = {};
+describe('the PlayerOrderPrompt', function() {
+    beforeEach(function() {
+        this.activePrompt = { active: true };
+        this.waitingPrompt = { active: false };
 
-    beforeEach(() => {
-        game = new Game('1', 'Test Game');
-        player1 = new Player('1', { username: 'Player 1' }, true, game);
-        player2 = new Player('2', { username: 'Player 2' }, false, game);
-        player2.firstPlayer = true;
-        game.playersAndSpectators[0] = player1;
-        game.playersAndSpectators[1] = player2;
-        prompt = new PlayerOrderPrompt(game);
-        spyOn(prompt, 'activePrompt').and.returnValue(activePrompt);
-        spyOn(prompt, 'waitingPrompt').and.returnValue(waitingPrompt);
-        spyOn(player1, 'setPrompt');
-        spyOn(player2, 'setPrompt');
-        spyOn(player1, 'cancelPrompt');
-        spyOn(player2, 'cancelPrompt');
+        this.game = new Game('1', 'Test Game');
+        this.player1 = new Player('1', { username: 'Player 1' }, true, this.game);
+        this.player2 = new Player('2', { username: 'Player 2' }, false, this.game);
+        this.player2.firstPlayer = true;
+        this.game.playersAndSpectators[0] = this.player1;
+        this.game.playersAndSpectators[1] = this.player2;
+        this.prompt = new PlayerOrderPrompt(this.game);
+        spyOn(this.prompt, 'activePrompt').and.returnValue(this.activePrompt);
+        spyOn(this.prompt, 'waitingPrompt').and.returnValue(this.waitingPrompt);
+        spyOn(this.player1, 'setPrompt');
+        spyOn(this.player2, 'setPrompt');
+        spyOn(this.player1, 'cancelPrompt');
+        spyOn(this.player2, 'cancelPrompt');
     });
 
-    describe('the continue() function', () => {
-        describe('when there is a skip condition', () => {
-            beforeEach(() => {
-                spyOn(prompt, 'skipCondition').and.callFake(p => p === player2);
+    describe('the continue() function', function() {
+        describe('when there is a skip condition', function() {
+            beforeEach(function() {
+                spyOn(this.prompt, 'skipCondition').and.callFake(p => p === this.player2);
             });
 
-            it('should skip over the matching players', () => {
-                prompt.continue();
-                expect(prompt.currentPlayer).toBe(player1);
-            });
-        });
-
-        describe('when the prompt is incomplete', () => {
-            it('should prompt players in first-player order', () => {
-                prompt.continue();
-                expect(prompt.currentPlayer).toBe(player2);
-            });
-
-            it('should give the active prompt to the current player', () => {
-                prompt.continue();
-                expect(player2.setPrompt).toHaveBeenCalledWith(activePrompt);
-            });
-
-            it('should give the waiting prompt to the remaining players', () => {
-                prompt.continue();
-                expect(player1.setPrompt).toHaveBeenCalledWith(waitingPrompt);
-            });
-
-            it('should return false', () => {
-                expect(prompt.continue()).toBe(false);
+            it('should skip over the matching players', function() {
+                this.prompt.continue();
+                expect(this.prompt.currentPlayer).toBe(this.player1);
             });
         });
 
-        describe('when each player has been completed', () => {
-            beforeEach(() => {
-                prompt.completePlayer();
-                prompt.completePlayer();
+        describe('when the prompt is incomplete', function() {
+            it('should prompt players in first-player order', function() {
+                this.prompt.continue();
+                expect(this.prompt.currentPlayer).toBe(this.player2);
             });
 
-            it('should set the cancel prompts for each player', () => {
-                prompt.continue();
-                expect(player1.cancelPrompt).toHaveBeenCalled();
-                expect(player2.cancelPrompt).toHaveBeenCalled();
+            it('should give the active prompt to the current player', function() {
+                this.prompt.continue();
+                expect(this.player2.setPrompt).toHaveBeenCalledWith(this.activePrompt);
             });
 
-            it('should return true', () => {
-                expect(prompt.continue()).toBe(true);
+            it('should give the waiting prompt to the remaining players', function() {
+                this.prompt.continue();
+                expect(this.player1.setPrompt).toHaveBeenCalledWith(this.waitingPrompt);
+            });
+
+            it('should return false', function() {
+                expect(this.prompt.continue()).toBe(false);
+            });
+        });
+
+        describe('when each player has been completed', function() {
+            beforeEach(function() {
+                this.prompt.completePlayer();
+                this.prompt.completePlayer();
+            });
+
+            it('should set the cancel prompts for each player', function() {
+                this.prompt.continue();
+                expect(this.player1.cancelPrompt).toHaveBeenCalled();
+                expect(this.player2.cancelPrompt).toHaveBeenCalled();
+            });
+
+            it('should return true', function() {
+                expect(this.prompt.continue()).toBe(true);
             });
         });
 
         describe('when the first player order changes after construction', function() {
             beforeEach(function() {
-                player2.firstPlayer = false;
-                player1.firstPlayer = true;
+                this.player2.firstPlayer = false;
+                this.player1.firstPlayer = true;
             });
 
-            it('should prompt players in the current first-player order', () => {
-                prompt.continue();
-                expect(prompt.currentPlayer).toBe(player1);
+            it('should prompt players in the current first-player order', function() {
+                this.prompt.continue();
+                expect(this.prompt.currentPlayer).toBe(this.player1);
             });
 
-            it('should give the active prompt to the current player', () => {
-                prompt.continue();
-                expect(player1.setPrompt).toHaveBeenCalledWith(activePrompt);
+            it('should give the active prompt to the current player', function() {
+                this.prompt.continue();
+                expect(this.player1.setPrompt).toHaveBeenCalledWith(this.activePrompt);
             });
 
-            it('should give the waiting prompt to the remaining players', () => {
-                prompt.continue();
-                expect(player2.setPrompt).toHaveBeenCalledWith(waitingPrompt);
+            it('should give the waiting prompt to the remaining players', function() {
+                this.prompt.continue();
+                expect(this.player2.setPrompt).toHaveBeenCalledWith(this.waitingPrompt);
             });
 
-            it('should return false', () => {
-                expect(prompt.continue()).toBe(false);
+            it('should return false', function() {
+                expect(this.prompt.continue()).toBe(false);
             });
         });
     });


### PR DESCRIPTION
* Action windows such as those at the start of challenges phase and in the dominance phase were prompting in the order for the previous round because they're queued before the new first player is chosen. Action windows queued after first player was chosen were in the correct order.
* Any other prompts derived from `PlayerOrderPrompt` were potentially affected but less noticeable.
* Converts the `PlayerOrderPrompt` tests and makes them less integrationy. First commit is the real change, remaining 2 are conversion if that makes review easier.