### PR TITLE
Convert Marching Orders to an effect

### DIFF
--- a/server/game/cards/plots/01/marchingorders.js
+++ b/server/game/cards/plots/01/marchingorders.js
@@ -1,12 +1,19 @@
 const PlotCard = require('../../../plotcard.js');
 
 class MarchingOrders extends PlotCard {
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            match: card => card.getType() === 'location' || card.getType() === 'attachment',
+            targetLocation: 'hand',
+            effect: ability.effects.cannotMarshal()
+        });
+    }
     canPlay(player, card) {
         if(this.controller !== player || this.controller !== card.controller) {
             return true;
         }
 
-        if(card.getType() === 'location' || card.getType() === 'attachment' || card.getType() === 'event') {
+        if(card.getType() === 'event') {
             return false;
         }
 

--- a/server/game/cards/plots/01/marchingorders.js
+++ b/server/game/cards/plots/01/marchingorders.js
@@ -7,17 +7,11 @@ class MarchingOrders extends PlotCard {
             targetLocation: 'hand',
             effect: ability.effects.cannotMarshal()
         });
-    }
-    canPlay(player, card) {
-        if(this.controller !== player || this.controller !== card.controller) {
-            return true;
-        }
-
-        if(card.getType() === 'event') {
-            return false;
-        }
-
-        return true;
+        this.persistentEffect({
+            match: card => card.getType() === 'event',
+            targetLocation: 'hand',
+            effect: ability.effects.cannotPlay()
+        });
     }
 }
 

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -277,6 +277,16 @@ const Effects = {
             }
         };
     },
+    cannotPlay: function() {
+        return {
+            apply: function(card) {
+                card.cannotPlay = true;
+            },
+            unapply: function(card) {
+                card.cannotPlay = false;
+            }
+        };
+    },
     modifyChallengeTypeLimit: function(challengeType, value) {
         return {
             apply: function(player) {

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -267,6 +267,16 @@ const Effects = {
             }
         };
     },
+    cannotMarshal: function() {
+        return {
+            apply: function(card) {
+                card.cannotMarshal = true;
+            },
+            unapply: function(card) {
+                card.cannotMarshal = false;
+            }
+        };
+    },
     modifyChallengeTypeLimit: function(challengeType, value) {
         return {
             apply: function(player) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -332,6 +332,10 @@ class Player extends Spectator {
             return false;
         }
 
+        if(card.getType() === 'event' && card.cannotPlay) {
+            return false;
+        }
+
         if(!this.isCardUuidInList(this.hand, card) && !overrideHandCheck) {
             return false;
         }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -310,14 +310,6 @@ class Player extends Spectator {
     }
 
     canPlayCard(card, overrideHandCheck = false) {
-        if(this.activePlot && !this.activePlot.canPlay(this, card)) {
-            return false;
-        }
-
-        if(!this.cardsInPlay.all(c => c.canPlay(this, card))) {
-            return false;
-        }
-
         if(!card.canPlay(this, card)) {
             return false;
         }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -328,6 +328,10 @@ class Player extends Spectator {
             }
         }
 
+        if(card.getType() !== 'event' && this.phase === 'marshal' && card.cannotMarshal) {
+            return false;
+        }
+
         if(!this.isCardUuidInList(this.hand, card) && !overrideHandCheck) {
             return false;
         }


### PR DESCRIPTION
* Adds effects for 'cannot play' and 'cannot marshal' and updates Marching Orders to use them. This has the side effect of allowing Marching Orders to be blankable through Forgotten Plans (previously would have ignored the blank).
* Since Marching Orders was the only non-event card using the `canPlay` method, it was possible to stop asking all other cards in play for permission when playing a card. `canPlay` will only be called for events under the current scenario, and player will always be `this.controller` and card will always be `this`, rendering the parameters useless. I would have gone through and updated all usages but this was a first baby step towards experimenting w/ what I mentioned in #296, so usage may change more.