### PR TITLE
Bastard Daughter should self-react, not by name.

### DIFF
--- a/server/game/cards/characters/02/bastarddaughter.js
+++ b/server/game/cards/characters/02/bastarddaughter.js
@@ -6,7 +6,7 @@ class BastardDaughter extends DrawCard {
             when: {
                 onCharacterKilled: (event, player, card) => (
                     this.controller === card.controller &&
-                    (card.name === 'Bastard Daughter' || card.name === 'The Red Viper')
+                    (card === this || card.name === 'The Red Viper')
                 )
             },
             handler: () => {


### PR DESCRIPTION
Per the rules if a card refers to itself by name, its ability should
only trigger for that specific card. Previously, Bastard Daughter would
react to any other Bastard Daughter being killed, when it should only do
so for itself.

Fixes #314.