### PR TITLE
Reapply effects upon take control.

### DIFF
--- a/server/game/cards/characters/01/euroncrowseye.js
+++ b/server/game/cards/characters/01/euroncrowseye.js
@@ -23,9 +23,6 @@ class EuronCrowsEye extends DrawCard {
 
     onCardSelected(player, card) {
         this.game.takeControl(player, card);
-
-        player.moveCard(card, 'play area');
-
         this.game.addMessage('{0} uses {1} to put {2} into play from their opponent\'s discard pile', player, this, card);
 
         return true;

--- a/server/game/cards/characters/01/yoren.js
+++ b/server/game/cards/characters/01/yoren.js
@@ -19,9 +19,6 @@ class Yoren extends DrawCard {
 
     onCardSelected(player, card) {
         this.game.takeControl(player, card);
-
-        player.moveCard(card, 'play area');
-
         this.game.addMessage('{0} uses {1} to put {2} into play from {3}\'s discard pile under their control', player, this, card, card.owner);
 
         return true;

--- a/server/game/cards/locations/04/houseoftheundying.js
+++ b/server/game/cards/locations/04/houseoftheundying.js
@@ -31,7 +31,6 @@ class HouseOfTheUndying extends DrawCard {
 
         _.each(eligibleCharacters, card => {
             this.game.takeControl(this.controller, card);
-            card.moveTo('play area');
             this.atEndOfPhase(ability => ({
                 match: card,
                 effect: ability.effects.moveToDeadPileIfStillInPlay()

--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -6,7 +6,7 @@ class EffectEngine {
     constructor(game) {
         this.game = game;
         this.events = new EventRegistrar(game, this);
-        this.events.register(['onCardEntersPlay', 'onCardLeftPlay', 'onCardEntersHand', 'onCardLeftHand', 'onCardBlankToggled', 'onChallengeFinished', 'onPhaseEnded', 'onAtEndOfPhase', 'onRoundEnded']);
+        this.events.register(['onCardEntersPlay', 'onCardLeftPlay', 'onCardEntersHand', 'onCardLeftHand', 'onCardTakenControl', 'onCardBlankToggled', 'onChallengeFinished', 'onPhaseEnded', 'onAtEndOfPhase', 'onRoundEnded']);
         this.effects = [];
         this.recalculateEvents = {};
     }
@@ -45,6 +45,14 @@ class EffectEngine {
 
     onCardLeftHand(e, player, card) {
         this.removeTargetFromPersistentEffects(card, 'hand');
+    }
+
+    onCardTakenControl(e, card) {
+        _.each(this.effects, effect => {
+            if(effect.duration === 'persistent' && effect.source === card) {
+                effect.resetTargets(this.getTargets());
+            }
+        });
     }
 
     addTargetForPersistentEffects(card, targetLocation) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -653,14 +653,19 @@ class Game extends EventEmitter {
             }
         }
 
-        if(message.indexOf('/take-control') === 0) {
+        if(message.indexOf('/give-control') === 0) {
             this.promptForSelect(player, {
                 activePromptTitle: 'Select a character',
-                waitingPromptTitle: 'Waiting for opponent to take control',
-                cardCondition: card => card.location === 'play area' && card.controller !== player,
+                waitingPromptTitle: 'Waiting for opponent to give control',
+                cardCondition: card => card.location === 'play area' && card.controller === player,
                 onSelect: (p, card) => {
-                    this.takeControl(player, card);
-                    this.addMessage('{0} uses the /take-control command to control {1}', p, card);
+                    var otherPlayer = this.getOtherPlayer(player);
+                    if(!otherPlayer) {
+                        return true;
+                    }
+
+                    this.takeControl(otherPlayer, card);
+                    this.addMessage('{0} uses the /give-control command to pass control of {1} to {2}', p, card, otherPlayer);
 
                     return true;
                 }

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -657,7 +657,7 @@ class Game extends EventEmitter {
             this.promptForSelect(player, {
                 activePromptTitle: 'Select a character',
                 waitingPromptTitle: 'Waiting for opponent to give control',
-                cardCondition: card => card.location === 'play area' && card.controller === player,
+                cardCondition: card => ['play area', 'discard pile', 'dead pile'].includes(card.location) && card.controller === player,
                 onSelect: (p, card) => {
                     var otherPlayer = this.getOtherPlayer(player);
                     if(!otherPlayer) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -653,6 +653,22 @@ class Game extends EventEmitter {
             }
         }
 
+        if(message.indexOf('/take-control') === 0) {
+            this.promptForSelect(player, {
+                activePromptTitle: 'Select a character',
+                waitingPromptTitle: 'Waiting for opponent to take control',
+                cardCondition: card => card.location === 'play area' && card.controller !== player,
+                onSelect: (p, card) => {
+                    this.takeControl(player, card);
+                    this.addMessage('{0} uses the /take-control command to control {1}', p, card);
+
+                    return true;
+                }
+            });
+
+            return;
+        }
+
         if(message.indexOf('/reset-challenges-count') === 0) {
             player.challenges.reset();
             this.addMessage('{0} uses /reset-challenges-count to reset the number of challenges performed', player);

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -818,6 +818,8 @@ class Game extends EventEmitter {
         newController.cardsInPlay.push(card);
 
         card.controller = newController;
+
+        this.raiseEvent('onCardTakenControl', card);
     }
 
     watch(socketId, user) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -821,8 +821,13 @@ class Game extends EventEmitter {
 
         oldController.removeCardFromPile(card);
         newController.cardsInPlay.push(card);
-
         card.controller = newController;
+
+        if(card.location !== 'play area') {
+            card.play(newController, false);
+            card.moveTo('play area');
+            this.raiseEvent('onCardEntersPlay', card);
+        }
 
         this.raiseEvent('onCardTakenControl', card);
     }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -834,7 +834,7 @@ class Player extends Spectator {
 
         var targetPile = this.getSourceList(targetLocation);
 
-        if(!targetPile) {
+        if(!targetPile || targetPile.contains(card)) {
             return;
         }
 

--- a/test/server/player/movecard.spec.js
+++ b/test/server/player/movecard.spec.js
@@ -163,5 +163,24 @@ describe('Player', function() {
                 expect(this.player.drawDeck.last()).toBe(this.card);
             });
         });
+
+        describe('when the card location property and actual location do not match', function() {
+            // Game.takeControl used to push the card directly onto cardsInPlay
+            // but did not update the location for the card. This caused weird
+            // problems where the strength of the card would be doubled for both
+            // challenges and dominance.
+            beforeEach(function() {
+                // Put into play with the wrong location.
+                this.card.location = 'discard pile';
+                this.player.cardsInPlay = _([this.card]);
+
+                this.player.moveCard(this.card, 'play area');
+            });
+
+            it('should not duplicate the card', function() {
+                expect(this.player.cardsInPlay.size()).toBe(1);
+                expect(this.player.cardsInPlay.toArray()).toEqual([this.card]);
+            });
+        });
     });
 });


### PR DESCRIPTION
* Adds a /take-control command (useful for debugging purposes + cards that haven't been implemented yet)
* Recalculates effects once a card changes controller to ensure the new controller receives the benefits of the effect (and the old controller loses it).

Fixes #317.
Fixes #319.