### PR TITLE
Allow invalid attachments while card is blank.

### DIFF
--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -185,16 +185,29 @@ class DrawCard extends BaseCard {
         return true;
     }
 
+    clearBlank() {
+        super.clearBlank();
+        this.attachments.each(attachment => {
+            if(!this.allowAttachment(attachment)) {
+                this.controller.discardCard(attachment, false);
+            }
+        });
+    }
+
+    allowAttachment(attachment) {
+        return (
+            this.isBlank() ||
+            this.allowedAttachmentTrait === 'any' ||
+            this.allowedAttachmentTrait !== 'none' && attachment.hasTrait(this.allowedAttachmentTrait)
+        );
+    }
+
     canAttach(player, card) {
-        if(this.getType() !== 'attachment' || card.allowedAttachmentTrait === 'none') {
+        if(this.getType() !== 'attachment') {
             return false;
         }
 
-        if(card.allowedAttachmentTrait !== 'any') {
-            return this.hasTrait(card.allowedAttachmentTrait);
-        }
-
-        return true;
+        return card.allowAttachment(this);
     }
 
     attach() {

--- a/test/server/card/drawcard.canAttach.spec.js
+++ b/test/server/card/drawcard.canAttach.spec.js
@@ -1,95 +1,95 @@
 /*global describe, it, beforeEach, expect, jasmine*/
-/* eslint camelcase: 0 */
+/* eslint camelcase: 0, no-invalid-this: 0 */
 
 const DrawCard = require('../../../server/game/drawcard.js');
 
 describe('the DrawCard', function() {
-    var owner = {};
-    var player = {};
-    var targetCard;
-    var attachment;
-
     describe('the canAttach() function', function() {
+        beforeEach(function() {
+            this.owner = {
+                game: jasmine.createSpyObj('game', ['raiseEvent'])
+            };
+        });
+
         describe('when the card is not an attachment', function() {
             beforeEach(function() {
-                owner.game = jasmine.createSpyObj('game', ['raiseEvent']);
-                targetCard = new DrawCard(owner, { text: '' });
-                attachment = new DrawCard(owner, { type_code: 'event' });
+                this.targetCard = new DrawCard(this.owner, { text: '' });
+                this.attachment = new DrawCard(this.owner, { type_code: 'event' });
             });
 
             it('should return false', function() {
-                expect(attachment.canAttach(player, targetCard)).toBe(false);
+                expect(this.attachment.canAttach(this.player, this.targetCard)).toBe(false);
             });
         });
 
         describe('when the target card does not allow attachments', function() {
             beforeEach(function() {
-                targetCard = new DrawCard(owner, { text: 'No attachments.' });
-                attachment = new DrawCard(owner, { type_code: 'attachment' });
+                this.targetCard = new DrawCard(this.owner, { text: 'No attachments.' });
+                this.attachment = new DrawCard(this.owner, { type_code: 'attachment' });
             });
 
             it('should return false', function() {
-                expect(attachment.canAttach(player, targetCard)).toBe(false);
+                expect(this.attachment.canAttach(this.player, this.targetCard)).toBe(false);
             });
 
             describe('but the target card is blank', function() {
                 beforeEach(function() {
-                    targetCard.setBlank();
+                    this.targetCard.setBlank();
                 });
 
                 it('should return true', function() {
-                    expect(attachment.canAttach(player, targetCard)).toBe(true);
+                    expect(this.attachment.canAttach(this.player, this.targetCard)).toBe(true);
                 });
             });
         });
 
         describe('when the target card only allows certain kinds of attachments', function() {
             beforeEach(function() {
-                targetCard = new DrawCard(owner, { text: 'No attachments except <b>Weapon</b>.' });
+                this.targetCard = new DrawCard(this.owner, { text: 'No attachments except <b>Weapon</b>.' });
             });
 
             describe('and the card text has the target in italics', function() {
                 beforeEach(function() {
-                    targetCard = new DrawCard(owner, { text: 'No attachments except <i>Weapon</i>.' });
+                    this.targetCard = new DrawCard(this.owner, { text: 'No attachments except <i>Weapon</i>.' });
                 });
 
                 describe('and the attachment has that trait', function() {
                     beforeEach(function() {
-                        attachment = new DrawCard(owner, { type_code: 'attachment', traits: 'Condition. Weapon.' });
+                        this.attachment = new DrawCard(this.owner, { type_code: 'attachment', traits: 'Condition. Weapon.' });
                     });
 
                     it('should return true', function() {
-                        expect(attachment.canAttach(player, targetCard)).toBe(true);
+                        expect(this.attachment.canAttach(this.player, this.targetCard)).toBe(true);
                     });
                 });
             });
 
             describe('and the attachment has that trait', function() {
                 beforeEach(function() {
-                    attachment = new DrawCard(owner, { type_code: 'attachment', traits: 'Condition. Weapon.' });
+                    this.attachment = new DrawCard(this.owner, { type_code: 'attachment', traits: 'Condition. Weapon.' });
                 });
 
                 it('should return true', function() {
-                    expect(attachment.canAttach(player, targetCard)).toBe(true);
+                    expect(this.attachment.canAttach(this.player, this.targetCard)).toBe(true);
                 });
             });
 
             describe('and the attachment does not have that trait', function() {
                 beforeEach(function() {
-                    attachment = new DrawCard(owner, { type_code: 'attachment', traits: 'Condition.' });
+                    this.attachment = new DrawCard(this.owner, { type_code: 'attachment', traits: 'Condition.' });
                 });
 
                 it('should return false', function() {
-                    expect(attachment.canAttach(player, targetCard)).toBe(false);
+                    expect(this.attachment.canAttach(this.player, this.targetCard)).toBe(false);
                 });
 
                 describe('but the target card is blank', function() {
                     beforeEach(function() {
-                        targetCard.setBlank();
+                        this.targetCard.setBlank();
                     });
 
                     it('should return true', function() {
-                        expect(attachment.canAttach(player, targetCard)).toBe(true);
+                        expect(this.attachment.canAttach(this.player, this.targetCard)).toBe(true);
                     });
                 });
             });
@@ -97,12 +97,12 @@ describe('the DrawCard', function() {
 
         describe('when there are no restrictions', function() {
             beforeEach(function() {
-                targetCard = new DrawCard(owner, { text: '' });
-                attachment = new DrawCard(owner, { type_code: 'attachment', traits: '' });
+                this.targetCard = new DrawCard(this.owner, { text: '' });
+                this.attachment = new DrawCard(this.owner, { type_code: 'attachment', traits: '' });
             });
 
             it('should return true', function() {
-                expect(attachment.canAttach(player, targetCard)).toBe(true);
+                expect(this.attachment.canAttach(this.player, this.targetCard)).toBe(true);
             });
         });
     });

--- a/test/server/card/drawcard.canAttach.spec.js
+++ b/test/server/card/drawcard.canAttach.spec.js
@@ -1,4 +1,4 @@
-/*global describe, it, beforeEach, expect*/
+/*global describe, it, beforeEach, expect, jasmine*/
 /* eslint camelcase: 0 */
 
 const DrawCard = require('../../../server/game/drawcard.js');
@@ -12,6 +12,7 @@ describe('the DrawCard', function() {
     describe('the canAttach() function', function() {
         describe('when the card is not an attachment', function() {
             beforeEach(function() {
+                owner.game = jasmine.createSpyObj('game', ['raiseEvent']);
                 targetCard = new DrawCard(owner, { text: '' });
                 attachment = new DrawCard(owner, { type_code: 'event' });
             });
@@ -29,6 +30,16 @@ describe('the DrawCard', function() {
 
             it('should return false', function() {
                 expect(attachment.canAttach(player, targetCard)).toBe(false);
+            });
+
+            describe('but the target card is blank', function() {
+                beforeEach(function() {
+                    targetCard.setBlank();
+                });
+
+                it('should return true', function() {
+                    expect(attachment.canAttach(player, targetCard)).toBe(true);
+                });
             });
         });
 
@@ -70,6 +81,16 @@ describe('the DrawCard', function() {
 
                 it('should return false', function() {
                     expect(attachment.canAttach(player, targetCard)).toBe(false);
+                });
+
+                describe('but the target card is blank', function() {
+                    beforeEach(function() {
+                        targetCard.setBlank();
+                    });
+
+                    it('should return true', function() {
+                        expect(attachment.canAttach(player, targetCard)).toBe(true);
+                    });
                 });
             });
         });

--- a/test/server/card/drawcard.clearblank.spec.js
+++ b/test/server/card/drawcard.clearblank.spec.js
@@ -1,0 +1,50 @@
+/*global describe, it, beforeEach, expect, spyOn, jasmine*/
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+const DrawCard = require('../../../server/game/drawcard.js');
+
+describe('DrawCard', function() {
+    beforeEach(function() {
+        this.game = jasmine.createSpyObj('game', ['raiseEvent']);
+        this.player = jasmine.createSpyObj('player', ['discardCard']);
+        this.player.game = this.game;
+        this.card = new DrawCard(this.player, {});
+        this.card.setBlank();
+    });
+
+    describe('clearBlank()', function() {
+        it('should remove blanking', function() {
+            this.card.clearBlank();
+            expect(this.card.isBlank()).toBe(false);
+        });
+
+        describe('when the card has attachments', function() {
+            beforeEach(function() {
+                this.attachment = {};
+                this.card.attachments.push(this.attachment);
+            });
+
+            describe('and it will still be valid after unblanking', function() {
+                beforeEach(function() {
+                    spyOn(this.card, 'allowAttachment').and.returnValue(true);
+                });
+
+                it('should not discard the attachment', function() {
+                    this.card.clearBlank();
+                    expect(this.player.discardCard).not.toHaveBeenCalled();
+                });
+            });
+
+            describe('and it will no longer be valid after unblanking', function() {
+                beforeEach(function() {
+                    spyOn(this.card, 'allowAttachment').and.returnValue(false);
+                });
+
+                it('should discard the attachment without allowing saves', function() {
+                    this.card.clearBlank();
+                    expect(this.player.discardCard).toHaveBeenCalledWith(this.attachment, false);
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Previously, cards with 'No attachments' and 'No attachments except' in
their card text were ignoring blanking. Per the rules, if the card is
blanked through various means (e.g. Fortified Position) then the
attachment restriction goes away. If the card later becomes unblanked,
then any invalid attachments on it are discarded.