### PR TITLE
Get LoCR Cersei's reaction working again

### DIFF
--- a/server/game/cards/characters/05/cerseilannister.js
+++ b/server/game/cards/characters/05/cerseilannister.js
@@ -12,7 +12,10 @@ class CerseiLannister extends DrawCard {
         });
         this.reaction({
             when: {
-                onCardDiscarded: (event, player, card) => this.controller !== player && card.location === 'hand'
+                onCardDiscarded: (event, player, card, allowSave, originalLocation) => (
+                    this.controller !== card.controller &&
+                    originalLocation === 'hand'
+                )
             },
             limit: ability.limit.perRound(3),
             handler: () => {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -667,15 +667,14 @@ class Player extends Spectator {
         if(target === 'play area') {
             this.game.playCard(this.name, cardId, true, sourceList);
         } else {
-            // It's important that these events be raised prior to the card
-            // being moved. Moving the card out of play will remove event
-            // listeners and the card may need to react to itself being killed.
-            if(target === 'dead pile') {
-                this.game.raiseEvent('onCharacterKilled', this, card, false);
+            if(target === 'dead pile' && card.location === 'play area') {
+                this.killCharacter(card, false);
+                return true;
             }
 
             if(target === 'discard pile') {
-                this.game.raiseEvent('onCardDiscarded', this, card, false);
+                this.discardCard(card, false);
+                return true;
             }
 
             this.moveCard(card, target);

--- a/test/server/player/drop.spec.js
+++ b/test/server/player/drop.spec.js
@@ -354,15 +354,12 @@ describe('Player', () => {
                 this.cardSpy.getType.and.returnValue('character');
             });
 
-            it('should fire onCharacterKilled before onCardLeftPlay', function() {
-                var events = [];
-                this.gameSpy.raiseEvent.and.callFake((name) => {
-                    events.push(name);
-                });
+            it('should rely on killCharacter to maintain event order', function() {
+                spyOn(this.player, 'killCharacter');
 
                 var result = this.player.drop(this.cardSpy.uuid, 'play area', 'dead pile');
                 expect(result).toBe(true);
-                expect(events.indexOf('onCharacterKilled')).toBeLessThan(events.indexOf('onCardLeftPlay'));
+                expect(this.player.killCharacter).toHaveBeenCalledWith(this.cardSpy, false);
             });
         });
     });


### PR DESCRIPTION
* LoCR Cersei will react again when cards are discarded from hand. Note: This brings back bug #184 which only stopped because the event got wiped out somehow. So Cersei will again react to every single card discarded and thus trigger inappropriately on 2 claim intrigue and reserve discard. That will need to be fixed separately.
* Makes drag-drop handling more consistent by using the discardCard and killCharacter methods. Previously it was trying to simulate those methods by raising events but it didn't quite match up with what those methods do.