### PR TITLE
UI for Castamere schemes and 'out of game' cards.

### DIFF
--- a/client/GameBoard.jsx
+++ b/client/GameBoard.jsx
@@ -8,6 +8,7 @@ import PlayerRow from './GameComponents/PlayerRow.jsx';
 import MenuPane from './GameComponents/MenuPane.jsx';
 import CardZoom from './GameComponents/CardZoom.jsx';
 import Messages from './GameComponents/Messages.jsx';
+import AdditionalCardPile from './GameComponents/AdditionalCardPile.jsx';
 import Card from './GameComponents/Card.jsx';
 import CardCollection from './GameComponents/CardCollection.jsx';
 import {tryParseJSON} from './util.js';
@@ -213,6 +214,26 @@ export class InnerGameBoard extends React.Component {
         return cardsByLocation;
     }
 
+    getAdditionalPlotPiles(player, isMe) {
+        if(!player) {
+            return;
+        }
+
+        var piles = _.reject(player.additionalPiles, pile => pile.cards.length === 0 || pile.area !== 'plots');
+        var index = 0;
+        return _.map(piles, pile => {
+            return (
+                <AdditionalCardPile key={'additional-pile-' + index++}
+                    className='plot'
+                    isMe={isMe}
+                    onMouseOut={this.onMouseOut}
+                    onMouseOver={this.onMouseOver}
+                    pile={pile}
+                    spectating={this.state.spectating} />
+            );
+        });
+    }
+
     onCommand(command, arg, method) {
         var commandArg = arg;
 
@@ -309,6 +330,7 @@ export class InnerGameBoard extends React.Component {
                         <div className='middle'>
                              <div className='plots-pane'>
                                 <div className='plot-group'>
+                                    {this.getAdditionalPlotPiles(otherPlayer, false)}
                                     <CardCollection className={otherPlayer && otherPlayer.plotSelected ? 'plot plot-selected' : 'plot'}
                                                     title='Plots' source='plot deck' cards={otherPlayer ? otherPlayer.plotDeck : []}
                                                     topCard={{ facedown: true, kneeled: true }} orientation='horizontal'
@@ -325,6 +347,7 @@ export class InnerGameBoard extends React.Component {
                                     <CardCollection className={thisPlayer.plotSelected ? 'plot plot-selected' : 'plot'}
                                                     title='Plots' source='plot deck' cards={thisPlayer.plotDeck} topCard={{ facedown: true, kneeled: true }} orientation='horizontal'
                                                     onMouseOver={this.onMouseOver} onMouseOut={this.onMouseOut} onCardClick={this.onCardClick} onDragDrop={this.onDragDrop} onTouchMove={this.onTouchMove} />
+                                    {this.getAdditionalPlotPiles(thisPlayer, !this.state.spectating)}
                                 </div>
                             </div>
                             <div className='middle-right'>
@@ -356,6 +379,7 @@ export class InnerGameBoard extends React.Component {
 
                     <div className='center'>
                         <PlayerRow
+                            additionalPiles={otherPlayer ? otherPlayer.additionalPiles : {}}
                             hand={otherPlayer ? otherPlayer.hand : []} isMe={false}
                             numDrawCards={otherPlayer ? otherPlayer.numDrawCards : 0}
                             discardPile={otherPlayer ? otherPlayer.discardPile : []}
@@ -374,6 +398,7 @@ export class InnerGameBoard extends React.Component {
                             </div>
                         </div>
                         <PlayerRow isMe={!this.state.spectating}
+                            additionalPiles={thisPlayer.additionalPiles}
                             hand={thisPlayer.hand}
                             onCardClick={this.onCardClick}
                             onMouseOver={this.onMouseOver}

--- a/client/GameBoard.jsx
+++ b/client/GameBoard.jsx
@@ -340,7 +340,7 @@ export class InnerGameBoard extends React.Component {
                                                     topCard={otherPlayer ? otherPlayer.activePlot : undefined} orientation='horizontal' onMouseOver={this.onMouseOver}
                                                     onMouseOut={this.onMouseOut} onCardClick={this.onCardClick} />
                                 </div>
-                                <div className='plot-group'>
+                                <div className='plot-group our-side'>
                                     <CardCollection className='plot' title='Used Plots' source='revealed plots' cards={thisPlayer.plotDiscard} topCard={thisPlayer.activePlot}
                                                     onMouseOver={this.onMouseOver} onMouseOut={this.onMouseOut} orientation='horizontal' onMenuItemClick={this.onMenuItemClick}
                                                     onCardClick={this.onCardClick} onDragDrop={this.onDragDrop} />

--- a/client/GameComponents/AdditionalCardPile.jsx
+++ b/client/GameComponents/AdditionalCardPile.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import _ from 'underscore';
+
+import CardCollection from './CardCollection.jsx';
+
+class AdditionalCardPile extends React.Component {
+    render() {
+        var topCard = _.last(this.props.pile.cards);
+        if(this.props.pile.isPrivate) {
+            topCard = { facedown: true, kneeled: true };
+        } else if(topCard.facedown) {
+            topCard.kneeled = true;
+        }
+
+        return (
+            <CardCollection
+                className={this.props.className}
+                title={this.props.pile.title}
+                source='additional'
+                cards={this.props.pile.cards}
+                topCard={topCard}
+                onMouseOver={this.props.onMouseOver}
+                onMouseOut={this.props.onMouseOut}
+                popupLocation={this.props.isMe || this.props.spectating ? 'top' : 'bottom'}
+                disablePopup={this.props.pile.isPrivate && !(this.props.isMe || this.props.spectating)}
+                orientation='horizontal' />
+        );
+    }
+}
+
+AdditionalCardPile.displayName = 'AdditionalCardPile';
+AdditionalCardPile.propTypes = {
+    className: React.PropTypes.string,
+    isMe: React.PropTypes.bool,
+    onMouseOut: React.PropTypes.func,
+    onMouseOver: React.PropTypes.func,
+    pile: React.PropTypes.object,
+    spectating: React.PropTypes.bool
+};
+
+export default AdditionalCardPile;

--- a/client/GameComponents/Card.jsx
+++ b/client/GameComponents/Card.jsx
@@ -232,7 +232,7 @@ class Card extends React.Component {
 
         cardClass += ' card-type-' + this.props.card.type;
 
-        if(this.props.orientation === 'kneeled' || this.props.card.kneeled) {
+        if(this.props.orientation === 'kneeled' || this.props.card.kneeled || this.props.orientation === 'horizontal' && this.props.card.type !== 'plot') {
             cardClass += ' horizontal';
             imageClass += ' vertical kneeled';
         } else if(this.props.orientation === 'horizontal') {
@@ -326,7 +326,7 @@ Card.propTypes = {
     onMouseOut: React.PropTypes.func,
     onMouseOver: React.PropTypes.func,
     orientation: React.PropTypes.oneOf(['horizontal', 'kneeled', 'vertical']),
-    source: React.PropTypes.oneOf(['hand', 'discard pile', 'play area', 'dead pile', 'draw deck', 'plot deck', 'revealed plots', 'selected plot', 'attachment', 'agenda', 'faction']).isRequired,
+    source: React.PropTypes.oneOf(['hand', 'discard pile', 'play area', 'dead pile', 'draw deck', 'plot deck', 'revealed plots', 'selected plot', 'attachment', 'agenda', 'faction', 'additional']).isRequired,
     style: React.PropTypes.object,
     wrapped: React.PropTypes.bool
 };

--- a/client/GameComponents/CardCollection.jsx
+++ b/client/GameComponents/CardCollection.jsx
@@ -129,6 +129,7 @@ class CardCollection extends React.Component {
                 <div className='inner'>
                     {cardList}
                 </div>
+                <div className='arrow-indicator'></div>
             </div>);
 
         return popup;
@@ -204,7 +205,7 @@ CardCollection.propTypes = {
     orientation: React.PropTypes.string,
     popupLocation: React.PropTypes.string,
     popupMenu: React.PropTypes.array,
-    source: React.PropTypes.oneOf(['hand', 'discard pile', 'play area', 'dead pile', 'draw deck', 'plot deck', 'revealed plots', 'selected plot', 'attachment', 'agenda', 'faction']).isRequired,
+    source: React.PropTypes.oneOf(['hand', 'discard pile', 'play area', 'dead pile', 'draw deck', 'plot deck', 'revealed plots', 'selected plot', 'attachment', 'agenda', 'faction', 'additional']).isRequired,
     title: React.PropTypes.string,
     topCard: React.PropTypes.object
 };

--- a/client/GameComponents/PlayerRow.jsx
+++ b/client/GameComponents/PlayerRow.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import _ from 'underscore';
 import $ from 'jquery';
 
+import AdditionalCardPile from './AdditionalCardPile.jsx';
 import Card from './Card.jsx';
 import CardCollection from './CardCollection.jsx';
 import {tryParseJSON} from '../util.js';
@@ -147,6 +148,22 @@ class PlayerRow extends React.Component {
         }
     }
 
+    getAdditionalPiles() {
+        var piles = _.reject(this.props.additionalPiles, pile => pile.cards.length === 0 || pile.area !== 'player row');
+        var index = 0;
+        return _.map(piles, pile => {
+            return (
+                <AdditionalCardPile key={'additional-pile-' + index++}
+                    className='additional-cards'
+                    isMe={this.props.isMe}
+                    onMouseOut={this.props.onMouseOut}
+                    onMouseOver={this.props.onMouseOver}
+                    pile={pile}
+                    spectating={this.props.spectating} />
+            );
+        });
+    }
+
     render() {
         var className = 'panel hand';
         var needsSquish = this.props.hand && this.props.hand.length * 64 > 342;
@@ -156,6 +173,8 @@ class PlayerRow extends React.Component {
         }
 
         var hand = this.getHand(needsSquish);
+
+        var additionalPiles = this.getAdditionalPiles();
 
         var drawDeckMenu = [
             { text: 'Show', handler: this.onShowDeckClick, showPopup: true },
@@ -187,6 +206,7 @@ class PlayerRow extends React.Component {
                 <CardCollection className='dead' title='Dead' source='dead pile' cards={this.props.deadPile}
                                 onMouseOver={this.props.onMouseOver} onMouseOut={this.props.onMouseOut} onCardClick={this.props.onCardClick}
                                 popupLocation={this.props.isMe || this.props.spectating ? 'top' : 'bottom'} onDragDrop={this.props.onDragDrop} orientation='kneeled' />
+                  {additionalPiles}
                 </div>
             </div>
         );
@@ -195,6 +215,7 @@ class PlayerRow extends React.Component {
 
 PlayerRow.displayName = 'PlayerRow';
 PlayerRow.propTypes = {
+    additionalPiles: React.PropTypes.object,
     deadPile: React.PropTypes.array,
     discardPile: React.PropTypes.array,
     drawDeck: React.PropTypes.array,

--- a/less/gameboard.less
+++ b/less/gameboard.less
@@ -153,6 +153,17 @@
   align-items: center;
 }
 
+.plot-group {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  justify-content: flex-end;
+
+  &.our-side {
+    justify-content: flex-start;
+  }
+}
+
 .plot {
   margin: 5px;
  

--- a/less/gameboard.less
+++ b/less/gameboard.less
@@ -30,6 +30,11 @@
   }
 }
 
+.player-home-row .card-pile.horizontal {
+    margin-bottom: auto;
+    margin-top: auto;
+}
+
 .popup {
   z-index: @layer-card-menu;
 
@@ -296,7 +301,7 @@
   &.our-side {
     top: initial;
     bottom: 85px;
-   
+
     .arrow-indicator {
       transform: rotate(-45deg);
       top: inherit;
@@ -305,9 +310,30 @@
   }
 }
 
-.dead {
-  margin-top: auto;
-  margin-bottom: auto;
+.player-home-row .additional-cards .popup {
+  position: absolute;
+  left: -380px;
+  top: 65px;
+  bottom: initial;
+  width: 465px;
+  min-height: 92px;
+
+  .arrow-indicator {
+    transform: rotate(135deg);
+    top: -11px;
+    left: 400px;
+  }
+
+  &.our-side {
+    top: initial;
+    bottom: 70px;
+
+    .arrow-indicator {
+      transform: rotate(-45deg);
+      top: inherit;
+      bottom: -11px;
+    }
+  }
 }
 
 .dead .popup {

--- a/server/game/cards/agendas/therainsofcastamere.js
+++ b/server/game/cards/agendas/therainsofcastamere.js
@@ -36,6 +36,7 @@ class TheRainsOfCastamere extends AgendaCard {
     }
 
     onDecksPrepared() {
+        this.owner.createAdditionalPile('scheme plots', { title: 'Schemes', area: 'plots', isPrivate: true });
         var schemePartition = this.owner.plotDeck.partition(card => card.hasTrait('Scheme'));
         this.schemes = schemePartition[0];
         this.owner.plotDeck = _(schemePartition[1]);

--- a/server/game/cards/agendas/therainsofcastamere.js
+++ b/server/game/cards/agendas/therainsofcastamere.js
@@ -39,6 +39,9 @@ class TheRainsOfCastamere extends AgendaCard {
         var schemePartition = this.owner.plotDeck.partition(card => card.hasTrait('Scheme'));
         this.schemes = schemePartition[0];
         this.owner.plotDeck = _(schemePartition[1]);
+        _.each(this.schemes, scheme => {
+            this.owner.moveCard(scheme, 'scheme plots');
+        });
     }
 
     onPlotFlip() {
@@ -52,8 +55,7 @@ class TheRainsOfCastamere extends AgendaCard {
             return;
         }
 
-        this.owner.removeActivePlot();
-        previousPlot.moveTo('out of game');
+        this.owner.removeActivePlot('out of game');
     }
 
     menuButtons() {

--- a/server/game/cards/characters/01/varys.js
+++ b/server/game/cards/characters/01/varys.js
@@ -10,8 +10,7 @@ class Varys extends DrawCard {
             },
             handler: () => {
                 this.game.addMessage('{0} removes {1} from the game to discard all characters', this.controller, this);
-                this.controller.removeCardFromPile(this);
-                this.moveTo('out of game');
+                this.controller.moveCard(this, 'out of game');
                 _.each(this.game.getPlayers(), player => {
                     player.cardsInPlay.each(card => {
                         if(card.getType() === 'character') {

--- a/server/game/cards/locations/04/houseoftheundying.js
+++ b/server/game/cards/locations/04/houseoftheundying.js
@@ -12,8 +12,7 @@ class HouseOfTheUndying extends DrawCard {
     }
 
     controlDeadCharacters() {
-        this.controller.removeCardFromPile(this);
-        this.moveTo('out of game');
+        this.controller.moveCard(this, 'out of game');
 
         var opponent = this.game.getOtherPlayer(this.controller);
 

--- a/test/server/cards/agendas/05045 - therainsofcastamere.spec.js
+++ b/test/server/cards/agendas/05045 - therainsofcastamere.spec.js
@@ -29,7 +29,7 @@ describe('The Rains of Castamere', function() {
         this.scheme1 = scheme('3333');
         this.scheme2 = scheme('4444');
 
-        this.player = jasmine.createSpyObj('player', ['flipPlotFaceup', 'removeActivePlot', 'kneelCard']);
+        this.player = jasmine.createSpyObj('player', ['flipPlotFaceup', 'removeActivePlot', 'kneelCard', 'moveCard']);
         this.player.game = this.gameSpy;
         this.player.faction = {};
 
@@ -78,7 +78,6 @@ describe('The Rains of Castamere', function() {
 
             it('should not make the plot leave play directly', function() {
                 expect(this.player.removeActivePlot).not.toHaveBeenCalled();
-                expect(this.plot1.moveTo).not.toHaveBeenCalled();
             });
         });
 
@@ -90,8 +89,7 @@ describe('The Rains of Castamere', function() {
             });
 
             it('should remove the active plot from the game', function() {
-                expect(this.player.removeActivePlot).toHaveBeenCalled();
-                expect(this.scheme1.moveTo).toHaveBeenCalledWith('out of game');
+                expect(this.player.removeActivePlot).toHaveBeenCalledWith('out of game');
             });
         });
     });

--- a/test/server/cards/agendas/05045 - therainsofcastamere.spec.js
+++ b/test/server/cards/agendas/05045 - therainsofcastamere.spec.js
@@ -29,7 +29,7 @@ describe('The Rains of Castamere', function() {
         this.scheme1 = scheme('3333');
         this.scheme2 = scheme('4444');
 
-        this.player = jasmine.createSpyObj('player', ['flipPlotFaceup', 'removeActivePlot', 'kneelCard', 'moveCard']);
+        this.player = jasmine.createSpyObj('player', ['createAdditionalPile', 'flipPlotFaceup', 'removeActivePlot', 'kneelCard', 'moveCard']);
         this.player.game = this.gameSpy;
         this.player.faction = {};
 
@@ -41,6 +41,10 @@ describe('The Rains of Castamere', function() {
             this.player.plotDeck = _([this.plot1, this.scheme1, this.plot2, this.scheme2]);
 
             this.agenda.onDecksPrepared();
+        });
+
+        it('should create the schemes plot pile', function() {
+            expect(this.player.createAdditionalPile).toHaveBeenCalledWith('scheme plots', { title: jasmine.any(String), area: 'plots', isPrivate: true });
         });
 
         it('should remove the schemes from the players plot deck', function() {

--- a/test/server/player/flipplotfaceup.spec.js
+++ b/test/server/player/flipplotfaceup.spec.js
@@ -14,7 +14,10 @@ describe('Player', function() {
 
             this.selectedPlotSpy = jasmine.createSpyObj('plot', ['flipFaceup', 'moveTo', 'play']);
             this.selectedPlotSpy.uuid = '111';
+            this.selectedPlotSpy.location = 'plot deck';
             this.anotherPlotSpy = jasmine.createSpyObj('plot', ['flipFaceup', 'moveTo', 'play']);
+            this.selectedPlotSpy.uuid = '222';
+            this.anotherPlotSpy.location = 'plot deck';
 
             this.player.selectedPlot = this.selectedPlotSpy;
             this.player.plotDeck = _([this.selectedPlotSpy, this.anotherPlotSpy]);
@@ -50,6 +53,7 @@ describe('Player', function() {
         describe('when there is an active plot', function() {
             beforeEach(function() {
                 this.activePlotSpy = jasmine.createSpyObj('plot', ['leavesPlay', 'moveTo']);
+                this.activePlotSpy.location = 'active plot';
                 this.player.activePlot = this.activePlotSpy;
 
                 this.player.flipPlotFaceup();
@@ -73,6 +77,7 @@ describe('Player', function() {
             beforeEach(function() {
                 this.player.plotDeck = _([this.selectedPlotSpy]);
                 this.player.plotDiscard = _([this.anotherPlotSpy]);
+                this.anotherPlotSpy.location = 'revealed plots';
 
                 this.player.flipPlotFaceup();
             });

--- a/test/server/player/movecard.spec.js
+++ b/test/server/player/movecard.spec.js
@@ -182,5 +182,12 @@ describe('Player', function() {
                 expect(this.player.cardsInPlay.toArray()).toEqual([this.card]);
             });
         });
+
+        describe('when the target location is the active plot', function() {
+            it('should set the card as the active plot', function() {
+                this.player.moveCard(this.card, 'active plot');
+                expect(this.player.activePlot).toBe(this.card);
+            });
+        });
     });
 });


### PR DESCRIPTION
* Internally changes how plot cards are managed - they can now be placed like any other card using `Player.moveCard`.
* Adds support for additional card piles - including 'out of game' and the scheme plots for Rains of Castamere. 
![screen shot 2017-02-13 at 4 34 10 pm](https://cloud.githubusercontent.com/assets/145077/22910303/e6f039ac-f20d-11e6-93ca-00ec20d78d93.png)
* Castamere schemes are displayed in a pile below the normal plot piles. As with the normal plot pile, opponents / spectators can't view the cards. 
![screen shot 2017-02-13 at 4 34 30 pm](https://cloud.githubusercontent.com/assets/145077/22910312/f9aaaa0a-f20d-11e6-9cfa-b6afb5491b1e.png)
* Cards that have been removed from the game show up knelt next to the dead pile. If there are no cards in the pile, it won't be displayed. Like other face up piles, 'out of game' is open information and the opponent can view the cards. 
![screen shot 2017-02-13 at 4 34 49 pm](https://cloud.githubusercontent.com/assets/145077/22910316/fce5757e-f20d-11e6-80f9-37aa38f4afe8.png)

Resolves #253.