### PR TITLE
Always fire onCardLeftPlay when leaving play area.

### DIFF
--- a/server/game/player.js
+++ b/server/game/player.js
@@ -874,10 +874,8 @@ class Player extends Spectator {
                 this.removeDuplicate(card);
             }
 
-            if(this.phase !== 'setup') {
-                card.leavesPlay();
-                this.game.raiseEvent('onCardLeftPlay', this, card);
-            }
+            card.leavesPlay();
+            this.game.raiseEvent('onCardLeftPlay', this, card);
 
             if(card.parent && card.parent.attachments) {
                 card.parent.attachments = this.removeCardByUuid(card.parent.attachments, card.uuid);


### PR DESCRIPTION
Previously, if a card was played during set up, but then dragged back to
hand, any effects applied by the card would remain in place. The
reported example was The Arbor granting its +3 gold even though the
player moved it back to hand. This was because the onCardLeftPlay event
is relied upon by the effects engine and was explicitly not being fired
during the setup phase.

(during my brief testing this didn't seem to break anything but I can't really remember why it was written this way in the first place. No tests broke when removing the if, so whatever the reason it was apparently not important enough to test).