### PR TITLE
Limit game name to 140 characters, inspired by twitter char count (#405)

### DIFF
--- a/client/NewGame.jsx
+++ b/client/NewGame.jsx
@@ -28,7 +28,7 @@ class InnerNewGame extends React.Component {
     }
 
     onNameChange(event) {
-        this.setState({gameName: event.target.value});
+        this.setState({gameName: event.target.value.substr(0,140)});
     }
 
     onSpecatorsClick(event) {
@@ -45,12 +45,14 @@ class InnerNewGame extends React.Component {
     }
 
     render() {
+        let charsLeft = 140 - this.state.gameName.length;
         return this.props.socket ? (
             <div>
                 <form className='form'>
                     <div className='row'>
                         <div className='col-sm-5'>
                             <label htmlFor='gameName'>Name</label>
+                            <label className='game-name-char-limit'>{charsLeft >= 0 ? charsLeft: 0}</label>
                             <input className='form-control' placeholder='Game Name' type='text' onChange={this.onNameChange} value={this.state.gameName}/>
                         </div>
                     </div>

--- a/less/gamelist.less
+++ b/less/gamelist.less
@@ -14,13 +14,14 @@
 }
 
 .game-row {
-  height: 64px;
+  min-height: 64px;
   border-radius: 4px;
   border-width: 1px;
   border-color: @brand-primary;
   border-style: solid;
   padding: 3px 5px;
   margin-bottom: 5px;
+  word-wrap: break-word;
 }
 
 .game-row:hover {
@@ -64,4 +65,8 @@
 .spectators {
   height: 55px;
   clear: both;
+}
+
+.game-name-char-limit {
+  float: right;
 }


### PR DESCRIPTION
Added a 140 character limit for the game name with a character counter located to the top right of the text input.

![screen shot 2017-02-17 at 4 01 32 pm](https://cloud.githubusercontent.com/assets/20325071/23086711/56e19066-f534-11e6-8ca1-b34ca6cd876c.png)
![screen shot 2017-02-17 at 4 01 57 pm](https://cloud.githubusercontent.com/assets/20325071/23086731/7b03f2b8-f534-11e6-963a-53c89399a9ed.png)
![screen shot 2017-02-17 at 4 04 45 pm](https://cloud.githubusercontent.com/assets/20325071/23086733/7dc16e04-f534-11e6-9393-8dbd28f04da9.png)
(As ystros suggested, we want to prevent full texts of War & Peace as game titles)

Also added CSS adjustments to keep the text within its container, wrapping accordingly
![screen shot 2017-02-17 at 3 25 52 pm](https://cloud.githubusercontent.com/assets/20325071/23086750/9d35a2be-f534-11e6-9b57-6dbff472ac48.png)
![screen shot 2017-02-17 at 3 27 56 pm](https://cloud.githubusercontent.com/assets/20325071/23086752/9f0da154-f534-11e6-97f1-f5421e7eb060.png)

