### PR TITLE
Cost API for abilities + general action improvements.

### DIFF
--- a/docs/implementing-cards.md
+++ b/docs/implementing-cards.md
@@ -275,7 +275,7 @@ Actions are abilities provided by the card text that players may trigger during 
 
 #### Declaring an action
 
-When declaring an action, use the `action` method and provide it with a `title` and a `handler` property. The title is what will be displayed in the menu players see when clicking on the card. The handler is a function be called when the player chooses to trigger the action. The handler receives a context object as its only parameter which contains the `player` executing the action, and the `source` card that triggered the ability.
+When declaring an action, use the `action` method and provide it with a `title` and a `handler` property. The title is what will be displayed in the menu players see when clicking on the card. The handler is a function to be called when the player chooses to trigger the action. The handler receives a context object as its only parameter which contains the `player` executing the action, and the `source` card that triggered the ability.
 
 ```javascript
 class SealOfTheHand extends DrawCard {
@@ -524,6 +524,43 @@ this.reaction({
         'Gain 1 power': () => {
             // code to gain 1 power
         }
+    }
+});
+```
+
+#### Paying additional costs for reactions and interrupts
+
+Some abilities have an additional cost, such as kneeling the card. In these cases, specify the `cost` parameter. The ability will check if the cost can be paid. If it can't, the ability will not prompt the player. If it can, costs will be paid automatically and then the ability will execute.
+
+For a full list of costs, look at `/server/game/costs.js`.
+
+```javascript
+this.interrupt({
+    when: {
+        // condition for the Wall.
+    }
+    // This card must be knelt as a cost for the action.
+    cost: ability.costs.kneelSelf(),
+    handler: () => {
+        // Gain 2 power for your faction.
+    }
+});
+```
+
+If a card has multiple costs, an array of cost objects may be sent using the `cost` property.
+
+```javascript
+this.reaction({
+    when {
+        // condition for Ghaston Grey
+    }
+    // This card must be knelt AND sacrificed as a cost for the action.
+    cost: [
+        ability.costs.kneelSelf(),
+        ability.costs.sacrificeSelf()
+    ],
+    handler: () => {
+        // Choose and return an attacking character to your opponent's hand.
     }
 });
 ```

--- a/docs/implementing-cards.md
+++ b/docs/implementing-cards.md
@@ -269,43 +269,90 @@ this.untilEndOfRound(ability => ({
 
 ### Actions
 
-**Note:** Actions may be reworked in the future to separate out the action's cost from the action's effect. So this API may change slightly.
+**Note:** Actions may be reworked in the future to separate out targeting / choosing cards for the action. So this API may change slightly.
 
 Actions are abilities provided by the card text that players may trigger during action windows. They are declared using the `action` method. See `/server/game/cardaction.js` for full documentation. Here are some common scenarios:
 
 #### Declaring an action
 
-When declaring an action, use the `action` method and provide it with a `title` and a `method` property. The title is what will be displayed in the menu players see when clicking on the card. The method is a string that references a method on the card object to be called when the player chooses to trigger the action. The player executing the action is passed into the method.
+When declaring an action, use the `action` method and provide it with a `title` and a `handler` property. The title is what will be displayed in the menu players see when clicking on the card. The handler is a function be called when the player chooses to trigger the action. The handler receives a context object as its only parameter which contains the `player` executing the action, and the `source` card that triggered the ability.
 
 ```javascript
 class SealOfTheHand extends DrawCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.action({
             title: 'Stand attached character',
-            method: 'kneel'
+            handler: context => {
+                // Code to stand the parent card
+            }
         });
-    }
-
-    kneel(player) {
-        // Code to stand the parent card.
     }
 }
 ```
 
-#### Cancelling an action due to cost
+#### DEPRECATED - Specifying handler using `method` property.
 
-Some actions have an additional cost or requirement, such as kneeling the card. In these cases, if the cost cannot be paid, returning false from the handler will cancel the action.
+**Note:** This syntax is being phased out. Prefer using `handler` instead.
+
+You can specify a method on the card to call instead of a specific handler function by using the `method` property. The method is a string that references a method on the card object to be called when the player chooses to trigger the action. The player executing the action is passed into the method.
+
+#### Checking ability restrictions
+
+Card abilities can only be triggered if they have the potential to modify game state (outside of paying costs). To ensure that the action's play restrictions are met, pass a `condition` function that returns `true` when the restrictions are met, and `false` otherwise. If the condition returns `false`, the action will not be executed and costs will not be paid.
 
 ```javascript
-// Handler method for Seal of the Hand
-kneel(player) {
-    // ensure the parent is kneeled and the Seal is standing.
-    if(!this.parent || !this.parent.kneeled || this.kneeled) {
-        return false;
-    }
+this.action({
+    title: 'Stand attached character',
+    // Ensure that the parent card is knelt
+    condition: () => this.parent.kneeled,
+    // ...
+});
+```
 
-    // stand parent, kneel this.
-}
+#### Paying additional costs for action
+
+Some actions have an additional cost, such as kneeling the card. In these cases, specify the `cost` parameter. The action will check if the cost can be paid. If it can't, the action will not execute. If it can, costs will be paid automatically and then the action will execute.
+
+For a full list of costs, look at `/server/game/costs.js`.
+
+```javascript
+this.action({
+    title: 'Stand attached character',
+    // This card must be knelt as a cost for the action.
+    cost: ability.costs.kneelSelf(),
+    // ...
+});
+```
+
+If a card has multiple costs, an array of cost objects may be sent using the `cost` property.
+
+```javascript
+this.action({
+    title: 'Reduce the next character marshalled by 3',
+    // This card must be knelt AND sacrificed as a cost for the action.
+    cost: [
+        ability.costs.kneelSelf(),
+        ability.costs.sacrificeSelf()
+    ],
+    // ...
+});
+```
+
+#### Cancelling an action
+
+If after checking play requirements and paying costs an action needs to be cancelled for some reason, simply return `false` from the handler. **Note**: This should be very rare.
+
+```javascript
+this.action({
+    title: 'Do something',
+    handler: () => {
+        if(!this.canDoIt()) {
+            return false;
+        }
+
+        // normal handler code
+    }
+});
 ```
 
 If an action is cancelled in this manner, it is not counted towards any 'limit X per challenge/phase/round' requirements.
@@ -317,8 +364,8 @@ Some actions are limited to a specific phase by their card text (e.g. 'Challenge
 ```javascript
 this.action({
     title: 'Kneel Grey Wind to kill a character',
-    method: 'kill',
-    phase: 'challenge'
+    phase: 'challenge',
+    // ...
 });
 ```
 
@@ -329,8 +376,8 @@ Some actions have text limiting the number of times they may be used in a given 
 ```javascript
 this.action({
     title: 'Put a card with printed cost of 5 or lower in play',
-    method: 'putInPlay',
-    limit: ability.limit.perPhase(1)
+    limit: ability.limit.perPhase(1),
+    // ...
 });
 ```
 

--- a/server/game/abilitydsl.js
+++ b/server/game/abilitydsl.js
@@ -1,9 +1,11 @@
 const AbilityLimit = require('./abilitylimit.js');
 const Effects = require('./effects.js');
+const Costs = require('./costs.js');
 
 const AbilityDsl = {
     limit: AbilityLimit,
-    effects: Effects
+    effects: Effects,
+    costs: Costs
 };
 
 module.exports = AbilityDsl;

--- a/server/game/baseability.js
+++ b/server/game/baseability.js
@@ -25,8 +25,18 @@ class BaseAbility {
         this.game.queueStep(new AbilityResolver(this.game, this, context));
     }
 
-    checkIfCanPayCosts(context) {
-        return _.map(this.cost, cost => cost.canPay(context));
+    canPayCosts(context) {
+        return _.all(this.cost, cost => cost.canPay(context));
+    }
+
+    resolveCosts(context) {
+        return _.map(this.cost, cost => {
+            if(cost.resolve) {
+                return cost.resolve(context);
+            }
+
+            return { resolved: true, value: cost.canPay(context) };
+        });
     }
 
     payCosts(context) {

--- a/server/game/baseability.js
+++ b/server/game/baseability.js
@@ -2,7 +2,27 @@ const _ = require('underscore');
 
 const AbilityResolver = require('./gamesteps/abilityresolver.js');
 
+/**
+ * Base class representing an ability that can be done by the player. This
+ * includes card actions, reactions, interrupts, playing a card, marshaling a
+ * card, or ambushing a card.
+ *
+ * Most of the methods take a context object. While the structure will vary from
+ * inheriting classes, it is guaranteed to have at least the `game` object, the
+ * `player` that is executing the action, and the `source` card object that the
+ * ability is generated from.
+ */
 class BaseAbility {
+    /**
+     * Creates an ability.
+     *
+     * @param {Game} game - The game object.
+     * @param {Object} source - The source of the ability.
+     * @param {Object} properties - An object with ability related properties.
+     * @param {Object|Array} properties.cost - optional property that specifies
+     * the cost for the ability. Can either be a cost object or an array of cost
+     * objects.
+     */
     constructor(game, source, properties) {
         this.game = game;
         this.source = source;
@@ -21,14 +41,31 @@ class BaseAbility {
         return cost;
     }
 
+    /**
+     * Queues an AbilityResolver onto the game pipeline in order to pay costs
+     * and execute the ability if able.
+     */
     queueResolver(context) {
         this.game.queueStep(new AbilityResolver(this.game, this, context));
     }
 
+    /**
+     * Return whether all costs are capable of being paid for the ability.
+     *
+     * @returns {Boolean}
+     */
     canPayCosts(context) {
         return _.all(this.cost, cost => cost.canPay(context));
     }
 
+    /**
+     * Resolves all costs for the ability prior to payment. Some cost objects
+     * have a `resolve` method in order to prompt the user to make a choice,
+     * such as choosing a card to kneel. Consumers of this method should wait
+     * until all costs have a `resolved` value of `true` before proceeding.
+     *
+     * @returns {Array} An array of cost resolution results.
+     */
     resolveCosts(context) {
         return _.map(this.cost, cost => {
             if(cost.resolve) {
@@ -39,14 +76,21 @@ class BaseAbility {
         });
     }
 
+    /**
+     * Pays all costs for the ability simultaneously.
+     */
     payCosts(context) {
         _.each(this.cost, cost => {
             cost.pay(context);
         });
     }
 
-    executeHandler(context) {
-        // Should be overriden by inheritors
+    /**
+     * Executes the ability once all costs have been paid. Inheriting classes
+     * should override this method to implement their behavior; by default it
+     * does nothing.
+     */
+    executeHandler(context) { // eslint-disable-line no-unused-vars
     }
 }
 

--- a/server/game/baseability.js
+++ b/server/game/baseability.js
@@ -1,0 +1,43 @@
+const _ = require('underscore');
+
+const AbilityResolver = require('./gamesteps/abilityresolver.js');
+
+class BaseAbility {
+    constructor(game, source, properties) {
+        this.game = game;
+        this.source = source;
+        this.cost = this.buildCost(properties.cost);
+    }
+
+    buildCost(cost) {
+        if(!cost) {
+            return [];
+        }
+
+        if(!_.isArray(cost)) {
+            return [cost];
+        }
+
+        return cost;
+    }
+
+    queueResolver(context) {
+        this.game.queueStep(new AbilityResolver(this.game, this, context));
+    }
+
+    checkIfCanPayCosts(context) {
+        return _.map(this.cost, cost => cost.canPay(context));
+    }
+
+    payCosts(context) {
+        _.each(this.cost, cost => {
+            cost.pay(context);
+        });
+    }
+
+    executeHandler(context) {
+        // Should be overriden by inheritors
+    }
+}
+
+module.exports = BaseAbility;

--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -1,6 +1,4 @@
-const _ = require('underscore');
-
-const AbilityResolver = require('./gamesteps/abilityresolver.js');
+const BaseAbility = require('./baseability.js');
 
 /**
  * Represents an action ability provided by card text.
@@ -26,16 +24,16 @@ const AbilityResolver = require('./gamesteps/abilityresolver.js');
  * anyPlayer    - boolean indicating that the action may be executed by a player
  *                other than the card's controller. Defaults to false.
  */
-class CardAction {
+class CardAction extends BaseAbility {
     constructor(game, card, properties) {
-        this.game = game;
+        super(game, card, properties);
+
         this.card = card;
         this.title = properties.title;
         this.limit = properties.limit;
         this.phase = properties.phase || 'any';
         this.anyPlayer = properties.anyPlayer || false;
         this.condition = properties.condition;
-        this.cost = this.buildCost(properties.cost);
 
         this.handler = this.buildHandler(card, properties);
     }
@@ -56,18 +54,6 @@ class CardAction {
             //       the context object directly.
             return card[properties.method].call(card, context.player, context.arg, context);
         };
-    }
-
-    buildCost(cost) {
-        if(!cost) {
-            return [];
-        }
-
-        if(!_.isArray(cost)) {
-            return [cost];
-        }
-
-        return cost;
     }
 
     execute(player, arg) {
@@ -98,17 +84,7 @@ class CardAction {
             return;
         }
 
-        this.game.queueStep(new AbilityResolver(this.game, this, context));
-    }
-
-    checkIfCanPayCosts(context) {
-        return _.map(this.cost, cost => cost.canPay(context));
-    }
-
-    payCosts(context) {
-        _.each(this.cost, cost => {
-            cost.pay(context);
-        });
+        this.queueResolver(context);
     }
 
     executeHandler(context) {

--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -25,7 +25,7 @@ class CardAction {
         this.phase = properties.phase || 'any';
         this.anyPlayer = properties.anyPlayer || false;
 
-        this.handler = card[properties.method].bind(card);
+        this.handler = properties.handler || card[properties.method].bind(card);
     }
 
     execute(player, arg) {

--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -1,5 +1,7 @@
 const _ = require('underscore');
 
+const AbilityResolver = require('./gamesteps/abilityresolver.js');
+
 /**
  * Represents an action ability provided by card text.
  *
@@ -69,15 +71,22 @@ class CardAction {
             return;
         }
 
-        if(!_.all(this.cost, cost => cost.canPay(context))) {
-            return;
-        }
+        this.game.queueStep(new AbilityResolver(this.game, this, context));
+    }
 
+    checkIfCanPayCosts(context) {
+        return _.map(this.cost, cost => cost.canPay(context));
+    }
+
+    payCosts(context) {
         _.each(this.cost, cost => {
             cost.pay(context);
         });
+    }
 
-        if(this.handler(player, arg) !== false && this.limit) {
+    executeHandler(context) {
+        // TODO: Temporarily need to split the arguments out for backward compatibility.
+        if(this.handler(context.player, context.arg, context) !== false && this.limit) {
             this.limit.increment();
         }
     }

--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -8,6 +8,10 @@ const AbilityResolver = require('./gamesteps/abilityresolver.js');
  * Properties:
  * title        - string that is used within the card menu associated with this
  *                action.
+ * condition    - optional function that should return true when the action is
+ *                allowed, false otherwise. It should generally be used to check
+ *                if the action can modify game state (step #1 in ability
+ *                resolution in the rules).
  * cost         - object or array of objects representing the cost required to
  *                be paid before the action will activate. See Costs.
  * method       - string indicating the method on card that should be called
@@ -30,6 +34,7 @@ class CardAction {
         this.limit = properties.limit;
         this.phase = properties.phase || 'any';
         this.anyPlayer = properties.anyPlayer || false;
+        this.condition = properties.condition;
         this.cost = this.buildCost(properties.cost);
 
         this.handler = properties.handler || card[properties.method].bind(card);
@@ -68,6 +73,10 @@ class CardAction {
         }
 
         if(this.card.isBlank()) {
+            return;
+        }
+
+        if(this.condition && !this.condition()) {
             return;
         }
 

--- a/server/game/cards/attachments/01/sealofthehand.js
+++ b/server/game/cards/attachments/01/sealofthehand.js
@@ -1,22 +1,19 @@
 const DrawCard = require('../../../drawcard.js');
 
 class SealOfTheHand extends DrawCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.action({
             title: 'Stand attached character',
-            method: 'kneel'
+            cost: ability.costs.kneelSelf(),
+            handler: () => {
+                if(!this.parent.kneeled) {
+                    return;
+                }
+
+                this.controller.standCard(this.parent);
+                this.game.addMessage('{0} kneels {1} to stand {2}', this.controller, this, this.parent);
+            }
         });
-    }
-
-    kneel(player) {
-        if(!this.parent || !this.parent.kneeled) {
-            return false;
-        }
-
-        player.standCard(this.parent);
-        player.kneelCard(this);
-
-        this.game.addMessage('{0} kneels {1} to stand {2}', player, this, this.parent);
     }
 
     canAttach(player, card) {

--- a/server/game/cards/attachments/01/sealofthehand.js
+++ b/server/game/cards/attachments/01/sealofthehand.js
@@ -4,12 +4,9 @@ class SealOfTheHand extends DrawCard {
     setupCardAbilities(ability) {
         this.action({
             title: 'Stand attached character',
+            condition: () => this.parent.kneeled,
             cost: ability.costs.kneelSelf(),
             handler: () => {
-                if(!this.parent.kneeled) {
-                    return;
-                }
-
                 this.controller.standCard(this.parent);
                 this.game.addMessage('{0} kneels {1} to stand {2}', this.controller, this, this.parent);
             }

--- a/server/game/cards/characters/01/wildlinghorde.js
+++ b/server/game/cards/characters/01/wildlinghorde.js
@@ -5,12 +5,9 @@ class WildlingHorde extends DrawCard {
         this.action({
             title: 'Kneel your faction card',
             phase: 'challenge',
+            condition: () => this.game.currentChallenge,
             cost: ability.costs.kneelFactionCard(),
             handler: (player) => {
-                if(!this.game.currentChallenge) {
-                    return false;
-                }
-
                 this.game.promptForSelect(player, {
                     activePromptTitle: 'Select a Wildling character',
                     waitingPromptTitle: 'Waiting for opponent to use ' + this.name,

--- a/server/game/cards/characters/01/wildlinghorde.js
+++ b/server/game/cards/characters/01/wildlinghorde.js
@@ -7,11 +7,11 @@ class WildlingHorde extends DrawCard {
             phase: 'challenge',
             condition: () => this.game.currentChallenge,
             cost: ability.costs.kneelFactionCard(),
-            handler: (player) => {
-                this.game.promptForSelect(player, {
+            handler: (context) => {
+                this.game.promptForSelect(context.player, {
                     activePromptTitle: 'Select a Wildling character',
                     waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
-                    cardCondition: card => this.cardCondition(player, card),
+                    cardCondition: card => this.cardCondition(context.player, card),
                     onSelect: (p, card) => this.onCardSelected(p, card)
                 });
             }

--- a/server/game/cards/characters/01/wildlinghorde.js
+++ b/server/game/cards/characters/01/wildlinghorde.js
@@ -1,11 +1,23 @@
 const DrawCard = require('../../../drawcard.js');
 
 class WildlingHorde extends DrawCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.action({
             title: 'Kneel your faction card',
-            method: 'kneelFactionCard',
-            phase: 'challenge'
+            phase: 'challenge',
+            cost: ability.costs.kneelFactionCard(),
+            handler: (player) => {
+                if(!this.game.currentChallenge) {
+                    return false;
+                }
+
+                this.game.promptForSelect(player, {
+                    activePromptTitle: 'Select a Wildling character',
+                    waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
+                    cardCondition: card => this.cardCondition(player, card),
+                    onSelect: (p, card) => this.onCardSelected(p, card)
+                });
+            }
         });
     }
 
@@ -18,31 +30,10 @@ class WildlingHorde extends DrawCard {
         return card.location === 'play area' && card.controller === player && card.hasTrait('Wildling') && currentChallenge.isParticipating(card);
     }
 
-    kneelFactionCard(player) {
-        if(player.faction.kneeled) {
-            return false;
-        }
-
-        if(!this.game.currentChallenge) {
-            return false;
-        }
-
-        this.game.promptForSelect(player, {
-            activePromptTitle: 'Select a Wildling character',
-            waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
-            cardCondition: card => this.cardCondition(player, card),
-            onSelect: (p, card) => this.onCardSelected(p, card)
-        });
-
-        return true;
-    }
-
     onCardSelected(player, card) {
         if(this.controller !== player) {
             return false;
         }
-
-        player.kneelCard(player.faction);
 
         this.game.addMessage('{0} uses {1} to kneel their faction card and increase the strength of {2} by 2 until the end of the challenge', player, this, card);
         this.untilEndOfChallenge(ability => ({

--- a/server/game/cards/characters/02/halder.js
+++ b/server/game/cards/characters/02/halder.js
@@ -8,8 +8,8 @@ class Halder extends DrawCard {
                 card.getFaction() === 'thenightswatch' &&
                 (card.getType() === 'attachment' || card.getType() === 'location')
             )),
-            handler: (player, arg, context) => {
-                this.game.promptForSelect(player, {
+            handler: (context) => {
+                this.game.promptForSelect(context.player, {
                     cardCondition: card => card.getFaction() === 'thenightswatch' && card.getType() === 'character',
                     activePromptTitle: 'Select character',
                     waitingPromptTitle: 'Waiting for opponent to use ' + this.name,

--- a/server/game/cards/characters/02/halder.js
+++ b/server/game/cards/characters/02/halder.js
@@ -1,41 +1,27 @@
 const DrawCard = require('../../../drawcard.js');
 
 class Halder extends DrawCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.action({
             title: 'Kneel a location or attachment',
-            method: 'kneel'
+            cost: ability.costs.kneel(card => (
+                card.getFaction() === 'thenightswatch' &&
+                (card.getType() === 'attachment' || card.getType() === 'location')
+            )),
+            handler: (player, arg, context) => {
+                this.game.promptForSelect(player, {
+                    cardCondition: card => card.getFaction() === 'thenightswatch' && card.getType() === 'character',
+                    activePromptTitle: 'Select character',
+                    waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
+                    onSelect: (player, card) => this.onStrCardSelected(player, card, context.kneelingCostCard)
+                });
+            }
         });
     }
 
-    kneel(player) {
-        this.game.promptForSelect(player, {
-            cardCondition: card => card.getFaction() === 'thenightswatch' && (card.getType() === 'attachment' || card.getType() === 'location') && !card.kneeled,
-            activePromptTitle: 'Select location',
-            waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
-            onSelect: (player, card) => this.onCardSelected(player, card)
-        });
+    onStrCardSelected(player, card, kneelingCard) {
+        this.game.addMessage('{0} uses {1} to kneels {2} to give {3} +1 STR until the end of the phase', player, this, kneelingCard, card);
 
-        return true;
-    }
-
-    onCardSelected(player, card) {
-        this.game.promptForSelect(player, {
-            cardCondition: card => card.getFaction() === 'thenightswatch' && card.getType() === 'character',
-            activePromptTitle: 'Select character',
-            waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
-            onSelect: (player, card) => this.onStrCardSelected(player, card)
-        });
-
-        this.kneelingCard = card;
-
-        return true;
-    }
-
-    onStrCardSelected(player, card) {
-        this.game.addMessage('{0} uses {1} to kneels {2} to give {3} +1 STR until the end of the phase', player, this, this.kneelingCard, card);
-
-        this.kneelingCard.controller.kneelCard(this.kneelingCard);
         this.untilEndOfPhase(ability => ({
             match: card,
             effect: ability.effects.modifyStrength(1)

--- a/server/game/cards/locations/01/ghastongrey.js
+++ b/server/game/cards/locations/01/ghastongrey.js
@@ -1,52 +1,27 @@
 const DrawCard = require('../../../drawcard.js');
 
 class GhastonGrey extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['afterChallenge']);
-    }
-
-    afterChallenge(event, challenge) {
-        if(challenge.winner === this.controller || challenge.defendingPlayer !== this.controller || this.isBlank()) {
-            return;
-        }
-
-        this.game.promptWithMenu(this.controller, this, {
-            activePrompt: {
-                menuTitle: 'Trigger ' + this.name + '?',
-                buttons: [
-                    { text: 'Yes', method: 'sacrifice' },
-                    { text: 'No', method: 'cancel' }
-                ]
+    setupCardAbilities(ability) {
+        this.reaction({
+            when: {
+                afterChallenge: (event, challenge) => challenge.loser === this.controller && challenge.defendingPlayer === this.controller
             },
-            waitingPromptTitle: 'Waiting for opponent to use ' + this.name
+            cost: [
+                ability.costs.kneelSelf(),
+                ability.costs.sacrificeSelf()
+            ],
+            handler: () => {
+                this.game.promptForSelect(this.controller, {
+                    activePromptTitle: 'Select a character',
+                    waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
+                    cardCondition: card => card.location === 'play area' && card.getType() === 'character' && this.game.currentChallenge.isAttacking(card),
+                    onSelect: (p, card) => this.onCardSelected(p, card)
+                });
+            }
         });
-
-        return true;
-    }
-
-    sacrifice(player) {
-        this.game.promptForSelect(player, {
-            activePromptTitle: 'Select a character',
-            waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
-            cardCondition: card => card.location === 'play area' && card.getType() === 'character' && this.game.currentChallenge.isAttacking(card),
-            onSelect: (p, card) => this.onCardSelected(p, card)
-        });
-
-        return true;
-    }
-
-    cancel(player) {
-        this.game.addMessage('{0} declines to trigger {1}', player, this);
-
-        return true;
     }
 
     onCardSelected(player, card) {
-        player.kneelCard(this);
-        player.sacrificeCard(this);
-
         card.controller.moveCard(card, 'hand');
 
         this.game.addMessage('{0} uses {1} to return {2} to {3}\'s hand', player, this, card, card.controller);

--- a/server/game/cards/locations/01/thewall.js
+++ b/server/game/cards/locations/01/thewall.js
@@ -13,10 +13,10 @@ class TheWall extends DrawCard {
         });
         this.interrupt({
             when: {
-                onPhaseEnded: (e, phase) => phase === 'challenge' && !this.kneeled
+                onPhaseEnded: (e, phase) => phase === 'challenge'
             },
+            cost: ability.costs.kneelSelf(),
             handler: () => {
-                this.controller.kneelCard(this);
                 this.game.addPower(this.controller, 2);
                 this.game.addMessage('{0} kneels {1} to gain 2 power for their faction', this.controller, this);
             }

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -5,10 +5,7 @@ const Costs = {
     kneelSelf: function() {
         return {
             canPay: function(context) {
-                return {
-                    resolved: true,
-                    value: !context.source.kneeled
-                };
+                return !context.source.kneeled;
             },
             pay: function(context) {
                 context.source.controller.kneelCard(context.source);
@@ -21,10 +18,7 @@ const Costs = {
     kneelFactionCard: function() {
         return {
             canPay: function(context) {
-                return {
-                    resolved: true,
-                    value: !context.player.faction.kneeled
-                };
+                return !context.player.faction.kneeled;
             },
             pay: function(context) {
                 context.player.kneelCard(context.player.faction);
@@ -34,6 +28,9 @@ const Costs = {
     kneel: function(condition) {
         return {
             canPay: function(context) {
+                return context.player.cardsInPlay.any(condition);
+            },
+            resolve: function(context) {
                 var result = {
                     resolved: false
                 };

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -1,0 +1,53 @@
+const Costs = {
+    /**
+     * Cost that will kneel the card that initiated the ability.
+     */
+    kneelSelf: function() {
+        return {
+            canPay: function(context) {
+                return !context.source.kneeled;
+            },
+            pay: function(context) {
+                context.source.controller.kneelCard(context.source);
+            }
+        };
+    },
+    /**
+     * Cost that will kneel the player's faction card.
+     */
+    kneelFactionCard: function() {
+        return {
+            canPay: function(context) {
+                return !context.player.faction.kneeled;
+            },
+            pay: function(context) {
+                context.player.kneelCard(context.player.faction);
+            }
+        };
+    }
+    // kneel: function(condition) {
+    //     return {
+    //         canPay: function(context) {
+    //             return new Promise(function(resolve) {
+    //                 context.game.promptForSelect(context.player, {
+    //                     cardCondition: card => card.controller === context.player && condition(card),
+    //                     activePromptTitle: 'Select card to kneel',
+    //                     waitingPromptTitle: 'Waiting for opponent to use ' + context.source.name,
+    //                     onSelect: (player, card) => {
+    //                         context.kneelingCostCard = card;
+    //                         resolve(true);
+    //                     },
+    //                     onCancel: () => {
+    //                         resolve(false);
+    //                     }
+    //                 });
+    //             });
+    //         },
+    //         pay: function(context) {
+    //             context.player.kneelCard(context.kneelingCostCard);
+    //         }
+    //     };
+    // }
+};
+
+module.exports = Costs;

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -25,6 +25,10 @@ const Costs = {
             }
         };
     },
+    /**
+     * Cost that requires kneeling a card that matches the passed condition
+     * predicate function.
+     */
     kneel: function(condition) {
         return {
             canPay: function(context) {
@@ -56,6 +60,19 @@ const Costs = {
             },
             pay: function(context) {
                 context.player.kneelCard(context.kneelingCostCard);
+            }
+        };
+    },
+    /**
+     * Cost that will sacrifice the card that initiated the ability.
+     */
+    sacrificeSelf: function() {
+        return {
+            canPay: function() {
+                return true;
+            },
+            pay: function(context) {
+                context.source.controller.sacrificeCard(context.source);
             }
         };
     }

--- a/server/game/gamesteps/abilityresolver.js
+++ b/server/game/gamesteps/abilityresolver.js
@@ -1,0 +1,75 @@
+const _ = require('underscore');
+
+const BaseStep = require('./basestep.js');
+const GamePipeline = require('../gamepipeline.js');
+const SimpleStep = require('./simplestep.js');
+
+class AbilityResolver extends BaseStep {
+    constructor(game, ability, context) {
+        super(game);
+
+        this.ability = ability;
+        this.context = context;
+        this.pipeline = new GamePipeline();
+        this.pipeline.initialise([
+            new SimpleStep(game, () => this.checkIfCanPayCosts()),
+            new SimpleStep(game, () => this.canPayCosts()),
+            new SimpleStep(game, () => this.payCosts()),
+            new SimpleStep(game, () => this.executeHandler())
+        ]);
+    }
+
+    queueStep(step) {
+        this.pipeline.queueStep(step);
+    }
+
+    isComplete() {
+        return this.pipeline.length === 0;
+    }
+
+    onCardClicked(player, card) {
+        return this.pipeline.handleCardClicked(player, card);
+    }
+
+    onMenuCommand(player, arg, method) {
+        return this.pipeline.handleMenuCommand(player, arg, method);
+    }
+
+    cancelStep() {
+        this.pipeline.cancelStep();
+    }
+
+    continue() {
+        return this.pipeline.continue();
+    }
+
+    checkIfCanPayCosts() {
+        this.canPayResults = this.ability.checkIfCanPayCosts(this.context);
+    }
+
+    canPayCosts() {
+        this.cancelled = _.any(this.canPayResults, result => result.resolved && !result.value);
+
+        if(!_.all(this.canPayResults, result => result.resolved)) {
+            return false;
+        }
+    }
+
+    payCosts() {
+        if(this.cancelled) {
+            return;
+        }
+
+        this.ability.payCosts(this.context);
+    }
+
+    executeHandler() {
+        if(this.cancelled) {
+            return;
+        }
+
+        this.ability.executeHandler(this.context);
+    }
+}
+
+module.exports = AbilityResolver;

--- a/server/game/gamesteps/abilityresolver.js
+++ b/server/game/gamesteps/abilityresolver.js
@@ -12,8 +12,8 @@ class AbilityResolver extends BaseStep {
         this.context = context;
         this.pipeline = new GamePipeline();
         this.pipeline.initialise([
-            new SimpleStep(game, () => this.checkIfCanPayCosts()),
-            new SimpleStep(game, () => this.canPayCosts()),
+            new SimpleStep(game, () => this.resolveCosts()),
+            new SimpleStep(game, () => this.waitForCostResolution()),
             new SimpleStep(game, () => this.payCosts()),
             new SimpleStep(game, () => this.executeHandler())
         ]);
@@ -43,11 +43,11 @@ class AbilityResolver extends BaseStep {
         return this.pipeline.continue();
     }
 
-    checkIfCanPayCosts() {
-        this.canPayResults = this.ability.checkIfCanPayCosts(this.context);
+    resolveCosts() {
+        this.canPayResults = this.ability.resolveCosts(this.context);
     }
 
-    canPayCosts() {
+    waitForCostResolution() {
         this.cancelled = _.any(this.canPayResults, result => result.resolved && !result.value);
 
         if(!_.all(this.canPayResults, result => result.resolved)) {

--- a/server/game/promptedtriggeredability.js
+++ b/server/game/promptedtriggeredability.js
@@ -17,6 +17,8 @@ const TriggeredAbility = require('./triggeredability.js');
  *           possible triggers for the same reaction.
  * title   - function that returns the string to be used as the prompt title. If
  *           none provided, then the title will be "Trigger {card name}?".
+ * cost    - object or array of objects representing the cost required to be
+ *           paid before the action will activate. See Costs.
  * handler - function that will be executed if the player chooses 'Yes' when
  *           asked to trigger the reaction. If the reaction has more than one
  *           choice, use the choices sub object instead.
@@ -69,13 +71,19 @@ class PromptedTriggeredAbility extends TriggeredAbility {
     }
 
     triggerReaction(player, choice) {
-        var handler = this.choices[choice];
+        this.currentContext.choice = choice;
+
+        this.queueResolver(this.currentContext);
+
+        return true;
+    }
+
+    executeHandler(context) {
+        var handler = this.choices[context.choice];
 
         if(handler && handler(this.currentContext) !== false && this.limit) {
             this.limit.increment();
         }
-
-        return true;
     }
 
     cancel() {

--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -1,10 +1,13 @@
 const _ = require('underscore');
 
+const BaseAbility = require('./baseability.js');
+
 class TriggeredAbilityContext {
     constructor(event, game, source) {
         this.event = event;
         this.game = game;
         this.source = source;
+        this.player = source.controller;
     }
 
     cancel() {
@@ -16,9 +19,10 @@ class TriggeredAbilityContext {
     }
 }
 
-class TriggeredAbility {
+class TriggeredAbility extends BaseAbility {
     constructor(game, card, eventType, properties) {
-        this.game = game;
+        super(game, card, properties);
+
         this.card = card;
         this.limit = properties.limit;
         this.when = properties.when;
@@ -27,6 +31,8 @@ class TriggeredAbility {
 
     createEventHandlerFor(eventName) {
         return (...args) => {
+            var context = new TriggeredAbilityContext(args[0], this.game, this.source);
+
             if(this.game.currentPhase === 'setup') {
                 return;
             }
@@ -43,7 +49,11 @@ class TriggeredAbility {
                 return;
             }
 
-            this.executeReaction(new TriggeredAbilityContext(args[0], this.game, this.source));
+            if(!this.canPayCosts(context)) {
+                return;
+            }
+
+            this.executeReaction(context);
         };
     }
 

--- a/test/server/card/baseability.spec.js
+++ b/test/server/card/baseability.spec.js
@@ -1,0 +1,105 @@
+/*global describe, it, beforeEach, expect, jasmine */
+/*eslint camelcase: 0, no-invalid-this: 0 */
+
+const BaseAbility = require('../../../server/game/baseability.js');
+
+const AbilityResolver = require('../../../server/game/gamesteps/abilityresolver.js');
+
+describe('BaseAbility', function () {
+    beforeEach(function () {
+        this.gameSpy = jasmine.createSpyObj('game', ['queueStep']);
+
+        this.cardSpy = jasmine.createSpyObj('card', ['']);
+        this.properties = {};
+    });
+
+    describe('constructor', function() {
+        describe('cost', function() {
+            describe('when no cost is passed', function() {
+                beforeEach(function() {
+                    delete this.properties.cost;
+                    this.ability = new BaseAbility(this.gameSpy, this.cardSpy, this.properties);
+                });
+
+                it('should set cost to be empty array', function() {
+                    expect(this.ability.cost).toEqual([]);
+                });
+            });
+
+            describe('when a single cost is passed', function() {
+                beforeEach(function() {
+                    this.cost = { cost: 1 };
+                    this.properties.cost = this.cost;
+                    this.ability = new BaseAbility(this.gameSpy, this.cardSpy, this.properties);
+                });
+
+                it('should set cost to be an array with the cost', function() {
+                    expect(this.ability.cost).toEqual([this.cost]);
+                });
+            });
+
+            describe('when multiple costs are passed', function() {
+                beforeEach(function() {
+                    this.cost1 = { cost: 1 };
+                    this.cost2 = { cost: 2 };
+                    this.properties.cost = [this.cost1, this.cost2];
+                    this.ability = new BaseAbility(this.gameSpy, this.cardSpy, this.properties);
+                });
+
+                it('should set cost to be the array', function() {
+                    expect(this.ability.cost).toEqual([this.cost1, this.cost2]);
+                });
+            });
+        });
+    });
+
+    describe('queueResolver()', function() {
+        beforeEach(function() {
+            this.context = { context: true };
+            this.ability = new BaseAbility(this.gameSpy, this.cardSpy, this.properties);
+            this.ability.queueResolver(this.context);
+        });
+
+        it('should queue an AbilityResolver step onto game', function() {
+            expect(this.gameSpy.queueStep).toHaveBeenCalledWith(jasmine.any(AbilityResolver));
+        });
+    });
+
+    describe('checkIfCanPayCosts()', function() {
+        beforeEach(function() {
+            this.cost1 = jasmine.createSpyObj('cost1', ['canPay']);
+            this.cost2 = jasmine.createSpyObj('cost1', ['canPay']);
+            this.cost1.canPay.and.returnValue(1);
+            this.cost2.canPay.and.returnValue(2);
+            this.ability = new BaseAbility(this.gameSpy, this.cardSpy, this.properties);
+            this.ability.cost = [this.cost1, this.cost2];
+            this.context = { context: 1 };
+        });
+
+        it('should call canPay with the context object', function() {
+            this.ability.checkIfCanPayCosts(this.context);
+            expect(this.cost1.canPay).toHaveBeenCalledWith(this.context);
+            expect(this.cost2.canPay).toHaveBeenCalledWith(this.context);
+        });
+
+        it('should return the results of the canPay method for all costs', function() {
+            expect(this.ability.checkIfCanPayCosts(this.context)).toEqual([1, 2]);
+        });
+    });
+
+    describe('payCosts()', function() {
+        beforeEach(function() {
+            this.cost1 = jasmine.createSpyObj('cost1', ['pay']);
+            this.cost2 = jasmine.createSpyObj('cost1', ['pay']);
+            this.ability = new BaseAbility(this.gameSpy, this.cardSpy, this.properties);
+            this.ability.cost = [this.cost1, this.cost2];
+            this.context = { context: 1 };
+        });
+
+        it('should call pay with the context object', function() {
+            this.ability.payCosts(this.context);
+            expect(this.cost1.pay).toHaveBeenCalledWith(this.context);
+            expect(this.cost2.pay).toHaveBeenCalledWith(this.context);
+        });
+    });
+});

--- a/test/server/card/cardaction.spec.js
+++ b/test/server/card/cardaction.spec.js
@@ -212,6 +212,36 @@ describe('CardAction', function () {
             });
         });
 
+        describe('when a condition is provided', function() {
+            beforeEach(function() {
+                this.condition = jasmine.createSpy('condition');
+                this.properties.condition = this.condition;
+                this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+            });
+
+            describe('and the condition returns true', function() {
+                beforeEach(function() {
+                    this.condition.and.returnValue(true);
+                    this.action.execute(this.player, 'arg');
+                });
+
+                it('should queue the ability resolver', function() {
+                    expect(this.gameSpy.queueStep).toHaveBeenCalledWith(jasmine.any(AbilityResolver));
+                });
+            });
+
+            describe('and the condition returns false', function() {
+                beforeEach(function() {
+                    this.condition.and.returnValue(false);
+                    this.action.execute(this.player, 'arg');
+                });
+
+                it('should not queue the ability resolver', function() {
+                    expect(this.gameSpy.queueStep).not.toHaveBeenCalled();
+                });
+            });
+        });
+
         describe('when all conditions met', function() {
             beforeEach(function() {
                 this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);

--- a/test/server/card/cardaction.spec.js
+++ b/test/server/card/cardaction.spec.js
@@ -24,6 +24,14 @@ describe('CardAction', function () {
 
     describe('constructor', function() {
         describe('handler', function() {
+            beforeEach(function() {
+                this.context = {
+                    player: 'player',
+                    arg: 'arg',
+                    foo: 'bar'
+                };
+            });
+
             describe('when passed a method reference', function() {
                 beforeEach(function() {
                     this.properties = {
@@ -34,8 +42,8 @@ describe('CardAction', function () {
                 });
 
                 it('should use the specified method on the card object', function() {
-                    this.action.handler();
-                    expect(this.cardSpy.handler).toHaveBeenCalled();
+                    this.action.handler(this.context);
+                    expect(this.cardSpy.handler).toHaveBeenCalledWith('player', 'arg', this.context);
                 });
             });
 
@@ -49,8 +57,8 @@ describe('CardAction', function () {
                 });
 
                 it('should use the handler directly', function() {
-                    this.action.handler();
-                    expect(this.properties.handler).toHaveBeenCalled();
+                    this.action.handler(this.context);
+                    expect(this.properties.handler).toHaveBeenCalledWith(this.context);
                 });
             });
         });
@@ -377,6 +385,8 @@ describe('CardAction', function () {
                 player: this.player,
                 arg: 'arg'
             };
+            this.handler = jasmine.createSpy('handler');
+            this.properties.handler = this.handler;
         });
 
         describe('when the action has no limit', function() {
@@ -386,7 +396,7 @@ describe('CardAction', function () {
             });
 
             it('should call the handler', function() {
-                expect(this.cardSpy.handler).toHaveBeenCalledWith(this.player, 'arg', this.context);
+                expect(this.handler).toHaveBeenCalledWith(this.context);
             });
         });
 
@@ -398,13 +408,13 @@ describe('CardAction', function () {
 
             describe('and the handler returns false', function() {
                 beforeEach(function() {
-                    this.cardSpy.handler.and.returnValue(false);
+                    this.handler.and.returnValue(false);
 
                     this.action.executeHandler(this.context);
                 });
 
                 it('should call the handler', function() {
-                    expect(this.cardSpy.handler).toHaveBeenCalledWith(this.player, 'arg', this.context);
+                    expect(this.handler).toHaveBeenCalledWith(this.context);
                 });
 
                 it('should not count towards the limit', function() {
@@ -414,13 +424,13 @@ describe('CardAction', function () {
 
             describe('and the handler returns undefined or a non-false value', function() {
                 beforeEach(function() {
-                    this.cardSpy.handler.and.returnValue(undefined);
+                    this.handler.and.returnValue(undefined);
 
                     this.action.executeHandler(this.context);
                 });
 
                 it('should call the handler', function() {
-                    expect(this.cardSpy.handler).toHaveBeenCalledWith(this.player, 'arg', this.context);
+                    expect(this.handler).toHaveBeenCalledWith(this.context);
                 });
 
                 it('should count towards the limit', function() {

--- a/test/server/card/cardaction.spec.js
+++ b/test/server/card/cardaction.spec.js
@@ -293,59 +293,6 @@ describe('CardAction', function () {
         });
     });
 
-    describe('checkIfCanPayCosts()', function() {
-        beforeEach(function() {
-            this.cost1 = jasmine.createSpyObj('cost1', ['canPay']);
-            this.cost2 = jasmine.createSpyObj('cost1', ['canPay']);
-            this.cost1.canPay.and.returnValue(1);
-            this.cost2.canPay.and.returnValue(2);
-            this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
-            this.action.cost = [this.cost1, this.cost2];
-        });
-
-        it('should return the results of the canPay method for all costs', function() {
-            expect(this.action.checkIfCanPayCosts()).toEqual([1, 2]);
-        });
-    });
-
-    describe('checkIfCanPayCosts()', function() {
-        beforeEach(function() {
-            this.cost1 = jasmine.createSpyObj('cost1', ['canPay']);
-            this.cost2 = jasmine.createSpyObj('cost1', ['canPay']);
-            this.cost1.canPay.and.returnValue(1);
-            this.cost2.canPay.and.returnValue(2);
-            this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
-            this.action.cost = [this.cost1, this.cost2];
-            this.context = { context: 1 };
-        });
-
-        it('should call canPay with the context object', function() {
-            this.action.checkIfCanPayCosts(this.context);
-            expect(this.cost1.canPay).toHaveBeenCalledWith(this.context);
-            expect(this.cost2.canPay).toHaveBeenCalledWith(this.context);
-        });
-
-        it('should return the results of the canPay method for all costs', function() {
-            expect(this.action.checkIfCanPayCosts(this.context)).toEqual([1, 2]);
-        });
-    });
-
-    describe('payCosts()', function() {
-        beforeEach(function() {
-            this.cost1 = jasmine.createSpyObj('cost1', ['pay']);
-            this.cost2 = jasmine.createSpyObj('cost1', ['pay']);
-            this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
-            this.action.cost = [this.cost1, this.cost2];
-            this.context = { context: 1 };
-        });
-
-        it('should call pay with the context object', function() {
-            this.action.payCosts(this.context);
-            expect(this.cost1.pay).toHaveBeenCalledWith(this.context);
-            expect(this.cost2.pay).toHaveBeenCalledWith(this.context);
-        });
-    });
-
     describe('executeHandler()', function() {
         beforeEach(function() {
             this.player = { player: true };

--- a/test/server/card/cardaction.spec.js
+++ b/test/server/card/cardaction.spec.js
@@ -20,6 +20,38 @@ describe('CardAction', function () {
         };
     });
 
+    describe('constructor', function() {
+        describe('when passed a method reference', function() {
+            beforeEach(function() {
+                this.properties = {
+                    title: 'Do the thing',
+                    method: 'handler'
+                };
+                this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+            });
+
+            it('should use the specified method on the card object', function() {
+                this.action.handler();
+                expect(this.cardSpy.handler).toHaveBeenCalled();
+            });
+        });
+
+        describe('when passed a handler directly', function() {
+            beforeEach(function() {
+                this.properties = {
+                    title: 'Do the thing',
+                    handler: jasmine.createSpy('handler')
+                };
+                this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+            });
+
+            it('should use the handler directly', function() {
+                this.action.handler();
+                expect(this.properties.handler).toHaveBeenCalled();
+            });
+        });
+    });
+
     describe('execute()', function() {
         beforeEach(function() {
             this.player = {};

--- a/test/server/card/cardaction.spec.js
+++ b/test/server/card/cardaction.spec.js
@@ -198,6 +198,52 @@ describe('CardAction', function () {
             });
         });
 
+        describe('when the action has a cost', function() {
+            beforeEach(function() {
+                this.cost1 = jasmine.createSpyObj('cost1', ['canPay', 'pay']);
+                this.cost2 = jasmine.createSpyObj('cost2', ['canPay', 'pay']);
+                this.properties.cost = [this.cost1, this.cost2];
+
+                this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+            });
+
+            describe('and at least one cost cannot be paid', function() {
+                beforeEach(function() {
+                    this.cost1.canPay.and.returnValue(true);
+                    this.cost2.canPay.and.returnValue(false);
+
+                    this.action.execute(this.player, 'arg');
+                });
+
+                it('should not pay any of the costs', function() {
+                    expect(this.cost1.pay).not.toHaveBeenCalled();
+                    expect(this.cost2.pay).not.toHaveBeenCalled();
+                });
+
+                it('should not call the handler', function() {
+                    expect(this.cardSpy.handler).not.toHaveBeenCalled();
+                });
+            });
+
+            describe('and all costs can be paid', function() {
+                beforeEach(function() {
+                    this.cost1.canPay.and.returnValue(true);
+                    this.cost2.canPay.and.returnValue(true);
+
+                    this.action.execute(this.player, 'arg');
+                });
+
+                it('should pay all of the costs', function() {
+                    expect(this.cost1.pay).toHaveBeenCalled();
+                    expect(this.cost2.pay).toHaveBeenCalled();
+                });
+
+                it('should call the handler', function() {
+                    expect(this.cardSpy.handler).toHaveBeenCalled();
+                });
+            });
+        });
+
         describe('when all conditions met', function() {
             beforeEach(function() {
                 this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);

--- a/test/server/card/cardaction.spec.js
+++ b/test/server/card/cardaction.spec.js
@@ -3,11 +3,9 @@
 
 const CardAction = require('../../../server/game/cardaction.js');
 
-const AbilityResolver = require('../../../server/game/gamesteps/abilityresolver.js');
-
 describe('CardAction', function () {
     beforeEach(function () {
-        this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener', 'queueStep']);
+        this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener']);
         this.gameSpy.currentPhase = 'marshal';
 
         this.cardSpy = jasmine.createSpyObj('card', ['isBlank']);
@@ -62,44 +60,6 @@ describe('CardAction', function () {
                 });
             });
         });
-
-        describe('cost', function() {
-            describe('when no cost is passed', function() {
-                beforeEach(function() {
-                    delete this.properties.cost;
-                    this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
-                });
-
-                it('should set cost to be empty array', function() {
-                    expect(this.action.cost).toEqual([]);
-                });
-            });
-
-            describe('when a single cost is passed', function() {
-                beforeEach(function() {
-                    this.cost = { cost: 1 };
-                    this.properties.cost = this.cost;
-                    this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
-                });
-
-                it('should set cost to be an array with the cost', function() {
-                    expect(this.action.cost).toEqual([this.cost]);
-                });
-            });
-
-            describe('when multiple costs are passed', function() {
-                beforeEach(function() {
-                    this.cost1 = { cost: 1 };
-                    this.cost2 = { cost: 2 };
-                    this.properties.cost = [this.cost1, this.cost2];
-                    this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
-                });
-
-                it('should set cost to be the array', function() {
-                    expect(this.action.cost).toEqual([this.cost1, this.cost2]);
-                });
-            });
-        });
     });
 
     describe('execute()', function() {
@@ -112,6 +72,7 @@ describe('CardAction', function () {
             beforeEach(function() {
                 this.properties.limit = this.limitSpy;
                 this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+                spyOn(this.action, 'queueResolver');
             });
 
             describe('and the use count has reached the limit', function() {
@@ -122,7 +83,7 @@ describe('CardAction', function () {
                 });
 
                 it('should not queue the ability resolver', function() {
-                    expect(this.gameSpy.queueStep).not.toHaveBeenCalled();
+                    expect(this.action.queueResolver).not.toHaveBeenCalled();
                 });
             });
 
@@ -132,7 +93,7 @@ describe('CardAction', function () {
                 });
 
                 it('should queue the ability resolver', function() {
-                    expect(this.gameSpy.queueStep).toHaveBeenCalledWith(jasmine.any(AbilityResolver));
+                    expect(this.action.queueResolver).toHaveBeenCalled();
                 });
             });
         });
@@ -145,11 +106,12 @@ describe('CardAction', function () {
             describe('and the anyPlayer property is not set', function() {
                 beforeEach(function() {
                     this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+                    spyOn(this.action, 'queueResolver');
                     this.action.execute(this.otherPlayer, 'arg');
                 });
 
                 it('should not queue the ability resolver', function() {
-                    expect(this.gameSpy.queueStep).not.toHaveBeenCalled();
+                    expect(this.action.queueResolver).not.toHaveBeenCalled();
                 });
             });
 
@@ -157,11 +119,12 @@ describe('CardAction', function () {
                 beforeEach(function() {
                     this.properties.anyPlayer = true;
                     this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+                    spyOn(this.action, 'queueResolver');
                     this.action.execute(this.otherPlayer, 'arg');
                 });
 
                 it('should queue the ability resolver', function() {
-                    expect(this.gameSpy.queueStep).toHaveBeenCalledWith(jasmine.any(AbilityResolver));
+                    expect(this.action.queueResolver).toHaveBeenCalled();
                 });
             });
         });
@@ -170,11 +133,12 @@ describe('CardAction', function () {
             beforeEach(function() {
                 this.cardSpy.isBlank.and.returnValue(true);
                 this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+                spyOn(this.action, 'queueResolver');
                 this.action.execute(this.player, 'arg');
             });
 
             it('should not queue the ability resolver', function() {
-                expect(this.gameSpy.queueStep).not.toHaveBeenCalled();
+                expect(this.action.queueResolver).not.toHaveBeenCalled();
             });
         });
 
@@ -182,6 +146,7 @@ describe('CardAction', function () {
             beforeEach(function() {
                 this.properties.phase = 'challenge';
                 this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+                spyOn(this.action, 'queueResolver');
             });
 
             describe('and it is not that phase', function() {
@@ -191,7 +156,7 @@ describe('CardAction', function () {
                 });
 
                 it('should not queue the ability resolver', function() {
-                    expect(this.gameSpy.queueStep).not.toHaveBeenCalled();
+                    expect(this.action.queueResolver).not.toHaveBeenCalled();
                 });
             });
 
@@ -202,7 +167,7 @@ describe('CardAction', function () {
                 });
 
                 it('should queue the ability resolver', function() {
-                    expect(this.gameSpy.queueStep).toHaveBeenCalledWith(jasmine.any(AbilityResolver));
+                    expect(this.action.queueResolver).toHaveBeenCalled();
                 });
             });
         });
@@ -212,11 +177,12 @@ describe('CardAction', function () {
                 this.gameSpy.currentPhase = 'setup';
                 this.properties.phase = 'any';
                 this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+                spyOn(this.action, 'queueResolver');
                 this.action.execute(this.player, 'arg');
             });
 
             it('should not queue the ability resolver', function() {
-                expect(this.gameSpy.queueStep).not.toHaveBeenCalled();
+                expect(this.action.queueResolver).not.toHaveBeenCalled();
             });
         });
 
@@ -225,6 +191,7 @@ describe('CardAction', function () {
                 this.condition = jasmine.createSpy('condition');
                 this.properties.condition = this.condition;
                 this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+                spyOn(this.action, 'queueResolver');
             });
 
             describe('and the condition returns true', function() {
@@ -234,7 +201,7 @@ describe('CardAction', function () {
                 });
 
                 it('should queue the ability resolver', function() {
-                    expect(this.gameSpy.queueStep).toHaveBeenCalledWith(jasmine.any(AbilityResolver));
+                    expect(this.action.queueResolver).toHaveBeenCalled();
                 });
             });
 
@@ -245,7 +212,7 @@ describe('CardAction', function () {
                 });
 
                 it('should not queue the ability resolver', function() {
-                    expect(this.gameSpy.queueStep).not.toHaveBeenCalled();
+                    expect(this.action.queueResolver).not.toHaveBeenCalled();
                 });
             });
         });
@@ -253,11 +220,12 @@ describe('CardAction', function () {
         describe('when all conditions met', function() {
             beforeEach(function() {
                 this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+                spyOn(this.action, 'queueResolver');
                 this.action.execute(this.player, 'arg');
             });
 
             it('should queue the ability resolver', function() {
-                expect(this.gameSpy.queueStep).toHaveBeenCalledWith(jasmine.any(AbilityResolver));
+                expect(this.action.queueResolver).toHaveBeenCalled();
             });
         });
     });

--- a/test/server/gamesteps/abilityresolver.spec.js
+++ b/test/server/gamesteps/abilityresolver.spec.js
@@ -1,0 +1,97 @@
+/*global describe, it, beforeEach, expect, jasmine*/
+/* eslint no-invalid-this: 0 */
+
+const AbilityResolver = require('../../../server/game/gamesteps/abilityresolver.js');
+
+describe('AbilityResolver', function() {
+    beforeEach(function() {
+        this.game = jasmine.createSpyObj('game', ['']);
+        this.ability = jasmine.createSpyObj('ability', ['checkIfCanPayCosts', 'payCosts', 'executeHandler']);
+        this.context = { foo: 'bar' };
+        this.resolver = new AbilityResolver(this.game, this.ability, this.context);
+    });
+
+    describe('continue()', function() {
+        describe('when all costs can be paid', function() {
+            beforeEach(function() {
+                this.ability.checkIfCanPayCosts.and.returnValue([{ resolved: true, value: true }, { resolved: true, value: true }]);
+                this.resolver.continue();
+            });
+
+            it('should pay the costs', function() {
+                expect(this.ability.payCosts).toHaveBeenCalledWith(this.context);
+            });
+
+            it('should execute the handler', function() {
+                expect(this.ability.executeHandler).toHaveBeenCalledWith(this.context);
+            });
+        });
+
+        describe('when not all costs can be paid', function() {
+            beforeEach(function() {
+                this.ability.checkIfCanPayCosts.and.returnValue([{ resolved: true, value: true }, { resolved: true, value: false }]);
+                this.resolver.continue();
+            });
+
+            it('should not pay the costs', function() {
+                expect(this.ability.payCosts).not.toHaveBeenCalled();
+            });
+
+            it('should not execute the handler', function() {
+                expect(this.ability.executeHandler).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('when a cost cannot be immediately resolved', function() {
+            beforeEach(function() {
+                this.canPayResult = { resolved: false };
+                this.ability.checkIfCanPayCosts.and.returnValue([this.canPayResult]);
+                this.resolver.continue();
+            });
+
+            it('should not pay the costs', function() {
+                expect(this.ability.payCosts).not.toHaveBeenCalled();
+            });
+
+            it('should not execute the handler', function() {
+                expect(this.ability.executeHandler).not.toHaveBeenCalled();
+            });
+
+            describe('when the costs have resolved', function() {
+                beforeEach(function() {
+                    this.canPayResult.resolved = true;
+                });
+
+                describe('and the cost could be paid', function() {
+                    beforeEach(function() {
+                        this.canPayResult.value = true;
+                        this.resolver.continue();
+                    });
+
+                    it('should pay the costs', function() {
+                        expect(this.ability.payCosts).toHaveBeenCalledWith(this.context);
+                    });
+
+                    it('should execute the handler', function() {
+                        expect(this.ability.executeHandler).toHaveBeenCalledWith(this.context);
+                    });
+                });
+
+                describe('and the cost could not be paid', function() {
+                    beforeEach(function() {
+                        this.canPayResult.value = false;
+                        this.resolver.continue();
+                    });
+
+                    it('should not pay the costs', function() {
+                        expect(this.ability.payCosts).not.toHaveBeenCalled();
+                    });
+
+                    it('should not execute the handler', function() {
+                        expect(this.ability.executeHandler).not.toHaveBeenCalled();
+                    });
+                });
+            });
+        });
+    });
+});

--- a/test/server/gamesteps/abilityresolver.spec.js
+++ b/test/server/gamesteps/abilityresolver.spec.js
@@ -6,7 +6,7 @@ const AbilityResolver = require('../../../server/game/gamesteps/abilityresolver.
 describe('AbilityResolver', function() {
     beforeEach(function() {
         this.game = jasmine.createSpyObj('game', ['']);
-        this.ability = jasmine.createSpyObj('ability', ['checkIfCanPayCosts', 'payCosts', 'executeHandler']);
+        this.ability = jasmine.createSpyObj('ability', ['resolveCosts', 'payCosts', 'executeHandler']);
         this.context = { foo: 'bar' };
         this.resolver = new AbilityResolver(this.game, this.ability, this.context);
     });
@@ -14,7 +14,7 @@ describe('AbilityResolver', function() {
     describe('continue()', function() {
         describe('when all costs can be paid', function() {
             beforeEach(function() {
-                this.ability.checkIfCanPayCosts.and.returnValue([{ resolved: true, value: true }, { resolved: true, value: true }]);
+                this.ability.resolveCosts.and.returnValue([{ resolved: true, value: true }, { resolved: true, value: true }]);
                 this.resolver.continue();
             });
 
@@ -29,7 +29,7 @@ describe('AbilityResolver', function() {
 
         describe('when not all costs can be paid', function() {
             beforeEach(function() {
-                this.ability.checkIfCanPayCosts.and.returnValue([{ resolved: true, value: true }, { resolved: true, value: false }]);
+                this.ability.resolveCosts.and.returnValue([{ resolved: true, value: true }, { resolved: true, value: false }]);
                 this.resolver.continue();
             });
 
@@ -45,7 +45,7 @@ describe('AbilityResolver', function() {
         describe('when a cost cannot be immediately resolved', function() {
             beforeEach(function() {
                 this.canPayResult = { resolved: false };
-                this.ability.checkIfCanPayCosts.and.returnValue([this.canPayResult]);
+                this.ability.resolveCosts.and.returnValue([this.canPayResult]);
                 this.resolver.continue();
             });
 


### PR DESCRIPTION
* Introduces an optional `condition` property on actions. This should be used to check non-cost requirements for an action prior to allowing it to execute. For example - if the action is supposed to stand the parent card, the condition should make sure the parent card is currently kneeling.
* Converts actions to take a `handler` property more similar to reactions / interrupts. Instead of taking the separate player and arg arguments, it takes a context object that has those objects as properties. The context object will also contain the card knelt to pay costs and will (later) contain card targets chosen by the player.
* Introduces an optional `cost` property on actions, reactions and interrupts. This is used to specify the cost of the ability, such as kneeling the card, kneeling the player's faction card, sacrificing the card, etc. If an action has multiple costs (e.g. kneel + sacrifice), then you can pass the costs in an array. By specifying costs this way, you no longer need to explicitly check that the costs can be paid, nor pay the costs yourself in the handler.
* To ensure consistent execution around cost and ability resolution, actions, reactions and interrupts now have the same base class. The AbilityResolver game step operates on this base class to ensure costs are resolved (including any player choices) and paid prior to executing the ability.