### PR TITLE
Don't display counters / tokens when facedown

### DIFF
--- a/client/GameComponents/Card.jsx
+++ b/client/GameComponents/Card.jsx
@@ -121,6 +121,10 @@ class Card extends React.Component {
             return null;
         }
 
+        if(this.props.card.facedown) {
+            return null;
+        }
+
         counters['power'] = this.props.card.power || undefined;
         counters['strength'] = this.props.card.baseStrength !== this.props.card.strength ? this.props.card.strength : undefined;
         counters['dupe'] = this.props.card.dupes && this.props.card.dupes.length > 0 ? this.props.card.dupes.length : undefined;


### PR DESCRIPTION
Previously, if the effects engine caused a card to gain icons during the
setup phase, the icons would appear on the facedown card, potentially
revealing information to the opponent. For example, if the Shadow Tower
Mason was placed along with 3 Night's Watch locations, the intrigue and
military icons gained would be visible to the opponent even if the card
was face down.