### PR TITLE
Only fetch images if one exists.

### DIFF
--- a/server/fetchdata.js
+++ b/server/fetchdata.js
@@ -32,7 +32,7 @@ request.get(apiUrl + 'cards', function(error, res, body) {
     cards.forEach(function(card) {
         var imagePath = path.join(imageDir, card.code + '.png');
 
-        if(!fs.existsSync(imagePath)) {
+        if(card.imagesrc && !fs.existsSync(imagePath)) {
             console.info(card.imagesrc, card.code, imagePath);
             fetchImage(card.imagesrc, card.code, imagePath, i++ * 200);
         }


### PR DESCRIPTION
Previously, if the card.imagesrc property returned by ThronesDB was
null to indicate they don't have an image for the card, the fetch data
script would create a zero byte file locally. This prevented the image
from being fetched after the image had been uploaded, because there was
a local file (even though it was empty).