### PR TITLE
Highlight cards that can be selected by prompt

### DIFF
--- a/client/GameComponents/Card.jsx
+++ b/client/GameComponents/Card.jsx
@@ -246,6 +246,8 @@ class Card extends React.Component {
 
         if(this.props.card.selected) {
             cardClass += ' selected';
+        } else if(this.props.card.selectable) {
+            cardClass += ' selectable';
         } else if(this.props.card.inChallenge) {
             cardClass += ' challenge';
         } else if(this.props.card.stealth) {
@@ -313,6 +315,7 @@ Card.propTypes = {
         name: React.PropTypes.string,
         new: React.PropTypes.bool,
         power: React.PropTypes.number,
+        selectable: React.PropTypes.bool,
         selected: React.PropTypes.bool,
         stealth: React.PropTypes.bool,
         strength: React.PropTypes.number,

--- a/less/cards.less
+++ b/less/cards.less
@@ -26,6 +26,20 @@
     width: @card-height;
   }
 
+  &.selectable {
+    animation: selectable-pulse 4s infinite;
+    box-shadow: 0 0 10px 1px fadeout(lighten(@brand-primary, 60%), 10%);
+  }
+
+  @keyframes selectable-pulse {
+    0% {
+      box-shadow: 0 0 10px 1px fadeout(lighten(@brand-primary, 60%), 10%);
+    }
+    50% {
+      box-shadow: 0 0 10px 1px fadeout(lighten(@brand-primary, 60%), 50%);
+    }
+  }
+
   &.selected {
     box-shadow: 0 0 1px 4px @brand-primary;
   }

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -417,6 +417,7 @@ class BaseCard {
             name: this.cardData.label,
             new: this.new,
             selected: (isActivePlayer && this.selected) || this.opponentSelected,
+            selectable: (isActivePlayer && this.selectable),
             tokens: this.tokens,
             type: this.getType(),
             uuid: this.uuid

--- a/server/game/gamesteps/selectcardprompt.js
+++ b/server/game/gamesteps/selectcardprompt.js
@@ -64,6 +64,22 @@ class SelectCardPrompt extends UiPrompt {
         });
     }
 
+    continue() {
+        if(!this.isComplete()) {
+            this.highlightSelectableCards();
+        }
+
+        return super.continue();
+    }
+
+    highlightSelectableCards() {
+        this.game.allCards.each(card => {
+            if(['character', 'attachment', 'location', 'event'].includes(card.getType())) {
+                card.selectable = this.properties.cardCondition(card);
+            }
+        });
+    }
+
     activeCondition(player) {
         return player === this.choosingPlayer;
     }
@@ -168,6 +184,9 @@ class SelectCardPrompt extends UiPrompt {
             card.opponentSelected = false;
         });
         this.selectedCards = [];
+        this.game.allCards.each(card => {
+            card.selectable = false;
+        });
 
         // Restore previous selections.
         _.each(this.previouslySelectedCards, selection => {


### PR DESCRIPTION
Adds a glow around cards that can be selected during a card selection
prompt.

I've made the color a bit closer to white (though still green tinted) so that it's more distinct from the selection color itself. Here's a preview (excuse the GIF artifacts, Github apparently won't let me embed a video directly):

![feb-19-2017 14-25-45](https://cloud.githubusercontent.com/assets/145077/23107297/65dd90b6-f6af-11e6-9f42-d6dbdb1b6e0a.gif)

I figure this is a good starting point and those with more design savvy can improve it.

Resolves #422.