### PR TITLE
Add support for formatting arrays in messages

### DIFF
--- a/client/GameComponents/Messages.jsx
+++ b/client/GameComponents/Messages.jsx
@@ -45,8 +45,10 @@ class InnerMessages extends React.Component {
             if(_.isNull(fragment) || _.isUndefined(fragment)) {
                 return '';
             }
-            
-            if(fragment.code && fragment.label) {
+
+            if(fragment.message) {
+                return this.formatMessageText(fragment.message);
+            } else if(fragment.code && fragment.label) {
                 return (
                     <span key={index++}
                         className='card-link'

--- a/server/game/cards/attachments/02/kingrobertswarhammer.js
+++ b/server/game/cards/attachments/02/kingrobertswarhammer.js
@@ -36,22 +36,11 @@ class KingRobertsWarhammer extends DrawCard {
     }
 
     onSelect(player, cards) {
-        var cardNames = '';
-        var firstCard = true;
-        var paramIndex = 2;
-
         _.each(cards, card => {
-            if(!firstCard) {
-                cardNames += ', {' + paramIndex++ + '}';
-            } else {
-                firstCard = false;
-                cardNames += '{' + paramIndex++ + '}';
-            }
-
             card.controller.kneelCard(card);
         });
 
-        this.game.addMessage('{0} sacrifices {1} to kneel ' + cardNames, player, this, ...cards);
+        this.game.addMessage('{0} sacrifices {1} to kneel {2}', player, this, cards);
 
         this.selectedStrength = 0;
 

--- a/server/game/cards/characters/01/stannisbaratheon.js
+++ b/server/game/cards/characters/01/stannisbaratheon.js
@@ -35,20 +35,14 @@ class StannisBaratheon extends DrawCard {
             var player = selection.player;
             var toStand = selection.cards;
 
-            var params = '';
-            var paramIndex = 2;
-
             _.each(toStand, card => {
                 card.controller.standCard(card);
-
-                params += '{' + paramIndex++ + '} ';
-
             });
 
             if(_.isEmpty(toStand)) {
                 this.game.addMessage('{0} does not stand any characters with {1}', player, this);
             } else {
-                this.game.addMessage('{0} uses {1} to stand ' + params, player, this, ...toStand);
+                this.game.addMessage('{0} uses {1} to stand {2}', player, this, toStand);
             }
 
             // Stand all non character cards

--- a/server/game/cards/characters/04/roosebolton.js
+++ b/server/game/cards/characters/04/roosebolton.js
@@ -34,22 +34,11 @@ class RooseBolton extends DrawCard {
     }
 
     onSelect(player, cards) {
-        var cardNames = '';
-        var firstCard = true;
-        var paramIndex = 2;
-
         _.each(cards, card => {
-            if(!firstCard) {
-                cardNames += ', {' + paramIndex++ + '}';
-            } else {
-                firstCard = false;
-                cardNames += '{' + paramIndex++ + '}';
-            }
-
             card.controller.killCharacter(card);
         });
 
-        this.game.addMessage('{0} sacrifices {1} to kill ' + cardNames, player, this, ...cards);
+        this.game.addMessage('{0} sacrifices {1} to kill {2}', player, this, cards);
 
         this.selectedStrength = 0;
 

--- a/server/game/cards/events/01/consolidationofpower.js
+++ b/server/game/cards/events/01/consolidationofpower.js
@@ -54,24 +54,13 @@ class ConsolidationOfPower extends DrawCard {
     }
 
     onPowerSelected(player, card) {
-        var cardNames = '';
-        var firstCard = true;
-        var paramIndex = 2;
-
         _.each(this.cards, card => {
-            if(!firstCard) {
-                cardNames += ', {' + paramIndex++ + '}';
-            } else {
-                firstCard = false;
-                cardNames += '{' + paramIndex++ + '}';
-            }
-
             card.controller.kneelCard(card);
         });
 
         card.modifyPower(1);
 
-        this.game.addMessage('{0} uses {1} to kneel ' + cardNames, player, this, ...this.cards);
+        this.game.addMessage('{0} uses {1} to kneel {2}', player, this, this.cards);
         this.game.addMessage('{0} uses {1} to have {2} gain 1 power', player, this, card);
 
         this.selectedStrength = 0;

--- a/server/game/cards/events/02/agiftofarborred.js
+++ b/server/game/cards/events/02/agiftofarborred.js
@@ -38,14 +38,7 @@ class AGiftOfArborRed extends DrawCard {
     }
 
     revealCards(player, cards) {
-        var params = '';
-        var paramIndex = 3;
-
-        _.each(cards, () => {
-            params += '{' + paramIndex++ + '} ';
-        });
-
-        this.game.addMessage('{0} uses {1} to kneel their faction card and reveal the top 4 cards of {2}\'s deck as: ' + params, player, this, player, ...cards);
+        this.game.addMessage('{0} uses {1} to kneel their faction card and reveal the top 4 cards of {2}\'s deck as: {3}', player, this, player, cards);
     }
 
     selectThisPlayerCardForHand(player, cardId) {

--- a/server/game/cards/events/02/ineverbetagainstmyfamily.js
+++ b/server/game/cards/events/02/ineverbetagainstmyfamily.js
@@ -24,14 +24,7 @@ class INeverBetAgainstMyFamily extends DrawCard {
 
         this.remainingCards = this.controller.searchDrawDeck(-5);
 
-        var revealedCardIndex = 0;
-        var revealedCards = '';
-        while(revealedCardIndex < this.remainingCards.length) {
-            revealedCards += '{' + (revealedCardIndex + 2) + '} ';
-            revealedCardIndex += 1;
-        }
-
-        this.game.addMessage('{0} uses {1} to reveal from the bottom of their deck: ' + revealedCards, player, this, ...this.remainingCards);
+        this.game.addMessage('{0} uses {1} to reveal from the bottom of their deck: {2}', player, this, this.remainingCards);
 
         this.uniqueCharacters = _.filter(this.remainingCards, card => card.isUnique() && card.getType() === 'character' && card.getFaction() === 'lannister');
 

--- a/server/game/cards/events/03/evenhandedjustice.js
+++ b/server/game/cards/events/03/evenhandedjustice.js
@@ -68,7 +68,7 @@ class EvenHandedJustice extends DrawCard {
 
         var kneeledCards = _.map(this.toKneel, card => card.name);
         this.game.addMessage('{0} uses {1} to kneel {2}',
-                             player, this, kneeledCards.join(' and '));
+                             player, this, kneeledCards);
 
         return true;
     }

--- a/server/game/cards/events/04/thereismyclaim.js
+++ b/server/game/cards/events/04/thereismyclaim.js
@@ -1,5 +1,3 @@
-const _ = require('underscore');
-
 const ChallengeEvent = require('../../challengeevent.js');
 
 class ThereIsMyClaim extends ChallengeEvent {

--- a/server/game/cards/events/04/thereismyclaim.js
+++ b/server/game/cards/events/04/thereismyclaim.js
@@ -39,11 +39,8 @@ class ThereIsMyClaim extends ChallengeEvent {
             effect: ability.effects.modifyClaim(1)
         }));
 
-        // TODO use card name renderer helper, refactored from Wildfire Assault
-        var reveleadCharacters = _.map(cards, card => card.name).join(', ');
-
         this.game.addMessage('{0} uses {1} to reveal {2} and raise their claim value until the end of the challenge',
-                             player, this, reveleadCharacters);
+                             player, this, cards);
 
         return true;
     }

--- a/server/game/cards/locations/04/houseoftheundying.js
+++ b/server/game/cards/locations/04/houseoftheundying.js
@@ -36,13 +36,7 @@ class HouseOfTheUndying extends DrawCard {
             }));
         });
 
-        var format = '';
-        var index = 0;
-        while(index < eligibleCharacters.length) {
-            format += ' {' + (index + 2) + '}';
-            index++;
-        }
-        this.game.addMessage('{0} removes {1} from the game to control' + format, this.controller, this, ...eligibleCharacters);
+        this.game.addMessage('{0} removes {1} from the game to control {2}', this.controller, this, eligibleCharacters);
     }
 }
 

--- a/server/game/cards/plots/01/rebuilding.js
+++ b/server/game/cards/plots/01/rebuilding.js
@@ -23,18 +23,13 @@ class Rebuilding extends PlotCard {
     }
 
     doneSelect(player, cards) {
-        var params = '';
-        var paramIndex = 2;
-
         _.each(cards, card => {
             player.moveCard(card, 'draw deck');
             player.shuffleDrawDeck();
-
-            params += '{' + paramIndex++ + '} ';
         });
 
         if(!_.isEmpty(cards)) {
-            this.game.addMessage('{0} uses {1} to shuffle ' + params + 'into their deck', player, this, ...cards);
+            this.game.addMessage('{0} uses {1} to shuffle {2} into their deck', player, this, cards);
         }
 
         return true;

--- a/server/game/cards/plots/01/wildfireassault.js
+++ b/server/game/cards/plots/01/wildfireassault.js
@@ -14,6 +14,11 @@ class WildfireAssault extends PlotCard {
     }
 
     onSelect(player, cards) {
+        if(_.isEmpty(cards)) {
+            this.game.addMessage('{0} does not choose any characters to save from {1}', player, this);
+        } else {
+            this.game.addMessage('{0} chooses to save {1} from {2}', player, cards, this);
+        }
         this.selections.push({ player: player, cards: cards });
         this.proceedToNextStep();
         return true;

--- a/server/game/cards/plots/01/wildfireassault.js
+++ b/server/game/cards/plots/01/wildfireassault.js
@@ -29,19 +29,14 @@ class WildfireAssault extends PlotCard {
             var player = selection.player;
             var toKill = _.difference(player.cardsInPlay.filter(card => card.getType() === 'character'), selection.cards);
 
-            var params = '';
-            var paramIndex = 2;
-
             _.each(toKill, card => {
                 player.killCharacter(card, false);
-
-                params += '{' + paramIndex++ + '} ';
             });
 
             if(_.isEmpty(toKill)) {
                 this.game.addMessage('{0} does not kill any characters with {1}', player, this);
             } else {
-                this.game.addMessage('{0} uses {1} to kill ' + params, player, this, ...toKill);
+                this.game.addMessage('{0} uses {1} to kill {2}', player, this, toKill);
             }
         });
 

--- a/server/game/cards/plots/02/politicaldisaster.js
+++ b/server/game/cards/plots/02/politicaldisaster.js
@@ -29,20 +29,14 @@ class PoliticalDisaster extends PlotCard {
             var player = selection.player;
             var toDiscard = _.difference(player.cardsInPlay.filter(card => card.getType() === 'location'), selection.cards);
 
-            var params = '';
-            var paramIndex = 2;
-
             _.each(toDiscard, card => {
                 player.discardCard(card);
-
-                params += '{' + paramIndex++ + '} ';
-
             });
 
             if(_.isEmpty(toDiscard)) {
                 this.game.addMessage('{0} does not discard any locations with {1}', player, this);
             } else {
-                this.game.addMessage('{0} uses {1} to discard ' + params, player, this, ...toDiscard);
+                this.game.addMessage('{0} uses {1} to discard {2}', player, this, toDiscard);
             }
         });
 

--- a/server/game/cards/plots/02/wardensofthewest.js
+++ b/server/game/cards/plots/02/wardensofthewest.js
@@ -27,16 +27,12 @@ class WardensOfTheWest extends PlotCard {
 
     onSelect(player, cards) {
         this.game.addGold(this.controller, -2);
-        var cardStr = '';
-        var index = 1;
 
         _.each(cards, card => {
             card.controller.moveCard(card, 'discard pile');
-
-            cardStr += ' {' + index++ + '}';
         });
 
-        this.game.addMessage('{0} chooses' + cardStr + ' to discard from their hand', player, ...cards);
+        this.game.addMessage('{0} chooses {1} to discard from their hand', player, cards);
 
         return true;
     }

--- a/server/game/gamechat.js
+++ b/server/game/gamechat.js
@@ -46,7 +46,9 @@ class GameChat {
             if(argMatch) {
                 var arg = args[argMatch[1]];
                 if(!_.isUndefined(arg) && !_.isNull(arg)) {
-                    if(arg instanceof BaseCard) {
+                    if(_.isArray(arg)) {
+                        return this.formatArray(arg);
+                    } else if(arg instanceof BaseCard) {
                         return { code: arg.code, label: arg.name, type: arg.getType() };
                     } else if(arg instanceof Spectator) {
                         return { name: arg.user.username, emailHash: arg.user.emailHash };
@@ -60,6 +62,23 @@ class GameChat {
 
             return fragment;
         });
+    }
+
+    formatArray(array) {
+        if(array.length === 0) {
+            return '';
+        }
+
+        var format;
+
+        if(array.length === 1) {
+            format = '{0}';
+        } else {
+            var range = _.map(_.range(array.length - 1), i => '{' + i + '}');
+            format = range.join(', ') + ', and {' + (array.length - 1) + '}';
+        }
+
+        return { message: this.formatMessage(format, array) };
     }
 }
 

--- a/server/game/gamechat.js
+++ b/server/game/gamechat.js
@@ -73,6 +73,8 @@ class GameChat {
 
         if(array.length === 1) {
             format = '{0}';
+        } else if(array.length === 2) {
+            format = '{0} and {1}';
         } else {
             var range = _.map(_.range(array.length - 1), i => '{' + i + '}');
             format = range.join(', ') + ', and {' + (array.length - 1) + '}';

--- a/server/game/gamesteps/challenge/fulfillmilitaryclaim.js
+++ b/server/game/gamesteps/challenge/fulfillmilitaryclaim.js
@@ -35,14 +35,7 @@ class FulfillMilitaryClaim extends BaseStep {
             return false;
         }
 
-        var targets = '';
-        for(var i = 1; i <= cards.length; i++) {
-            if(i > 1) {
-                targets += (cards.length > 2 ? ',' : '') + (i === cards.length ? ' and' : '') + ' ';
-            }
-            targets += '{' + i + '}';
-        }
-        this.game.addMessage('{0} chooses ' + targets + ' for claim', this.player, ...cards);
+        this.game.addMessage('{0} chooses {1} for claim', this.player, cards);
 
         _.each(cards, card => {
             card.controller.killCharacter(card);

--- a/test/server/game/gamechat.formatMessage.spec.js
+++ b/test/server/game/gamechat.formatMessage.spec.js
@@ -75,6 +75,20 @@ describe('GameChat', function() {
                     });
                 });
 
+                describe('and it is a pair entry array', function() {
+                    beforeEach(function() {
+                        this.args = [
+                            'foo',
+                            ['bar', 'baz']
+                        ];
+                    });
+
+                    it('should return a sub-message with no commas', function() {
+                        var message = this.chat.formatMessage('Hello {0} world {1}', this.args);
+                        expect(message[3]).toEqual({ message: ['', 'bar', ' and ', 'baz', ''] });
+                    });
+                });
+
                 describe('and it is a multiple entry array', function() {
                     beforeEach(function() {
                         this.args = [

--- a/test/server/game/gamechat.formatMessage.spec.js
+++ b/test/server/game/gamechat.formatMessage.spec.js
@@ -45,6 +45,50 @@ describe('GameChat', function() {
                 var message = this.chat.formatMessage('Hello {2} world', this.args);
                 expect(message[1]).toEqual('');
             });
+
+            describe('when the arg is an array', function() {
+                describe('and it is an empty array', function() {
+                    beforeEach(function() {
+                        this.args = [
+                            'foo',
+                            []
+                        ];
+                    });
+
+                    it('should return an empty string fragment', function() {
+                        var message = this.chat.formatMessage('Hello {0} world {1}', this.args);
+                        expect(message[3]).toEqual('');
+                    });
+                });
+
+                describe('and it is a single entry array', function() {
+                    beforeEach(function() {
+                        this.args = [
+                            'foo',
+                            ['bar']
+                        ];
+                    });
+
+                    it('should return a sub-message with no separators', function() {
+                        var message = this.chat.formatMessage('Hello {0} world {1}', this.args);
+                        expect(message[3]).toEqual({ message: ['', 'bar', ''] });
+                    });
+                });
+
+                describe('and it is a multiple entry array', function() {
+                    beforeEach(function() {
+                        this.args = [
+                            'foo',
+                            ['bar', 'baz', 'ball']
+                        ];
+                    });
+
+                    it('should return a sub-message with separators', function() {
+                        var message = this.chat.formatMessage('Hello {0} world {1}', this.args);
+                        expect(message[3]).toEqual({ message: ['', 'bar', ', ', 'baz', ', and ', 'ball', ''] });
+                    });
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
You can now pass arrays directly into `addMessage` and have them be formatted for you automatically instead of manually building up the format message manually in your card implementations. The formatting output is based on the number of items in the array - either 1, 2 or 3+ items. Examples:

[cardA] = 'card A'
[cardA, cardB] = 'card A and card B'
[cardA, cardB, cardC, cardD] = 'card A, card B, card C, and card D'

Also adds an announcement message to Wildfire upon a player choosing which characters to save, since the choices should be public info and could modify the second player's decision making.