### PR TITLE
Only recalc targets for conditional effects.

### DIFF
--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -51,6 +51,7 @@ class Effect {
         this.context = { game: game, source: source };
         this.active = true;
         this.recalculateWhen = properties.recalculateWhen || [];
+        this.isConditional = !!properties.condition;
         this.isStateDependent = properties.condition || this.effect.isStateDependent;
     }
 
@@ -156,9 +157,20 @@ class Effect {
         this.targets = [];
     }
 
-    resetTargets(newTargets) {
-        this.cancel();
-        this.addTargets(newTargets);
+    reapply(newTargets) {
+        if(!this.active) {
+            return;
+        }
+
+        if(this.isConditional) {
+            this.cancel();
+            this.addTargets(newTargets);
+        } else if(this.effect.isStateDependent) {
+            _.each(this.targets, target => {
+                this.effect.unapply(target, this.context);
+                this.effect.apply(target, this.context);
+            });
+        }
     }
 }
 

--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -25,7 +25,7 @@ class EffectEngine {
     reapplyStateDependentEffects() {
         _.each(this.effects, effect => {
             if(effect.isStateDependent) {
-                effect.resetTargets(this.getTargets());
+                effect.reapply(this.getTargets());
             }
         });
     }
@@ -50,7 +50,7 @@ class EffectEngine {
     onCardTakenControl(e, card) {
         _.each(this.effects, effect => {
             if(effect.duration === 'persistent' && effect.source === card) {
-                effect.resetTargets(this.getTargets());
+                effect.reapply(this.getTargets());
             }
         });
     }
@@ -125,7 +125,7 @@ class EffectEngine {
     recalculateEvent(event) {
         _.each(this.effects, effect => {
             if(effect.isStateDependent && effect.recalculateWhen.includes(event.name)) {
-                effect.resetTargets(this.getTargets());
+                effect.reapply(this.getTargets());
             }
         });
     }

--- a/test/server/effect.spec.js
+++ b/test/server/effect.spec.js
@@ -489,4 +489,142 @@ describe('Effect', function () {
             });
         });
     });
+
+    describe('reapply()', function() {
+        beforeEach(function() {
+            this.target = { target: 1, location: 'play area' };
+            this.newTarget = { target: 2, location: 'play area' };
+            this.effect.targets = [this.target];
+            this.newTargets = [this.target, this.newTarget];
+        });
+
+        describe('when the effect is neither state dependent nor conditional', function() {
+            beforeEach(function() {
+                this.effect.isConditional = false;
+                this.properties.effect.isStateDependent = false;
+            });
+
+            describe('when the effect is inactive', function() {
+                beforeEach(function() {
+                    this.effect.active = false;
+
+                    this.effect.reapply(this.newTargets);
+                });
+
+                it('should not unapply the effect from existing targets', function() {
+                    expect(this.properties.effect.unapply).not.toHaveBeenCalled();
+                });
+
+                it('should not apply the effect for new or existing targets', function() {
+                    expect(this.properties.effect.apply).not.toHaveBeenCalled();
+                });
+            });
+
+            describe('when the effect is active', function() {
+                beforeEach(function() {
+                    this.effect.active = true;
+
+                    this.effect.reapply(this.newTargets);
+                });
+
+                it('should not unapply the effect from existing targets', function() {
+                    expect(this.properties.effect.unapply).not.toHaveBeenCalled();
+                });
+
+                it('should not apply the effect for new or existing targets', function() {
+                    expect(this.properties.effect.apply).not.toHaveBeenCalled();
+                });
+            });
+        });
+
+        describe('when the effect is state dependent but not conditional', function() {
+            beforeEach(function() {
+                this.effect.isConditional = false;
+                this.properties.effect.isStateDependent = true;
+            });
+
+            describe('when the effect is inactive', function() {
+                beforeEach(function() {
+                    this.effect.active = false;
+
+                    this.effect.reapply(this.newTargets);
+                });
+
+                it('should not unapply the effect from existing targets', function() {
+                    expect(this.properties.effect.unapply).not.toHaveBeenCalled();
+                });
+
+                it('should not apply the effect for new or existing targets', function() {
+                    expect(this.properties.effect.apply).not.toHaveBeenCalled();
+                });
+            });
+
+            describe('when the effect is active', function() {
+                beforeEach(function() {
+                    this.effect.active = true;
+
+                    this.effect.reapply(this.newTargets);
+                });
+
+                it('should unapply the effect for existing targets', function() {
+                    expect(this.properties.effect.unapply).toHaveBeenCalledWith(this.target, jasmine.any(Object));
+                });
+
+                it('should apply the effect for existing targets', function() {
+                    expect(this.properties.effect.apply).toHaveBeenCalledWith(this.target, jasmine.any(Object));
+                });
+
+                it('should not apply the effect to new targets', function() {
+                    expect(this.properties.effect.apply).not.toHaveBeenCalledWith(this.newTarget, jasmine.any(Object));
+                });
+            });
+        });
+
+        describe('when the effect is conditional', function() {
+            beforeEach(function() {
+                this.effect.isConditional = true;
+            });
+
+            describe('when the effect is inactive', function() {
+                beforeEach(function() {
+                    this.effect.active = false;
+
+                    this.effect.reapply(this.newTargets);
+                });
+
+                it('should not unapply the effect from existing targets', function() {
+                    expect(this.properties.effect.unapply).not.toHaveBeenCalled();
+                });
+
+                it('should not apply the effect from existing targets', function() {
+                    expect(this.properties.effect.apply).not.toHaveBeenCalled();
+                });
+            });
+
+            describe('when the effect is active', function() {
+                beforeEach(function() {
+                    this.effect.active = true;
+
+                    this.effect.reapply(this.newTargets);
+                });
+
+                it('should unapply the effect from existing targets', function() {
+                    expect(this.properties.effect.unapply).toHaveBeenCalledWith(this.target, jasmine.any(Object));
+                });
+
+                it('should apply the effect from existing targets', function() {
+                    expect(this.properties.effect.apply).toHaveBeenCalledWith(this.target, jasmine.any(Object));
+                });
+
+                it('should apply the effect to new targets', function() {
+                    expect(this.properties.effect.apply).toHaveBeenCalledWith(this.newTarget, jasmine.any(Object));
+                });
+
+                it('should update the target list', function() {
+                    expect(this.effect.targets).toContain(this.target);
+                    expect(this.effect.targets).toContain(this.newTarget);
+                });
+            });
+        });
+    });
 });

--- a/test/server/effectengine.spec.js
+++ b/test/server/effectengine.spec.js
@@ -15,7 +15,7 @@ describe('EffectEngine', function () {
         this.gameSpy.getPlayers.and.returnValue([]);
         this.gameSpy.allCards = _([this.handCard, this.playAreaCard, this.discardedCard]);
 
-        this.effectSpy = jasmine.createSpyObj('effect', ['addTargets', 'resetTargets', 'removeTarget', 'cancel', 'setActive']);
+        this.effectSpy = jasmine.createSpyObj('effect', ['addTargets', 'reapply', 'removeTarget', 'cancel', 'setActive']);
         this.effectSpy.targetLocation = 'play area';
 
         this.engine = new EffectEngine(this.gameSpy);
@@ -57,8 +57,8 @@ describe('EffectEngine', function () {
                 this.engine.reapplyStateDependentEffects();
             });
 
-            it('should reset valid targets', function() {
-                expect(this.effectSpy.resetTargets).toHaveBeenCalledWith([this.handCard, this.playAreaCard]);
+            it('should reapply valid targets', function() {
+                expect(this.effectSpy.reapply).toHaveBeenCalledWith([this.handCard, this.playAreaCard]);
             });
         });
 
@@ -68,8 +68,8 @@ describe('EffectEngine', function () {
                 this.engine.reapplyStateDependentEffects();
             });
 
-            it('should not reset valid targets', function() {
-                expect(this.effectSpy.resetTargets).not.toHaveBeenCalled();
+            it('should not reapply valid targets', function() {
+                expect(this.effectSpy.reapply).not.toHaveBeenCalled();
             });
         });
     });


### PR DESCRIPTION
Previously, if an effect was state dependent (dynamic strength, kill on
0 strength, etc) OR an effect was conditional, the recalculation
mechanism would always remove all targets and go through all cards for
eligible targets. This lead to a bug with Dracarys which is state
dependent, not conditional, and not persistent. The effect of Dracarys
would be re-applied if the card killed by its effect was manually
dragged back into play - the target was removed when it left play, but
the matching function would allow it to be reapplied after entering play
again.

Now, only conditional effects will update their target lists upon
recalculation. Effects that are solely state dependent will unapply and
reapply their effect to existing targets, but will not add any
additional targets.

Fixes #454.