### PR TITLE
make Newly Made Lord activable on kneeled location

### DIFF
--- a/server/game/cards/characters/02/newly-madelord.js
+++ b/server/game/cards/characters/02/newly-madelord.js
@@ -18,7 +18,7 @@ class NewlyMadeLord extends DrawCard {
     }
 
     cardCondition(card) {
-        return !card.kneeled && card.getType() === 'location' && !card.isLimited() && card.getCost() <= 3;
+        return card.getType() === 'location' && !card.isLimited() && card.getCost() <= 3;
     }
 
     onCardSelected(player, card) {


### PR DESCRIPTION
the requirement of target location being standing is not part of the card
behavior