### PR TITLE
implement Ser Edmure Tully

### DIFF
--- a/server/game/cards/characters/04/seredmuretully.js
+++ b/server/game/cards/characters/04/seredmuretully.js
@@ -1,0 +1,59 @@
+const DrawCard = require('../../../drawcard.js');
+
+class SerEdmureTully extends DrawCard {
+
+    setupCardAbilities(ability) {
+        this.reaction({
+            when: {
+                // TODO this should trigger only when power is *gained*, but currently also
+                // triggers when power is *moved* between cards. To make the distinction we
+                // need a new high-level event and review all uses of card power modifications
+                onCardPowerChanged: (event, card, power) => {
+                    var tullyCharacters = this.game.findAnyCardsInPlay(this.isTullyCharacter);
+
+                    if(card.getType() === 'character'
+                       && power > 0
+                       && tullyCharacters.length > 0) {
+                        this.powerGainingCharacter = card;
+
+                        return true;
+                    }
+                    return false;
+                }
+            },
+            limit: ability.limit.perRound(1),
+            handler: () => {
+                this.game.promptForSelect(this.controller, {
+                    cardCondition: card =>
+                        card.location === 'play area' && this.isTullyCharacter(card),
+                    activePromptTitle: 'Select a Tully character to move power to',
+                    waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
+                    onSelect: (player, card) => this.transferPower(card)
+                });
+            }
+        });
+    }
+
+    isTullyCharacter(card) {
+        return card.getType() === 'character' && card.hasTrait('House Tully');
+    }
+
+    transferPower(toCharacter) {
+        if(!this.powerGainingCharacter) {
+            return false;
+        }
+
+        this.powerGainingCharacter.modifyPower(-1);
+        toCharacter.modifyPower(1);
+
+        this.game.addMessage('{0} uses {1} to move 1 power from {2} to {3}',
+                             this.controller, this, this.powerGainingCharacter, toCharacter);
+
+        this.powerGainingCharacter = undefined;
+    }
+
+}
+
+SerEdmureTully.code = '04041';
+
+module.exports = SerEdmureTully;


### PR DESCRIPTION
This is an implementation of Edmure. But there is a BUT (that is also noted as
a TODO in the card code). It will trigger even when power is *moved* between
cards, rather than only when it is *gained*. To achieve the proper semantics
however we need to:

- introduce a new event (!= onCardPowerChanged) that is raised when power is
  moved between cards

- add a new function to move power, so that cards that need to do so have a
  high-level way of implementing it, rather than using two distinct power
  modifications on two cards

- review all current uses of power modifications to check whether they should
  be ported to the new high level effect

Do we want to do the above as a condition for having Edmure implemented, or do
we prefer to have a suboptimal implementation of Edmure in right now, and
improve it later?