### PR TITLE
Add support for non-repeating ability limits

### DIFF
--- a/server/game/abilitylimit.js
+++ b/server/game/abilitylimit.js
@@ -1,9 +1,11 @@
-class AbilityLimit {
-    constructor(max, eventName) {
+class FixedAbilityLimit {
+    constructor(max) {
         this.max = max;
-        this.eventName = eventName;
         this.useCount = 0;
-        this.resetHandler = () => this.reset();
+    }
+
+    isRepeatable() {
+        return false;
     }
 
     isAtMax() {
@@ -18,6 +20,27 @@ class AbilityLimit {
         this.useCount = 0;
     }
 
+    registerEvents() {
+        // No event handling
+    }
+
+    unregisterEvents() {
+        // No event handling
+    }
+}
+
+class RepeatableAbilityLimit extends FixedAbilityLimit {
+    constructor(max, eventName) {
+        super(max);
+
+        this.eventName = eventName;
+        this.resetHandler = () => this.reset();
+    }
+
+    isRepeatable() {
+        return true;
+    }
+
     registerEvents(eventEmitter) {
         eventEmitter.on(this.eventName, this.resetHandler);
     }
@@ -27,16 +50,26 @@ class AbilityLimit {
     }
 }
 
+var AbilityLimit = {};
+
+AbilityLimit.fixed = function(max) {
+    return new FixedAbilityLimit(max);
+};
+
+AbilityLimit.repeatable = function(max, eventName) {
+    return new RepeatableAbilityLimit(max, eventName);
+};
+
 AbilityLimit.perChallenge = function(max) {
-    return new AbilityLimit(max, 'onChallengeFinished');
+    return new RepeatableAbilityLimit(max, 'onChallengeFinished');
 };
 
 AbilityLimit.perPhase = function(max) {
-    return new AbilityLimit(max, 'onPhaseEnded');
+    return new RepeatableAbilityLimit(max, 'onPhaseEnded');
 };
 
 AbilityLimit.perRound = function(max) {
-    return new AbilityLimit(max, 'onRoundEnded');
+    return new RepeatableAbilityLimit(max, 'onRoundEnded');
 };
 
 module.exports = AbilityLimit;

--- a/test/server/abilitylimit.spec.js
+++ b/test/server/abilitylimit.spec.js
@@ -9,7 +9,7 @@ describe('AbilityLimit', function () {
     beforeEach(function () {
         this.eventEmitterSpy = jasmine.createSpyObj('event emitter', ['on', 'removeListener']);
 
-        this.limit = new AbilityLimit(2, 'onEventForReset');
+        this.limit = AbilityLimit.repeatable(2, 'onEventForReset');
     });
 
     describe('increment()', function() {


### PR DESCRIPTION
Can be used for per-game limits and the upcoming changes for cost reducing effects.