### PR TITLE
Convert reducers to normal actions.

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -137,7 +137,9 @@ class BaseCard {
     action(properties) {
         var action = new CardAction(this.game, this, properties);
         this.abilities.action = action;
-        this.menu.push(action.getMenuItem());
+        if(!action.isClickToActivate()) {
+            this.menu.push(action.getMenuItem());
+        }
     }
 
     reaction(properties) {
@@ -234,7 +236,9 @@ class BaseCard {
             return;
         }
 
-        this.abilities.action.execute(player, arg);
+        var context = this.abilities.action.createContext(player, arg);
+
+        this.abilities.action.execute(context);
     }
 
     hasKeyword(keyword) {
@@ -417,7 +421,12 @@ class BaseCard {
         }
     }
 
-    onClick() {
+    onClick(player) {
+        var action = this.abilities.action;
+        if(action && action.isClickToActivate()) {
+            return action.execute(player);
+        }
+
         return false;
     }
 

--- a/server/game/cards/locations/01/thekingsroad.js
+++ b/server/game/cards/locations/01/thekingsroad.js
@@ -1,28 +1,27 @@
 const DrawCard = require('../../../drawcard.js');
 
 class TheKingsroad extends DrawCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.plotModifiers({
             initiative: 1
         });
-    }
-
-    onClick(player) {
-        if(player.phase !== 'marshal' || this.controller !== player || this.kneeled) {
-            return false;
-        }
-
-        player.kneelCard(this);
-        player.sacrificeCard(this);
-        this.game.addMessage('{0} kneels and sacrifices {1} to reduce the cost of the next character by 3', player, this);
-
-        this.untilEndOfPhase(ability => ({
-            targetType: 'player',
-            targetController: 'current',
-            effect: ability.effects.reduceNextMarshalledCardCost(3, card => card.getType() === 'character')
-        }));
-
-        return true;
+        this.action({
+            title: 'Kneel and sacrifice',
+            clickToActivate: true,
+            phase: 'marshal',
+            cost: [
+                ability.costs.kneelSelf(),
+                ability.costs.sacrificeSelf()
+            ],
+            handler: () => {
+                this.game.addMessage('{0} kneels and sacrifices {1} to reduce the cost of the next character by 3', this.controller, this);
+                this.untilEndOfPhase(ability => ({
+                    targetType: 'player',
+                    targetController: 'current',
+                    effect: ability.effects.reduceNextMarshalledCardCost(3, card => card.getType() === 'character')
+                }));
+            }
+        });
     }
 }
 

--- a/server/game/cards/locations/05/oceanroad.js
+++ b/server/game/cards/locations/05/oceanroad.js
@@ -1,22 +1,25 @@
-const Reducer = require('../../reducer.js').Reducer;
+const DrawCard = require('../../../drawcard');
 
-class OceanRoad extends Reducer {
-    constructor(owner, cardData) {
-        super(owner, cardData, 1, (card) => {
-            return card.isFaction('neutral') || !card.isFaction(this.controller.faction.getPrintedFaction());
+class OceanRoad extends DrawCard {
+    setupCardAbilities(ability) {
+        this.action({
+            title: 'Kneel to reduce',
+            clickToActivate: true,
+            phase: 'marshal',
+            cost: ability.costs.kneelSelf(),
+            handler: () => {
+                this.game.addMessage('{0} uses {1} to reduce the cost of the next {2} card by {3}',
+                    this.controller, this, this.faction, 1);
+                this.untilEndOfPhase(ability => ({
+                    targetType: 'player',
+                    targetController: 'current',
+                    effect: ability.effects.reduceNextMarshalledCardCost(
+                        1,
+                        card => card.isFaction('neutral') || !card.isFaction(this.controller.faction.getPrintedFaction())
+                    )
+                }));
+            }
         });
-    }
-
-    onClick(player) {
-        var ret = super.onClick(player);
-
-        if(!ret || this.isBlank()) {
-            return false;
-        }
-
-        this.game.addMessage('{0} kneels {1} to reduce the cost of the next neutral or out of faction card marshalled by 1', player, this);
-
-        return ret;
     }
 }
 

--- a/server/game/cards/reducer.js
+++ b/server/game/cards/reducer.js
@@ -1,74 +1,63 @@
 const DrawCard = require('../drawcard.js');
 
-class Reducer extends DrawCard {
-    constructor(owner, cardData, reduceBy, condition) {
+class FactionCostReducer extends DrawCard {
+    constructor(owner, cardData, reduceBy, faction) {
         super(owner, cardData);
 
         this.reduceBy = reduceBy;
-        this.condition = condition;
-    }
-
-    onClick(player) {
-        if(player.phase !== 'marshal' || this.controller !== player || this.kneeled || this.abilityUsed) {
-            return false;
-        }
-
-        player.kneelCard(this);
-
-        this.untilEndOfPhase(ability => ({
-            targetType: 'player',
-            targetController: 'current',
-            effect: ability.effects.reduceNextMarshalledCardCost(this.reduceBy, this.condition)
-        }));
-
-        return true;
-    }
-}
-
-class FactionCostReducer extends Reducer {
-    constructor(owner, cardData, reduceBy, faction) {
-        super(owner, cardData, reduceBy, (card) => {
-            return card.isFaction(faction);
-        });
-
         this.faction = faction;
     }
 
-    onClick(player) {
-        var canUse = super.onClick(player);
-
-        if(canUse) {
-            this.game.addMessage('{0} uses {1} to reduce the cost of the next {2} card by {3}',
-                player, this, this.faction, this.reduceBy);
-        }
-
-        return canUse;
+    setupCardAbilities(ability) {
+        this.action({
+            title: 'Kneel to reduce',
+            clickToActivate: true,
+            phase: 'marshal',
+            cost: ability.costs.kneelSelf(),
+            handler: () => {
+                this.game.addMessage('{0} uses {1} to reduce the cost of the next {2} card by {3}',
+                    this.controller, this, this.faction, this.reduceBy);
+                this.untilEndOfPhase(ability => ({
+                    targetType: 'player',
+                    targetController: 'current',
+                    effect: ability.effects.reduceNextMarshalledCardCost(this.reduceBy, card => card.isFaction(this.faction))
+                }));
+            }
+        });
     }
 }
 
-class FactionCharacterCostReducer extends Reducer {
+class FactionCharacterCostReducer extends DrawCard {
     constructor(owner, cardData, reduceBy, faction) {
-        super(owner, cardData, reduceBy, (card) => {
-            return card.getType() === 'character' && card.isFaction(faction);
-        });
+        super(owner, cardData);
 
+        this.reduceBy = reduceBy;
         this.faction = faction;
     }
 
-    onClick(player) {
-        var canUse = super.onClick(player);
-
-        if(canUse) {
-            this.game.addMessage('{0} uses {1} to reduce the cost of the next {2} character by {3}',
-                player, this, this.faction, this.reduceBy);
-        }
-
-        return canUse;
+    setupCardAbilities(ability) {
+        this.action({
+            title: 'Kneel to reduce',
+            clickToActivate: true,
+            phase: 'marshal',
+            cost: ability.costs.kneelSelf(),
+            handler: () => {
+                this.game.addMessage('{0} uses {1} to reduce the cost of the next {2} character by {3}',
+                    this.controller, this, this.faction, this.reduceBy);
+                this.untilEndOfPhase(ability => ({
+                    targetType: 'player',
+                    targetController: 'current',
+                    effect: ability.effects.reduceNextMarshalledCardCost(
+                        this.reduceBy,
+                        card => card.getType() === 'character' && card.isFaction(this.faction)
+                    )
+                }));
+            }
+        });
     }
 }
 
 module.exports = {
-    Reducer: Reducer,
     FactionCostReducer: FactionCostReducer,
     FactionCharacterCostReducer: FactionCharacterCostReducer
 };


### PR DESCRIPTION
This converts all reducers to use the standard action syntax. An
additional property, `clickToActivate`, can be passed into actions now
indicating they can be executed by clicking the card instead of using
the menu.