### PR TITLE
fix Forgotten Plans condition check to verify current phase on players

### DIFF
--- a/server/game/cards/plots/02/forgottenplans.js
+++ b/server/game/cards/plots/02/forgottenplans.js
@@ -3,7 +3,7 @@ const PlotCard = require('../../../plotcard.js');
 class ForgottenPlans extends PlotCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            condition: () => this.game.phase !== 'plot',
+            condition: () => this.game.currentPhase !== 'plot',
             match: card => card.getType() === 'plot' && !card.hasTrait('Scheme'),
             targetController: 'any',
             effect: ability.effects.blank


### PR DESCRIPTION
The .phase attribute is not defined on Game objects, but as the condition was
negated in this plot, it always succeeded. The proper way to do this is
checking .phase on Player objects.

We now check it on both player at once, which is OK as phases are always
updated simultaneously.