### PR TITLE
Introduce integration testing helpers

### DIFF
--- a/test/helpers/gameflowwrapper.js
+++ b/test/helpers/gameflowwrapper.js
@@ -1,0 +1,97 @@
+/* global jasmine */
+
+const _ = require('underscore');
+
+const Game = require('../../server/game/game.js');
+const PlayerInteractionWrapper = require('./playerinteractionwrapper.js');
+
+class GameFlowWrapper {
+    constructor() {
+        var creator = { username: 'player1' };
+        var gameRepository = jasmine.createSpyObj('gameRepository', ['save']);
+        this.game = new Game(creator.username, {}, { gameRepository: gameRepository });
+        this.game.join('111', creator);
+        this.game.join('222', { username: 'player2' });
+
+        this.player1 = new PlayerInteractionWrapper(this.game, this.game.getPlayerByName('player1'));
+        this.player2 = new PlayerInteractionWrapper(this.game, this.game.getPlayerByName('player2'));
+        this.allPlayers = [this.player1, this.player2];
+    }
+
+    eachPlayerInFirstPlayerOrder(handler) {
+        var playersInOrder = _.sortBy(this.allPlayers, player => !player.firstPlayer);
+
+        _.each(playersInOrder, player => handler(player));
+    }
+
+    startGame() {
+        this.game.initialise();
+    }
+
+    keepStartingHands() {
+        _.each(this.allPlayers, player => player.clickPrompt('Keep Hand'));
+    }
+
+    skipSetupPhase() {
+        this.keepStartingHands();
+        _.each(this.allPlayers, player => player.clickPrompt('Done'));
+    }
+
+    guardCurrentPhase(phase) {
+        if(this.game.currentPhase !== phase) {
+            throw new Error(`Expected to be in the ${phase} phase but actually was ${this.game.currentPhase}`);
+        }
+    }
+
+    completeSetup() {
+        this.guardCurrentPhase('setup');
+        _.each(this.allPlayers, player => player.clickPrompt('Done'));
+    }
+
+    completeMarshalPhase() {
+        this.guardCurrentPhase('marshal');
+        this.eachPlayerInFirstPlayerOrder(player => player.clickPrompt('Done'));
+    }
+
+    completeChallengesPhase() {
+        this.guardCurrentPhase('challenge');
+        // Pre challenge action window
+        this.eachPlayerInFirstPlayerOrder(player => player.clickPrompt('Done'));
+        // Each player clicks 'Done' when challenge initiation prompt shows up.
+        this.eachPlayerInFirstPlayerOrder(player => player.clickPrompt('Done'));
+    }
+
+    completeDominancePhase() {
+        this.guardCurrentPhase('dominance');
+        this.eachPlayerInFirstPlayerOrder(player => player.clickPrompt('Done'));
+    }
+
+    completeTaxationPhase() {
+        this.guardCurrentPhase('taxation');
+        // TODO: Discard down to reserve in case of tests that fill up the player's hand
+        this.eachPlayerInFirstPlayerOrder(player => player.clickPrompt('End Round'));
+    }
+
+    getPromptedPlayer(title) {
+        var promptedPlayer = this.allPlayers.find(p => p.hasPrompt(title));
+
+        if(!promptedPlayer) {
+            var promptString = _.map(this.allPlayers, player => player.name + ': ' + player.formatPrompt()).join('\n\n');
+            throw new Error(`No players are being prompted with "${title}". Current prompts are:\n\n${promptString}`);
+        }
+
+        return promptedPlayer;
+    }
+
+    selectFirstPlayer(player) {
+        var promptedPlayer = this.getPromptedPlayer('Select first player');
+        promptedPlayer.clickPrompt(player.name);
+    }
+
+    selectPlotOrder(player) {
+        var promptedPlayer = this.getPromptedPlayer('Select a player to resolve their plot effects');
+        promptedPlayer.clickPrompt(player.name);
+    }
+}
+
+module.exports = GameFlowWrapper;

--- a/test/helpers/integrationhelper.js
+++ b/test/helpers/integrationhelper.js
@@ -1,0 +1,32 @@
+/* global describe, beforeEach */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+const _ = require('underscore');
+
+const GameFlowWrapper = require('./gameflowwrapper.js');
+
+const ProxiedGameFlowWrapperMethods = [
+    'startGame', 'keepStartingHands', 'skipSetupPhase', 'selectFirstPlayer',
+    'completeMarshalPhase', 'completeChallengesPhase', 'completeDominancePhase',
+    'completeTaxationPhase', 'selectPlotOrder', 'completeSetup'
+];
+
+global.integration = function(definitions) {
+    describe('integration', function() {
+        beforeEach(function() {
+            this.flow = new GameFlowWrapper();
+
+            this.game = this.flow.game;
+            this.player1Object = this.game.getPlayerByName('player1');
+            this.player2Object = this.game.getPlayerByName('player2');
+            this.player1 = this.flow.player1;
+            this.player2 = this.flow.player2;
+
+            _.each(ProxiedGameFlowWrapperMethods, method => {
+                this[method] = (...args) => this.flow[method].apply(this.flow, args);
+            });
+        });
+
+        definitions();
+    });
+};

--- a/test/helpers/playerinteractionwrapper.js
+++ b/test/helpers/playerinteractionwrapper.js
@@ -1,0 +1,91 @@
+const _ = require('underscore');
+
+class PlayerInteractionWrapper {
+    constructor(game, player) {
+        this.game = game;
+        this.player = player;
+    }
+
+    get name() {
+        return this.player.name;
+    }
+
+    get firstPlayer() {
+        return this.player.firstPlayer;
+    }
+
+    currentPrompt() {
+        return this.player.currentPrompt();
+    }
+
+    formatPrompt() {
+        var prompt = this.currentPrompt();
+
+        if(!prompt) {
+            return 'no prompt active';
+        }
+
+        return prompt.menuTitle + '\n' + _.map(prompt.buttons, button => '[ ' + button.text + ' ]').join('\n');
+    }
+
+    findCardByName(name) {
+        return this.filterCardsByName(name)[0];
+    }
+
+    filterCardsByName(name) {
+        var cards = this.player.allCards.filter(card => card.name === name);
+
+        if(cards.length === 0) {
+            throw new Error(`Could not find any matching card "${name}" for ${this.player.name}`);
+        }
+
+        return cards;
+    }
+
+    findCard(condition) {
+        return this.filterCards(condition)[0];
+    }
+
+    filterCards(condition) {
+        var cards = this.player.allCards.filter(condition);
+
+        if(cards.length === 0) {
+            throw new Error(`Could not find any matching cards for ${this.player.name}`);
+        }
+
+        return cards;
+    }
+
+    hasPrompt(title) {
+        var currentPrompt = this.player.currentPrompt();
+        return !!currentPrompt && currentPrompt.menuTitle.toLowerCase() === title.toLowerCase();
+    }
+
+    selectDeck(deck) {
+        this.game.selectDeck(this.player.name, deck);
+    }
+
+    selectPlot(plot) {
+        this.player.selectedPlot = plot;
+        this.clickPrompt('Done');
+    }
+
+    clickPrompt(text) {
+        var currentPrompt = this.player.currentPrompt();
+        var promptButton = _.find(currentPrompt.buttons, button => button.text.toLowerCase() === text.toLowerCase());
+
+        if(!promptButton) {
+            throw new Error(`Couldn't click on "${text}" for ${this.player.name}. Current prompt is:\n${this.formatPrompt()}`);
+        }
+
+        this.game.menuButton(this.player.name, promptButton.arg, promptButton.method);
+        this.game.continue();
+    }
+
+    clickCard(card) {
+        this.game.cardClicked(this.player.name, card.uuid);
+        this.game.continue();
+    }
+}
+
+module.exports = PlayerInteractionWrapper;

--- a/test/server/cards/locations/01/01137 - thewall.spec.js
+++ b/test/server/cards/locations/01/01137 - thewall.spec.js
@@ -1,60 +1,39 @@
-/* global describe, it, expect, beforeEach, jasmine */
+/* global describe, it, expect, beforeEach, integration */
 /* eslint camelcase: 0, no-invalid-this: 0 */
 
-const _ = require('underscore');
-
-const TheWall = require('../../../../../server/game/cards/locations/01/thewall.js');
-
 describe('TheWall', function() {
-    describe('integration', function() {
-        const Game = require('../../../../../server/game/game.js');
-        const Player = require('../../../../../server/game/player.js');
-        const DrawCard = require('../../../../../server/game/drawcard.js');
+    integration(function() {
+        const wallCardData = { 'pack_code' : 'Core', 'pack_name' : 'Core Set', 'type_code' : 'location', 'type_name' : 'Location', 'faction_code' : 'thenightswatch', 'faction_name' : 'The Night\'s Watch', 'position' : 137, 'code' : '01137', 'name' : 'The Wall', 'cost' : 4, 'text' : 'Each [thenightswatch] character you control gets +1 STR.\n<b>Forced Reaction:</b> After you lose an unopposed challenge, kneel The Wall.\n<b>Interrupt:</b> When the challenges phase ends, kneel The Wall to gain 2 power for your faction.', 'quantity' : 1, 'income' : null, 'initiative' : null, 'claim' : null, 'reserve' : null, 'deck_limit' : 3, 'strength' : null, 'traits' : 'Stronghold. The North.', 'flavor' : null, 'illustrator' : 'Lino Drieghe', 'is_unique' : true, 'is_loyal' : false, 'is_military' : false, 'is_intrigue' : false, 'is_power' : false, 'octgn_id' : '5d20e021-5d12-4338-8bdd-42d008bff919', 'url' : 'https://thronesdb.com/card/01137', 'imagesrc' : '/bundles/cards/01137.png', 'label' : 'The Wall', 'ci' : 4, 'si' : -1 };
+
+        const deck = {
+            faction: { value: 'thenightswatch' },
+            drawCards: [
+                { count: 2, card: wallCardData },
+                { count: 1, card: { faction_code: 'thenightswatch', name: 'Test Character', type_code: 'character', strength: 1, cost: 0 } }
+            ],
+            plotCards: []
+        };
 
         describe('when dupes are put out in the setup phase', function() {
             beforeEach(function() {
-                this.gameRepository = jasmine.createSpyObj('gameRepository', ['save']);
-                this.game = new Game(null, {}, { gameRepository: this.gameRepository });
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
 
-                this.player = new Player(1, { username: 'foo' }, false, this.game);
-
-                this.game.playersAndSpectators['foo'] = this.player;
-                this.game.initialise();
-
-                this.game.currentPhase = 'setup';
-                this.player.phase = 'setup';
-                this.player.gold = 10;
-
-                var wallData = { 'pack_code' : 'Core', 'pack_name' : 'Core Set', 'type_code' : 'location', 'type_name' : 'Location', 'faction_code' : 'thenightswatch', 'faction_name' : 'The Night\'s Watch', 'position' : 137, 'code' : '01137', 'name' : 'The Wall', 'cost' : 4, 'text' : 'Each [thenightswatch] character you control gets +1 STR.\n<b>Forced Reaction:</b> After you lose an unopposed challenge, kneel The Wall.\n<b>Interrupt:</b> When the challenges phase ends, kneel The Wall to gain 2 power for your faction.', 'quantity' : 1, 'income' : null, 'initiative' : null, 'claim' : null, 'reserve' : null, 'deck_limit' : 3, 'strength' : null, 'traits' : 'Stronghold. The North.', 'flavor' : null, 'illustrator' : 'Lino Drieghe', 'is_unique' : true, 'is_loyal' : false, 'is_military' : false, 'is_intrigue' : false, 'is_power' : false, 'octgn_id' : '5d20e021-5d12-4338-8bdd-42d008bff919', 'url' : 'https://thronesdb.com/card/01137', 'imagesrc' : '/bundles/cards/01137.png', 'label' : 'The Wall', 'ci' : 4, 'si' : -1 };
-
-                this.wall1 = new TheWall(this.player, wallData);
-                this.wall1.location = 'draw deck';
-                this.wall2 = new TheWall(this.player, wallData);
-                this.wall2.location = 'draw deck';
-                this.character = new DrawCard(this.player, { faction_code: 'thenightswatch', type_code: 'character', strength: 1, cost: 0 });
-                this.character.location = 'draw deck';
-
-
-                this.player.drawDeck = _([this.wall1, this.wall2, this.character]);
-                this.player.moveCard(this.wall1, 'hand');
-                this.player.moveCard(this.wall2, 'hand');
-                this.player.moveCard(this.character, 'hand');
-                this.player.keep();
-                this.player.startGame();
+                [this.wall1, this.wall2] = this.player1.filterCardsByName('The Wall');
+                this.character = this.player1.findCardByName('Test Character');
             });
 
             it('should not count duplicates toward character strength', function() {
-                this.game.playCard(this.player.name, this.wall1.uuid, false, this.player.hand);
-                this.game.playCard(this.player.name, this.wall2.uuid, false, this.player.hand);
-                this.game.playCard(this.player.name, this.character.uuid, false, this.player.hand);
-                this.player.setupDone();
-                this.player.startPlotPhase();
-                this.player.phase = 'plot';
-                this.game.currentPhase = 'plot';
-                // Resolve events in pipeline.
-                this.game.continue();
+                this.player1.clickCard(this.wall1);
+                this.player1.clickCard(this.wall2);
+                this.player1.clickCard(this.character);
+
+                this.completeSetup();
+
                 expect(this.wall1.dupes.size()).toBe(1);
-                expect(this.player.cardsInPlay.size()).toBe(2);
+                expect(this.player1Object.cardsInPlay.size()).toBe(2);
                 expect(this.character.getStrength()).toBe(2);
             });
         });

--- a/test/server/cards/plots/04/04039 - summerharvest.spec.js
+++ b/test/server/cards/plots/04/04039 - summerharvest.spec.js
@@ -1,56 +1,48 @@
-/* global describe, it, expect, beforeEach, jasmine */
+/* global describe, it, expect, beforeEach, integration */
 /* eslint camelcase: 0, no-invalid-this: 0, quotes: 0 */
 
-const _ = require('underscore');
-
-const SummerHarvest = require('../../../../../server/game/cards/plots/04/summerharvest.js');
-
 describe('SummerHarvest', function() {
-    describe('integration', function() {
-        const Game = require('../../../../../server/game/game.js');
-        const PlotCard = require('../../../../../server/game/plotcard.js');
+    integration(function() {
+        const summerHarvestCardData = { "pack_code" : "CtA", "pack_name" : "Called to Arms", "type_code" : "plot", "type_name" : "Plot", "faction_code" : "neutral", "faction_name" : "Neutral", "position" : 39, "code" : "04039", "name" : "Summer Harvest", "cost" : null, "text" : "<b>When Revealed:</b> Choose an opponent. X is 2 higher than the printed gold value on that player's revealed plot card.", "quantity" : 3, "income" : 0, "initiative" : 4, "claim" : 1, "reserve" : 6, "deck_limit" : 2, "strength" : null, "traits" : "Summer.", "flavor" : null, "illustrator" : "Tomasz Jedruszek", "is_unique" : false, "is_loyal" : false, "is_military" : false, "is_intrigue" : false, "is_power" : false, "octgn_id" : "9804cffd-3269-4860-8285-135446dd3dba", "url" : "https://thronesdb.com/card/04039", "imagesrc" : "/bundles/cards/04039.png", "label" : "Summer Harvest", "ci" : null, "si" : 4 };
+        const nobleCauseCardData = { "pack_code" : "Core", "pack_name" : "Core Set", "type_code" : "plot", "type_name" : "Plot", "faction_code" : "neutral", "faction_name" : "Neutral", "position" : 4, "code" : "01004", "name" : "A Noble Cause", "cost" : null, "text" : "Reduce the cost of the first <i>Lord</i> or <i>Lady</i> character you marshal this round by 2.", "quantity" : 1, "income" : 5, "initiative" : 0, "claim" : 1, "reserve" : 6, "deck_limit" : 2, "strength" : null, "traits" : "Kingdom. Noble.", "flavor" : null, "illustrator" : "Drazenka Kimpel", "is_unique" : false, "is_loyal" : false, "is_military" : false, "is_intrigue" : false, "is_power" : false, "octgn_id" : "0fb3ad4b-5cf3-49e9-a33f-484ecafeabf8", "url" : "https://thronesdb.com/card/01004", "imagesrc" : "/bundles/cards/01004.png", "label" : "A Noble Cause", "ci" : 5, "si" : null };
+        const varysRiddleCardData = { "pack_code" : "AtSK", "pack_name" : "Across the Seven Kingdoms", "type_code" : "plot", "type_name" : "Plot", "faction_code" : "neutral", "faction_name" : "Neutral", "position" : 20, "code" : "04020", "name" : "Varys's Riddle", "cost" : null, "text" : "<b>When Revealed:</b> Initiate the when revealed ability on a revealed non-<i>Riddle</i> plot card as if you had just revealed it.", "quantity" : 3, "income" : 5, "initiative" : 6, "claim" : 1, "reserve" : 7, "deck_limit" : 2, "strength" : null, "traits" : "Riddle. Scheme.", "flavor" : "\"In a room sit three great men, a king, a priest, and a rich man with his gold. Between them stands a sellsword, a little man of common birth and no great mind. Each of the great ones bids him slay the other two.\" <cite>Varys</cite>", "illustrator" : "Serena Malyon", "is_unique" : false, "is_loyal" : false, "is_military" : false, "is_intrigue" : false, "is_power" : false, "octgn_id" : "d68d7083-089d-4d28-8249-e70613639680", "url" : "https://thronesdb.com/card/04020", "imagesrc" : "/bundles/cards/04020.png", "label" : "Varys's Riddle", "ci" : 5, "si" : 6 };
+
+        const deck1 = {
+            faction: { value: 'lannister' },
+            plotCards: [
+                { count: 1, card: summerHarvestCardData }
+            ],
+            drawCards: []
+        };
+        const deck2 = {
+            faction: { value: 'lannister' },
+            plotCards: [
+                { count: 1, card: nobleCauseCardData },
+                { count: 1, card: varysRiddleCardData }
+            ],
+            drawCards: []
+        };
 
         beforeEach(function() {
-            this.gameRepository = jasmine.createSpyObj('gameRepository', ['save']);
-            this.game = new Game(null, {}, { gameRepository: this.gameRepository });
-            this.game.join('1', { username: 'foo' });
-            this.game.join('2', { username: 'bar' });
+            this.player = this.player1Object;
+            this.opponent = this.player2Object;
 
-            this.player = this.game.getPlayerByName('foo');
-            this.opponent = this.game.getPlayerByName('bar');
+            this.player1.selectDeck(deck1);
+            this.player2.selectDeck(deck2);
+            this.startGame();
+            this.skipSetupPhase();
 
-            this.game.initialise();
-
-            var summerHarvestCardData = { "pack_code" : "CtA", "pack_name" : "Called to Arms", "type_code" : "plot", "type_name" : "Plot", "faction_code" : "neutral", "faction_name" : "Neutral", "position" : 39, "code" : "04039", "name" : "Summer Harvest", "cost" : null, "text" : "<b>When Revealed:</b> Choose an opponent. X is 2 higher than the printed gold value on that player's revealed plot card.", "quantity" : 3, "income" : 0, "initiative" : 4, "claim" : 1, "reserve" : 6, "deck_limit" : 2, "strength" : null, "traits" : "Summer.", "flavor" : null, "illustrator" : "Tomasz Jedruszek", "is_unique" : false, "is_loyal" : false, "is_military" : false, "is_intrigue" : false, "is_power" : false, "octgn_id" : "9804cffd-3269-4860-8285-135446dd3dba", "url" : "https://thronesdb.com/card/04039", "imagesrc" : "/bundles/cards/04039.png", "label" : "Summer Harvest", "ci" : null, "si" : 4 };
-            this.summerHarvest = new SummerHarvest(this.player, summerHarvestCardData);
-            this.player.plotDeck = _([this.summerHarvest]);
-
-            var nobleCauseCardData = { "pack_code" : "Core", "pack_name" : "Core Set", "type_code" : "plot", "type_name" : "Plot", "faction_code" : "neutral", "faction_name" : "Neutral", "position" : 4, "code" : "01004", "name" : "A Noble Cause", "cost" : null, "text" : "Reduce the cost of the first <i>Lord</i> or <i>Lady</i> character you marshal this round by 2.", "quantity" : 1, "income" : 5, "initiative" : 0, "claim" : 1, "reserve" : 6, "deck_limit" : 2, "strength" : null, "traits" : "Kingdom. Noble.", "flavor" : null, "illustrator" : "Drazenka Kimpel", "is_unique" : false, "is_loyal" : false, "is_military" : false, "is_intrigue" : false, "is_power" : false, "octgn_id" : "0fb3ad4b-5cf3-49e9-a33f-484ecafeabf8", "url" : "https://thronesdb.com/card/01004", "imagesrc" : "/bundles/cards/01004.png", "label" : "A Noble Cause", "ci" : 5, "si" : null };
-            this.nobleCause = new PlotCard(this.opponent, nobleCauseCardData);
-            this.opponent.plotDeck = _([this.nobleCause]);
-
-            this.player.keep();
-            this.opponent.keep();
-            this.player.startGame();
-            this.opponent.startGame();
+            this.summerHarvest = this.player1.findCardByName('Summer Harvest');
+            this.nobleCause = this.player2.findCardByName('A Noble Cause');
+            this.varysRiddle = this.player2.findCardByName('Varys\'s Riddle');
         });
 
         describe('when played against a normal plot', function() {
             beforeEach(function() {
-                this.game.currentPhase = 'plot';
-                this.player.phase = 'plot';
-                this.opponent.phase = 'plot';
-                this.player.startPlotPhase();
-                this.opponent.startPlotPhase();
-                this.player.selectedPlot = this.summerHarvest;
-                this.opponent.selectedPlot = this.nobleCause;
-                this.player.flipPlotFaceup();
-                this.opponent.flipPlotFaceup();
-                // Resolve events in pipeline.
-                this.game.continue();
-                this.game.raiseEvent('onPlotRevealed', this.player);
-                // Resolve events in pipeline.
-                this.game.continue();
+                this.player1.selectPlot(this.summerHarvest);
+                this.player2.selectPlot(this.nobleCause);
+
+                this.selectFirstPlayer(this.player1);
             });
 
             it('should calculate the gold amount properly', function() {
@@ -59,20 +51,18 @@ describe('SummerHarvest', function() {
 
             describe('when playing it again after going through all plots', function() {
                 beforeEach(function() {
-                    this.game.currentPhase = 'plot';
-                    this.player.phase = 'plot';
-                    this.opponent.phase = 'plot';
-                    this.player.startPlotPhase();
-                    this.opponent.startPlotPhase();
-                    this.player.selectedPlot = this.summerHarvest;
-                    this.opponent.selectedPlot = this.nobleCause;
-                    this.player.flipPlotFaceup();
-                    this.opponent.flipPlotFaceup();
-                    // Resolve events in pipeline.
-                    this.game.continue();
-                    this.game.raiseEvent('onPlotRevealed', this.player);
-                    // Resolve events in pipeline.
-                    this.game.continue();
+                    this.completeMarshalPhase();
+                    this.completeChallengesPhase();
+                    this.completeDominancePhase();
+                    this.completeTaxationPhase();
+
+                    // Move Summer Harvest back to the plot deck so it's eligible to be picked again.
+                    this.summerHarvest.controller.moveCard(this.summerHarvest, 'plot deck');
+
+                    this.player1.selectPlot(this.summerHarvest);
+                    this.player2.selectPlot(this.nobleCause);
+
+                    this.selectFirstPlayer(this.player1);
                 });
 
                 it('should still properly calculate the gold amount properly', function() {
@@ -82,35 +72,17 @@ describe('SummerHarvest', function() {
         });
 
         describe('when played against Varys\'s Riddle', function() {
-            const VaryssRiddle = require('../../../../../server/game/cards/plots/04/varyssriddle.js');
-
             beforeEach(function() {
-                var varysRiddleCardData = { "pack_code" : "AtSK", "pack_name" : "Across the Seven Kingdoms", "type_code" : "plot", "type_name" : "Plot", "faction_code" : "neutral", "faction_name" : "Neutral", "position" : 20, "code" : "04020", "name" : "Varys's Riddle", "cost" : null, "text" : "<b>When Revealed:</b> Initiate the when revealed ability on a revealed non-<i>Riddle</i> plot card as if you had just revealed it.", "quantity" : 3, "income" : 5, "initiative" : 6, "claim" : 1, "reserve" : 7, "deck_limit" : 2, "strength" : null, "traits" : "Riddle. Scheme.", "flavor" : "\"In a room sit three great men, a king, a priest, and a rich man with his gold. Between them stands a sellsword, a little man of common birth and no great mind. Each of the great ones bids him slay the other two.\" <cite>Varys</cite>", "illustrator" : "Serena Malyon", "is_unique" : false, "is_loyal" : false, "is_military" : false, "is_intrigue" : false, "is_power" : false, "octgn_id" : "d68d7083-089d-4d28-8249-e70613639680", "url" : "https://thronesdb.com/card/04020", "imagesrc" : "/bundles/cards/04020.png", "label" : "Varys's Riddle", "ci" : 5, "si" : 6 };
-                this.varysRiddle = new VaryssRiddle(this.opponent, varysRiddleCardData);
-                this.opponent.plotDeck = _([this.varysRiddle]);
+                this.player1.selectPlot(this.summerHarvest);
+                this.player2.selectPlot(this.varysRiddle);
 
-                this.game.currentPhase = 'plot';
-                this.player.phase = 'plot';
-                this.opponent.phase = 'plot';
-                this.player.startPlotPhase();
-                this.opponent.startPlotPhase();
-                this.player.selectedPlot = this.summerHarvest;
-                this.opponent.selectedPlot = this.varysRiddle;
-                this.player.flipPlotFaceup();
-                this.opponent.flipPlotFaceup();
-                // Resolve events in pipeline.
-                this.game.continue();
+                this.selectFirstPlayer(this.player1);
 
-                // Opponent is first player, chooses to resolve Summer Harvest first.
-                this.game.raiseEvent('onPlotRevealed', this.player);
-                // Resolve events in pipeline.
-                this.game.continue();
-
-                // Resolves Varys' Riddle, which will overwrite the Summer Harvest value.
+                // Opponent is first player, chooses to resolve Summer Harvest
+                // first, then Varys' Riddle, which will overwrite the Summer
+                // Harvest value.
                 // See this thread for details: http://www.cardgamedb.com/forums/index.php?/topic/32255-varys-riddle-vs-summer-harvest/?p=281948
-                this.game.raiseEvent('onPlotRevealed', this.opponent);
-                // Resolve events in pipeline.
-                this.game.continue();
+                this.selectPlotOrder(this.player1);
             });
 
             it('should use the second value for Summer Harvest', function() {


### PR DESCRIPTION
Adds an `integration` method as a spec helper. Using this method instead
of a normal `describe` block will create a set of integration objects
that allow you to simulate game flow in tests without having to manually
manipulate the game, player and pipeline objects.