### PR TITLE
Make Edmure Tully clearer.

### DIFF
--- a/server/game/cards/characters/04/seredmuretully.js
+++ b/server/game/cards/characters/04/seredmuretully.js
@@ -21,11 +21,15 @@ class SerEdmureTully extends DrawCard {
                     return false;
                 }
             },
+            title: () => 'Use ' + this.name + ' to move power from ' + this.powerGainingCharacter.name + '?',
             limit: ability.limit.perRound(1),
             handler: () => {
                 this.game.promptForSelect(this.controller, {
-                    cardCondition: card =>
-                        card.location === 'play area' && this.isTullyCharacter(card),
+                    cardCondition: card => (
+                        card.location === 'play area' &&
+                        card !== this.powerGainingCharacter &&
+                        this.isTullyCharacter(card)
+                    ),
                     activePromptTitle: 'Select a Tully character to move power to',
                     waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
                     onSelect: (player, card) => this.transferPower(card)
@@ -50,6 +54,8 @@ class SerEdmureTully extends DrawCard {
                              this.controller, this, this.powerGainingCharacter, toCharacter);
 
         this.powerGainingCharacter = undefined;
+
+        return true;
     }
 
 }


### PR DESCRIPTION
Adds a title for the prompt for Edmure to make it clear which character
is moving power away from, do not allow Edmure to move power to and from
the same character, and return true from select card to ensure that the
prompt completes.