### PR TITLE
implement Renly Baratheon (For Family Honor)

### DIFF
--- a/server/game/cards/characters/04/renlybaratheon.js
+++ b/server/game/cards/characters/04/renlybaratheon.js
@@ -1,0 +1,29 @@
+const DrawCard = require('../../../drawcard.js');
+
+class RenlyBaratheon extends DrawCard {
+    setupCardAbilities() {
+        this.reaction({
+            when: {
+                onInsight: (event, challenge, card, drawn) => {
+                    this.drawnCard = drawn;
+
+                    // postpone the check about drawn card loyalty, to avoid
+                    // leaking game state to the opponent
+                    return true;
+                }
+            },
+            handler: () => {
+                if(this.drawnCard.isLoyal()) {
+                    this.controller.drawCardsToHand(1);
+
+                    this.game.addMessage('{0} uses {1} to reveal {2} and draw a card',
+                                         this.controller, this, this.drawnCard);
+                }
+            }
+        });
+    }
+}
+
+RenlyBaratheon.code = '04043';
+
+module.exports = RenlyBaratheon;

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -215,7 +215,9 @@ class ChallengeFlow extends BaseStep {
 
         _.each(winnerCards, card => {
             if(card.hasKeyword('Insight')) {
-                this.challenge.winner.drawCardsToHand(1);
+                var drawn = this.challenge.winner.drawCardsToHand(1);
+
+                this.game.raiseEvent('onInsight', this.challenge, card, drawn);
 
                 this.game.addMessage('{0} draws a card from Insight on {1}', this.challenge.winner, card);
             }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -155,6 +155,8 @@ class Player extends Spectator {
         if(this.drawDeck.size() === 0) {
             this.game.playerDecked(this);
         }
+
+        return (cards.length > 1) ? cards : cards[0];
     }
 
     searchDrawDeck(limit, predicate) {


### PR DESCRIPTION
To that end, raise a new onInsight event, carrying the list of cards drawn
using the Insight keyword.

Passing note: I find super annoying that the "drawn" parameter of the new event
is either a singleton element (a card) or an array of cards. But I've done it
that way for consistency with what we do for onPillage/discardFromDraw. IMHO
it'd be nice to uniform all of those to always return an array of cards.