### PR TITLE
fix A Gift of Arbor Red log message to always state controller's name

### DIFF
--- a/server/game/cards/events/02/agiftofarborred.js
+++ b/server/game/cards/events/02/agiftofarborred.js
@@ -38,7 +38,7 @@ class AGiftOfArborRed extends DrawCard {
     }
 
     revealCards(player, cards) {
-        this.game.addMessage('{0} uses {1} to kneel their faction card and reveal the top 4 cards of {2}\'s deck as: {3}', player, this, player, cards);
+        this.game.addMessage('{0} uses {1} to kneel their faction card and reveal the top 4 cards of {2}\'s deck as: {3}', this.controller, this, player, cards);
     }
 
     selectThisPlayerCardForHand(player, cardId) {


### PR DESCRIPTION
before this change the card made it seems that opponents choose themselves to
active the tutoring effect, while it is always the card controller who does so