### PR TITLE
Fix kneel cost + Wardens of the North + Winterfell Kennel Master

### DIFF
--- a/server/game/cards/characters/02/winterfellkennelmaster.js
+++ b/server/game/cards/characters/02/winterfellkennelmaster.js
@@ -1,0 +1,37 @@
+const DrawCard = require('../../../drawcard.js');
+
+class WinterfellKennelMaster extends DrawCard {
+    setupCardAbilities(ability) {
+        this.action({
+            title: 'Kneel a Direwolf to have it participate in the current challenge',
+            phase: 'challenge',
+            limit: ability.limit.perPhase(1),
+            condition: () => this.isStarkCardParticipatingInChallenge(),
+            cost: ability.costs.kneel(card => this.isDirewolfOrHasAttachment(card)),
+            handler: context => {
+                var card = context.kneelingCostCard;
+                if(this.game.currentChallenge.attackingPlayer === context.player) {
+                    this.game.currentChallenge.addAttacker(card);
+                } else {
+                    this.game.currentChallenge.addDefender(card);
+                }
+
+                this.game.addMessage('{0} uses {1} to kneel {2} and add them to the challenge', context.player, this, card);
+            }
+        });
+    }
+
+    isStarkCardParticipatingInChallenge() {
+        return this.game.currentChallenge && this.controller.cardsInPlay.any(card => {
+            return this.game.currentChallenge.isParticipating(card) && card.isFaction('stark');
+        });
+    }
+
+    isDirewolfOrHasAttachment(card) {
+        return card.hasTrait('Direwolf') || card.attachments.any(attachment => attachment.hasTrait('Direwolf'));
+    }
+}
+
+WinterfellKennelMaster.code = '02021';
+
+module.exports = WinterfellKennelMaster;

--- a/server/game/cards/plots/02/wardensofthenorth.js
+++ b/server/game/cards/plots/02/wardensofthenorth.js
@@ -4,41 +4,27 @@ class WardensOfTheNorth extends PlotCard {
     setupCardAbilities(ability) {
         this.action({
             title: 'Kneel a character to have it participate in the current challenge',
-            method: 'onClick',
             phase: 'challenge',
-            limit: ability.limit.perRound(2)
+            limit: ability.limit.perRound(2),
+            condition: () => this.isStarkCardParticipatingInChallenge(),
+            cost: ability.costs.kneel(card => card.getType() === 'character' && card.isFaction('stark')),
+            handler: context => {
+                var card = context.kneelingCostCard;
+                if(this.game.currentChallenge.attackingPlayer === context.player) {
+                    this.game.currentChallenge.addAttacker(card);
+                } else {
+                    this.game.currentChallenge.addDefender(card);
+                }
+
+                this.game.addMessage('{0} uses {1} to kneel {2} and add them to the challenge', context.player, this, card);
+            }
         });
     }
 
-    onClick(player) {
-        if(!this.game.currentChallenge || !this.controller.cardsInPlay.any(card => {
+    isStarkCardParticipatingInChallenge() {
+        return this.game.currentChallenge && this.controller.cardsInPlay.any(card => {
             return this.game.currentChallenge.isParticipating(card) && card.isFaction('stark');
-        })) {
-            return false;
-        }
-
-        this.game.promptForSelect(player, {
-            cardCondition: card => card.isFaction('stark') && !card.kneeled,
-            activePromptTitle: 'Select character',
-            source: this,
-            onSelect: (player, card) => this.onCardSelected(player, card)
         });
-
-        return true;
-    }
-
-    onCardSelected(player, card) {
-        player.kneelCard(card);
-
-        if(this.game.currentChallenge.attackingPlayer === this.controller) {
-            this.game.currentChallenge.addAttacker(card);
-        } else {
-            this.game.currentChallenge.addDefender(card);
-        }
-
-        this.game.addMessage('{0} uses {1} to kneel {2} and add them to the challenge', player, this, card);
-
-        return true;
     }
 }
 

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -30,9 +30,15 @@ const Costs = {
      * predicate function.
      */
     kneel: function(condition) {
+        var fullCondition = (card, context) => (
+            !card.kneeled &&
+            card.location === 'play area' &&
+            card.controller === context.player &&
+            condition(card)
+        );
         return {
             canPay: function(context) {
-                return context.player.cardsInPlay.any(condition);
+                return context.player.cardsInPlay.any(card => fullCondition(card, context));
             },
             resolve: function(context) {
                 var result = {
@@ -40,9 +46,9 @@ const Costs = {
                 };
 
                 context.game.promptForSelect(context.player, {
-                    cardCondition: card => card.controller === context.player && condition(card),
+                    cardCondition: card => fullCondition(card, context),
                     activePromptTitle: 'Select card to kneel',
-                    waitingPromptTitle: 'Waiting for opponent to use ' + context.source.name,
+                    source: context.source,
                     onSelect: (player, card) => {
                         context.kneelingCostCard = card;
                         result.value = true;


### PR DESCRIPTION
* Fixes a problem with `Costs.kneel` which allowed you to select cards that were already knelt or not in the play area.
* Fixes Wardens of the North plot to disallow kneeling an opponent's Stark character (since the kneel is part of the cost and you can only use your own cards to pay costs)
* Implements Winterfell Kennel Master since it's almost identical to Wardens of the North.