### PR TITLE
Fix setup problems

### DIFF
--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -44,7 +44,7 @@ class DrawCard extends BaseCard {
 
     addDuplicate(card) {
         this.dupes.push(card);
-        card.location = 'duplicate';
+        card.moveTo('duplicate');
     }
 
     removeDuplicate() {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -352,6 +352,10 @@ class Player extends Spectator {
             return false;
         }
 
+        if(card.getType() === 'event' && this.phase === 'setup') {
+            return false;
+        }
+
         if(this.phase !== 'setup' && this.phase !== 'marshal' && card.getType() !== 'event') {
             if(this.phase !== 'challenge' || !card.isAmbush()) {
                 return false;

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -927,11 +927,7 @@ class Player extends Spectator {
             this.game.raiseEvent('onCardLeftPlay', this, card);
         }
 
-        if(!options.isDupe) {
-            card.moveTo(targetLocation);
-        } else {
-            card.location = 'dupe';
-        }
+        card.moveTo(targetLocation);
 
         if(targetLocation === 'active plot') {
             this.activePlot = card;

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -378,7 +378,7 @@ class Player extends Spectator {
             return false;
         }
 
-        if(this.limitedPlayed >= this.maxLimited && card.isLimited() && !dupe) {
+        if(this.limitedPlayed >= this.maxLimited && card.isLimited()) {
             return false;
         }
 

--- a/test/helpers/integrationhelper.js
+++ b/test/helpers/integrationhelper.js
@@ -1,4 +1,4 @@
-/* global describe, beforeEach */
+/* global describe, beforeEach, jasmine */
 /* eslint camelcase: 0, no-invalid-this: 0 */
 
 const _ = require('underscore');
@@ -13,6 +13,31 @@ const ProxiedGameFlowWrapperMethods = [
 ];
 
 const deckBuilder = new DeckBuilder();
+
+var customMatchers = {
+    toHavePrompt: function(util, customEqualityMatchers) {
+        return {
+            compare: function(actual, expected) {
+                var currentTitle = actual.currentPrompt().menuTitle;
+                var result = {};
+
+                result.pass = util.equals(currentTitle, expected, customEqualityMatchers);
+
+                if(result.pass) {
+                    result.message = `Expected ${actual.name} not to have prompt "${expected}" but it did.`;
+                } else {
+                    result.message = `Expected ${actual.name} to have prompt "${expected}" but it had "${currentTitle}".`;
+                }
+
+                return result;
+            }
+        };
+    }
+};
+
+beforeEach(function() {
+    jasmine.addMatchers(customMatchers);
+})
 
 global.integration = function(definitions) {
     describe('integration', function() {

--- a/test/helpers/integrationhelper.js
+++ b/test/helpers/integrationhelper.js
@@ -37,7 +37,7 @@ var customMatchers = {
 
 beforeEach(function() {
     jasmine.addMatchers(customMatchers);
-})
+});
 
 global.integration = function(definitions) {
     describe('integration', function() {

--- a/test/helpers/playerinteractionwrapper.js
+++ b/test/helpers/playerinteractionwrapper.js
@@ -89,6 +89,10 @@ class PlayerInteractionWrapper {
         this.game.cardClicked(this.player.name, card.uuid);
         this.game.continue();
     }
+
+    dragCard(card, targetLocation) {
+        this.game.drop(this.player.name, card.uuid, card.location, targetLocation);
+    }
 }
 
 module.exports = PlayerInteractionWrapper;

--- a/test/server/integration/setup.spec.js
+++ b/test/server/integration/setup.spec.js
@@ -1,0 +1,79 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('setup phase', function() {
+    integration(function() {
+        describe('when attachments are put out in the setup phase', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('baratheon', ['Red God\'s Blessing', 'Dragonstone Faithful']);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.character = this.player1.findCardByName('Dragonstone Faithful');
+                this.attachment = this.player1.findCardByName('Red God\'s Blessing');
+
+                this.player1.clickCard(this.character);
+                this.player1.clickCard(this.attachment);
+
+                this.completeSetup();
+            });
+
+            it('should prompt the user to attach stray attachments', function() {
+                expect(this.player1).toHavePrompt('Select attachment locations');
+            });
+
+            describe('when the attachments have been placed', function() {
+                beforeEach(function() {
+                    this.player1.clickCard(this.attachment);
+                    this.player1.clickCard(this.character);
+                });
+
+                it('should attach to the selected card', function() {
+                    expect(this.character.attachments).toContain(this.attachment);
+                });
+
+                it('should properly calculate the effects of the attachment', function() {
+                    expect(this.character.getStrength()).toBe(2);
+                });
+
+                it('should continue to the plot phase', function() {
+                    expect(this.player1).toHavePrompt('Select a plot');
+                });
+            });
+        });
+
+        describe('when dupes are put out in the setup phase', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('thenightswatch', ['The Wall', 'The Wall', 'Steward at the Wall']);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                [this.wall1, this.wall2] = this.player1.filterCardsByName('The Wall');
+                this.character = this.player1.findCardByName('Steward at the Wall');
+
+                this.player1.clickCard(this.wall1);
+                this.player1.clickCard(this.wall2);
+                this.player1.clickCard(this.character);
+            });
+
+            it('should not count duplicates toward character strength', function() {
+                this.completeSetup();
+
+                expect(this.wall1.dupes.size()).toBe(1);
+                expect(this.player1Object.cardsInPlay.size()).toBe(2);
+                expect(this.character.getStrength()).toBe(2);
+            });
+
+            it('should allow dupes to be dragged back to hand', function() {
+                this.player1.dragCard(this.wall2, 'hand');
+
+                expect(this.wall2.location).toBe('hand');
+                expect(this.player1Object.cardsInPlay).not.toContain(this.wall2);
+            });
+        });
+    });
+});

--- a/test/server/integration/setup.spec.js
+++ b/test/server/integration/setup.spec.js
@@ -52,7 +52,7 @@ describe('setup phase', function() {
                     this.player1.clickCard(this.ned1);
                 });
 
-                it('should the same card to be set up as a dupe for free', function() {
+                it('should allow the same card to be set up as a dupe for free', function() {
                     this.player1.clickCard(this.ned2);
 
                     expect(this.player1Object.gold).toBe(1);
@@ -63,7 +63,7 @@ describe('setup phase', function() {
                     expect(this.ned1.dupes).toContain(this.ned2);
                 });
 
-                it('should a card with the same name to be set up as a dupe for free', function() {
+                it('should allow a card with the same name to be set up as a dupe for free', function() {
                     this.player1.clickCard(this.wotnNed);
 
                     expect(this.player1Object.gold).toBe(1);
@@ -148,14 +148,16 @@ describe('setup phase', function() {
 
         describe('when dupes are put out in the setup phase', function() {
             beforeEach(function() {
-                const deck = this.buildDeck('thenightswatch', ['The Wall', 'The Wall', 'Steward at the Wall']);
+                const deck = this.buildDeck('thenightswatch', ['Sneak Attack', 'The Wall', 'The Wall', 'Steward at the Wall']);
                 this.player1.selectDeck(deck);
                 this.player2.selectDeck(deck);
                 this.startGame();
                 this.keepStartingHands();
 
+                this.sneakAttack = this.player1.findCardByName('Sneak Attack');
                 [this.wall1, this.wall2] = this.player1.filterCardsByName('The Wall');
                 this.character = this.player1.findCardByName('Steward at the Wall');
+                this.opponentSneakAttack = this.player2.findCardByName('Sneak Attack');
 
                 this.player1.clickCard(this.wall1);
                 this.player1.clickCard(this.wall2);
@@ -175,6 +177,21 @@ describe('setup phase', function() {
 
                 expect(this.wall2.location).toBe('hand');
                 expect(this.player1Object.cardsInPlay).not.toContain(this.wall2);
+            });
+
+            it('should not double trigger reactions', function() {
+                this.completeSetup();
+                this.player1.selectPlot(this.sneakAttack);
+                this.player2.selectPlot(this.opponentSneakAttack);
+                this.selectFirstPlayer(this.player1);
+                this.completeMarshalPhase();
+                this.completeChallengesPhase();
+
+                expect(this.player1).toHavePrompt('Trigger The Wall?');
+
+                this.player1.clickPrompt('No');
+
+                expect(this.player1).not.toHavePrompt('Trigger The Wall?');
             });
         });
     });

--- a/test/server/integration/setup.spec.js
+++ b/test/server/integration/setup.spec.js
@@ -3,6 +3,35 @@
 
 describe('setup phase', function() {
     integration(function() {
+        describe('when a card is limited', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('tyrell', ['The Roseroad', 'The Arbor', 'The Arbor']);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.roseroad = this.player1.findCardByName('The Roseroad');
+                [this.arbor1, this.arbor2] = this.player1.filterCardsByName('The Arbor');
+            });
+
+            it('should not allow more than one limited location to be placed', function() {
+                this.player1.clickCard(this.roseroad);
+                this.player1.clickCard(this.arbor1);
+
+                expect(this.roseroad.location).toBe('play area');
+                expect(this.arbor1.location).toBe('hand');
+            });
+
+            it('should not allow duplicates of a single limited location to be placed', function() {
+                this.player1.clickCard(this.arbor1);
+                this.player1.clickCard(this.arbor2);
+
+                expect(this.arbor1.location).toBe('play area');
+                expect(this.arbor2.location).toBe('hand');
+            });
+        });
+
         describe('when attachments are put out in the setup phase', function() {
             beforeEach(function() {
                 const deck = this.buildDeck('baratheon', ['Red God\'s Blessing', 'Dragonstone Faithful']);

--- a/test/server/integration/setup.spec.js
+++ b/test/server/integration/setup.spec.js
@@ -3,6 +3,79 @@
 
 describe('setup phase', function() {
     integration(function() {
+        describe('setting up normal cards', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('stark', ['Arya Stark (Core)', 'Eddard Stark (Core)', 'Eddard Stark (Core)', 'Eddard Stark (WotN)', 'The Roseroad', 'Hear Me Roar!']);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.arya = this.player1.findCardByName('Arya Stark (Core)');
+                [this.ned1, this.ned2] = this.player1.filterCardsByName('Eddard Stark (Core)');
+                this.wotnNed = this.player1.findCardByName('Eddard Stark (WotN)');
+                this.roseroad = this.player1.findCardByName('The Roseroad');
+                this.hearMeRoar = this.player1.findCardByName('Hear Me Roar!');
+            });
+
+            it('should only allow placement of 8 gold worth of cards', function() {
+                this.player1.clickCard(this.roseroad);
+                this.player1.clickCard(this.ned1);
+                this.player1.clickCard(this.arya);
+
+
+                expect(this.roseroad.location).toBe('play area');
+                expect(this.ned1.location).toBe('play area');
+                expect(this.arya.location).toBe('hand');
+                expect(this.player1Object.gold).toBe(1);
+            });
+
+            it('should not trigger any enters play abilities', function() {
+                this.player1.clickCard(this.arya);
+                expect(this.player1).toHavePrompt('Select setup cards');
+
+                this.completeSetup();
+
+                expect(this.arya.dupes.size()).toBe(0);
+                expect(this.player1).toHavePrompt('Select a plot');
+            });
+
+            it('should not allow events to be played', function() {
+                this.player1.clickCard(this.hearMeRoar);
+
+                expect(this.player1Object.gold).toBe(8);
+                expect(this.hearMeRoar.location).toBe('hand');
+            });
+
+            describe('when setting up dupes', function() {
+                beforeEach(function() {
+                    this.player1.clickCard(this.ned1);
+                });
+
+                it('should the same card to be set up as a dupe for free', function() {
+                    this.player1.clickCard(this.ned2);
+
+                    expect(this.player1Object.gold).toBe(1);
+
+                    this.completeSetup();
+
+                    expect(this.player1Object.cardsInPlay.size()).toBe(1);
+                    expect(this.ned1.dupes).toContain(this.ned2);
+                });
+
+                it('should a card with the same name to be set up as a dupe for free', function() {
+                    this.player1.clickCard(this.wotnNed);
+
+                    expect(this.player1Object.gold).toBe(1);
+
+                    this.completeSetup();
+
+                    expect(this.player1Object.cardsInPlay.size()).toBe(1);
+                    expect(this.ned1.dupes).toContain(this.wotnNed);
+                });
+            });
+        });
+
         describe('when a card is limited', function() {
             beforeEach(function() {
                 const deck = this.buildDeck('tyrell', ['The Roseroad', 'The Arbor', 'The Arbor']);

--- a/test/server/player/canplaycard.spec.js
+++ b/test/server/player/canplaycard.spec.js
@@ -101,8 +101,8 @@ describe('Player', function () {
                         this.canPlay = this.player.canPlayCard(this.cardSpy);
                     });
 
-                    it('should return true', function() {
-                        expect(this.canPlay).toBe(true);
+                    it('should return false', function() {
+                        expect(this.canPlay).toBe(false);
                     });
                 });
 


### PR DESCRIPTION
* Prevents more than 1 limited card from being setup, even if they're dupes.
* Fixes a bug where dupes dragged back to hand during setup would end up both places and face up.
* Prevents events from being played during setup.