### PR TITLE
Introduce a 'put into play' method

### DIFF
--- a/server/game/cards/characters/04/salladhorsaan.js
+++ b/server/game/cards/characters/04/salladhorsaan.js
@@ -18,9 +18,9 @@ class SalladhorSaan extends DrawCard {
                         ((card.hasTrait('Warship') && card.getType() === 'location') ||
                         (card.hasTrait('Weapon') && card.getType() === 'attachment'))),
                     onSelect: (player, card) => {
-                        player.playCard(card, true);
+                        player.putIntoPlay(card);
                         this.game.addMessage('{0} uses {1} to put {2} into play', this.controller, this, card);
-                        
+
                         return true;
                     }
                 });

--- a/server/game/cards/characters/05/serkevanlannister.js
+++ b/server/game/cards/characters/05/serkevanlannister.js
@@ -16,7 +16,7 @@ class SerKevanLannister extends DrawCard {
                         (card.isFaction('lannister') || card.isFaction('neutral')) &&
                         (card.getType() === 'location' || card.getType() === 'attachment')),
                     onSelect: (player, card) => {
-                        player.playCard(card, true);
+                        player.putIntoPlay(card);
                         this.game.addMessage('{0} uses {1} to put {2} into play', this.controller, this, card);
 
                         return true;

--- a/server/game/cards/events/01/hearmeroar.js
+++ b/server/game/cards/events/01/hearmeroar.js
@@ -19,7 +19,7 @@ class HearMeRoar extends DrawCard {
     }
 
     onCardSelected(player, card) {
-        player.playCard(card, true);
+        player.putIntoPlay(card);
 
         this.atEndOfPhase(ability => ({
             match: card,

--- a/server/game/cards/events/02/ineverbetagainstmyfamily.js
+++ b/server/game/cards/events/02/ineverbetagainstmyfamily.js
@@ -63,7 +63,7 @@ class INeverBetAgainstMyFamily extends DrawCard {
         }
 
         this.remainingCards = _.reject(this.remainingCards, card => card.uuid === cardId);
-        this.controller.playCard(card, true, true);
+        this.controller.putIntoPlay(card);
         this.game.addMessage('{0} uses {1} to put {2} into play', this.controller, this, card);
         this.untilEndOfPhase(ability => ({
             match: card,

--- a/server/game/cards/events/04/bloodofmyblood.js
+++ b/server/game/cards/events/04/bloodofmyblood.js
@@ -39,7 +39,7 @@ class BloodOfMyBlood extends DrawCard {
             return false;
         }
 
-        player.playCard(card, true, true);
+        player.putIntoPlay(card);
         player.shuffleDrawDeck();
 
         this.atEndOfPhase(ability => ({

--- a/server/game/cards/locations/04/bitterbridgeencampment.js
+++ b/server/game/cards/locations/04/bitterbridgeencampment.js
@@ -34,7 +34,7 @@ class BitterbridgeEncampment extends DrawCard {
     doPutIntoPlay() {
         _.each(this.selections, selection => {
             var player = selection.player;
-            player.playCard(selection.card, true);
+            player.putIntoPlay(selection.card);
         });
     }
 

--- a/server/game/cards/locations/05/oldwyk.js
+++ b/server/game/cards/locations/05/oldwyk.js
@@ -19,7 +19,7 @@ class OldWyk extends DrawCard {
                     return;
                 }
 
-                this.controller.playCard(card, true, true);
+                this.controller.putIntoPlay(card);
                 this.game.currentChallenge.addAttacker(card);
 
                 this.game.addMessage('{0} uses {1} to put into play {2} as an attacker from their dead pile', this.controller, this, card);

--- a/server/game/cards/plots/01/reinforcement.js
+++ b/server/game/cards/plots/01/reinforcement.js
@@ -27,7 +27,7 @@ class Reinforcements extends PlotCard {
 
         this.game.addMessage('{0} uses {1} to put {2} into play from their {3}', player, this, card, hand ? 'hand' : 'discard pile');
 
-        player.playCard(card, true);
+        player.putIntoPlay(card);
 
         return true;
     }

--- a/server/game/cards/plots/02/heretoserve.js
+++ b/server/game/cards/plots/02/heretoserve.js
@@ -36,7 +36,7 @@ class HereToServe extends PlotCard {
 
         player.shuffleDrawDeck();
         this.game.addMessage('{0} uses {1} to put {2} into play', player, this, card);
-        player.playCard(card, true);
+        player.putIntoPlay(card);
 
         return true;
     }

--- a/server/game/cards/plots/03/atimeforwolves.js
+++ b/server/game/cards/plots/03/atimeforwolves.js
@@ -78,7 +78,7 @@ class ATimeForWolves extends PlotCard {
         }
 
         this.game.addMessage('{0} uses {1} to reveal {2} and put it in play', player, this, this.revealedCard);
-        player.playCard(this.revealedCard, true);
+        player.putIntoPlay(this.revealedCard);
         this.revealedCard = null;
 
         return true;

--- a/test/server/player/playcard.spec.js
+++ b/test/server/player/playcard.spec.js
@@ -77,7 +77,7 @@ describe('Player', function() {
 
             describe('and it is the challenge phase', function() {
                 beforeEach(function() {
-                    this.player.phase = 'challenge';
+                    this.gameSpy.currentPhase = 'challenge';
                     this.canPlay = this.player.playCard(this.cardSpy, false);
                 });
 
@@ -88,7 +88,7 @@ describe('Player', function() {
 
             describe('and it is not the challenge phase', function() {
                 beforeEach(function() {
-                    this.player.phase = 'setup';
+                    this.gameSpy.currentPhase = 'setup';
                     this.canPlay = this.player.playCard(this.cardSpy, false);
                 });
 
@@ -158,7 +158,7 @@ describe('Player', function() {
 
             describe('and this is the setup phase', function() {
                 beforeEach(function() {
-                    this.player.phase = 'setup';
+                    this.gameSpy.currentPhase = 'setup';
 
                     this.canPlay = this.player.playCard(this.cardSpy);
                 });

--- a/test/server/player/putintoplay.spec.js
+++ b/test/server/player/putintoplay.spec.js
@@ -1,0 +1,233 @@
+/* global describe, it, beforeEach, expect, spyOn, jasmine */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+const Player = require('../../../server/game/player.js');
+
+describe('Player', function() {
+    beforeEach(function() {
+        this.gameSpy = jasmine.createSpyObj('game', ['raiseEvent', 'playerDecked']);
+        this.player = new Player('1', 'Player 1', true, this.gameSpy);
+        this.player.initialise();
+
+        spyOn(this.player, 'getDuplicateInPlay');
+
+        this.cardSpy = jasmine.createSpyObj('card', ['getType', 'getCost', 'play', 'moveTo']);
+        this.dupeCardSpy = jasmine.createSpyObj('dupecard', ['addDuplicate']);
+        this.player.hand.push(this.cardSpy);
+        this.cardSpy.location = 'hand';
+    });
+
+    describe('putIntoPlay', function() {
+        describe('when the playing type is marshal', function() {
+            describe('and the card is not a duplicate', function() {
+                beforeEach(function() {
+                    this.player.getDuplicateInPlay.and.returnValue(null);
+                    this.player.putIntoPlay(this.cardSpy, 'marshal');
+                });
+
+                it('should add the card to cards in play', function() {
+                    expect(this.player.cardsInPlay).toContain(this.cardSpy);
+                });
+
+                it('should be placed face up', function() {
+                    expect(this.cardSpy.facedown).toBe(false);
+                });
+
+                it('should be marked as new', function() {
+                    expect(this.cardSpy.new).toBe(true);
+                });
+
+                it('should play the card as non-ambush', function() {
+                    expect(this.cardSpy.play).toHaveBeenCalledWith(this.player, false);
+                });
+
+                it('should raise the onCardEntersPlay event', function() {
+                    expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onCardEntersPlay', this.cardSpy);
+                });
+            });
+
+            describe('and the card is a duplicate', function() {
+                beforeEach(function() {
+                    this.player.getDuplicateInPlay.and.returnValue(this.dupeCardSpy);
+                    this.player.putIntoPlay(this.cardSpy, 'marshal');
+                });
+
+                it('should not add the card to cards in play', function() {
+                    expect(this.player.cardsInPlay).not.toContain(this.cardSpy);
+                });
+
+                it('should not play the card as an ambush', function() {
+                    expect(this.cardSpy.play).not.toHaveBeenCalled();
+                });
+
+                it('should not raise the onCardEntersPlay event', function() {
+                    expect(this.gameSpy.raiseEvent).not.toHaveBeenCalledWith('onCardEntersPlay', this.cardSpy);
+                });
+
+                it('should add as a duplicate', function() {
+                    expect(this.dupeCardSpy.addDuplicate).toHaveBeenCalledWith(this.cardSpy);
+                });
+            });
+        });
+
+        describe('when card is an attachment', function() {
+            beforeEach(function() {
+                spyOn(this.player, 'promptForAttachment');
+
+                this.cardSpy.getType.and.returnValue('attachment');
+            });
+
+            describe('and there is no duplicate out', function() {
+                beforeEach(function() {
+                    this.player.getDuplicateInPlay.and.returnValue(null);
+                    this.player.putIntoPlay(this.cardSpy, 'marshal');
+                });
+
+                it('should prompt for attachment target', function() {
+                    expect(this.player.promptForAttachment).toHaveBeenCalled();
+                });
+
+                it('should not remove the card from hand', function() {
+                    expect(this.player.hand).toContain(this.cardSpy);
+                });
+            });
+
+            describe('and there is a duplicate out', function() {
+                beforeEach(function() {
+                    this.player.getDuplicateInPlay.and.returnValue(this.dupeCardSpy);
+                    this.player.putIntoPlay(this.cardSpy, 'marshal');
+                });
+
+                it('should not prompt for attachment target', function() {
+                    expect(this.player.promptForAttachment).not.toHaveBeenCalled();
+                });
+
+                it('should remove the card from hand', function() {
+                    expect(this.player.hand).not.toContain(this.cardSpy);
+                });
+
+                it('should add a duplicate to the existing card in play', function() {
+                    expect(this.dupeCardSpy.addDuplicate).toHaveBeenCalledWith(this.cardSpy);
+                });
+
+                it('should not add a new card to play', function() {
+                    expect(this.player.cardsInPlay).not.toContain(this.cardSpy);
+                });
+            });
+        });
+
+        describe('when the playing type is setup', function() {
+            describe('and the card is not a duplicate', function() {
+                beforeEach(function() {
+                    this.player.getDuplicateInPlay.and.returnValue(null);
+                    this.gameSpy.currentPhase = 'setup';
+                    this.player.putIntoPlay(this.cardSpy, 'setup');
+                });
+
+                it('should add the card to cards in play', function() {
+                    expect(this.player.cardsInPlay).toContain(this.cardSpy);
+                });
+
+                it('should be placed face down', function() {
+                    expect(this.cardSpy.facedown).toBe(true);
+                });
+
+                it('should be marked as new', function() {
+                    expect(this.cardSpy.new).toBe(true);
+                });
+
+                it('should play the card as non-ambush', function() {
+                    expect(this.cardSpy.play).toHaveBeenCalledWith(this.player, false);
+                });
+
+                it('should raise the onCardEntersPlay event', function() {
+                    expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onCardEntersPlay', this.cardSpy);
+                });
+            });
+
+            describe('and the card is a duplicate', function() {
+                beforeEach(function() {
+                    this.player.getDuplicateInPlay.and.returnValue(this.dupeCardSpy);
+                    this.gameSpy.currentPhase = 'setup';
+                    this.player.putIntoPlay(this.cardSpy, 'setup');
+                });
+
+                it('should add the card to cards in play', function() {
+                    expect(this.player.cardsInPlay).toContain(this.cardSpy);
+                });
+
+                it('should be placed face down', function() {
+                    expect(this.cardSpy.facedown).toBe(true);
+                });
+
+                it('should be marked as new', function() {
+                    expect(this.cardSpy.new).toBe(true);
+                });
+
+                it('should not play the card', function() {
+                    expect(this.cardSpy.play).not.toHaveBeenCalled();
+                });
+
+                it('should raise the onCardEntersPlay event', function() {
+                    expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onCardEntersPlay', this.cardSpy);
+                });
+
+                it('should not add as a duplicate', function() {
+                    expect(this.dupeCardSpy.addDuplicate).not.toHaveBeenCalledWith(this.cardSpy);
+                });
+            });
+        });
+
+        describe('when the playing type is ambush', function() {
+            describe('and the card is not a duplicate', function() {
+                beforeEach(function() {
+                    this.player.getDuplicateInPlay.and.returnValue(null);
+                    this.player.putIntoPlay(this.cardSpy, 'ambush');
+                });
+
+                it('should add the card to cards in play', function() {
+                    expect(this.player.cardsInPlay).toContain(this.cardSpy);
+                });
+
+                it('should be placed face up', function() {
+                    expect(this.cardSpy.facedown).toBe(false);
+                });
+
+                it('should be marked as new', function() {
+                    expect(this.cardSpy.new).toBe(true);
+                });
+
+                it('should play the card as an ambush', function() {
+                    expect(this.cardSpy.play).toHaveBeenCalledWith(this.player, true);
+                });
+
+                it('should raise the onCardEntersPlay event', function() {
+                    expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onCardEntersPlay', this.cardSpy);
+                });
+            });
+
+            describe('and the card is a duplicate', function() {
+                beforeEach(function() {
+                    this.player.getDuplicateInPlay.and.returnValue(this.dupeCardSpy);
+                    this.player.putIntoPlay(this.cardSpy, 'ambush');
+                });
+
+                it('should not add the card to cards in play', function() {
+                    expect(this.player.cardsInPlay).not.toContain(this.cardSpy);
+                });
+
+                it('should not play the card as an ambush', function() {
+                    expect(this.cardSpy.play).not.toHaveBeenCalled();
+                });
+
+                it('should not raise the onCardEntersPlay event', function() {
+                    expect(this.gameSpy.raiseEvent).not.toHaveBeenCalledWith('onCardEntersPlay', this.cardSpy);
+                });
+
+                it('should add as a duplicate', function() {
+                    expect(this.dupeCardSpy.addDuplicate).toHaveBeenCalledWith(this.cardSpy);
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
* Replaces usages of `playCard(card, true)` a.k.a force-play with a new `putIntoPlay` method.
* I'll fix usages introduced in #515 once it's merged (force play will continue to work even with this change, putIntoPlay is just simpler / reads better)
* `putIntoPlay` will ultimately be used by the forthcoming marshaling refactor