### PR TITLE
Add "discard 1 gold"-cost to the cost framework

### DIFF
--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -95,6 +95,20 @@ const Costs = {
                 context.source.controller.standCard(context.source);
             }
         };
+    },
+    /**
+     * Cost that will discard a gold from the card. Used mainly by cards
+     * having the bestow keyword.
+     */
+    discardGold: function() {
+        return {
+            canPay: function(context) {
+                return context.source.hasToken('gold');
+            },
+            pay: function(context) {
+                context.source.removeToken('gold', 1);
+            }
+        };
     }
 };
 


### PR DESCRIPTION
Don't see discarding more than 1 gold as a cost or discarding different types of tokens as a cost happening soon, so I kept it simple.

Edit: Hmm, probably better to do it right the first time, have it take type and amount arguments...