### PR TITLE
Add tests for various discarding abilities

### DIFF
--- a/test/helpers/gameflowwrapper.js
+++ b/test/helpers/gameflowwrapper.js
@@ -56,20 +56,24 @@ class GameFlowWrapper {
     completeChallengesPhase() {
         this.guardCurrentPhase('challenge');
         // Pre challenge action window
-        this.eachPlayerInFirstPlayerOrder(player => player.clickPrompt('Done'));
+        this.skipActionWindow();
         // Each player clicks 'Done' when challenge initiation prompt shows up.
         this.eachPlayerInFirstPlayerOrder(player => player.clickPrompt('Done'));
     }
 
     completeDominancePhase() {
         this.guardCurrentPhase('dominance');
-        this.eachPlayerInFirstPlayerOrder(player => player.clickPrompt('Done'));
+        this.skipActionWindow();
     }
 
     completeTaxationPhase() {
         this.guardCurrentPhase('taxation');
         // TODO: Discard down to reserve in case of tests that fill up the player's hand
         this.eachPlayerInFirstPlayerOrder(player => player.clickPrompt('End Round'));
+    }
+
+    skipActionWindow() {
+        this.eachPlayerInFirstPlayerOrder(player => player.clickPrompt('Done'));
     }
 
     getPromptedPlayer(title) {

--- a/test/helpers/gameflowwrapper.js
+++ b/test/helpers/gameflowwrapper.js
@@ -96,6 +96,22 @@ class GameFlowWrapper {
         var promptedPlayer = this.getPromptedPlayer('Select a player to resolve their plot effects');
         promptedPlayer.clickPrompt(player.name);
     }
+
+    unopposedChallenge(player, type, participant) {
+        var opponent = this.allPlayers.find(p => p !== player);
+
+        this.skipActionWindow();
+
+        player.clickPrompt(type);
+        player.clickCard(participant, 'play area');
+        player.clickPrompt('Done');
+
+        this.skipActionWindow();
+
+        opponent.clickPrompt('Done');
+
+        this.skipActionWindow();
+    }
 }
 
 module.exports = GameFlowWrapper;

--- a/test/helpers/integrationhelper.js
+++ b/test/helpers/integrationhelper.js
@@ -10,7 +10,7 @@ const ProxiedGameFlowWrapperMethods = [
     'startGame', 'keepStartingHands', 'skipSetupPhase', 'selectFirstPlayer',
     'completeMarshalPhase', 'completeChallengesPhase', 'completeDominancePhase',
     'completeTaxationPhase', 'selectPlotOrder', 'completeSetup',
-    'skipActionWindow'
+    'skipActionWindow', 'unopposedChallenge'
 ];
 
 const deckBuilder = new DeckBuilder();

--- a/test/helpers/integrationhelper.js
+++ b/test/helpers/integrationhelper.js
@@ -9,7 +9,8 @@ const GameFlowWrapper = require('./gameflowwrapper.js');
 const ProxiedGameFlowWrapperMethods = [
     'startGame', 'keepStartingHands', 'skipSetupPhase', 'selectFirstPlayer',
     'completeMarshalPhase', 'completeChallengesPhase', 'completeDominancePhase',
-    'completeTaxationPhase', 'selectPlotOrder', 'completeSetup'
+    'completeTaxationPhase', 'selectPlotOrder', 'completeSetup',
+    'skipActionWindow'
 ];
 
 const deckBuilder = new DeckBuilder();

--- a/test/helpers/playerinteractionwrapper.js
+++ b/test/helpers/playerinteractionwrapper.js
@@ -99,6 +99,21 @@ class PlayerInteractionWrapper {
         this.game.continue();
     }
 
+    clickMenu(card, menuText) {
+        if(_.isString(card)) {
+            card = this.findCardByName(card);
+        }
+
+        var items = _.filter(card.getMenu(), item => item.text === menuText);
+
+        if(items.length === 0) {
+            throw new Error(`Card ${card.name} does not have a menu item "${menuText}"`);
+        }
+
+        this.game.menuItemClick(this.player.name, card.uuid, items[0]);
+        this.game.continue();
+    }
+
     dragCard(card, targetLocation) {
         this.game.drop(this.player.name, card.uuid, card.location, targetLocation);
     }

--- a/test/server/cards/characters/01/01088-thetickler.spec.js
+++ b/test/server/cards/characters/01/01088-thetickler.spec.js
@@ -1,0 +1,51 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('The Tickler', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck1 = this.buildDeck('lannister', [
+                'Sneak Attack',
+                'The Tickler'
+            ]);
+            const deck2 = this.buildDeck('lannister', [
+                'Sneak Attack',
+                'The Roseroad', 'The Roseroad'
+            ]);
+            this.player1.selectDeck(deck1);
+            this.player2.selectDeck(deck2);
+            this.startGame();
+            this.keepStartingHands();
+            this.player1.clickCard('The Tickler', 'hand');
+            this.player2.clickCard('The Roseroad', 'hand');
+            this.completeSetup();
+            this.player1.selectPlot('Sneak Attack');
+            this.player2.selectPlot('Sneak Attack');
+            this.selectFirstPlayer(this.player1);
+
+            // Move remaining cards back to draw deck.
+            this.player2Object.hand.each(card => {
+                this.player2Object.moveCard(card, 'draw deck');
+            });
+
+            this.completeMarshalPhase();
+            this.completeChallengesPhase();
+
+            this.roseroad = this.player2.findCardByName('The Roseroad', 'play area');
+
+            this.player1.clickMenu('The Tickler', 'Discard opponents top card');
+        });
+
+        it('should discard the top card of the opponents deck', function() {
+            expect(this.player2Object.drawDeck.size()).toBe(0);
+            expect(this.player2Object.discardPile.size()).toBe(1);
+        });
+
+        it('should allow the Tickler to discard a card of the same name in play', function() {
+            this.player1.clickCard(this.roseroad);
+
+            expect(this.player2Object.discardPile.size()).toBe(2);
+            expect(this.roseroad.location).toBe('discard pile');
+        });
+    });
+});

--- a/test/server/cards/characters/02/02053-croneofvaesdothrak.spec.js
+++ b/test/server/cards/characters/02/02053-croneofvaesdothrak.spec.js
@@ -1,0 +1,122 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('Crone of Vaes Dothrak', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck1 = this.buildDeck('targaryen', [
+                'A Noble Cause',
+                'Crone of Vaes Dothrak', 'Braided Warrior', 'Black Wind\'s Crew'
+            ]);
+            const deck2 = this.buildDeck('lannister', [
+                'Sneak Attack',
+                'Hedge Knight', 'Hedge Knight', 'The Roseroad', 'The Roseroad'
+            ]);
+            this.player1.selectDeck(deck1);
+            this.player2.selectDeck(deck2);
+            this.startGame();
+            this.keepStartingHands();
+            this.player1.clickCard('Crone of Vaes Dothrak', 'hand');
+            this.player1.clickCard('Braided Warrior', 'hand');
+            this.player1.clickCard('Black Wind\'s Crew', 'hand');
+            this.completeSetup();
+            this.player1.selectPlot('A Noble Cause');
+            this.player2.selectPlot('Sneak Attack');
+            this.selectFirstPlayer(this.player1);
+        });
+
+        describe('when a card is discarded from the draw deck', function() {
+            describe('when a character gets discarded', function() {
+                beforeEach(function() {
+                    // Move characters back to draw
+                    this.player2Object.hand.each(card => {
+                        if(card.getType() === 'character') {
+                            this.player2Object.moveCard(card, 'draw deck');
+                        }
+                    });
+
+                    this.completeMarshalPhase();
+                    this.unopposedChallenge(this.player1, 'Power', 'Black Wind\'s Crew');
+                    this.player1.clickPrompt('Apply Claim');
+                });
+
+                it('should move the opponent character into the dead pile', function() {
+                    expect(this.player1).toHavePrompt('Trigger Crone of Vaes Dothrak?');
+                    this.player1.clickPrompt('Yes');
+                    this.player1.clickCard('Crone of Vaes Dothrak', 'play area');
+
+                    expect(this.player2Object.discardPile.size()).toBe(0);
+                    expect(this.player2Object.deadPile.size()).toBe(1);
+                });
+            });
+
+            describe('when a non-character gets discarded', function() {
+                beforeEach(function() {
+                    // Move non-characters back to draw
+                    this.player2Object.hand.each(card => {
+                        if(card.getType() !== 'character') {
+                            this.player2Object.moveCard(card, 'draw deck');
+                        }
+                    });
+
+                    this.completeMarshalPhase();
+                    this.unopposedChallenge(this.player1, 'Power', 'Black Wind\'s Crew');
+                    this.player1.clickPrompt('Apply Claim');
+                });
+
+                it('should move the opponent character into the discard pile', function() {
+                    expect(this.player1).not.toHavePrompt('Trigger Crone of Vaes Dothrak?');
+                    expect(this.player2Object.discardPile.size()).toBe(1);
+                    expect(this.player2Object.deadPile.size()).toBe(0);
+                });
+            });
+        });
+
+        describe('when a card is discarded from hand', function() {
+            describe('when a character gets discarded', function() {
+                beforeEach(function() {
+                    // Move non-characters back to draw
+                    this.player2Object.hand.each(card => {
+                        if(card.getType() !== 'character') {
+                            this.player2Object.moveCard(card, 'draw deck');
+                        }
+                    });
+
+                    this.completeMarshalPhase();
+                    this.unopposedChallenge(this.player1, 'Intrigue', 'Crone of Vaes Dothrak');
+                    this.player1.clickPrompt('Apply Claim');
+                });
+
+                it('should move the opponent character into the dead pile', function() {
+                    expect(this.player1).toHavePrompt('Trigger Crone of Vaes Dothrak?');
+                    this.player1.clickPrompt('Yes');
+                    this.player1.clickCard('Braided Warrior', 'play area');
+
+                    expect(this.player2Object.discardPile.size()).toBe(0);
+                    expect(this.player2Object.deadPile.size()).toBe(1);
+                });
+            });
+
+            describe('when a non-character gets discarded', function() {
+                beforeEach(function() {
+                    // Move characters back to draw
+                    this.player2Object.hand.each(card => {
+                        if(card.getType() === 'character') {
+                            this.player2Object.moveCard(card, 'draw deck');
+                        }
+                    });
+
+                    this.completeMarshalPhase();
+                    this.unopposedChallenge(this.player1, 'Intrigue', 'Crone of Vaes Dothrak');
+                    this.player1.clickPrompt('Apply Claim');
+                });
+
+                it('should move the opponent character into the discard pile', function() {
+                    expect(this.player1).not.toHavePrompt('Trigger Crone of Vaes Dothrak?');
+                    expect(this.player2Object.discardPile.size()).toBe(1);
+                    expect(this.player2Object.deadPile.size()).toBe(0);
+                });
+            });
+        });
+    });
+});

--- a/test/server/cards/plots/01/01013-headsonspikes.spec.js
+++ b/test/server/cards/plots/01/01013-headsonspikes.spec.js
@@ -1,0 +1,80 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('Heads on Spikes', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck1 = this.buildDeck('lannister', [
+                'Heads on Spikes',
+                'Cersei Lannister (LoCR)'
+            ]);
+            const deck2 = this.buildDeck('lannister', [
+                'Sneak Attack',
+                'Hedge Knight', 'Hedge Knight', 'The Roseroad', 'The Roseroad'
+            ]);
+            this.player1.selectDeck(deck1);
+            this.player2.selectDeck(deck2);
+            this.startGame();
+            this.keepStartingHands();
+            this.completeSetup();
+        });
+
+        describe('when a character gets discarded', function() {
+            beforeEach(function() {
+                // Move non-characters back to draw
+                this.player2Object.hand.each(card => {
+                    if(card.getType() !== 'character') {
+                        this.player2Object.moveCard(card, 'draw deck');
+                    }
+                });
+
+                this.player1.selectPlot('Heads on Spikes');
+                this.player2.selectPlot('Sneak Attack');
+                this.selectFirstPlayer(this.player1);
+            });
+
+            it('should discard a card from the opponent hand', function() {
+                // 1 card discarded, 2 drawn from draw phase
+                expect(this.player2Object.hand.size()).toBe(3);
+            });
+
+            it('should move the opponent character into the dead pile', function() {
+                expect(this.player2Object.discardPile.size()).toBe(0);
+                expect(this.player2Object.deadPile.size()).toBe(1);
+            });
+
+            it('should gain 2 power for the current player', function() {
+                expect(this.player1Object.faction.power).toBe(2);
+            });
+        });
+
+        describe('when a non-character gets discarded', function() {
+            beforeEach(function() {
+                // Move characters back to draw
+                this.player2Object.hand.each(card => {
+                    if(card.getType() === 'character') {
+                        this.player2Object.moveCard(card, 'draw deck');
+                    }
+                });
+
+                this.player1.selectPlot('Heads on Spikes');
+                this.player2.selectPlot('Sneak Attack');
+                this.selectFirstPlayer(this.player1);
+            });
+
+            it('should discard a card from the opponent hand', function() {
+                // 1 card discarded, 2 drawn from draw phase
+                expect(this.player2Object.hand.size()).toBe(3);
+            });
+
+            it('should move the opponent character into the discard pile', function() {
+                expect(this.player2Object.discardPile.size()).toBe(1);
+                expect(this.player2Object.deadPile.size()).toBe(0);
+            });
+
+            it('should not gain power for the current player', function() {
+                expect(this.player1Object.faction.power).toBe(0);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Prep work for refactoring how discarding cards work.

* Adds tests for The Tickler, Crone of Vaes Dothrak, and Heads on Spikes.
* Adds support for menus in integration tests, helpers for skipping an action window, and for doing compact unopposed challenges.