### PR TITLE
Introduce play actions for cards

### DIFF
--- a/server/game/baseability.js
+++ b/server/game/baseability.js
@@ -1,7 +1,5 @@
 const _ = require('underscore');
 
-const AbilityResolver = require('./gamesteps/abilityresolver.js');
-
 /**
  * Base class representing an ability that can be done by the player. This
  * includes card actions, reactions, interrupts, playing a card, marshaling a
@@ -16,16 +14,12 @@ class BaseAbility {
     /**
      * Creates an ability.
      *
-     * @param {Game} game - The game object.
-     * @param {Object} source - The source of the ability.
      * @param {Object} properties - An object with ability related properties.
      * @param {Object|Array} properties.cost - optional property that specifies
      * the cost for the ability. Can either be a cost object or an array of cost
      * objects.
      */
-    constructor(game, source, properties) {
-        this.game = game;
-        this.source = source;
+    constructor(properties) {
         this.cost = this.buildCost(properties.cost);
     }
 
@@ -39,14 +33,6 @@ class BaseAbility {
         }
 
         return cost;
-    }
-
-    /**
-     * Queues an AbilityResolver onto the game pipeline in order to pay costs
-     * and execute the ability if able.
-     */
-    queueResolver(context) {
-        this.game.queueStep(new AbilityResolver(this.game, this, context));
     }
 
     /**

--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -28,8 +28,9 @@ const BaseAbility = require('./baseability.js');
  */
 class CardAction extends BaseAbility {
     constructor(game, card, properties) {
-        super(game, card, properties);
+        super(properties);
 
+        this.game = game;
         this.card = card;
         this.title = properties.title;
         this.limit = properties.limit;
@@ -99,7 +100,7 @@ class CardAction extends BaseAbility {
             return false;
         }
 
-        this.queueResolver(context);
+        this.game.resolveAbility(this, context);
 
         return true;
     }

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -109,6 +109,45 @@ const Costs = {
                 context.source.removeToken('gold', 1);
             }
         };
+    },
+    /**
+     * Cost that ensures that the player can still play a Limited card this
+     * round.
+     */
+    playLimited: function() {
+        return {
+            canPay: function(context) {
+                return !context.source.isLimited() || context.player.limitedPlayed < context.player.maxLimited;
+            },
+            pay: function(context) {
+                if(context.source.isLimited()) {
+                    context.player.limitedPlayed += 1;
+                }
+            }
+        };
+    },
+    /**
+     * Cost that will pay the exact printed gold cost for the card.
+     */
+    payPrintedGoldCost: function() {
+        return {
+            canPay: function(context) {
+                var hasDupe = context.player.getDuplicateInPlay(context.source);
+                if(hasDupe) {
+                    return true;
+                }
+
+                return context.player.gold >= context.source.getCost();
+            },
+            pay: function(context) {
+                var hasDupe = context.player.getDuplicateInPlay(context.source);
+                if(hasDupe) {
+                    return;
+                }
+
+                context.player.gold -= context.source.getCost();
+            }
+        };
     }
 };
 

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -1,6 +1,11 @@
 const _ = require('underscore');
 
 const BaseCard = require('./basecard.js');
+const SetupCardAction = require('./setupcardaction.js');
+
+const StandardPlayActions = [
+    new SetupCardAction()
+];
 
 class DrawCard extends BaseCard {
     constructor(owner, cardData) {
@@ -217,6 +222,10 @@ class DrawCard extends BaseCard {
         _.each(this.abilities.persistentEffects, effect => {
             this.game.addEffect(this, effect);
         });
+    }
+
+    getPlayActions() {
+        return StandardPlayActions;
     }
 
     play(player, isAmbush) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -21,6 +21,7 @@ const SimpleStep = require('./gamesteps/simplestep.js');
 const MenuPrompt = require('./gamesteps/menuprompt.js');
 const SelectCardPrompt = require('./gamesteps/selectcardprompt.js');
 const EventWindow = require('./gamesteps/eventwindow.js');
+const AbilityResolver = require('./gamesteps/abilityresolver.js');
 const GameRepository = require('../repositories/gameRepository.js');
 
 class Game extends EventEmitter {
@@ -523,6 +524,10 @@ class Game extends EventEmitter {
 
     queueStep(step) {
         this.pipeline.queueStep(step);
+    }
+
+    resolveAbility(ability, context) {
+        this.queueStep(new AbilityResolver(this.game, ability, context));
     }
 
     raiseEvent(eventName, ...params) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -403,6 +403,16 @@ class Player extends Spectator {
         if(!card) {
             return false;
         }
+        var context = {
+            game: this.game,
+            player: this,
+            source: card
+        };
+        var playAction = _.find(card.getPlayActions(), action => action.meetsRequirements(context) && action.canPayCosts(context));
+        if(playAction) {
+            this.game.resolveAbility(playAction, context);
+            return true;
+        }
 
         var playingType = this.getPlayingType(card, forcePlay);
         var dupeCard = this.getDuplicateInPlay(card);

--- a/server/game/promptedtriggeredability.js
+++ b/server/game/promptedtriggeredability.js
@@ -73,7 +73,7 @@ class PromptedTriggeredAbility extends TriggeredAbility {
     triggerReaction(player, choice) {
         this.currentContext.choice = choice;
 
-        this.queueResolver(this.currentContext);
+        this.game.resolveAbility(this, this.currentContext);
 
         return true;
     }

--- a/server/game/setupcardaction.js
+++ b/server/game/setupcardaction.js
@@ -1,0 +1,27 @@
+const BaseAbility = require('./baseability.js');
+const Costs = require('./costs.js');
+
+class SetupCardAction extends BaseAbility {
+    constructor() {
+        super({
+            cost: [
+                Costs.payPrintedGoldCost(),
+                Costs.playLimited()
+            ]
+        });
+    }
+
+    meetsRequirements(context) {
+        return (
+            context.game.currentPhase === 'setup' &&
+            context.player.hand.contains(context.source) &&
+            context.source.getType() !== 'event'
+        );
+    }
+
+    executeHandler(context) {
+        context.player.putIntoPlay(context.source, 'setup');
+    }
+}
+
+module.exports = SetupCardAction;

--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -21,8 +21,9 @@ class TriggeredAbilityContext {
 
 class TriggeredAbility extends BaseAbility {
     constructor(game, card, eventType, properties) {
-        super(game, card, properties);
+        super(properties);
 
+        this.game = game;
         this.card = card;
         this.limit = properties.limit;
         this.when = properties.when;
@@ -31,7 +32,7 @@ class TriggeredAbility extends BaseAbility {
 
     createEventHandlerFor(eventName) {
         return (...args) => {
-            var context = new TriggeredAbilityContext(args[0], this.game, this.source);
+            var context = new TriggeredAbilityContext(args[0], this.game, this.card);
 
             if(this.game.currentPhase === 'setup') {
                 return;

--- a/test/server/card/baseability.spec.js
+++ b/test/server/card/baseability.spec.js
@@ -3,13 +3,8 @@
 
 const BaseAbility = require('../../../server/game/baseability.js');
 
-const AbilityResolver = require('../../../server/game/gamesteps/abilityresolver.js');
-
 describe('BaseAbility', function () {
     beforeEach(function () {
-        this.gameSpy = jasmine.createSpyObj('game', ['queueStep']);
-
-        this.cardSpy = jasmine.createSpyObj('card', ['']);
         this.properties = {};
     });
 
@@ -18,7 +13,7 @@ describe('BaseAbility', function () {
             describe('when no cost is passed', function() {
                 beforeEach(function() {
                     delete this.properties.cost;
-                    this.ability = new BaseAbility(this.gameSpy, this.cardSpy, this.properties);
+                    this.ability = new BaseAbility(this.properties);
                 });
 
                 it('should set cost to be empty array', function() {
@@ -30,7 +25,7 @@ describe('BaseAbility', function () {
                 beforeEach(function() {
                     this.cost = { cost: 1 };
                     this.properties.cost = this.cost;
-                    this.ability = new BaseAbility(this.gameSpy, this.cardSpy, this.properties);
+                    this.ability = new BaseAbility(this.properties);
                 });
 
                 it('should set cost to be an array with the cost', function() {
@@ -43,7 +38,7 @@ describe('BaseAbility', function () {
                     this.cost1 = { cost: 1 };
                     this.cost2 = { cost: 2 };
                     this.properties.cost = [this.cost1, this.cost2];
-                    this.ability = new BaseAbility(this.gameSpy, this.cardSpy, this.properties);
+                    this.ability = new BaseAbility(this.properties);
                 });
 
                 it('should set cost to be the array', function() {
@@ -53,23 +48,11 @@ describe('BaseAbility', function () {
         });
     });
 
-    describe('queueResolver()', function() {
-        beforeEach(function() {
-            this.context = { context: true };
-            this.ability = new BaseAbility(this.gameSpy, this.cardSpy, this.properties);
-            this.ability.queueResolver(this.context);
-        });
-
-        it('should queue an AbilityResolver step onto game', function() {
-            expect(this.gameSpy.queueStep).toHaveBeenCalledWith(jasmine.any(AbilityResolver));
-        });
-    });
-
     describe('canPayCosts()', function() {
         beforeEach(function() {
             this.cost1 = jasmine.createSpyObj('cost1', ['canPay']);
             this.cost2 = jasmine.createSpyObj('cost1', ['canPay']);
-            this.ability = new BaseAbility(this.gameSpy, this.cardSpy, this.properties);
+            this.ability = new BaseAbility(this.properties);
             this.ability.cost = [this.cost1, this.cost2];
             this.context = { context: 1 };
         });
@@ -107,7 +90,7 @@ describe('BaseAbility', function () {
         beforeEach(function() {
             this.noResolveCost = jasmine.createSpyObj('cost1', ['canPay']);
             this.resolveCost = jasmine.createSpyObj('cost2', ['canPay', 'resolve']);
-            this.ability = new BaseAbility(this.gameSpy, this.cardSpy, this.properties);
+            this.ability = new BaseAbility(this.properties);
 
             this.context = { context: 1 };
         });
@@ -155,7 +138,7 @@ describe('BaseAbility', function () {
         beforeEach(function() {
             this.cost1 = jasmine.createSpyObj('cost1', ['pay']);
             this.cost2 = jasmine.createSpyObj('cost1', ['pay']);
-            this.ability = new BaseAbility(this.gameSpy, this.cardSpy, this.properties);
+            this.ability = new BaseAbility(this.properties);
             this.ability.cost = [this.cost1, this.cost2];
             this.context = { context: 1 };
         });

--- a/test/server/card/cardaction.spec.js
+++ b/test/server/card/cardaction.spec.js
@@ -5,7 +5,7 @@ const CardAction = require('../../../server/game/cardaction.js');
 
 describe('CardAction', function () {
     beforeEach(function () {
-        this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener']);
+        this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener', 'resolveAbility']);
         this.gameSpy.currentPhase = 'marshal';
 
         this.cardSpy = jasmine.createSpyObj('card', ['isBlank']);
@@ -72,7 +72,6 @@ describe('CardAction', function () {
             beforeEach(function() {
                 this.properties.limit = this.limitSpy;
                 this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
-                spyOn(this.action, 'queueResolver');
             });
 
             describe('and the use count has reached the limit', function() {
@@ -83,7 +82,7 @@ describe('CardAction', function () {
                 });
 
                 it('should not queue the ability resolver', function() {
-                    expect(this.action.queueResolver).not.toHaveBeenCalled();
+                    expect(this.gameSpy.resolveAbility).not.toHaveBeenCalled();
                 });
             });
 
@@ -93,7 +92,7 @@ describe('CardAction', function () {
                 });
 
                 it('should queue the ability resolver', function() {
-                    expect(this.action.queueResolver).toHaveBeenCalled();
+                    expect(this.gameSpy.resolveAbility).toHaveBeenCalled();
                 });
             });
         });
@@ -106,12 +105,11 @@ describe('CardAction', function () {
             describe('and the anyPlayer property is not set', function() {
                 beforeEach(function() {
                     this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
-                    spyOn(this.action, 'queueResolver');
                     this.action.execute(this.otherPlayer, 'arg');
                 });
 
                 it('should not queue the ability resolver', function() {
-                    expect(this.action.queueResolver).not.toHaveBeenCalled();
+                    expect(this.gameSpy.resolveAbility).not.toHaveBeenCalled();
                 });
             });
 
@@ -119,12 +117,11 @@ describe('CardAction', function () {
                 beforeEach(function() {
                     this.properties.anyPlayer = true;
                     this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
-                    spyOn(this.action, 'queueResolver');
                     this.action.execute(this.otherPlayer, 'arg');
                 });
 
                 it('should queue the ability resolver', function() {
-                    expect(this.action.queueResolver).toHaveBeenCalled();
+                    expect(this.gameSpy.resolveAbility).toHaveBeenCalled();
                 });
             });
         });
@@ -133,12 +130,11 @@ describe('CardAction', function () {
             beforeEach(function() {
                 this.cardSpy.isBlank.and.returnValue(true);
                 this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
-                spyOn(this.action, 'queueResolver');
                 this.action.execute(this.player, 'arg');
             });
 
             it('should not queue the ability resolver', function() {
-                expect(this.action.queueResolver).not.toHaveBeenCalled();
+                expect(this.gameSpy.resolveAbility).not.toHaveBeenCalled();
             });
         });
 
@@ -146,7 +142,6 @@ describe('CardAction', function () {
             beforeEach(function() {
                 this.properties.phase = 'challenge';
                 this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
-                spyOn(this.action, 'queueResolver');
             });
 
             describe('and it is not that phase', function() {
@@ -156,7 +151,7 @@ describe('CardAction', function () {
                 });
 
                 it('should not queue the ability resolver', function() {
-                    expect(this.action.queueResolver).not.toHaveBeenCalled();
+                    expect(this.gameSpy.resolveAbility).not.toHaveBeenCalled();
                 });
             });
 
@@ -167,7 +162,7 @@ describe('CardAction', function () {
                 });
 
                 it('should queue the ability resolver', function() {
-                    expect(this.action.queueResolver).toHaveBeenCalled();
+                    expect(this.gameSpy.resolveAbility).toHaveBeenCalled();
                 });
             });
         });
@@ -177,12 +172,11 @@ describe('CardAction', function () {
                 this.gameSpy.currentPhase = 'setup';
                 this.properties.phase = 'any';
                 this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
-                spyOn(this.action, 'queueResolver');
                 this.action.execute(this.player, 'arg');
             });
 
             it('should not queue the ability resolver', function() {
-                expect(this.action.queueResolver).not.toHaveBeenCalled();
+                expect(this.gameSpy.resolveAbility).not.toHaveBeenCalled();
             });
         });
 
@@ -191,7 +185,6 @@ describe('CardAction', function () {
                 this.condition = jasmine.createSpy('condition');
                 this.properties.condition = this.condition;
                 this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
-                spyOn(this.action, 'queueResolver');
             });
 
             describe('and the condition returns true', function() {
@@ -201,7 +194,7 @@ describe('CardAction', function () {
                 });
 
                 it('should queue the ability resolver', function() {
-                    expect(this.action.queueResolver).toHaveBeenCalled();
+                    expect(this.gameSpy.resolveAbility).toHaveBeenCalled();
                 });
             });
 
@@ -212,7 +205,7 @@ describe('CardAction', function () {
                 });
 
                 it('should not queue the ability resolver', function() {
-                    expect(this.action.queueResolver).not.toHaveBeenCalled();
+                    expect(this.gameSpy.resolveAbility).not.toHaveBeenCalled();
                 });
             });
         });
@@ -220,12 +213,11 @@ describe('CardAction', function () {
         describe('when all conditions met', function() {
             beforeEach(function() {
                 this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
-                spyOn(this.action, 'queueResolver');
                 this.action.execute(this.player, 'arg');
             });
 
             it('should queue the ability resolver', function() {
-                expect(this.action.queueResolver).toHaveBeenCalled();
+                expect(this.gameSpy.resolveAbility).toHaveBeenCalled();
             });
         });
     });

--- a/test/server/card/cardreaction.spec.js
+++ b/test/server/card/cardreaction.spec.js
@@ -1,11 +1,11 @@
-/*global describe, it, beforeEach, expect, jasmine, spyOn */
+/*global describe, it, beforeEach, expect, jasmine */
 /*eslint camelcase: 0, no-invalid-this: 0 */
 
 const CardReaction = require('../../../server/game/cardreaction.js');
 
 describe('CardReaction', function () {
     beforeEach(function () {
-        this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener', 'promptWithMenu']);
+        this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener', 'promptWithMenu', 'resolveAbility']);
         this.cardSpy = jasmine.createSpyObj('card', ['isBlank']);
         this.limitSpy = jasmine.createSpyObj('limit', ['increment', 'isAtMax', 'registerEvents', 'unregisterEvents']);
 
@@ -137,7 +137,6 @@ describe('CardReaction', function () {
                 handler: jasmine.createSpy('handler')
             };
             this.reaction = this.createReaction();
-            spyOn(this.reaction, 'queueResolver');
 
             this.context = {};
             this.reaction.currentContext = this.context;
@@ -149,7 +148,7 @@ describe('CardReaction', function () {
         });
 
         it('should queue the ability resolver', function() {
-            expect(this.reaction.queueResolver).toHaveBeenCalledWith(this.context);
+            expect(this.gameSpy.resolveAbility).toHaveBeenCalledWith(this.reaction, this.context);
         });
     });
 

--- a/test/server/setupcardaction.spec.js
+++ b/test/server/setupcardaction.spec.js
@@ -1,0 +1,71 @@
+/* global describe, it, beforeEach, expect, jasmine */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+const _ = require('underscore');
+
+const SetupCardAction = require('../../server/game/setupcardaction');
+
+describe('SetupCardAction', function () {
+    beforeEach(function() {
+        this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener']);
+        this.playerSpy = jasmine.createSpyObj('player', ['putIntoPlay']);
+        this.cardSpy = jasmine.createSpyObj('card', ['getType']);
+        this.context = {
+            game: this.gameSpy,
+            player: this.playerSpy,
+            source: this.cardSpy
+        };
+        this.action = new SetupCardAction();
+    });
+
+    describe('meetsRequirements()', function() {
+        beforeEach(function() {
+            this.gameSpy.currentPhase = 'setup';
+            this.playerSpy.hand = _([this.cardSpy]);
+            this.cardSpy.getType.and.returnValue('character');
+        });
+
+        describe('when all conditions are met', function() {
+            it('should return true', function() {
+                expect(this.action.meetsRequirements(this.context)).toBe(true);
+            });
+        });
+
+        describe('when the phase is not setup', function() {
+            beforeEach(function() {
+                this.gameSpy.currentPhase = 'marshal';
+            });
+
+            it('should return false', function() {
+                expect(this.action.meetsRequirements(this.context)).toBe(false);
+            });
+        });
+
+        describe('when the card is not in hand', function() {
+            beforeEach(function() {
+                this.playerSpy.hand = _([]);
+            });
+
+            it('should return false', function() {
+                expect(this.action.meetsRequirements(this.context)).toBe(false);
+            });
+        });
+
+        describe('when the card is an event', function() {
+            beforeEach(function() {
+                this.cardSpy.getType.and.returnValue('event');
+            });
+
+            it('should return false', function() {
+                expect(this.action.meetsRequirements(this.context)).toBe(false);
+            });
+        });
+    });
+
+    describe('executeHandler()', function() {
+        it('should put the card in play for the player', function() {
+            this.action.executeHandler(this.context);
+            expect(this.playerSpy.putIntoPlay).toHaveBeenCalledWith(this.cardSpy, 'setup');
+        });
+    });
+});


### PR DESCRIPTION
* Introduces the concept of 'play actions' for cards. These are game actions / abilities that can occur when clicking on cards in hand. This includes playing a card during setup, marshaling, ambushing, in-hand actions, or other special in-hand abilities (e.g. marshal Lady in Waiting as a duplicate on a lady).
* This converts the setup phase to use these actions.

Later changes will prompt the player if multiple actions are valid at any one time (e.g. marshal LiW directly or marshal her as a dupe, ambush a card or use their in-hand action, etc).