### PR TITLE
fix Castle Black to properly implement card semantics

### DIFF
--- a/server/game/cards/locations/01/castleblack.js
+++ b/server/game/cards/locations/01/castleblack.js
@@ -20,7 +20,9 @@ class CastleBlack extends DrawCard {
     }
 
     cardCondition(card) {
-        return card.getType() === 'character' && card.location === 'play area' && this.game.currentChallenge.attackingPlayer !== this.controller && card.isFaction('thenightswatch');
+        return card.getType() === 'character'
+            && this.game.currentChallenge.isDefending(card)
+            && card.isFaction('thenightswatch');
     }
 
     onCardSelected(player, card) {


### PR DESCRIPTION
In particular, it is possible (although probably never what you want to do) to
use Castle Black on opponents' characters, as long as they are Night's Watch
and defending.  While at it, drop redundant (and maybe incorrect in the future)
checks, such as play area positioning.