### PR TITLE
Convert all usages of force play to put into play

### DIFF
--- a/server/game/cards/characters/01/aerondamphair.js
+++ b/server/game/cards/characters/01/aerondamphair.js
@@ -36,7 +36,7 @@ class AeronDamphair extends DrawCard {
     }
 
     onCardSelected(player, card) {
-        player.playCard(card, true);
+        player.putIntoPlay(card);
 
         this.game.addMessage('{0} uses {1} to put {2} into play from their dead pile', player, this, card);
 

--- a/server/game/cards/characters/01/ariannemartell.js
+++ b/server/game/cards/characters/01/ariannemartell.js
@@ -25,7 +25,7 @@ class ArianneMartell extends DrawCard {
     }
 
     onCardSelected(player, card) {
-        player.playCard(card, true);
+        player.putIntoPlay(card);
         player.moveCard(this, 'hand');
 
         this.game.addMessage('{0} uses {1} to put {2} in play from their hand and return {1} to their hand', player, this, card);

--- a/server/game/cards/characters/01/oldbearmormont.js
+++ b/server/game/cards/characters/01/oldbearmormont.js
@@ -23,7 +23,7 @@ class OldBearMormont extends DrawCard {
     }
 
     onCardSelected(player, card) {
-        player.playCard(card, true);
+        player.putIntoPlay(card);
 
         this.game.addMessage('{0} uses {1} to put {2} into play from their hand', player, this, card);
 

--- a/server/game/cards/characters/01/thequeenofthorns.js
+++ b/server/game/cards/characters/01/thequeenofthorns.js
@@ -18,7 +18,7 @@ class TheQueenOfThorns extends DrawCard {
     }
 
     onCardSelected(player, card) {
-        player.playCard(card, true);
+        player.putIntoPlay(card);
 
         this.game.addMessage('{0} uses {1} to put {2} in play from their hand', player, this, card);
 

--- a/server/game/cards/events/01/fireandblood.js
+++ b/server/game/cards/events/01/fireandblood.js
@@ -40,7 +40,7 @@ class FireAndBlood extends DrawCard {
     }
 
     putIntoPlay(player) {
-        player.playCard(this.selectedCard, true);
+        player.putIntoPlay(this.selectedCard);
 
         this.game.addMessage('{0} uses {1} to remove {2} from their dead pile and put it into play', player, this, this.selectedCard);
 

--- a/server/game/cards/plots/04/ghostsofharrenhal.js
+++ b/server/game/cards/plots/04/ghostsofharrenhal.js
@@ -11,7 +11,7 @@ class GhostsOfHarrenhal extends PlotCard {
                     var deadCharacters = player.findCards(player.deadPile, card => card.getType() === 'character');
                     if(!_.isEmpty(deadCharacters)) {
                         var lastDeadCharacter = _.last(deadCharacters);
-                        player.playCard(lastDeadCharacter, true);
+                        player.putIntoPlay(lastDeadCharacter);
 
                         this.game.addMessage('{0} uses {1} to put {2} into play from {3}\'s dead pile',
                                              this.controller, this, lastDeadCharacter, lastDeadCharacter.controller);

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -130,20 +130,12 @@ class Game extends EventEmitter {
         this.effectEngine.add(new Effect(this, source, properties));
     }
 
-    playCard(playerName, cardId, isDrop, sourceList) {
-        var player = this.getPlayerByName(playerName);
-
-        if(!player) {
+    playCard(player, card) {
+        if(this.pipeline.handleCardClicked(player, card)) {
             return;
         }
 
-        var card = player.findCardByUuid(sourceList, cardId);
-
-        if(card && !isDrop && this.pipeline.handleCardClicked(player, card)) {
-            return;
-        }
-
-        if(!player.playCard(card, isDrop)) {
+        if(!player.playCard(card)) {
             return;
         }
 
@@ -191,7 +183,7 @@ class Game extends EventEmitter {
 
         switch(card.location) {
             case 'hand':
-                this.playCard(player.name, cardId, false, player.hand);
+                this.playCard(player, card);
                 return;
             case 'plot deck':
                 this.selectPlot(player, cardId);

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -717,7 +717,7 @@ class Player extends Spectator {
         }
 
         if(target === 'play area') {
-            this.game.playCard(this.name, cardId, true, sourceList);
+            this.putIntoPlay(card);
         } else {
             if(target === 'dead pile' && card.location === 'play area') {
                 this.killCharacter(card, false);

--- a/test/server/player/drop.spec.js
+++ b/test/server/player/drop.spec.js
@@ -7,10 +7,11 @@ const Player = require('../../../server/game/player.js');
 describe('Player', () => {
     describe('drop()', function() {
         beforeEach(function() {
-            this.gameSpy = jasmine.createSpyObj('game', ['playCard', 'getOtherPlayer', 'raiseEvent', 'playerDecked']);
+            this.gameSpy = jasmine.createSpyObj('game', ['getOtherPlayer', 'raiseEvent', 'playerDecked']);
 
             this.player = new Player('1', 'Player 1', true, this.gameSpy);
             this.player.initialise();
+            spyOn(this.player, 'putIntoPlay');
 
             this.gameSpy.playersAndSpectators = [];
             this.gameSpy.playersAndSpectators[this.player.name] = this.player;
@@ -49,7 +50,7 @@ describe('Player', () => {
 
                 it('should return true and add the card to the play area', function() {
                     expect(this.dropSucceeded).toBe(true);
-                    expect(this.gameSpy.playCard).toHaveBeenCalled();
+                    expect(this.player.putIntoPlay).toHaveBeenCalledWith(this.cardSpy);
                 });
             });
 
@@ -62,7 +63,7 @@ describe('Player', () => {
 
                 it('should return true and add the card to the play area', function() {
                     expect(this.dropSucceeded).toBe(true);
-                    expect(this.gameSpy.playCard).toHaveBeenCalled();
+                    expect(this.player.putIntoPlay).toHaveBeenCalledWith(this.cardSpy);
                 });
             });
 
@@ -75,7 +76,7 @@ describe('Player', () => {
 
                 it('should return false and not add the card to the play area', function() {
                     expect(this.dropSucceeded).toBe(false);
-                    expect(this.gameSpy.playCard).not.toHaveBeenCalled();
+                    expect(this.player.putIntoPlay).not.toHaveBeenCalled();
                 });
             });
 
@@ -88,7 +89,7 @@ describe('Player', () => {
 
                 it('should return true and play the card', function() {
                     expect(this.dropSucceeded).toBe(true);
-                    expect(this.gameSpy.playCard).toHaveBeenCalled();
+                    expect(this.player.putIntoPlay).toHaveBeenCalledWith(this.cardSpy);
                 });
             });
         });


### PR DESCRIPTION
Replaces all usages of `Player.playCard(card, true)` with
`Player.putIntoPlay(card)`. This simplified the way drag and drop works,
so the extra parameters on `Game.playCard` could be removed.