### PR TITLE
Remove gold check from Lady In Waiting

### DIFF
--- a/server/game/cards/characters/02/ladyinwaiting.js
+++ b/server/game/cards/characters/02/ladyinwaiting.js
@@ -4,7 +4,7 @@ class LadyInWaiting extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onCardEntersPlay: (event, card) => card === this && this.game.currentPhase === 'marshal' && this.controller.gold >= 2
+                onCardEntersPlay: (event, card) => card === this && this.game.currentPhase === 'marshal'
             },
             handler: () => {
                 this.marshalAsDupe();


### PR DESCRIPTION
This should make the temporary implementation work in more cases. Only case in which this won't be "perfect" is if you want to play her as a dupe while having less than 2 gold. Manually adding gold to be able to marshal her, then substracting the gold you got from the handler should solve that.