### PR TITLE
Allow putIntoPlay to transfer control of cards.

### DIFF
--- a/server/game/cards/characters/01/euroncrowseye.js
+++ b/server/game/cards/characters/01/euroncrowseye.js
@@ -22,7 +22,7 @@ class EuronCrowsEye extends DrawCard {
     }
 
     onCardSelected(player, card) {
-        this.game.takeControl(player, card);
+        player.putIntoPlay(card);
         this.game.addMessage('{0} uses {1} to put {2} into play from their opponent\'s discard pile', player, this, card);
 
         return true;

--- a/server/game/cards/characters/01/yoren.js
+++ b/server/game/cards/characters/01/yoren.js
@@ -18,7 +18,7 @@ class Yoren extends DrawCard {
     }
 
     onCardSelected(player, card) {
-        this.game.takeControl(player, card);
+        player.putIntoPlay(card);
         this.game.addMessage('{0} uses {1} to put {2} into play from {3}\'s discard pile under their control', player, this, card, card.owner);
 
         return true;

--- a/server/game/cards/events/04/nightgathers.js
+++ b/server/game/cards/events/04/nightgathers.js
@@ -31,8 +31,6 @@ class NightGathers extends DrawCard {
     }
 
     onCardSelected(player, card) {
-        this.game.takeControl(player, card);
-
         player.playCard(card, false, true);
 
         this.game.promptForSelect(player, {

--- a/server/game/cards/locations/04/houseoftheundying.js
+++ b/server/game/cards/locations/04/houseoftheundying.js
@@ -29,7 +29,7 @@ class HouseOfTheUndying extends DrawCard {
         });
 
         _.each(eligibleCharacters, card => {
-            this.game.takeControl(this.controller, card);
+            this.controller.putIntoPlay(card);
             this.atEndOfPhase(ability => ({
                 match: card,
                 effect: ability.effects.moveToDeadPileIfStillInPlay()

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -476,6 +476,7 @@ class Player extends Spectator {
 
             card.new = true;
             this.moveCard(card, 'play area', { isDupe: !!dupeCard });
+            card.controller = this;
 
             this.game.raiseEvent('onCardEntersPlay', card);
 
@@ -1033,7 +1034,7 @@ class Player extends Spectator {
     }
 
     removeCardFromPile(card) {
-        if(card.controller !== card.owner && card.controller !== this) {
+        if(card.controller !== this) {
             card.controller.removeCardFromPile(card);
 
             card.controller = card.owner;

--- a/test/server/cards/events/04/04046-nightgathers.spec.js
+++ b/test/server/cards/events/04/04046-nightgathers.spec.js
@@ -1,0 +1,57 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('Night Gathers...', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck1 = this.buildDeck('thenightswatch', [
+                'A Noble Cause',
+                'Night Gathers...', 'Steward at the Wall'
+            ]);
+            const deck2 = this.buildDeck('lannister', [
+                'Sneak Attack',
+                'Tyrion Lannister (Core)', 'Gold Cloaks'
+            ]);
+
+            this.player1.selectDeck(deck1);
+            this.player2.selectDeck(deck2);
+            this.startGame();
+            this.skipSetupPhase();
+            this.player1.selectPlot('A Noble Cause');
+            this.player2.selectPlot('Sneak Attack');
+            this.selectFirstPlayer(this.player1);
+
+            this.steward = this.player1.findCardByName('Steward at the Wall');
+            this.tyrion = this.player2.findCardByName('Tyrion Lannister (Core)');
+            this.goldCloaks = this.player2.findCardByName('Gold Cloaks');
+            this.player2Object.moveCard(this.tyrion, 'discard pile');
+            this.player2Object.moveCard(this.goldCloaks, 'discard pile');
+
+            this.player1.clickCard('Night Gathers...', 'hand');
+        });
+
+        it('should allow marshaling of your own cards from hand', function() {
+            this.player1.clickCard(this.steward);
+            expect(this.steward.location).toBe('play area');
+            expect(this.player1Object.gold).toBe(3);
+        });
+
+        it('should allow marshaling of cards from opponents discard', function() {
+            this.player1.clickCard(this.goldCloaks);
+            expect(this.goldCloaks.location).toBe('play area');
+            expect(this.goldCloaks.controller).toBe(this.player1Object);
+            expect(this.player1Object.cardsInPlay.pluck('uuid')).toContain(this.goldCloaks.uuid);
+            expect(this.player2Object.discardPile.pluck('uuid')).not.toContain(this.goldCloaks.uuid);
+            expect(this.player1Object.gold).toBe(0);
+        });
+
+        it('should apply reducers to cards from opponents discard', function() {
+            this.player1.clickCard(this.tyrion);
+            expect(this.tyrion.location).toBe('play area');
+            expect(this.tyrion.controller).toBe(this.player1Object);
+            expect(this.player1Object.cardsInPlay.pluck('uuid')).toContain(this.tyrion.uuid);
+            expect(this.player2Object.discardPile.pluck('uuid')).not.toContain(this.tyrion.uuid);
+            expect(this.player1Object.gold).toBe(1);
+        });
+    });
+});

--- a/test/server/player/flipplotfaceup.spec.js
+++ b/test/server/player/flipplotfaceup.spec.js
@@ -15,9 +15,11 @@ describe('Player', function() {
             this.selectedPlotSpy = jasmine.createSpyObj('plot', ['flipFaceup', 'moveTo', 'play']);
             this.selectedPlotSpy.uuid = '111';
             this.selectedPlotSpy.location = 'plot deck';
+            this.selectedPlotSpy.controller = this.player;
             this.anotherPlotSpy = jasmine.createSpyObj('plot', ['flipFaceup', 'moveTo', 'play']);
-            this.selectedPlotSpy.uuid = '222';
+            this.anotherPlotSpy.uuid = '222';
             this.anotherPlotSpy.location = 'plot deck';
+            this.anotherPlotSpy.controller = this.player;
 
             this.player.selectedPlot = this.selectedPlotSpy;
             this.player.plotDeck = _([this.selectedPlotSpy, this.anotherPlotSpy]);
@@ -54,6 +56,7 @@ describe('Player', function() {
             beforeEach(function() {
                 this.activePlotSpy = jasmine.createSpyObj('plot', ['leavesPlay', 'moveTo']);
                 this.activePlotSpy.location = 'active plot';
+                this.activePlotSpy.controller = this.player;
                 this.player.activePlot = this.activePlotSpy;
 
                 this.player.flipPlotFaceup();

--- a/test/server/player/playcard.spec.js
+++ b/test/server/player/playcard.spec.js
@@ -20,6 +20,7 @@ describe('Player', function() {
             this.canPlaySpy.and.returnValue(true);
             this.player.hand.push(this.cardSpy);
             this.cardSpy.location = 'hand';
+            this.cardSpy.controller = this.player;
         });
 
         describe('when card is undefined', function() {


### PR DESCRIPTION
Previously, the `takeControl` method was being used for putting
opponents non-play area cards into play for the current player. This has
been changed to use the `putIntoPlay` method directly, which more
closely matches the card text.

Additionally, this fixes Night Gathers as it uses the `playCard` method,
which uses `putIntoPlay` internally.

Fixes #366.