### PR TITLE
log details of moved cards when they move from/to public places

### DIFF
--- a/server/game/game.js
+++ b/server/game/game.js
@@ -288,7 +288,18 @@ class Game extends EventEmitter {
         }
 
         if(player.drop(cardId, source, target)) {
-            this.addMessage('{0} has moved a card from their {1} to their {2}', player, source, target);
+            var movedCard = 'a card';
+            if(!_.isEmpty(_.intersection(['dead pile', 'discard pile', 'out of game', 'play area'],
+                                         [source, target]))) {
+                // log the moved card only if it moved from/to a public place
+                var card = this.findAnyCardInAnyList(cardId);
+                if(card && this.currentPhase !== 'setup') {
+                    movedCard = card;
+                }
+            }
+
+            this.addMessage('{0} has moved {1} from their {2} to their {3}',
+                            player, movedCard, source, target);
         }
     }
 


### PR DESCRIPTION
Currently the list of public places is hard coded in the Game.drop() method, as
they are just strings throughout the code. If/when they become abstract
objects (e.g., Pile, Places, or something such), we should make sure they have
isPublic() properties to make this and similar checks more clean.