### PR TITLE
Convert event cards to use play actions.

### DIFF
--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -2,9 +2,11 @@ const _ = require('underscore');
 
 const BaseCard = require('./basecard.js');
 const SetupCardAction = require('./setupcardaction.js');
+const PlayCardAction = require('./playcardaction.js');
 
 const StandardPlayActions = [
-    new SetupCardAction()
+    new SetupCardAction(),
+    new PlayCardAction()
 ];
 
 class DrawCard extends BaseCard {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -145,8 +145,6 @@ class Game extends EventEmitter {
         if(!player.playCard(card)) {
             return;
         }
-
-        this.raiseEvent('onCardPlayed', player, card);
     }
 
     processCardClicked(player, card) {

--- a/server/game/playcardaction.js
+++ b/server/game/playcardaction.js
@@ -1,0 +1,32 @@
+const BaseAbility = require('./baseability.js');
+const Costs = require('./costs.js');
+
+class PlayCardAction extends BaseAbility {
+    constructor() {
+        super({
+            cost: [
+                Costs.payReduceableGoldCost('play'),
+                Costs.playLimited()
+            ]
+        });
+    }
+
+    meetsRequirements(context) {
+        return (
+            context.game.currentPhase !== 'setup' &&
+            context.source.getType() === 'event' &&
+            !context.source.cannotPlay &&
+            context.player.hand.contains(context.source) &&
+            context.source.canPlay(context.player, context.source)
+        );
+    }
+
+    executeHandler(context) {
+        context.game.addMessage('{0} plays {1} costing {2}', context.player, context.source, context.costs.gold);
+        context.source.play(context.player);
+        context.player.moveCard(context.source, 'discard pile');
+        context.game.raiseEvent('onCardPlayed', context.player, context.source);
+    }
+}
+
+module.exports = PlayCardAction;

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -358,14 +358,6 @@ class Player extends Spectator {
     }
 
     canPlayCard(card, overrideHandCheck = false) {
-        if(!card.canPlay(this, card)) {
-            return false;
-        }
-
-        if(card.getType() === 'event' && this.phase === 'setup') {
-            return false;
-        }
-
         if(this.phase !== 'setup' && this.phase !== 'marshal' && card.getType() !== 'event') {
             if(this.phase !== 'challenge' || !card.isAmbush()) {
                 return false;
@@ -373,10 +365,6 @@ class Player extends Spectator {
         }
 
         if(card.getType() !== 'event' && this.phase === 'marshal' && card.cannotMarshal) {
-            return false;
-        }
-
-        if(card.getType() === 'event' && card.cannotPlay) {
             return false;
         }
 
@@ -420,6 +408,12 @@ class Player extends Spectator {
             return true;
         }
 
+        // TODO: These are implemented via play actions now. Once everything is
+        // converted, this guard will not be necessary.
+        if(card.getType() === 'event' || this.game.currentPhase === 'setup') {
+            return false;
+        }
+
         var playingType = this.getPlayingType(card, forcePlay);
         var dupeCard = this.getDuplicateInPlay(card);
         var cost = (dupeCard && playingType !== 'ambush' || forcePlay) ? 0 : this.getReducedCost(playingType, card);
@@ -431,16 +425,6 @@ class Player extends Spectator {
         this.gold -= cost;
 
         this.markUsedReducers(playingType, card);
-
-        if(card.getType() === 'event') {
-            this.game.addMessage('{0} plays {1} costing {2}', this, card, cost);
-
-            card.play(this);
-
-            this.moveCard(card, 'discard pile');
-
-            return true;
-        }
 
         if(this.phase === 'marshal') {
             this.game.addMessage('{0} {1} {2} costing {3}', this, dupeCard ? 'duplicates' : 'marshals', card, cost);

--- a/test/server/playcardaction.spec.js
+++ b/test/server/playcardaction.spec.js
@@ -1,0 +1,109 @@
+/* global describe, it, beforeEach, expect, jasmine */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+const _ = require('underscore');
+
+const PlayCardAction = require('../../server/game/playcardaction.js');
+
+describe('PlayCardAction', function () {
+    beforeEach(function() {
+        this.gameSpy = jasmine.createSpyObj('game', ['addMessage', 'on', 'raiseEvent', 'removeListener']);
+        this.playerSpy = jasmine.createSpyObj('player', ['moveCard']);
+        this.cardSpy = jasmine.createSpyObj('card', ['canPlay', 'getType', 'play']);
+        this.context = {
+            costs: {},
+            game: this.gameSpy,
+            player: this.playerSpy,
+            source: this.cardSpy
+        };
+        this.action = new PlayCardAction();
+    });
+
+    describe('meetsRequirements()', function() {
+        beforeEach(function() {
+            this.gameSpy.currentPhase = 'marshal';
+            this.playerSpy.hand = _([this.cardSpy]);
+            this.cardSpy.getType.and.returnValue('event');
+            this.cardSpy.canPlay.and.returnValue(true);
+        });
+
+        describe('when all conditions are met', function() {
+            it('should return true', function() {
+                expect(this.action.meetsRequirements(this.context)).toBe(true);
+            });
+        });
+
+        describe('when the phase is setup', function() {
+            beforeEach(function() {
+                this.gameSpy.currentPhase = 'setup';
+            });
+
+            it('should return false', function() {
+                expect(this.action.meetsRequirements(this.context)).toBe(false);
+            });
+        });
+
+        describe('when the card is not in hand', function() {
+            beforeEach(function() {
+                this.playerSpy.hand = _([]);
+            });
+
+            it('should return false', function() {
+                expect(this.action.meetsRequirements(this.context)).toBe(false);
+            });
+        });
+
+        describe('when the card is not an event', function() {
+            beforeEach(function() {
+                this.cardSpy.getType.and.returnValue('character');
+            });
+
+            it('should return false', function() {
+                expect(this.action.meetsRequirements(this.context)).toBe(false);
+            });
+        });
+
+        describe('when the card is forbidden from being played', function() {
+            beforeEach(function() {
+                this.cardSpy.cannotPlay = true;
+            });
+
+            it('should return false', function() {
+                expect(this.action.meetsRequirements(this.context)).toBe(false);
+            });
+        });
+
+        describe('when the card cannot be played', function() {
+            beforeEach(function() {
+                this.cardSpy.canPlay.and.returnValue(false);
+            });
+
+            it('should check can play with the right arguments', function() {
+                this.action.meetsRequirements(this.context);
+                expect(this.cardSpy.canPlay).toHaveBeenCalledWith(this.playerSpy, this.cardSpy);
+            });
+
+            it('should return false', function() {
+                expect(this.action.meetsRequirements(this.context)).toBe(false);
+            });
+        });
+    });
+
+    describe('executeHandler()', function() {
+        beforeEach(function() {
+            this.action.executeHandler(this.context);
+        });
+
+        it('should play the card', function() {
+            expect(this.cardSpy.play).toHaveBeenCalledWith(this.playerSpy);
+        });
+
+        it('should place the card in discard', function() {
+            expect(this.playerSpy.moveCard).toHaveBeenCalledWith(this.cardSpy, 'discard pile');
+        });
+
+        it('should raise the onCardPlayed event', function() {
+            expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onCardPlayed', this.playerSpy, this.cardSpy);
+        });
+    });
+});


### PR DESCRIPTION
Converts playing event cards from hand to play actions. Also moves the onCardPlayed event to only apply to playing events, which should make #553 easier.