### PR TITLE
Clear games when worker is restarted or times out

### DIFF
--- a/server/gamerouter.js
+++ b/server/gamerouter.js
@@ -106,6 +106,7 @@ class GameRouter extends EventEmitter {
         var message = JSON.parse(msg.toString());
         switch(message.command) {
             case 'HELLO':
+                this.emit('onWorkerStarted', identityStr);
                 this.workers[identityStr] = {
                     identity: identityStr,
                     maxGames: message.arg.maxGames,
@@ -154,6 +155,7 @@ class GameRouter extends EventEmitter {
             if(worker.pingSent && currentTime - worker.pingSent > 5 * 60 * 1000) {
                 logger.info('worker', worker.identity + ' timed out');
                 delete this.workers[worker.identity];
+                this.emit('onWorkerTimedOut', worker.identity);
             } else if(!worker.pingSent) {
                 if(currentTime - worker.lastMessage > 5 * 60 * 1000) {
                     worker.pingSent = currentTime;


### PR DESCRIPTION
Previously, if a game server worker timed out, the games would remain in
the lobby view even though they were no longer running / accessible.
Additionally, if a worker was restarted, any games that were on that
worker would also remain stuck in the lobby.