### PR TITLE
Convert Lady-in-Waiting to use custom play action

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -7,6 +7,7 @@ const CardForcedInterrupt = require('./cardforcedinterrupt.js');
 const CardForcedReaction = require('./cardforcedreaction.js');
 const CardInterrupt = require('./cardinterrupt.js');
 const CardReaction = require('./cardreaction.js');
+const CustomPlayAction = require('./customplayaction.js');
 const EventRegistrar = require('./eventregistrar.js');
 
 const ValidKeywords = [
@@ -48,7 +49,7 @@ class BaseCard {
         this.menu = _([]);
         this.events = new EventRegistrar(this.game, this);
 
-        this.abilities = { reactions: [], persistentEffects: [] };
+        this.abilities = { reactions: [], persistentEffects: [], playActions: [] };
         this.parseKeywords(cardData.text || '');
         this.parseTraits(cardData.traits || '');
         this.setupCardAbilities(AbilityDsl);
@@ -176,6 +177,14 @@ class BaseCard {
             }
         };
         this.forcedInterrupt(_.extend(whenClause, properties));
+    }
+
+    /**
+     * Defines a special play action that can occur when the card is outside the
+     * play area (e.g. Lady-in-Waiting's dupe marshal ability)
+     */
+    playAction(properties) {
+        this.abilities.playActions.push(new CustomPlayAction(properties));
     }
 
     /**

--- a/server/game/customplayaction.js
+++ b/server/game/customplayaction.js
@@ -1,0 +1,20 @@
+const BaseAbility = require('./baseability.js');
+
+class CustomPlayAction extends BaseAbility {
+    constructor(properties) {
+        super(properties);
+        this.condition = properties.condition || (() => true);
+        this.handler = properties.handler;
+        this.title = properties.title;
+    }
+
+    meetsRequirements(context) {
+        return this.condition(context);
+    }
+
+    executeHandler(context) {
+        this.handler(context);
+    }
+}
+
+module.exports = CustomPlayAction;

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -231,7 +231,7 @@ class DrawCard extends BaseCard {
     }
 
     getPlayActions() {
-        return StandardPlayActions;
+        return StandardPlayActions.concat(this.abilities.playActions);
     }
 
     play(player, isAmbush) {

--- a/test/server/cards/characters/02/02023-ladyinwaiting.spec.js
+++ b/test/server/cards/characters/02/02023-ladyinwaiting.spec.js
@@ -1,0 +1,72 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('Lady-in-Waiting', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck = this.buildDeck('tyrell', [
+                'A Noble Cause',
+                'Lady-in-Waiting', 'Margaery Tyrell (Core)'
+            ]);
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.keepStartingHands();
+            this.completeSetup();
+            this.player1.selectPlot('A Noble Cause');
+            this.player2.selectPlot('A Noble Cause');
+            this.selectFirstPlayer(this.player1);
+
+            this.ladyInWaiting = this.player1.findCardByName('Lady-in-Waiting');
+            this.margaery = this.player1.findCardByName('Margaery Tyrell');
+        });
+
+        describe('when there is no Lady character out', function() {
+            beforeEach(function() {
+                this.player1.clickCard('Lady-in-Waiting', 'hand');
+            });
+
+            it('should marshal as normal', function() {
+                expect(this.ladyInWaiting.location).toBe('play area');
+            });
+
+            it('should cost the normal amount of gold', function() {
+                // 5 gold from plot - 2 for LiW.
+                expect(this.player1Object.gold).toBe(3);
+            });
+        });
+
+        describe('when there is Lady character out', function() {
+            beforeEach(function() {
+                this.player1.clickCard('Margaery Tyrell', 'hand');
+                this.player1.clickCard('Lady-in-Waiting', 'hand');
+            });
+
+            it('should not put Lady in Waiting into play immediately', function() {
+                expect(this.ladyInWaiting.location).toBe('hand');
+            });
+
+            it('should prompt whether to marshal as a dupe', function() {
+                expect(this.player1).toHavePrompt('Play Lady-in-Waiting:');
+            });
+
+            describe('and the player chooses to marshal as a dupe', function() {
+                beforeEach(function() {
+                    this.player1.clickPrompt('Marshal as dupe');
+                    this.player1.clickCard('Margaery Tyrell', 'play area');
+                });
+
+                it('should add it as a dupe', function() {
+                    expect(this.ladyInWaiting.location).toBe('duplicate');
+                    expect(this.margaery.dupes.size()).toBe(1);
+                    expect(this.margaery.dupes).toContain(this.ladyInWaiting);
+                });
+
+                it('should not cost any gold', function() {
+                    // 5 gold from plot - 1 from Margaery - 0 for LiW.
+                    expect(this.player1Object.gold).toBe(4);
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
* Adds a `playAction` method to the ability API that allows you to define custom behavior when a player tries to play the card.
* Converts Lady-in-Waiting to use a play action for her marshal-as-a-dupe ability. Clicking on LiW during the marshal phase will now allow the player to choose whether to marshal her as normal or play her as a dupe. This prompt will only appear if both actions are eligible - if the player doesn't have enough gold to marshal, it will default to playing as a dupe. If the player doesn't have a Lady character out, it defaults to normal marshaling. If neither is possible, nothing happens.

Fixes #593.