### PR TITLE
Allow in-hand actions and implement Dolorous Edd

### DIFF
--- a/docs/implementing-cards.md
+++ b/docs/implementing-cards.md
@@ -381,6 +381,18 @@ this.action({
 });
 ```
 
+#### Actions outside of play
+
+Certain actions, such as those for Dolorous Edd, can only be activated while the character is in hand. Such actions should be defined by specifying the `location` property with the location from which the ability may be activated. The player can then activate the ability by simply clicking the card. If there is a conflict (e.g. both the ability and normal marshaling can occur), then the player will be prompted.
+
+```javascript
+this.action({
+    title: 'Add Dolorous Edd as a defender',
+    location: 'hand',
+    // ...
+})
+```
+
 ### Triggered abilities
 
 Triggered abilities include all card abilities that have **Interrupt**, **Forced Interrupt**, **Reaction**, **Forced Reaction**, or **When Revealed**. For full documentation of properties, see `/server/game/promptedtriggeredability.js` and `/server/game/forcedtriggeredability.js`. Here are some common scenarios:

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -143,7 +143,7 @@ class BaseCard {
     action(properties) {
         var action = new CardAction(this.game, this, properties);
         this.abilities.action = action;
-        if(!action.isClickToActivate()) {
+        if(!action.isClickToActivate() && action.location === 'play area') {
             this.menu.push(action.getMenuItem());
         }
     }

--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -19,6 +19,8 @@ const BaseAbility = require('./baseability.js');
  * phase        - string representing which phases the action may be executed.
  *                Defaults to 'any' which allows the action to be executed in
  *                any phase.
+ * location     - string indicating the location the card should be in in order
+ *                to activate the action. Defaults to 'play area'.
  * limit        - optional AbilityLimit object that represents the max number of
  *                uses for the action as well as when it resets.
  * anyPlayer    - boolean indicating that the action may be executed by a player
@@ -38,6 +40,7 @@ class CardAction extends BaseAbility {
         this.anyPlayer = properties.anyPlayer || false;
         this.condition = properties.condition;
         this.clickToActivate = !!properties.clickToActivate;
+        this.location = properties.location || 'play area';
 
         this.handler = this.buildHandler(card, properties);
     }
@@ -79,6 +82,10 @@ class CardAction extends BaseAbility {
         }
 
         if(context.player !== this.card.controller && !this.anyPlayer) {
+            return false;
+        }
+
+        if(this.location !== this.card.location) {
             return false;
         }
 

--- a/server/game/cards/characters/04/dolorousedd.js
+++ b/server/game/cards/characters/04/dolorousedd.js
@@ -1,0 +1,55 @@
+const DrawCard = require('../../../drawcard.js');
+
+class DolorousEdd extends DrawCard {
+    setupCardAbilities(ability) {
+        this.action({
+            title: 'Add as a defender',
+            location: 'hand',
+            condition: () => (
+                this.game.currentChallenge &&
+                this.game.currentChallenge.challengeType === 'intrigue' &&
+                this.game.currentChallenge.defendingPlayer === this.controller
+            ),
+            cost: ability.costs.kneelFactionCard(),
+            handler: () => {
+                this.game.addMessage('{0} kneels their faction card to put {1} into play as a defender', this.controller, this);
+                this.controller.putIntoPlay(this);
+                // Manually kneel Edd, since he enters play that way - should not fire a kneeling event.
+                this.kneeled = true;
+                this.game.currentChallenge.addDefender(this);
+                this.game.once('afterChallenge:interrupt', (event, challenge) => this.promptOnWin(challenge));
+            }
+        });
+    }
+
+    promptOnWin(challenge) {
+        if(challenge.winner !== this.controller) {
+            return;
+        }
+
+        this.game.promptWithMenu(this.controller, this, {
+            activePrompt: {
+                menuTitle: 'Return ' + this.name + ' to your hand?',
+                buttons: [
+                    { text: 'Yes', method: 'returnToHand' },
+                    { text: 'No', method: 'cancelReturnToHand' }
+                ]
+            }
+        });
+    }
+
+    returnToHand() {
+        this.game.addMessage('{0} chooses to return {1} to their hand after winning the challenge', this.controller, this);
+        this.controller.returnCardToHand(this, false);
+        return true;
+    }
+
+    cancelReturnToHand() {
+        this.game.addMessage('{0} declines to return {1} to their hand', this.controller, this);
+        return true;
+    }
+}
+
+DolorousEdd.code = '04025';
+
+module.exports = DolorousEdd;

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -231,7 +231,13 @@ class DrawCard extends BaseCard {
     }
 
     getPlayActions() {
-        return StandardPlayActions.concat(this.abilities.playActions);
+        var playActions = StandardPlayActions.concat(this.abilities.playActions);
+
+        if(this.abilities.action && this.abilities.action.location !== 'play area') {
+            playActions = playActions.concat([this.abilities.action]);
+        }
+
+        return playActions;
     }
 
     play(player, isAmbush) {

--- a/test/server/card/cardaction.spec.js
+++ b/test/server/card/cardaction.spec.js
@@ -60,12 +60,26 @@ describe('CardAction', function () {
                 });
             });
         });
+
+        describe('location', function() {
+            it('should default to play area', function() {
+                this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+                expect(this.action.location).toBe('play area');
+            });
+
+            it('should use the location sent via properties', function() {
+                this.properties.location = 'foo';
+                this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+                expect(this.action.location).toBe('foo');
+            });
+        });
     });
 
     describe('execute()', function() {
         beforeEach(function() {
             this.player = {};
             this.cardSpy.controller = this.player;
+            this.cardSpy.location = 'play area';
         });
 
         describe('when the action has limited uses', function() {
@@ -123,6 +137,19 @@ describe('CardAction', function () {
                 it('should queue the ability resolver', function() {
                     expect(this.gameSpy.resolveAbility).toHaveBeenCalled();
                 });
+            });
+        });
+
+        describe('when the card is not in a location for the action', function() {
+            beforeEach(function() {
+                this.cardSpy.location = 'hand';
+                this.properties.location = 'play area';
+                this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+                this.action.execute(this.player, 'arg');
+            });
+
+            it('should not queue the ability resolver', function() {
+                expect(this.gameSpy.resolveAbility).not.toHaveBeenCalled();
             });
         });
 

--- a/test/server/cards/characters/04/04025-dolorousedd.spec.js
+++ b/test/server/cards/characters/04/04025-dolorousedd.spec.js
@@ -1,0 +1,113 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('Dolorous Edd', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck1 = this.buildDeck('thenightswatch', [
+                'Sneak Attack',
+                'Dolorous Edd'
+            ]);
+            const deck2 = this.buildDeck('lannister', [
+                'Sneak Attack',
+                'Grand Maester Pycelle', 'Ser Jaime Lannister (LoCR)'
+            ]);
+            this.player1.selectDeck(deck1);
+            this.player2.selectDeck(deck2);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.player2.clickCard('Grand Maester Pycelle', 'hand');
+            this.player2.clickCard('Ser Jaime Lannister', 'hand');
+            this.completeSetup();
+            this.player1.selectPlot('Sneak Attack');
+            this.player2.selectPlot('Sneak Attack');
+            this.selectFirstPlayer(this.player2);
+            this.completeMarshalPhase();
+
+            this.edd = this.player1.findCardByName('Dolorous Edd', 'hand');
+
+            this.skipActionWindow();
+
+            this.player2.clickPrompt('Intrigue');
+        });
+
+        it('should allow Dolorous Edd to jump in to the challenge', function() {
+            this.player2.clickCard('Grand Maester Pycelle', 'play area');
+            this.player2.clickPrompt('Done');
+
+            // Skip player 2's action window
+            this.player2.clickPrompt('Done');
+
+            this.player1.clickCard('Dolorous Edd', 'hand');
+
+            expect(this.edd.location).toBe('play area');
+            expect(this.edd.kneeled).toBe(true);
+            expect(this.player1Object.faction.kneeled).toBe(true);
+        });
+
+        describe('when the player wins the challenge Edd enters', function() {
+            beforeEach(function() {
+                this.player2.clickCard('Grand Maester Pycelle', 'play area');
+                this.player2.clickPrompt('Done');
+
+                // Skip player 2's action window
+                this.player2.clickPrompt('Done');
+
+                this.player1.clickCard('Dolorous Edd', 'hand');
+
+                // Complete player 1's action window
+                this.player1.clickPrompt('Done');
+                this.player2.clickPrompt('Done');
+                this.player1.clickPrompt('Done');
+
+                // Do not explicitly defend
+                expect(this.player1).toHavePrompt('Select defenders');
+                this.player1.clickPrompt('Done');
+
+                this.skipActionWindow();
+            });
+
+            it('should prompt the player to return Edd to hand', function() {
+                expect(this.player1).toHavePrompt('Return Dolorous Edd to your hand?');
+            });
+
+            it('should allow the player to return Edd to hand', function() {
+                this.player1.clickPrompt('Yes');
+                expect(this.edd.location).toBe('hand');
+            });
+
+            it('should allow the player to decline to return Edd to hand', function() {
+                this.player1.clickPrompt('No');
+                expect(this.edd.location).toBe('play area');
+            });
+        });
+
+        describe('when the player does not win the challenge Edd enters', function() {
+            beforeEach(function() {
+                this.player2.clickCard('Ser Jaime Lannister', 'play area');
+                this.player2.clickPrompt('Done');
+
+                // Skip player 2's action window
+                this.player2.clickPrompt('Done');
+
+                this.player1.clickCard('Dolorous Edd', 'hand');
+
+                // Complete player 1's action window
+                this.player1.clickPrompt('Done');
+                this.player2.clickPrompt('Done');
+                this.player1.clickPrompt('Done');
+
+                // Do not explicitly defend
+                expect(this.player1).toHavePrompt('Select defenders');
+                this.player1.clickPrompt('Done');
+
+                this.skipActionWindow();
+            });
+
+            it('should not prompt the player to return Edd to hand', function() {
+                expect(this.player1).not.toHavePrompt('Return Dolorous Edd to hand?');
+            });
+        });
+    });
+});

--- a/test/server/playcardaction.spec.js
+++ b/test/server/playcardaction.spec.js
@@ -25,6 +25,7 @@ describe('PlayCardAction', function () {
             this.playerSpy.hand = _([this.cardSpy]);
             this.cardSpy.getType.and.returnValue('event');
             this.cardSpy.canPlay.and.returnValue(true);
+            this.cardSpy.abilities = {};
         });
 
         describe('when all conditions are met', function() {


### PR DESCRIPTION
* Allows an optional `location` property to be specified on actions. This indicates where the action may be activated from. For 'hand' actions, clicking the card will activate the ability (or prompt the player if multiple play actions are eligible).
* Implements Dolorous Edd.