### PR TITLE
Always remove player from pending game when left

### DIFF
--- a/server/pendinggame.js
+++ b/server/pendinggame.js
@@ -109,7 +109,7 @@ class PendingGame {
             this.addMessage('{0} has left the game', playerName);
         }
 
-        if(this.players[playerName] && !this.started) {
+        if(this.players[playerName]) {
             delete this.players[playerName];
         } else {
             delete this.spectators[playerName];


### PR DESCRIPTION
Previously, if a player left a game, the game listing in the lobby would
continue to list that player in the game.