### PR TITLE
Hide users that have left in lobby listings.

### DIFF
--- a/server/lobby.js
+++ b/server/lobby.js
@@ -48,9 +48,7 @@ class Lobby {
 
     // Helpers
     findGameForUser(user) {
-        return _.find(this.games, game => {
-            return game.players[user] || game.spectators[user];
-        });
+        return _.find(this.games, game => game.hasActivePlayer(user));
     }
 
     handshake(socket, next) {

--- a/server/pendinggame.js
+++ b/server/pendinggame.js
@@ -109,8 +109,12 @@ class PendingGame {
             this.addMessage('{0} has left the game', playerName);
         }
 
-        if(this.players[playerName] && !this.started) {
-            delete this.players[playerName];
+        if(this.players[playerName]) {
+            if(this.started) {
+                this.players[playerName].left = true;
+            } else {
+                delete this.players[playerName];
+            }
         } else {
             delete this.spectators[playerName];
         }
@@ -171,11 +175,16 @@ class PendingGame {
         return true;
     }
 
+    hasActivePlayer(playerName) {
+        return this.players[playerName] && !this.players[playerName].left || this.spectators[playerName];
+    }
+
     // Summary
     getSummary(activePlayer) {
         var playerSummaries = {};
+        var playersInGame = _.filter(this.players, player => !player.left);
 
-        _.each(this.players, player => {
+        _.each(playersInGame, player => {
             var deck = undefined;
 
             if(activePlayer === player.name && player.deck) {


### PR DESCRIPTION
Previously, if a player left the game after it had been started, they
could still be considered active in the game from the perspective of the
lobby. This would leave their name listed in the game and could also
potentially cause reconnect issues. Now, once they leave an active game,
they are marked as 'left' in the lobby listing.