### PR TITLE
Ensure persistent plot effects apply only once.

### DIFF
--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -101,6 +101,10 @@ class Effect {
             return false;
         }
 
+        if(this.targets.includes(target)) {
+            return false;
+        }
+
         if(this.targetType === 'card') {
             if(this.targetController === 'current') {
                 return target.controller === this.source.controller;

--- a/test/server/cards/plots/04/04020-varyssriddle.spec.js
+++ b/test/server/cards/plots/04/04020-varyssriddle.spec.js
@@ -1,0 +1,38 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('WraithsInTheirMidst', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck1 = this.buildDeck('greyjoy', [
+                'Varys\'s Riddle'
+            ]);
+
+            this.player1.selectDeck(deck1);
+        });
+
+        describe('when played against Wraiths in Their Midst', function() {
+            beforeEach(function() {
+                const deck2 = this.buildDeck('lannister', [
+                    'Wraiths in Their Midst'
+                ]);
+
+                this.player2.selectDeck(deck2);
+                this.startGame();
+                this.keepStartingHands();
+                this.completeSetup();
+
+                this.varysRiddle = this.player1.findCardByName('Varys\'s Riddle');
+
+                this.player1.selectPlot('Varys\'s Riddle');
+                this.player2.selectPlot('Wraiths in Their Midst');
+                this.selectFirstPlayer(this.player1);
+            });
+
+            it('should reduce Varys\'s Riddle by the proper amount', function() {
+                // Reduce 7 by 2 from Wraiths
+                expect(this.varysRiddle.getReserve()).toBe(5);
+            });
+        });
+    });
+});

--- a/test/server/cards/plots/04/04020-varyssriddle.spec.js
+++ b/test/server/cards/plots/04/04020-varyssriddle.spec.js
@@ -1,7 +1,7 @@
 /* global describe, it, expect, beforeEach, integration */
 /* eslint camelcase: 0, no-invalid-this: 0 */
 
-describe('WraithsInTheirMidst', function() {
+describe('Varys\'s Riddle', function() {
     integration(function() {
         beforeEach(function() {
             const deck1 = this.buildDeck('greyjoy', [

--- a/test/server/effect.spec.js
+++ b/test/server/effect.spec.js
@@ -104,6 +104,17 @@ describe('Effect', function () {
             });
         });
 
+        describe('when the target is already applied', function() {
+            beforeEach(function() {
+                this.effect.targets.push(this.matchingCard);
+                this.effect.addTargets([this.matchingCard]);
+            });
+
+            it('should not add the target again', function() {
+                expect(this.effect.targets).toEqual([this.matchingCard]);
+            });
+        });
+
         describe('when the effect target type is card', function() {
             beforeEach(function() {
                 this.effect.active = true;
@@ -381,7 +392,7 @@ describe('Effect', function () {
     describe('setActive()', function() {
         beforeEach(function() {
             this.target = {};
-            this.effect.targets =[this.target];
+            this.effect.targets = [this.target];
         });
 
         describe('when the effect is active', function() {


### PR DESCRIPTION
Previously, there were scenarios in which a plot with persistent effects
could end up being applied to the same card twice. Wraiths in their
Midst, for instance, would get applied twice when it was revealed as the
second plot during a round. Now the effect engine checks whether the
target is already in the current targets list for an effect before
adding it again.

Fixes #615.