### PR TITLE
Add card targeting to ability API

### DIFF
--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -97,7 +97,7 @@ class CardAction extends BaseAbility {
             return false;
         }
 
-        return this.canPayCosts(context);
+        return this.canPayCosts(context) && this.canResolveTargets(context);
     }
 
     execute(player, arg) {

--- a/server/game/cards/attachments/01/ice.js
+++ b/server/game/cards/attachments/01/ice.js
@@ -13,13 +13,14 @@ class Ice extends DrawCard {
                     challenge.isParticipating(this.parent)
                 )
             },
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    activePromptTitle: 'Select a character to kill',
-                    source: this,
-                    cardCondition: card => card.location === 'play area' && card.controller !== this.controller && card.getType() === 'character',
-                    onSelect: (p, card) => this.onCardSelected(p, card)
-                });
+            cost: ability.costs.sacrificeSelf(),
+            target: {
+                activePromptTitle: 'Select a character to kill',
+                cardCondition: card => card.location === 'play area' && card.controller !== this.controller && card.getType() === 'character'
+            },
+            handler: context => {
+                context.target.owner.killCharacter(context.target);
+                this.game.addMessage('{0} sacrifices {1} to kill {2}', context.player, this, context.target);
             }
         });
     }
@@ -30,16 +31,6 @@ class Ice extends DrawCard {
         }
 
         return super.canAttach(player, card);
-    }
-
-    onCardSelected(player, card) {
-        card.owner.killCharacter(card);
-
-        this.controller.sacrificeCard(this);
-
-        this.game.addMessage('{0} sacrifices {1} to kill {2}', player, this, card);
-
-        return true;
     }
 }
 

--- a/server/game/cards/characters/01/greywind.js
+++ b/server/game/cards/characters/01/greywind.js
@@ -4,35 +4,23 @@ class GreyWind extends DrawCard {
     setupCardAbilities(ability) {
         this.action({
             title: 'Kneel Grey Wind to kill a character',
-            method: 'kill',
             cost: ability.costs.kneelSelf(),
-            phase: 'challenge'
+            phase: 'challenge',
+            target: {
+                activePromptTitle: 'Select a character',
+                cardCondition: card => this.cardCondition(card)
+            },
+            handler: context => {
+                context.target.controller.killCharacter(context.target);
+                this.game.addMessage('{0} kneels {1} to kill {2}', context.player, this, context.target);
+            }
         });
-    }
-
-    kill(player) {
-        this.game.promptForSelect(player, {
-            cardCondition: card => this.cardCondition(card),
-            activePromptTitle: 'Select a character',
-            source: this,
-            onSelect: (player, card) => this.onCardSelected(player, card)
-        });
-
-        return true;
     }
 
     cardCondition(card) {
         var str = this.controller.findCardByName(this.controller.cardsInPlay, 'Robb Stark') ? 2 : 1;
 
         return card.getStrength() <= str && card.location === 'play area' && card.getType() === 'character';
-    }
-
-    onCardSelected(player, card) {
-        card.controller.killCharacter(card);
-
-        this.game.addMessage('{0} kneels {1} to kill {2}', player, this, card);
-
-        return true;
     }
 }
 

--- a/server/game/cards/characters/03/aggo.js
+++ b/server/game/cards/characters/03/aggo.js
@@ -1,35 +1,20 @@
 const DrawCard = require('../../../drawcard.js');
-const _ = require('underscore');
 
 class Aggo extends DrawCard {
     setupCardAbilities(ability) {
         this.action({
             title: 'Stand a Bloodrider (if a Summer plot is revealed)',
-            method: 'stand',
-            limit: ability.limit.perRound(1)
+            condition: () => this.game.anyPlotHasTrait('Summer'),
+            target: {
+                activePromptTitle: 'Select a character',
+                cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.hasTrait('Bloodrider')
+            },
+            limit: ability.limit.perRound(1),
+            handler: context => {
+                this.game.addMessage('{0} uses {1} to stand {2}', context.player, this, context.target);
+                this.controller.standCard(context.target);
+            }
         });
-    }
-
-    stand(player) {
-        if(!_.any(this.game.getPlayers(), player => {
-            return player.activePlot.hasTrait('Summer');
-        })) {
-            return false;
-        }
-
-        this.game.promptForSelect(player, {
-            activePromptTitle: 'Select a character',
-            source: this,
-            cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.hasTrait('Bloodrider'),
-            onSelect: (p, card) => this.onCardSelected(p, card)
-        });
-        return true;
-    }
-
-    onCardSelected(player, card) {
-        this.game.addMessage('{0} uses {1} to stand {2}', player, this, card);
-        this.controller.standCard(card);
-        return true;
     }
 }
 

--- a/server/game/cards/characters/03/eddardstark.js
+++ b/server/game/cards/characters/03/eddardstark.js
@@ -6,31 +6,19 @@ class EddardStark extends DrawCard {
             when: {
                 onRenown: (event, challenge, card) => card === this
             },
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    cardCondition: card => this.cardCondition(this.game.currentChallenge, card),
-                    activePromptTitle: 'Select character to gain power',
-                    source: this,
-                    onSelect: (player, card) => this.onCardSelected(player, card)
-                });
+            target: {
+                activePromptTitle: 'Select character to gain power',
+                cardCondition: card => this.cardCondition(this.game.currentChallenge, card)
+            },
+            handler: context => {
+                context.target.modifyPower(1);
+                this.game.addMessage('{0} uses {1} to allow {2} to gain 1 power', context.player, this, context.target);
             }
         });
     }
 
     cardCondition(challenge, card) {
         return card !== this && card.getType() === 'character' && challenge.isParticipating(card);
-    }
-
-    onCardSelected(player, card) {
-        if(this.isBlank() || this.controller !== player) {
-            return;
-        }
-
-        card.modifyPower(1);
-
-        this.game.addMessage('{0} uses {1} to allow {2} to gain 1 power', player, this, card);
-
-        return true;
     }
 }
 

--- a/server/game/cards/locations/04/renlyspavilion.js
+++ b/server/game/cards/locations/04/renlyspavilion.js
@@ -5,64 +5,33 @@ class RenlysPavilion extends DrawCard {
         this.action({
             title: 'Kneel this card to modify the strength of two characters',
             cost: ability.costs.kneelSelf(),
-            method: 'kneel'
+            targets: {
+                toLower: {
+                    activePromptTitle: 'Select a character to get -1 STR',
+                    cardCondition: card => this.cardCondition(card)
+                },
+                toRaise: {
+                    activePromptTitle: 'Select a character to get +1 STR',
+                    cardCondition: card => this.cardCondition(card)
+                }
+            },
+            handler: context => {
+                this.game.addMessage('{0} uses {1} to give -1 STR to {2} and +1 STR to {3}',
+                             context.player, this, context.targets.toLower, context.targets.toRaise);
+                this.untilEndOfPhase(ability => ({
+                    match: context.targets.toLower,
+                    effect: ability.effects.modifyStrength(-1)
+                }));
+                this.untilEndOfPhase(ability => ({
+                    match: context.targets.toRaise,
+                    effect: ability.effects.modifyStrength(1)
+                }));
+            }
         });
-    }
-
-    kneel(player) {
-        this.game.promptForSelect(player, {
-            cardCondition: card => this.cardCondition(card),
-            activePromptTitle: 'Select a character to get -1 STR',
-            source: this,
-            onSelect: (player, card) => this.firstCardSelected(player, card)
-        });
-        
-        return true;
     }
 
     cardCondition(card) {
-        return card.getType() === 'character' && card.location === 'play area'; 
-    }
-
-    firstCardSelected(player, card) {
-        this.toLower = card;
-
-        this.game.promptForSelect(player, {
-            cardCondition: card => this.cardCondition(card),
-            activePromptTitle: 'Select a character to get +1 STR',
-            source: this,
-            onSelect: (player, card) => this.secondCardSelected(player, card)
-        });
-
-        return true;
-    }
-
-    secondCardSelected(player, card) {
-        this.lowerStr(player, this.toLower);
-        this.raiseStr(player, card);
-
-        this.game.addMessage('{0} uses {1} to give -1 STR to {2} and +1 STR to {3}',
-                             player, this, this.toLower, card);
-
-        this.toLower = undefined;
-
-        return true;
-    }
-
-    lowerStr(player, card) {
-        this.untilEndOfPhase(ability => ({
-            match: card,
-            effect: ability.effects.modifyStrength(-1)
-        }));
-        return true;
-    }
-
-    raiseStr(player, card) {
-        this.untilEndOfPhase(ability => ({
-            match: card,
-            effect: ability.effects.modifyStrength(1)
-        }));
-        return true;
+        return card.getType() === 'character' && card.location === 'play area';
     }
 }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -362,7 +362,7 @@ class Player extends Spectator {
             player: this,
             source: card
         };
-        var playActions = _.filter(card.getPlayActions(), action => action.meetsRequirements(context) && action.canPayCosts(context));
+        var playActions = _.filter(card.getPlayActions(), action => action.meetsRequirements(context) && action.canPayCosts(context) && action.canResolveTargets(context));
 
         if(playActions.length === 0) {
             return false;

--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -50,7 +50,7 @@ class TriggeredAbility extends BaseAbility {
                 return;
             }
 
-            if(!this.canPayCosts(context)) {
+            if(!this.canPayCosts(context) || !this.canResolveTargets(context)) {
                 return;
             }
 

--- a/test/server/player/playcard.spec.js
+++ b/test/server/player/playcard.spec.js
@@ -14,7 +14,7 @@ describe('Player', function() {
 
     describe('playCard', function() {
         beforeEach(function() {
-            this.playActionSpy = jasmine.createSpyObj('playAction', ['meetsRequirements', 'canPayCosts']);
+            this.playActionSpy = jasmine.createSpyObj('playAction', ['meetsRequirements', 'canPayCosts', 'canResolveTargets']);
             this.cardSpy = jasmine.createSpyObj('card', ['getPlayActions']);
 
             this.player.hand.push(this.cardSpy);
@@ -46,6 +46,7 @@ describe('Player', function() {
                 beforeEach(function() {
                     this.playActionSpy.meetsRequirements.and.returnValue(true);
                     this.playActionSpy.canPayCosts.and.returnValue(true);
+                    this.playActionSpy.canResolveTargets.and.returnValue(true);
                 });
 
                 it('should resolve the play action', function() {
@@ -62,6 +63,7 @@ describe('Player', function() {
                 beforeEach(function() {
                     this.playActionSpy.meetsRequirements.and.returnValue(true);
                     this.playActionSpy.canPayCosts.and.returnValue(false);
+                    this.playActionSpy.canResolveTargets.and.returnValue(true);
                 });
 
                 it('should not resolve the play action', function() {
@@ -78,6 +80,24 @@ describe('Player', function() {
                 beforeEach(function() {
                     this.playActionSpy.meetsRequirements.and.returnValue(false);
                     this.playActionSpy.canPayCosts.and.returnValue(true);
+                    this.playActionSpy.canResolveTargets.and.returnValue(true);
+                });
+
+                it('should not resolve the play action', function() {
+                    this.player.playCard(this.cardSpy);
+                    expect(this.gameSpy.resolveAbility).not.toHaveBeenCalled();
+                });
+
+                it('should return false', function() {
+                    expect(this.player.playCard(this.cardSpy)).toBe(false);
+                });
+            });
+
+            describe('when targets cannot be resolved', function() {
+                beforeEach(function() {
+                    this.playActionSpy.meetsRequirements.and.returnValue(true);
+                    this.playActionSpy.canPayCosts.and.returnValue(true);
+                    this.playActionSpy.canResolveTargets.and.returnValue(false);
                 });
 
                 it('should not resolve the play action', function() {
@@ -95,9 +115,11 @@ describe('Player', function() {
             beforeEach(function() {
                 this.playActionSpy.meetsRequirements.and.returnValue(true);
                 this.playActionSpy.canPayCosts.and.returnValue(true);
-                this.playActionSpy2 = jasmine.createSpyObj('playAction', ['meetsRequirements', 'canPayCosts']);
+                this.playActionSpy.canResolveTargets.and.returnValue(true);
+                this.playActionSpy2 = jasmine.createSpyObj('playAction', ['meetsRequirements', 'canPayCosts', 'canResolveTargets']);
                 this.playActionSpy2.meetsRequirements.and.returnValue(true);
                 this.playActionSpy2.canPayCosts.and.returnValue(true);
+                this.playActionSpy2.canResolveTargets.and.returnValue(true);
                 this.cardSpy.getPlayActions.and.returnValue([this.playActionSpy, this.playActionSpy2]);
             });
 


### PR DESCRIPTION
* Simplifies and automates card selection prompts by providing a `target` property. If an ability requires multiple targets to be chosen (somewhat rare), they can be specified and named using `targets` property instead.
* If an ability has no valid targets, it will no longer be allowed to trigger (similar to if costs couldn't be paid).
* Converts a few cards over as examples.