### PR TITLE
implement Funeral Pyre (partial)

### DIFF
--- a/server/game/cards/events/02/funeralpyre.js
+++ b/server/game/cards/events/02/funeralpyre.js
@@ -1,0 +1,31 @@
+const DrawCard = require('../../../drawcard.js');
+
+class FuneralPyre extends DrawCard {
+
+    canPlay(player, card) {
+        if(player.faction.kneeled) {
+            return false;
+        }
+
+        return super.canPlay(player, card);
+    }
+
+    play(player) {
+        player.kneelCard(player.faction);
+
+        // TODO should allow to draw only if we're reacting to a lord/lady
+        // being killed. This will be possible only when the in-hand reaction
+        // mechanism will be available.
+        this.controller.drawCardsToHand(3);
+
+        this.game.addMessage('{0} uses {1} to draw 3 cards',
+                             this.controller, this);
+
+        return true;
+    }
+
+}
+
+FuneralPyre.code = '02114';
+
+module.exports = FuneralPyre;


### PR DESCRIPTION
As is, the event is always playable rather than only when a Lord/Lady character
dies, because we don't have yet in place the scaffolding for in-hand reactions.