### PR TITLE
Properly handle multiple pillages.

### DIFF
--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -233,11 +233,13 @@ class ChallengeFlow extends BaseStep {
             }
 
             if(card.hasKeyword('Pillage')) {
-                this.challenge.loser.discardFromDraw(1, cards => {
-                    var discarded = cards[0];
-                    this.game.raiseEvent('onPillage', this.challenge, card, discarded);
+                this.game.queueSimpleStep(() => {
+                    this.challenge.loser.discardFromDraw(1, cards => {
+                        var discarded = cards[0];
+                        this.game.raiseEvent('onPillage', this.challenge, card, discarded);
 
-                    this.game.addMessage('{0} discards {1} from the top of their deck due to Pillage from {2}', this.challenge.loser, discarded, card);
+                        this.game.addMessage('{0} discards {1} from the top of their deck due to Pillage from {2}', this.challenge.loser, discarded, card);
+                    });
                 });
             }
 

--- a/test/server/integration/pillage.spec.js
+++ b/test/server/integration/pillage.spec.js
@@ -1,0 +1,56 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('pillage', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck = this.buildDeck('stark', [
+                'Trading with the Pentoshi',
+                'Wildling Horde', 'Wildling Horde'
+            ]);
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.skipSetupPhase();
+
+            this.player1.selectPlot('Trading with the Pentoshi');
+            this.player2.selectPlot('Trading with the Pentoshi');
+            this.selectFirstPlayer(this.player1);
+
+            // Resolve plot order
+            this.player1.clickPrompt('player1');
+
+            [this.wildlingHorde1, this.wildlingHorde2] = this.player1.filterCardsByName('Wildling Horde');
+
+            this.player1.clickCard(this.wildlingHorde1);
+            this.player1.clickCard(this.wildlingHorde2);
+            this.completeMarshalPhase();
+
+            // Return cards to deck
+            this.player2Object.hand.each(card => {
+                this.player2Object.moveCard(card, 'draw deck');
+            });
+        });
+
+        describe('when more than one pillage occurs', function() {
+            beforeEach(function() {
+                this.skipActionWindow();
+                this.player1.clickPrompt('Power');
+                this.player1.clickCard(this.wildlingHorde1);
+                this.player1.clickCard(this.wildlingHorde2);
+                this.player1.clickPrompt('Done');
+                this.skipActionWindow();
+                this.player2.clickPrompt('Done');
+                this.skipActionWindow();
+
+                this.player1.clickPrompt('Apply Claim');
+            });
+
+            it('should discard two cards', function() {
+                expect(this.player2Object.drawDeck.size()).toBe(0);
+                expect(this.player2Object.discardPile.size()).toBe(2);
+            });
+        });
+
+    });
+});


### PR DESCRIPTION
Previously, if multiple instances of pillage would trigger at once, only
the first card would actually be discarded. This was because pillage
determined which card would be discarded synchronously, but executed
asynchronously. Now the entire pillage step is asynchronous.

Fixes #641.