### PR TITLE
Fix Selyse Baratheon

### DIFF
--- a/server/game/cards/characters/01/selysebaratheon.js
+++ b/server/game/cards/characters/01/selysebaratheon.js
@@ -1,38 +1,22 @@
 const DrawCard = require('../../../drawcard.js');
 
 class SelyseBaratheon extends DrawCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.action({
             title: 'Pay 1 gold to give an intrigue icon to a character',
-            method: 'addIcon'
+            cost: ability.costs.payGold(1),
+            target: {
+                activePromptTitle: 'Select character',
+                cardCondition: card => card.location === 'play area' && card.isFaction('baratheon') && card.getType() === 'character'
+            },
+            handler: context => {
+                this.game.addMessage('{0} uses {1} to give {2} an {3} icon', context.player, this, context.target, 'intrigue');
+                this.untilEndOfPhase(ability => ({
+                    match: context.target,
+                    effect: ability.effects.addIcon('intrigue')
+                }));
+            }
         });
-    }
-
-    addIcon(player) {
-        if(this.location !== 'play area' || player.gold <= 0) {
-            return false;
-        }
-
-        this.game.promptForSelect(this.controller, {
-            activePromptTitle: 'Select character',
-            source: this,
-            cardCondition: card => card.location === 'play area' && card.isFaction('baratheon') && card.getType() === 'character',
-            onSelect: (p, card) => this.onCardSelected(p, card)
-        });
-
-        return true;
-    }
-
-    onCardSelected(player, card) {
-        this.game.addMessage('{0} uses {1} to give {2} an {3} icon', player, this, card, 'intrigue');
-
-        this.game.addGold(this.controller, -1);
-        this.untilEndOfPhase(ability => ({
-            match: card,
-            effect: ability.effects.addIcon('intrigue')
-        }));
-
-        return true;
     }
 }
 

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -232,6 +232,19 @@ const Costs = {
                 }
             }
         };
+    },
+    /**
+     * Cost in which the player must pay a fixed, non-reduceable amount of gold.
+     */
+    payGold: function(amount) {
+        return {
+            canPay: function(context) {
+                return context.player.gold >= amount;
+            },
+            pay: function(context) {
+                context.game.addGold(context.player, -amount);
+            }
+        };
     }
 };
 

--- a/test/helpers/playerinteractionwrapper.js
+++ b/test/helpers/playerinteractionwrapper.js
@@ -116,6 +116,7 @@ class PlayerInteractionWrapper {
 
     dragCard(card, targetLocation) {
         this.game.drop(this.player.name, card.uuid, card.location, targetLocation);
+        this.game.continue();
     }
 }
 

--- a/test/server/cards/characters/01/01049-selysebaratheon.spec.js
+++ b/test/server/cards/characters/01/01049-selysebaratheon.spec.js
@@ -1,0 +1,46 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('Selyse Baratheon', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck1 = this.buildDeck('baratheon', [
+                'Sneak Attack',
+                'Selyse Baratheon'
+            ]);
+            const deck2 = this.buildDeck('martell', [
+                'Sneak Attack',
+                'Nymeria Sand'
+            ]);
+            this.player1.selectDeck(deck1);
+            this.player2.selectDeck(deck2);
+            this.startGame();
+            this.keepStartingHands();
+            this.player1.clickCard('Selyse Baratheon', 'hand');
+            this.player2.clickCard('Nymeria Sand', 'hand');
+            this.completeSetup();
+            this.player1.selectPlot('Sneak Attack');
+            this.player2.selectPlot('Sneak Attack');
+            this.selectFirstPlayer(this.player1);
+            this.completeMarshalPhase();
+
+            this.selyse = this.player1.findCardByName('Selyse Baratheon', 'play area');
+            this.player2.clickMenu('Nymeria Sand', 'Remove icon from opponent\'s character');
+            this.player2.clickCard(this.selyse);
+            this.player2.clickPrompt('Intrigue');
+
+            expect(this.selyse.hasIcon('intrigue')).toBe(false);
+
+            this.player1.clickMenu(this.selyse, 'Pay 1 gold to give an intrigue icon to a character');
+            this.player1.clickCard(this.selyse);
+        });
+
+        it('should allow a stolen icon to be restored', function() {
+            expect(this.selyse.hasIcon('intrigue')).toBe(true);
+        });
+
+        it('should cost 1 gold', function() {
+            expect(this.player1Object.gold).toBe(4);
+        });
+    });
+});


### PR DESCRIPTION
Previously, Selyse's action was not working at all because the `addIcon`
method had been overridden to handle the action. When the effect was
attempted to be applied, it would call the prompt again instead of
actually adding the icon.

Fixes #639.