### PR TITLE
Fix Fealty reduction

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -143,7 +143,7 @@ class BaseCard {
     action(properties) {
         var action = new CardAction(this.game, this, properties);
         this.abilities.action = action;
-        if(!action.isClickToActivate() && action.location === 'play area') {
+        if(!action.isClickToActivate() && ['play area', 'agenda'].includes(action.location)) {
             this.menu.push(action.getMenuItem());
         }
     }

--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -40,7 +40,7 @@ class CardAction extends BaseAbility {
         this.anyPlayer = properties.anyPlayer || false;
         this.condition = properties.condition;
         this.clickToActivate = !!properties.clickToActivate;
-        this.location = properties.location || 'play area';
+        this.location = properties.location || (card.getType() === 'agenda' ? 'agenda' : 'play area');
 
         this.handler = this.buildHandler(card, properties);
     }

--- a/test/server/card/cardaction.spec.js
+++ b/test/server/card/cardaction.spec.js
@@ -8,7 +8,7 @@ describe('CardAction', function () {
         this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener', 'resolveAbility']);
         this.gameSpy.currentPhase = 'marshal';
 
-        this.cardSpy = jasmine.createSpyObj('card', ['isBlank']);
+        this.cardSpy = jasmine.createSpyObj('card', ['getType', 'isBlank']);
         this.cardSpy.handler = function() {};
         spyOn(this.cardSpy, 'handler').and.returnValue(true);
 
@@ -65,6 +65,12 @@ describe('CardAction', function () {
             it('should default to play area', function() {
                 this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
                 expect(this.action.location).toBe('play area');
+            });
+
+            it('should default to agenda for cards with type agenda', function() {
+                this.cardSpy.getType.and.returnValue('agenda');
+                this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+                expect(this.action.location).toBe('agenda');
             });
 
             it('should use the location sent via properties', function() {

--- a/test/server/cards/agendas/01027-fealty.spec.js
+++ b/test/server/cards/agendas/01027-fealty.spec.js
@@ -1,0 +1,43 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('Fealty', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck = this.buildDeck('greyjoy', [
+                'Fealty',
+                'Sneak Attack',
+                'Balon Greyjoy (Core)', 'Theon Greyjoy'
+            ]);
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.skipSetupPhase();
+
+            this.player1.selectPlot('Sneak Attack');
+            this.player2.selectPlot('Sneak Attack');
+            this.selectFirstPlayer(this.player1);
+
+            this.balon = this.player1.findCardByName('Balon Greyjoy (Core)', 'hand');
+            this.theon = this.player1.findCardByName('Theon Greyjoy', 'hand');
+
+            this.player1.clickMenu('Fealty', 'Kneel your faction card');
+        });
+
+        it('should kneel the faction card', function() {
+            expect(this.player1Object.faction.kneeled).toBe(true);
+        });
+
+        it('should reduce the cost of loyal cards by 1', function() {
+            this.player1.clickCard(this.balon);
+            expect(this.balon.location).toBe('play area');
+            expect(this.player1Object.gold).toBe(0);
+        });
+
+        it('should not reduce the cost of non-loyal cards', function() {
+            this.player1.clickCard(this.theon);
+            expect(this.theon.location).toBe('play area');
+            expect(this.player1Object.gold).toBe(1);
+        });
+    });
+});


### PR DESCRIPTION
The introduction of `location` onto actions broke Fealty because it's
location is 'agenda' but by default the action assumes it should be
'play area'.

Now cards with type 'agenda' are defaulted to have their actions in that
location.

Fixes #647.