### PR TITLE
Always delete disconnected sockets.

### DIFF
--- a/server/lobby.js
+++ b/server/lobby.js
@@ -232,8 +232,9 @@ class Lobby {
             return;
         }
 
+        delete this.sockets[socket.id];
+
         if(!socket.user) {
-            delete this.sockets[socket.id];
             return;
         }
 
@@ -245,16 +246,12 @@ class Lobby {
         }
 
         game.disconnect(socket.user.username);
-        socket.send('gamestate', game.getSummary(socket.user.username));
-        socket.leaveChannel(game.id);
 
         if(game.isEmpty()) {
             delete this.games[game.id];
         } else {
             this.sendGameState(game);
         }
-
-        delete this.sockets[socket.id];
 
         this.broadcastGameList();
     }


### PR DESCRIPTION
Previously, sockets that belonged to a user that was logged in but was
not in a game were not being removed from the socket list.

Additionally, it isn't possible to send game state to a socket that has
been disconnected, and rooms are left automatically upon disconnection.