### PR TITLE
Add target API support to forced abilities.

### DIFF
--- a/server/game/cards/characters/03/houseflorentknight.js
+++ b/server/game/cards/characters/03/houseflorentknight.js
@@ -7,21 +7,15 @@ class HouseFlorentKnight extends DrawCard {
             when: {
                 onCardEntersPlay: (event, card) => card === this
             },
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    activePromptTitle: 'Select a character with the lowest strength in play',
-                    source: this,
-                    cardCondition: card => {
-                        return card.getStrength() === this.getLowestStrInPlay() && card.location === 'play area';
-                    },
-                    onSelect: (player, card) => {
-                        player.discardCard(card);
-
-                        this.game.addMessage('{0} uses {1} to discard {2}', player, this, card);
-
-                        return true;
-                    }
-                });
+            target: {
+                activePromptTitle: 'Select a character with the lowest strength in play',
+                cardCondition: card => {
+                    return card.getStrength() === this.getLowestStrInPlay() && card.location === 'play area';
+                }
+            },
+            handler: context => {
+                this.game.addMessage('{0} uses {1} to discard {2}', context.player, this, context.target);
+                context.target.controller.discardCard(context.target);
             }
         });
     }

--- a/server/game/cards/plots/01/confiscation.js
+++ b/server/game/cards/plots/01/confiscation.js
@@ -3,27 +3,20 @@ const PlotCard = require('../../../plotcard.js');
 class Confiscation extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    cardCondition: card => this.cardCondition(card),
-                    activePromptTitle: 'Select an attachment to discard',
-                    source: this,
-                    onSelect: (player, card) => this.onCardSelected(player, card)
-                });
+            target: {
+                activePromptTitle: 'Select an attachment to discard',
+                cardCondition: card => this.cardCondition(card)
+            },
+            handler: context => {
+                var attachment = context.target;
+                attachment.owner.discardCard(attachment);
+                this.game.addMessage('{0} uses {1} to discard {2}', context.player, this, attachment);
             }
         });
     }
 
     cardCondition(card) {
         return card.getType() === 'attachment';
-    }
-
-    onCardSelected(player, attachment) {
-        attachment.owner.discardCard(attachment);
-
-        this.game.addMessage('{0} uses {1} to discard {2}', player, this, attachment);
-
-        return true;
     }
 }
 

--- a/server/game/forcedtriggeredability.js
+++ b/server/game/forcedtriggeredability.js
@@ -27,6 +27,10 @@ class ForcedTriggeredAbility extends TriggeredAbility {
     }
 
     executeReaction(context) {
+        this.game.resolveAbility(this, context);
+    }
+
+    executeHandler(context) {
         if(this.handler(context) !== false && this.limit) {
             this.limit.increment();
         }

--- a/test/server/card/cardforcedreaction.spec.js
+++ b/test/server/card/cardforcedreaction.spec.js
@@ -5,7 +5,7 @@ const CardForcedReaction = require('../../../server/game/cardforcedreaction.js')
 
 describe('CardForcedReaction', function () {
     beforeEach(function () {
-        this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener']);
+        this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener', 'resolveAbility']);
         this.cardSpy = jasmine.createSpyObj('card', ['isBlank']);
         this.limitSpy = jasmine.createSpyObj('limit', ['increment', 'isAtMax', 'registerEvents', 'unregisterEvents']);
 
@@ -43,8 +43,8 @@ describe('CardForcedReaction', function () {
                 this.executeEventHandler(1, 2, 3);
             });
 
-            it('should not execute the handler', function() {
-                expect(this.properties.handler).not.toHaveBeenCalled();
+            it('should not resolve the ability', function() {
+                expect(this.gameSpy.resolveAbility).not.toHaveBeenCalled();
             });
         });
 
@@ -54,8 +54,8 @@ describe('CardForcedReaction', function () {
                 this.executeEventHandler(1, 2, 3);
             });
 
-            it('should not execute the handler', function() {
-                expect(this.properties.handler).not.toHaveBeenCalled();
+            it('should not resolve the ability', function() {
+                expect(this.gameSpy.resolveAbility).not.toHaveBeenCalled();
             });
         });
 
@@ -65,8 +65,8 @@ describe('CardForcedReaction', function () {
                 this.executeEventHandler(1, 2, 3);
             });
 
-            it('should not execute the handler', function() {
-                expect(this.properties.handler).not.toHaveBeenCalled();
+            it('should not resolve the ability', function() {
+                expect(this.gameSpy.resolveAbility).not.toHaveBeenCalled();
             });
         });
 
@@ -81,12 +81,8 @@ describe('CardForcedReaction', function () {
                     this.executeEventHandler(1, 2, 3);
                 });
 
-                it('should not execute the handler', function() {
-                    expect(this.properties.handler).not.toHaveBeenCalled();
-                });
-
-                it('should not increment the limit', function() {
-                    expect(this.limitSpy.increment).not.toHaveBeenCalled();
+                it('should not resolve the ability', function() {
+                    expect(this.gameSpy.resolveAbility).not.toHaveBeenCalled();
                 });
             });
 
@@ -96,12 +92,48 @@ describe('CardForcedReaction', function () {
                     this.executeEventHandler(1, 2, 3);
                 });
 
-                it('should execute the handler', function() {
-                    expect(this.properties.handler).toHaveBeenCalled();
+                it('should resolve the ability', function() {
+                    expect(this.gameSpy.resolveAbility).toHaveBeenCalledWith(this.reaction, jasmine.any(Object));
+                });
+            });
+        });
+    });
+
+    describe('executeHandler', function() {
+        beforeEach(function() {
+            this.reaction = new CardForcedReaction(this.gameSpy, this.cardSpy, this.properties);
+            this.context = { context: 1 };
+        });
+
+        it('should execute the handler', function() {
+            this.reaction.executeHandler(this.context);
+            expect(this.properties.handler).toHaveBeenCalledWith(this.context);
+        });
+
+        describe('when there is a limit', function() {
+            beforeEach(function() {
+                this.reaction.limit = this.limitSpy;
+            });
+
+            describe('and the handler returns non-false', function() {
+                beforeEach(function() {
+                    this.properties.handler.and.returnValue(undefined);
+                    this.reaction.executeHandler(this.context);
                 });
 
                 it('should increment the limit', function() {
                     expect(this.limitSpy.increment).toHaveBeenCalled();
+                });
+            });
+
+            describe('and the handler returns explicitly false', function() {
+                beforeEach(function() {
+                    this.properties.handler.and.returnValue(false);
+                    this.reaction.executeHandler(this.context);
+                });
+
+                it('should not increment the limit', function() {
+                    expect(this.limitSpy.increment).not.toHaveBeenCalled();
                 });
             });
         });


### PR DESCRIPTION
The target API is now supported on forced interrupts, forced
reactions, and when revealed abilities.