### PR TITLE
Allow click to activate actions to be undone.

### DIFF
--- a/server/game/baseability.js
+++ b/server/game/baseability.js
@@ -87,6 +87,25 @@ class BaseAbility {
     }
 
     /**
+     * Return whether when unpay is implemented for the ability cost and the
+     * cost can be unpaid.
+     *
+     * @returns {boolean}
+     */
+    canUnpayCosts(context) {
+        return _.all(this.cost, cost => cost.unpay && cost.canUnpay(context));
+    }
+
+    /**
+     * Unpays each cost associated with the ability.
+     */
+    unpayCosts(context) {
+        _.each(this.cost, cost => {
+            cost.unpay(context);
+        });
+    }
+
+    /**
      * Returns whether there are eligible cards available to fulfill targets.
      *
      * @returns {Boolean}

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -441,7 +441,7 @@ class BaseCard {
     onClick(player) {
         var action = this.abilities.action;
         if(action && action.isClickToActivate()) {
-            return action.execute(player);
+            return action.execute(player) || action.deactivate(player);
         }
 
         return false;

--- a/server/game/cards/locations/03/tourneygrounds.js
+++ b/server/game/cards/locations/03/tourneygrounds.js
@@ -6,8 +6,9 @@ class TourneyGrounds extends DrawCard {
             title: 'Kneel to reduce event',
             clickToActivate: true,
             cost: ability.costs.kneelSelf(),
-            handler: () => {
+            handler: context => {
                 this.untilEndOfPhase(ability => ({
+                    condition: () => !context.abilityDeactivated,
                     targetType: 'player',
                     targetController: 'current',
                     effect: ability.effects.reduceNextPlayedCardCost(1, card => card.getType() === 'event')

--- a/server/game/cards/locations/05/oceanroad.js
+++ b/server/game/cards/locations/05/oceanroad.js
@@ -7,10 +7,11 @@ class OceanRoad extends DrawCard {
             clickToActivate: true,
             phase: 'marshal',
             cost: ability.costs.kneelSelf(),
-            handler: () => {
+            handler: context => {
                 this.game.addMessage('{0} uses {1} to reduce the cost of the next {2} card by {3}',
                     this.controller, this, this.faction, 1);
                 this.untilEndOfPhase(ability => ({
+                    condition: () => !context.abilityDeactivated,
                     targetType: 'player',
                     targetController: 'current',
                     effect: ability.effects.reduceNextMarshalledCardCost(

--- a/server/game/cards/reducer.js
+++ b/server/game/cards/reducer.js
@@ -14,10 +14,11 @@ class FactionCostReducer extends DrawCard {
             clickToActivate: true,
             phase: 'marshal',
             cost: ability.costs.kneelSelf(),
-            handler: () => {
+            handler: context => {
                 this.game.addMessage('{0} uses {1} to reduce the cost of the next {2} card by {3}',
                     this.controller, this, this.faction, this.reduceBy);
                 this.untilEndOfPhase(ability => ({
+                    condition: () => !context.abilityDeactivated,
                     targetType: 'player',
                     targetController: 'current',
                     effect: ability.effects.reduceNextMarshalledCardCost(this.reduceBy, card => card.isFaction(this.faction))
@@ -41,10 +42,11 @@ class FactionCharacterCostReducer extends DrawCard {
             clickToActivate: true,
             phase: 'marshal',
             cost: ability.costs.kneelSelf(),
-            handler: () => {
+            handler: context => {
                 this.game.addMessage('{0} uses {1} to reduce the cost of the next {2} character by {3}',
                     this.controller, this, this.faction, this.reduceBy);
                 this.untilEndOfPhase(ability => ({
+                    condition: () => !context.abilityDeactivated,
                     targetType: 'player',
                     targetController: 'current',
                     effect: ability.effects.reduceNextMarshalledCardCost(

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -9,6 +9,12 @@ const Costs = {
             },
             pay: function(context) {
                 context.source.controller.kneelCard(context.source);
+            },
+            canUnpay: function(context) {
+                return context.source.kneeled;
+            },
+            unpay: function(context) {
+                context.source.controller.standCard(context.source);
             }
         };
     },

--- a/test/server/card/cardaction.spec.js
+++ b/test/server/card/cardaction.spec.js
@@ -261,6 +261,97 @@ describe('CardAction', function () {
         });
     });
 
+    describe('deactivate()', function() {
+        beforeEach(function() {
+            this.player = { player: 1 };
+            this.cardSpy.controller = this.player;
+            this.cardSpy.location = 'play area';
+            this.costSpy = jasmine.createSpyObj('cost', ['canUnpay', 'unpay']);
+            this.costSpy.canUnpay.and.returnValue(true);
+            this.properties.cost = this.costSpy;
+            this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+            this.bottomContext = { context: 'bottom', player: this.player };
+            this.topContext = { context: 'top', player: this.player };
+            this.action.activationContexts.push(this.bottomContext);
+            this.action.activationContexts.push(this.topContext);
+        });
+
+        describe('when everything is normal', function() {
+            beforeEach(function() {
+                this.result = this.action.deactivate(this.player);
+            });
+
+            it('should unpay costs', function() {
+                expect(this.costSpy.unpay).toHaveBeenCalledWith(this.topContext);
+            });
+
+            it('should deactivate the top context', function() {
+                expect(this.bottomContext.abilityDeactivated).toBeFalsy();
+                expect(this.topContext.abilityDeactivated).toBe(true);
+            });
+
+            it('should return true', function() {
+                expect(this.result).toBe(true);
+            });
+        });
+
+        describe('when there are no previous activation contexts', function() {
+            beforeEach(function() {
+                this.action.activationContexts = [];
+                this.result = this.action.deactivate(this.player);
+            });
+
+            it('should not unpay costs', function() {
+                expect(this.costSpy.unpay).not.toHaveBeenCalled();
+            });
+
+            it('should not deactivate the top context', function() {
+                expect(this.topContext.abilityDeactivated).toBeFalsy();
+            });
+
+            it('should return false', function() {
+                expect(this.result).toBe(false);
+            });
+        });
+
+        describe('when the cost cannot be unpaid', function() {
+            beforeEach(function() {
+                this.costSpy.canUnpay.and.returnValue(false);
+                this.result = this.action.deactivate(this.player);
+            });
+
+            it('should not unpay costs', function() {
+                expect(this.costSpy.unpay).not.toHaveBeenCalled();
+            });
+
+            it('should not deactivate the top context', function() {
+                expect(this.topContext.abilityDeactivated).toBeFalsy();
+            });
+
+            it('should return false', function() {
+                expect(this.result).toBe(false);
+            });
+        });
+
+        describe('when the player does not control the source card', function() {
+            beforeEach(function() {
+                this.result = this.action.deactivate({ player: 2 });
+            });
+
+            it('should not unpay costs', function() {
+                expect(this.costSpy.unpay).not.toHaveBeenCalled();
+            });
+
+            it('should not deactivate the top context', function() {
+                expect(this.topContext.abilityDeactivated).toBeFalsy();
+            });
+
+            it('should return false', function() {
+                expect(this.result).toBe(false);
+            });
+        });
+    });
+
     describe('registerEvents()', function() {
         describe('when there is no limit', function() {
             beforeEach(function() {

--- a/test/server/integration/reducers.spec.js
+++ b/test/server/integration/reducers.spec.js
@@ -1,0 +1,85 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('reducer cards', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck = this.buildDeck('stark', [
+                'Power Behind the Throne',
+                'Winterfell Steward', 'Heart Tree Grove', 'Bran Stark'
+            ]);
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.steward = this.player1.findCardByName('Winterfell Steward', 'hand');
+            this.grove = this.player1.findCardByName('Heart Tree Grove', 'hand');
+
+            this.player1.clickCard(this.steward);
+            this.player1.clickCard(this.grove);
+            this.completeSetup();
+
+            this.player1.selectPlot('Power Behind the Throne');
+            this.player2.selectPlot('Power Behind the Throne');
+            this.selectFirstPlayer(this.player1);
+
+            // Resolve plot order
+            this.player1.clickPrompt('player1');
+        });
+
+        it('should allow reducers to activate', function() {
+            this.player1.clickCard(this.grove);
+            this.player1.clickCard('Bran Stark', 'hand');
+
+            expect(this.player1Object.gold).toBe(2);
+        });
+
+        it('should allow reducers to stack', function() {
+            this.player1.clickCard(this.grove);
+            this.player1.clickCard(this.steward);
+            this.player1.clickCard('Bran Stark', 'hand');
+
+            expect(this.player1Object.gold).toBe(3);
+        });
+
+        it('should allow reducers to be undone by clicking twice', function() {
+            // Activate
+            this.player1.clickCard(this.grove);
+            // Deactivate
+            this.player1.clickCard(this.grove);
+            this.player1.clickCard('Bran Stark', 'hand');
+
+            expect(this.player1Object.gold).toBe(1);
+        });
+
+        it('should allow reducers to be redone after being undone', function() {
+            // Activate
+            this.player1.clickCard(this.grove);
+            // Deactivate
+            this.player1.clickCard(this.grove);
+            expect(this.grove.kneeled).toBe(false);
+            // Reactivate
+            this.player1.clickCard(this.grove);
+            expect(this.grove.kneeled).toBe(true);
+            this.player1.clickCard('Bran Stark', 'hand');
+
+            expect(this.player1Object.gold).toBe(2);
+        });
+
+        it('should allow the same reducer to activate twice if stood through other means', function() {
+            this.player1.clickCard(this.steward);
+
+            this.player1.clickMenu('Power Behind the Throne', 'Discard a stand token');
+            this.player1.clickCard(this.steward);
+
+            expect(this.steward.kneeled).toBe(false);
+
+            this.player1.clickCard(this.steward);
+
+            this.player1.clickCard('Bran Stark', 'hand');
+
+            expect(this.player1Object.gold).toBe(3);
+        });
+    });
+});


### PR DESCRIPTION
After converting reducer cards to the effects API, it was no longer
possible to cancel the ability by standing the card. Now, for any click
to activate action, clicking the card again will cancel the ability and
unpay the costs associated with the action. Currently this is only
implemented on the kneelSelf cost but can be extended to other costs in
the future should the need arise.

Fixes #648.