### PR TITLE
Add support for multiple actions per card.

### DIFF
--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -134,8 +134,8 @@ class CardAction extends BaseAbility {
         }
     }
 
-    getMenuItem() {
-        return { text: this.title, method: 'doAction', anyPlayer: !!this.anyPlayer };
+    getMenuItem(arg) {
+        return { text: this.title, method: 'doAction', anyPlayer: !!this.anyPlayer, arg: arg };
     }
 
     isClickToActivate() {

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -232,13 +232,9 @@ class DrawCard extends BaseCard {
     }
 
     getPlayActions() {
-        var playActions = StandardPlayActions.concat(this.abilities.playActions);
-
-        if(this.abilities.action && this.abilities.action.location !== 'play area') {
-            playActions = playActions.concat([this.abilities.action]);
-        }
-
-        return playActions;
+        return StandardPlayActions
+            .concat(this.abilities.playActions)
+            .concat(_.filter(this.abilities.actions, action => !action.allowMenu()));
     }
 
     play(player, isAmbush) {

--- a/test/server/card/basecard.spec.js
+++ b/test/server/card/basecard.spec.js
@@ -20,23 +20,30 @@ describe('BaseCard', function () {
     describe('doAction()', function() {
         describe('when there is no action for the card', function() {
             beforeEach(function() {
-                this.card.abilities.action = null;
+                this.card.abilities.actions = [];
             });
 
             it('does not crash', function() {
-                expect(() => this.card.doAction('player', 'arg')).not.toThrow();
+                expect(() => this.card.doAction('player', 0)).not.toThrow();
             });
         });
 
-        describe('when there is an action for the card', function() {
+        describe('when there are actions for the card', function() {
             beforeEach(function() {
-                this.actionSpy = jasmine.createSpyObj('action', ['execute']);
-                this.card.abilities.action = this.actionSpy;
+                this.actionSpy1 = jasmine.createSpyObj('action', ['execute']);
+                this.actionSpy2 = jasmine.createSpyObj('action', ['execute']);
+                this.card.abilities.actions = [this.actionSpy1, this.actionSpy2];
             });
 
-            it('should call execute on the action', function() {
-                this.card.doAction('player', 'arg');
-                expect(this.actionSpy.execute).toHaveBeenCalledWith('player', 'arg');
+            it('should call execute on the action with the appropriate index', function() {
+                this.card.doAction('player', 1);
+                expect(this.actionSpy2.execute).toHaveBeenCalledWith('player', 1);
+            });
+
+            it('should handle out of bounds indices', function() {
+                this.card.doAction('player', 3);
+                expect(this.actionSpy1.execute).not.toHaveBeenCalled();
+                expect(this.actionSpy2.execute).not.toHaveBeenCalled();
             });
         });
     });

--- a/test/server/card/cardaction.spec.js
+++ b/test/server/card/cardaction.spec.js
@@ -407,11 +407,11 @@ describe('CardAction', function () {
     describe('getMenuItem()', function() {
         beforeEach(function() {
             this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
-            this.menuItem = this.action.getMenuItem();
+            this.menuItem = this.action.getMenuItem('arg');
         });
 
         it('returns the menu item format', function() {
-            expect(this.menuItem).toEqual({ text: 'Do the thing', method: 'doAction', anyPlayer: false });
+            expect(this.menuItem).toEqual({ text: 'Do the thing', method: 'doAction', anyPlayer: false, arg: 'arg' });
         });
     });
 


### PR DESCRIPTION
Previously, the ability API assumed that cards would only have a
single action. With the upcoming card The New Gift, cards must now
support multiple actions. The API now supports this and distinguishes
between actions using their index as the argument for the card menu.