### PR TITLE
Enforce in-play and dead checks for put into play

### DIFF
--- a/server/game/ambushcardaction.js
+++ b/server/game/ambushcardaction.js
@@ -17,7 +17,7 @@ class AmbushCardAction extends BaseAbility {
             context.game.currentPhase === 'challenge' &&
             context.source.isAmbush() &&
             context.player.hand.contains(context.source) &&
-            !context.player.isCharacterDead(context.source) &&
+            context.player.canPutIntoPlay(context.source) &&
             context.source.getType() !== 'event'
         );
     }

--- a/server/game/cards/characters/01/euroncrowseye.js
+++ b/server/game/cards/characters/01/euroncrowseye.js
@@ -6,26 +6,19 @@ class EuronCrowsEye extends DrawCard {
             when: {
                 onPillage: (event, challenge, card) => challenge.winner === this.controller && card === this
             },
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    cardCondition: card => this.cardCondition(card),
-                    activePromptTitle: 'Select location',
-                    source: this,
-                    onSelect: (player, card) => this.onCardSelected(player, card)
-                });
+            target: {
+                activePromptTitle: 'Select location',
+                cardCondition: card => this.cardCondition(card)
+            },
+            handler: context => {
+                context.player.putIntoPlay(context.target);
+                this.game.addMessage('{0} uses {1} to put {2} into play from their opponent\'s discard pile', context.player, this, context.target);
             }
         });
     }
 
     cardCondition(card) {
-        return card.controller !== this.controller && card.getType() === 'location' && card.location === 'discard pile';
-    }
-
-    onCardSelected(player, card) {
-        player.putIntoPlay(card);
-        this.game.addMessage('{0} uses {1} to put {2} into play from their opponent\'s discard pile', player, this, card);
-
-        return true;
+        return card.controller !== this.controller && card.getType() === 'location' && card.location === 'discard pile' && this.controller.canPutIntoPlay(card);
     }
 }
 

--- a/server/game/marshalcardaction.js
+++ b/server/game/marshalcardaction.js
@@ -14,20 +14,13 @@ class MarshalCardAction extends BaseAbility {
 
     meetsRequirements(context) {
         var {game, player, source} = context;
-        var owner = source.owner;
 
         return (
             game.currentPhase === 'marshal' &&
             !source.cannotMarshal &&
             source.getType() !== 'event' &&
             player.isCardInMarshalLocation(source) &&
-            !player.isCharacterDead(source) &&
-            (
-                owner === player ||
-                !player.getDuplicateInPlay(source) &&
-                !owner.getDuplicateInPlay(source) &&
-                !owner.isCharacterDead(source)
-            )
+            player.canPutIntoPlay(source)
         );
     }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -377,7 +377,28 @@ class Player extends Spectator {
         return true;
     }
 
+    canPutIntoPlay(card) {
+        var owner = card.owner;
+        return (
+            (!this.isCharacterDead(card) || this.canResurrect(card)) &&
+            (
+                owner === this ||
+                !this.getDuplicateInPlay(card) &&
+                !owner.getDuplicateInPlay(card) &&
+                (!owner.isCharacterDead(card) || owner.canResurrect(card))
+            )
+        );
+    }
+
+    canResurrect(card) {
+        return this.deadPile.includes(card) && (!card.isUnique() || this.deadPile.filter(c => c.name === card.name).length === 1);
+    }
+
     putIntoPlay(card, playingType = 'play') {
+        if(!this.canPutIntoPlay(card)) {
+            return;
+        }
+
         var dupeCard = this.getDuplicateInPlay(card);
 
         if(card.getType() === 'attachment' && playingType !== 'setup' && !dupeCard) {

--- a/test/server/ambushcardaction.spec.js
+++ b/test/server/ambushcardaction.spec.js
@@ -8,7 +8,7 @@ const AmbushCardAction = require('../../server/game/ambushcardaction.js');
 describe('AmbushCardAction', function () {
     beforeEach(function() {
         this.gameSpy = jasmine.createSpyObj('game', ['addMessage', 'on', 'removeListener']);
-        this.playerSpy = jasmine.createSpyObj('player', ['isCharacterDead', 'putIntoPlay']);
+        this.playerSpy = jasmine.createSpyObj('player', ['canPutIntoPlay', 'putIntoPlay']);
         this.cardSpy = jasmine.createSpyObj('card', ['getType', 'isAmbush']);
         this.context = {
             costs: {},
@@ -23,6 +23,7 @@ describe('AmbushCardAction', function () {
         beforeEach(function() {
             this.gameSpy.currentPhase = 'challenge';
             this.playerSpy.hand = _([this.cardSpy]);
+            this.playerSpy.canPutIntoPlay.and.returnValue(true);
             this.cardSpy.getType.and.returnValue('character');
             this.cardSpy.isAmbush.and.returnValue(true);
         });
@@ -73,9 +74,9 @@ describe('AmbushCardAction', function () {
             });
         });
 
-        describe('when the character is dead', function() {
+        describe('when the card cannot be put into play', function() {
             beforeEach(function() {
-                this.playerSpy.isCharacterDead.and.returnValue(true);
+                this.playerSpy.canPutIntoPlay.and.returnValue(false);
             });
 
             it('should return false', function() {

--- a/test/server/cards/characters/01/01069-euroncrowseye.spec.js
+++ b/test/server/cards/characters/01/01069-euroncrowseye.spec.js
@@ -1,0 +1,96 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('Euron Crow\'s Eye', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck1 = this.buildDeck('greyjoy', [
+                'Sneak Attack',
+                'Euron Crow\'s Eye', 'The Arbor'
+            ]);
+            const deck2 = this.buildDeck('tyrell', [
+                'Sneak Attack',
+                'The Arbor', 'The Arbor'
+            ]);
+            this.player1.selectDeck(deck1);
+            this.player2.selectDeck(deck2);
+            this.startGame();
+            this.keepStartingHands();
+            this.player1.clickCard('Euron Crow\'s Eye', 'hand');
+            this.completeSetup();
+            this.player1.selectPlot('Sneak Attack');
+            this.player2.selectPlot('Sneak Attack');
+            this.selectFirstPlayer(this.player1);
+
+            this.ourArbor = this.player1.findCardByName('The Arbor', 'hand');
+            [this.theirArbor1, this.theirArbor2] = this.player2.filterCardsByName('The Arbor', 'hand');
+        });
+
+        describe('when there are no locations in discard', function() {
+            beforeEach(function() {
+                this.completeMarshalPhase();
+                this.unopposedChallenge(this.player1, 'power', 'Euron Crow\'s Eye');
+                this.player1.clickPrompt('Apply Claim');
+            });
+
+            it('should not prompt', function() {
+                expect(this.player1).not.toHavePrompt('Trigger Euron Crow\'s Eye?');
+            });
+        });
+
+        describe('when a locations would end up in discard', function() {
+            beforeEach(function() {
+                // Move one of the Arbors back to draw
+                this.player2Object.moveCard(this.theirArbor2, 'draw deck');
+            });
+
+            describe('and the location is not in play already', function() {
+                beforeEach(function() {
+                    this.completeMarshalPhase();
+                    this.unopposedChallenge(this.player1, 'power', 'Euron Crow\'s Eye');
+                    this.player1.clickPrompt('Apply Claim');
+                });
+
+                it('should prompt', function() {
+                    expect(this.player1).toHavePrompt('Trigger Euron Crow\'s Eye?');
+                });
+
+                it('should allow a location be put into play', function() {
+                    this.player1.clickPrompt('Yes');
+                    this.player1.clickCard(this.theirArbor2);
+
+                    expect(this.theirArbor2.location).toBe('play area');
+                    expect(this.theirArbor2.controller).toBe(this.player1Object);
+                });
+            });
+
+            describe('and the location is in play for the opponent', function() {
+                beforeEach(function() {
+                    this.player1.clickPrompt('Done');
+                    this.player2.clickCard(this.theirArbor1);
+                    this.player2.clickPrompt('Done');
+                    this.unopposedChallenge(this.player1, 'power', 'Euron Crow\'s Eye');
+                    this.player1.clickPrompt('Apply Claim');
+                });
+
+                it('should not prompt', function() {
+                    expect(this.player1).not.toHavePrompt('Trigger Euron Crow\'s Eye?');
+                });
+            });
+
+            describe('and the location is in play for the current player', function() {
+                beforeEach(function() {
+                    this.player1.clickCard(this.ourArbor);
+                    this.player1.clickPrompt('Done');
+                    this.player2.clickPrompt('Done');
+                    this.unopposedChallenge(this.player1, 'power', 'Euron Crow\'s Eye');
+                    this.player1.clickPrompt('Apply Claim');
+                });
+
+                it('should not prompt', function() {
+                    expect(this.player1).not.toHavePrompt('Trigger Euron Crow\'s Eye?');
+                });
+            });
+        });
+    });
+});

--- a/test/server/marshalcardaction.spec.js
+++ b/test/server/marshalcardaction.spec.js
@@ -6,8 +6,7 @@ const MarshalCardAction = require('../../server/game/marshalcardaction.js');
 describe('MarshalCardAction', function () {
     beforeEach(function() {
         this.gameSpy = jasmine.createSpyObj('game', ['addMessage', 'on', 'removeListener']);
-        this.playerSpy = jasmine.createSpyObj('player', ['getDuplicateInPlay', 'isCardInMarshalLocation', 'isCharacterDead', 'putIntoPlay']);
-        this.opponentSpy = jasmine.createSpyObj('opponentPlayer', ['getDuplicateInPlay', 'isCharacterDead']);
+        this.playerSpy = jasmine.createSpyObj('player', ['canPutIntoPlay', 'isCardInMarshalLocation', 'putIntoPlay']);
         this.cardSpy = jasmine.createSpyObj('card', ['getType']);
         this.cardSpy.controller = this.playerSpy;
         this.cardSpy.owner = this.playerSpy;
@@ -23,6 +22,7 @@ describe('MarshalCardAction', function () {
     describe('meetsRequirements()', function() {
         beforeEach(function() {
             this.gameSpy.currentPhase = 'marshal';
+            this.playerSpy.canPutIntoPlay.and.returnValue(true);
             this.playerSpy.isCardInMarshalLocation.and.returnValue(true);
             this.cardSpy.getType.and.returnValue('character');
         });
@@ -73,65 +73,13 @@ describe('MarshalCardAction', function () {
             });
         });
 
-        describe('when the player is the owner of the card', function() {
+        describe('when the card cannot be put into play', function() {
             beforeEach(function() {
-                this.cardSpy.owner = this.playerSpy;
+                this.playerSpy.canPutIntoPlay.and.returnValue(false);
             });
 
-            describe('and the character is already in play', function() {
-                beforeEach(function() {
-                    this.playerSpy.getDuplicateInPlay.and.returnValue({ foo: 'bar' });
-                });
-
-                it('should return true', function() {
-                    expect(this.action.meetsRequirements(this.context)).toBe(true);
-                });
-            });
-
-            describe('and the character is dead', function() {
-                beforeEach(function() {
-                    this.playerSpy.isCharacterDead.and.returnValue(true);
-                });
-
-                it('should return false', function() {
-                    expect(this.action.meetsRequirements(this.context)).toBe(false);
-                });
-            });
-        });
-
-        describe('when the player is not the owner of the card', function() {
-            beforeEach(function() {
-                this.cardSpy.owner = this.opponentSpy;
-            });
-
-            describe('and the character is already in play', function() {
-                beforeEach(function() {
-                    this.playerSpy.getDuplicateInPlay.and.returnValue({ foo: 'bar' });
-                });
-
-                it('should return false', function() {
-                    expect(this.action.meetsRequirements(this.context)).toBe(false);
-                });
-            });
-
-            describe('and the character is in play for the owner', function() {
-                beforeEach(function() {
-                    this.opponentSpy.getDuplicateInPlay.and.returnValue({ foo: 'bar' });
-                });
-
-                it('should return false', function() {
-                    expect(this.action.meetsRequirements(this.context)).toBe(false);
-                });
-            });
-
-            describe('and the character is dead for the owner', function() {
-                beforeEach(function() {
-                    this.opponentSpy.isCharacterDead.and.returnValue(true);
-                });
-
-                it('should return false', function() {
-                    expect(this.action.meetsRequirements(this.context)).toBe(false);
-                });
+            it('should return false', function() {
+                expect(this.action.meetsRequirements(this.context)).toBe(false);
             });
         });
     });


### PR DESCRIPTION
Previously, the checks when putting into play cards from the opponent that:

1. Neither player already had the card in play if unique
2. Neither player had the card in their dead pile if unique (unless that card was the only copy)

were only being enforced when marshaling. Now `Player.canPutIntoPlay` is provided and is automatically checked when `Player.putIntoPlay` is called. Each card can also use it when searching for valid put-into-play targets.

Fixes #669.