### PR TITLE
Implement Lingering Venom

### DIFF
--- a/less/cards.less
+++ b/less/cards.less
@@ -233,6 +233,10 @@
   background-color: rgba(162, 255, 81, 0.85);
 }
 
+.venom {
+  background-color: rgba(29, 145, 163, 0.85);
+}
+
 .newintrigue {
   span {
     display: none;

--- a/server/game/cards/attachments/07/lingeringvenom.js
+++ b/server/game/cards/attachments/07/lingeringvenom.js
@@ -1,0 +1,32 @@
+const DrawCard = require('../../../drawcard.js');
+
+class LingeringVenom extends DrawCard {
+    setupCardAbilities() {
+        this.reaction({
+            when: {
+                afterChallenge: (event, challenge) => challenge.loser === this.controller
+            },
+            handler: () => {
+                this.parent.addToken('venom', 1);
+                this.game.addMessage('{0} uses {1} to place a venom token on {1}', this.controller, this);
+
+                if(this.parent.getStrength() <= this.parent.tokens['venom']) {
+                    this.parent.controller.killCharacter(this.parent);
+                    this.game.addMessage('{0} uses {1} to kill {2}', this.controller, this, this.parent);
+                }
+            }
+        });
+    }
+
+    canAttach(player, card) {
+        if(card.getType() !== 'character') {
+            return false;
+        }
+
+        return super.canAttach(player, card);
+    }
+}
+
+LingeringVenom.code = '07032';
+
+module.exports = LingeringVenom;

--- a/server/game/cards/attachments/07/lingeringvenom.js
+++ b/server/game/cards/attachments/07/lingeringvenom.js
@@ -7,10 +7,10 @@ class LingeringVenom extends DrawCard {
                 afterChallenge: (event, challenge) => challenge.loser === this.controller
             },
             handler: () => {
-                this.parent.addToken('venom', 1);
+                this.addToken('venom', 1);
                 this.game.addMessage('{0} uses {1} to place a venom token on {1}', this.controller, this);
 
-                if(this.parent.getStrength() <= this.parent.tokens['venom']) {
+                if(this.parent.getStrength() <= this.tokens['venom']) {
                     this.parent.controller.killCharacter(this.parent);
                     this.game.addMessage('{0} uses {1} to kill {2}', this.controller, this, this.parent);
                 }

--- a/server/game/chatcommands.js
+++ b/server/game/chatcommands.js
@@ -35,7 +35,8 @@ class ChatCommands {
             'poison',
             'betrayal',
             'vengeance',
-            'ear'
+            'ear',
+            'venom'
         ];
     }
 


### PR DESCRIPTION
<strike>I'm putting the tokens on the parent card for now. This causes issues when: 

1. The attachment is discarded, which leaves the now redundant tokens. This could further impact gamestate whenever a new Lingering Venom is attached to the same character later. 
2. Lingering Venom gets moved to a different character, which should move the venom tokens with it (but doesn't now).

Both cases are easily solvable with the /token command until we deal putting tokens/markers on attachment cards.</strike>

Put the tokens back on the attachment.