### PR TITLE
Add card name to ability prompts.

### DIFF
--- a/client/GameBoard.jsx
+++ b/client/GameBoard.jsx
@@ -397,7 +397,7 @@ export class InnerGameBoard extends React.Component {
                             <div className='middle-right'>
                                 <div className='inset-pane'>
                                     <div className={'phase-indicator ' + thisPlayer.phase}>{thisPlayer.phase} phase</div>
-                                    <MenuPane title={thisPlayer.menuTitle} buttons={thisPlayer.buttons} onButtonClick={this.onCommand}
+                                    <MenuPane title={thisPlayer.menuTitle} buttons={thisPlayer.buttons} source={thisPlayer.menuSource} onButtonClick={this.onCommand}
                                                 onMouseOver={this.onMouseOver} onMouseOut={this.onMouseOut} />
                                 </div>
                                 <div className='schemes-pane' />

--- a/client/GameComponents/MenuPane.jsx
+++ b/client/GameComponents/MenuPane.jsx
@@ -47,10 +47,17 @@ class MenuPane extends React.Component {
     }
 
     render() {
-        return (<div className='menu-pane'>
-            <div className='panel'>
-                <h4>{this.props.title}</h4>
-                {this.getButtons()}
+        let sourceTitle;
+        if(this.props.source) {
+            sourceTitle = (<div className='menu-pane-source'>{this.props.source.name}</div>);
+        }
+        return (<div>
+            {sourceTitle}
+            <div className='menu-pane'>
+                <div className='panel'>
+                    <h4>{this.props.title}</h4>
+                    {this.getButtons()}
+                </div>
             </div>
         </div>);
     }
@@ -63,6 +70,7 @@ MenuPane.propTypes = {
     onMouseOut: React.PropTypes.func,
     onMouseOver: React.PropTypes.func,
     socket: React.PropTypes.object,
+    source: React.PropTypes.object,
     title: React.PropTypes.string
 };
 

--- a/less/gameboard.less
+++ b/less/gameboard.less
@@ -218,6 +218,15 @@
   flex-direction: column;
 }
 
+.menu-pane-source {
+  background: rgba(160, 160, 160, 0.25);
+  font-size: 14px;
+  font-weight: normal;
+  margin: 0 5px;
+  padding: 4px;
+  text-align: center;
+}
+
 .menu-pane {
   text-align: center;
   z-index: @layer-prompt;

--- a/server/game/gamesteps/menuprompt.js
+++ b/server/game/gamesteps/menuprompt.js
@@ -29,7 +29,7 @@ class MenuPrompt extends UiPrompt {
     }
 
     activePrompt() {
-        return this.properties.activePrompt;
+        return _.extend({ source: this.properties.source }, this.properties.activePrompt);
     }
 
     waitingPrompt() {

--- a/server/game/gamesteps/selectcardprompt.js
+++ b/server/game/gamesteps/selectcardprompt.js
@@ -97,7 +97,8 @@ class SelectCardPrompt extends UiPrompt {
             menuTitle: this.properties.activePromptTitle || this.defaultActivePromptTitle(),
             buttons: this.properties.additionalButtons.concat([
                 { text: 'Done', arg: 'done' }
-            ])
+            ]),
+            source: this.properties.source
         };
     }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -1041,6 +1041,7 @@ class Player extends Spectator {
     setPrompt(prompt) {
         this.selectCard = prompt.selectCard || false;
         this.menuTitle = prompt.menuTitle || '';
+        this.menuSource = prompt.source;
         this.buttons = prompt.buttons || [];
     }
 
@@ -1072,6 +1073,7 @@ class Player extends Spectator {
             hand: this.getSummaryForCardList(this.hand, isActivePlayer, true),
             id: this.id,
             left: this.left,
+            menuSource: this.menuSource ? this.menuSource.getSummary(true) : undefined,
             menuTitle: isActivePlayer ? this.menuTitle : undefined,
             numDrawCards: this.drawDeck.size(),
             name: this.name,


### PR DESCRIPTION
Now when a character ability triggers a prompt, the name of the card
will be displayed in the menu prompt. This should help reduce confusion
during nested ability windows where a new window is opened and resolved
and then it returns to the original window.