### PR TITLE
Only allow targeting API to target draw cards.

### DIFF
--- a/server/game/baseability.js
+++ b/server/game/baseability.js
@@ -111,8 +111,15 @@ class BaseAbility {
      * @returns {Boolean}
      */
     canResolveTargets(context) {
+        const ValidTypes = ['character', 'attachment', 'location', 'event'];
         return _.all(this.targets, target => {
-            return context.game.allCards.any(card => target.cardCondition(card));
+            return context.game.allCards.any(card => {
+                if(!ValidTypes.includes(card.getType())) {
+                    return false;
+                }
+
+                return target.cardCondition(card);
+            });
         });
     }
 

--- a/server/game/cards/characters/03/houseflorentknight.js
+++ b/server/game/cards/characters/03/houseflorentknight.js
@@ -21,20 +21,9 @@ class HouseFlorentKnight extends DrawCard {
     }
 
     getLowestStrInPlay() {
-        var currentMin;
-        _.each(this.game.getPlayers(), (player) => {
-            var playerMin = player.cardsInPlay.min(card => {
-                if(card.getType() === 'character') {
-                    return card.getStrength();
-                }
-            }).getStrength();
-
-            if(!currentMin || playerMin < currentMin) {
-                currentMin = playerMin;
-            }
-        });
-
-        return currentMin;
+        let charactersInPlay = this.game.findAnyCardsInPlay(card => card.getType() === 'character');
+        let strengths = _.map(charactersInPlay, card => card.getStrength());
+        return _.min(strengths);
     }
 }
 HouseFlorentKnight.code = '03037';

--- a/test/server/cards/characters/03/03037-houseflorentknight.spec.js
+++ b/test/server/cards/characters/03/03037-houseflorentknight.spec.js
@@ -1,0 +1,56 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('House Florent Knight', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck = this.buildDeck('tyrell', [
+                'Trading with the Pentoshi',
+                'House Florent Knight', 'Hedge Knight'
+            ]);
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.keepStartingHands();
+            this.completeSetup();
+            this.player1.selectPlot('Trading with the Pentoshi');
+            this.player2.selectPlot('Trading with the Pentoshi');
+
+            this.florentKnight = this.player2.findCardByName('House Florent Knight', 'hand');
+        });
+
+        describe('when there is a lower strength character out', function() {
+            beforeEach(function() {
+                this.selectFirstPlayer(this.player1);
+                this.player1.clickPrompt('player1');
+
+                this.hedgeKnight = this.player1.findCardByName('Hedge Knight', 'hand');
+
+                this.player1.clickCard(this.hedgeKnight);
+                this.player1.clickPrompt('Done');
+
+                this.player2.clickCard(this.florentKnight);
+            });
+
+            it('should allow that character to be discarded', function() {
+                this.player2.clickCard(this.hedgeKnight);
+
+                expect(this.hedgeKnight.location).toBe('discard pile');
+            });
+        });
+
+        describe('when House Florent Knight would be the lowest strength', function() {
+            beforeEach(function() {
+                this.selectFirstPlayer(this.player2);
+                this.player2.clickPrompt('player2');
+
+                this.player2.clickCard(this.florentKnight);
+            });
+
+            it('should require HFK to be discarded', function() {
+                this.player2.clickCard(this.florentKnight);
+                expect(this.florentKnight.location).toBe('discard pile');
+            });
+        });
+    });
+});


### PR DESCRIPTION
Previously the targeting API was checking all cards, including plots,
agendas and factions, for whether they were valid targets. This made it
incredibly easy to generate an error by providing a card condition that
needed a method only found on `DrawCard`

Fixes #690.
Fixes #691.