### PR TITLE
Restrict Aeron's resurrection to current player.

### DIFF
--- a/server/game/cards/characters/01/aerondamphair.js
+++ b/server/game/cards/characters/01/aerondamphair.js
@@ -6,41 +6,25 @@ class AeronDamphair extends DrawCard {
             when: {
                 onDominanceDetermined: (event, winner) => this.controller === winner
             },
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    cardCondition: card => this.cardCondition(card),
-                    activePromptTitle: 'Select character',
-                    source: this,
-                    onSelect: (player, card) => this.onCardSelected(player, card)
-                });
+            target: {
+                activePromptTitle: 'Select character',
+                cardCondition: card => this.cardCondition(card)
+            },
+            handler: context => {
+                context.player.putIntoPlay(context.target);
+                this.game.addMessage('{0} uses {1} to put {2} into play from their dead pile', context.player, this, context.target);
             }
         });
     }
 
     cardCondition(card) {
-        var mainCondition = card.getType() === 'character' && card.location === 'dead pile' && card.hasTrait('Ironborn');
-
-        if(!mainCondition || !card.isUnique()) {
-            return mainCondition;
-        }
-
-        var sameCardsInDeadPile = this.controller.deadPile.filter(c => {
-            return c.name === card.name;
-        });
-
-        if(sameCardsInDeadPile.length > 1) {
-            return false;
-        }
-
-        return mainCondition;
-    }
-
-    onCardSelected(player, card) {
-        player.putIntoPlay(card);
-
-        this.game.addMessage('{0} uses {1} to put {2} into play from their dead pile', player, this, card);
-
-        return true;
+        return (
+            card.controller === this.controller &&
+            card.getType() === 'character' &&
+            card.location === 'dead pile' &&
+            card.hasTrait('Ironborn') &&
+            this.controller.canPutIntoPlay(card)
+        );
     }
 }
 


### PR DESCRIPTION
Previously, Core Aeron was able to put characters into play from the
opponent's dead pile. Now it is properly restricted to the dead pile
owned by Aeron's current controller. Additionally, it will no longer
trigger if there are no characters to put into play.

Fixes #660.