### PR TITLE
Improve recalculation of effects

### DIFF
--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -53,6 +53,7 @@ class Effect {
         this.recalculateWhen = properties.recalculateWhen || [];
         this.isConditional = !!properties.condition;
         this.isStateDependent = properties.condition || this.effect.isStateDependent;
+        this.currentCondition = false;
     }
 
     buildEffect(effect) {
@@ -63,8 +64,13 @@ class Effect {
         return effect;
     }
 
+    checkCondition() {
+        this.currentCondition = this.condition();
+        return this.currentCondition;
+    }
+
     addTargets(targets) {
-        if(!this.condition()) {
+        if(!this.checkCondition()) {
             return;
         }
 
@@ -167,9 +173,21 @@ class Effect {
         }
 
         if(this.isConditional) {
-            this.cancel();
-            this.addTargets(newTargets);
-        } else if(this.effect.isStateDependent) {
+            let oldCondition = this.currentCondition;
+            let newCondition = this.checkCondition();
+
+            if(oldCondition && !newCondition) {
+                this.cancel();
+                return;
+            }
+
+            if(!oldCondition && newCondition) {
+                this.addTargets(newTargets);
+                return;
+            }
+        }
+
+        if(this.effect.isStateDependent) {
             let reapplyFunc = this.createReapplyFunc();
             _.each(this.targets, target => reapplyFunc(target));
         }

--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -170,11 +170,20 @@ class Effect {
             this.cancel();
             this.addTargets(newTargets);
         } else if(this.effect.isStateDependent) {
-            _.each(this.targets, target => {
-                this.effect.unapply(target, this.context);
-                this.effect.apply(target, this.context);
-            });
+            let reapplyFunc = this.createReapplyFunc();
+            _.each(this.targets, target => reapplyFunc(target));
         }
+    }
+
+    createReapplyFunc() {
+        if(this.effect.reapply) {
+            return target => this.effect.reapply(target, this.context);
+        }
+
+        return target => {
+            this.effect.unapply(target, this.context);
+            this.effect.apply(target, this.context);
+        };
     }
 }
 

--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -50,7 +50,11 @@ class EffectEngine {
     onCardTakenControl(e, card) {
         _.each(this.effects, effect => {
             if(effect.duration === 'persistent' && effect.source === card) {
-                effect.reapply(this.getTargets());
+                // Since the controllers have changed, explicitly cancel the
+                // effect for existing targets and then recalculate effects for
+                // the new controller from scratch.
+                effect.cancel();
+                effect.addTargets(this.getTargets());
             }
         });
     }

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -6,14 +6,25 @@ const MarshalLocation = require('./marshallocation.js');
 
 const Effects = {
     all: function(effects) {
+        let stateDependentEffects = _.filter(effects, effect => effect.isStateDependent);
         return {
             apply: function(card, context) {
                 _.each(effects, effect => effect.apply(card, context));
             },
+            reapply: function(card, context) {
+                _.each(stateDependentEffects, effect => {
+                    if(effect.reapply) {
+                        effect.reapply(card, context);
+                    } else {
+                        effect.unapply(card, context);
+                        effect.apply(card, context);
+                    }
+                });
+            },
             unapply: function(card, context) {
                 _.each(effects, effect => effect.unapply(card, context));
             },
-            isStateDependent: _.any(effects, effect => !!effect.isStateDependent)
+            isStateDependent: (stateDependentEffects.length !== 0)
         };
     },
     allowAsAttacker: function(value) {
@@ -148,6 +159,12 @@ const Effects = {
                 context.dynamicStrength = context.dynamicStrength || {};
                 context.dynamicStrength[card.uuid] = calculate(card, context) || 0;
                 card.strengthModifier += context.dynamicStrength[card.uuid];
+            },
+            reapply: function(card, context) {
+                let currentStrength = context.dynamicStrength[card.uuid];
+                let newStrength = calculate(card, context) || 0;
+                context.dynamicStrength[card.uuid] = newStrength;
+                card.strengthModifier += newStrength - currentStrength;
             },
             unapply: function(card, context) {
                 card.strengthModifier -= context.dynamicStrength[card.uuid];
@@ -553,6 +570,12 @@ const Effects = {
                 context.dynamicUsedPlots = context.dynamicUsedPlots || {};
                 context.dynamicUsedPlots[player.name] = calculate(player, context) || 0;
                 player.modifyUsedPlots(context.dynamicUsedPlots[player.name]);
+            },
+            reapply: function(player, context) {
+                let oldValue = context.dynamicUsedPlots[player.name];
+                let newValue = calculate(player, context) || 0;
+                context.dynamicUsedPlots[player.name] = newValue;
+                player.modifyUsedPlots(newValue - oldValue);
             },
             unapply: function(player, context) {
                 player.modifyUsedPlots(-context.dynamicUsedPlots[player.name]);

--- a/test/server/effect.spec.js
+++ b/test/server/effect.spec.js
@@ -573,20 +573,47 @@ describe('Effect', function () {
             describe('when the effect is active', function() {
                 beforeEach(function() {
                     this.effect.active = true;
-
-                    this.effect.reapply(this.newTargets);
                 });
 
-                it('should unapply the effect for existing targets', function() {
-                    expect(this.properties.effect.unapply).toHaveBeenCalledWith(this.target, jasmine.any(Object));
+                describe('and the effect has a reapply method', function() {
+                    beforeEach(function() {
+                        this.properties.effect.reapply = jasmine.createSpy('reapply');
+                        this.effect.reapply(this.newTargets);
+                    });
+
+                    it('should reapply the effect for existing targets', function() {
+                        expect(this.properties.effect.reapply).toHaveBeenCalledWith(this.target, jasmine.any(Object));
+                    });
+
+                    it('should not unapply the effect for existing targets', function() {
+                        expect(this.properties.effect.unapply).not.toHaveBeenCalledWith(this.target, jasmine.any(Object));
+                    });
+
+                    it('should not apply the effect for existing targets', function() {
+                        expect(this.properties.effect.apply).not.toHaveBeenCalledWith(this.target, jasmine.any(Object));
+                    });
+
+                    it('should not apply the effect to new targets', function() {
+                        expect(this.properties.effect.apply).not.toHaveBeenCalledWith(this.newTarget, jasmine.any(Object));
+                    });
                 });
 
-                it('should apply the effect for existing targets', function() {
-                    expect(this.properties.effect.apply).toHaveBeenCalledWith(this.target, jasmine.any(Object));
-                });
+                describe('and the effect does not have a reapply method', function() {
+                    beforeEach(function() {
+                        this.effect.reapply(this.newTargets);
+                    });
 
-                it('should not apply the effect to new targets', function() {
-                    expect(this.properties.effect.apply).not.toHaveBeenCalledWith(this.newTarget, jasmine.any(Object));
+                    it('should unapply the effect for existing targets', function() {
+                        expect(this.properties.effect.unapply).toHaveBeenCalledWith(this.target, jasmine.any(Object));
+                    });
+
+                    it('should apply the effect for existing targets', function() {
+                        expect(this.properties.effect.apply).toHaveBeenCalledWith(this.target, jasmine.any(Object));
+                    });
+
+                    it('should not apply the effect to new targets', function() {
+                        expect(this.properties.effect.apply).not.toHaveBeenCalledWith(this.newTarget, jasmine.any(Object));
+                    });
                 });
             });
         });

--- a/test/server/effects/dynamicstrength.spec.js
+++ b/test/server/effects/dynamicstrength.spec.js
@@ -34,6 +34,19 @@ describe('Effects.dynamicStrength', function() {
         });
     });
 
+    describe('reapply()', function() {
+        beforeEach(function() {
+            this.calculateMethod.and.returnValue(3);
+            this.effect.apply(this.card1, this.context);
+            this.calculateMethod.and.returnValue(4);
+            this.effect.reapply(this.card1, this.context);
+        });
+
+        it('should increase the strength by the difference', function() {
+            expect(this.card1.strengthModifier).toBe(4);
+        });
+    });
+
     describe('unapply()', function() {
         beforeEach(function() {
             this.calculateMethod.and.returnValue(3);


### PR DESCRIPTION
* Allows effects to implement a `reapply` method to directly update their effect rather than unapplying and then reapplying it from scratch.
* Conditional effects are now only recalculated when the result of the `condition` method changes. If a condition goes from `true` to `false`, it is unapplied. If it goes from `false` to `true`, it's applied to all matching targets.

This should get rid of all effect churn I'm aware of and allows Randyll Tarly to be implemented without false positive triggers.