### PR TITLE
Fix challenge-related conditional effects.

### DIFF
--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -74,7 +74,9 @@ class Effect {
             return;
         }
 
-        _.each(targets, target => {
+        let newTargets = _.difference(targets, this.targets);
+
+        _.each(newTargets, target => {
             if(this.isValidTarget(target)) {
                 this.targets.push(target);
                 if(this.active) {
@@ -104,10 +106,6 @@ class Effect {
         }
 
         if(!this.match(target, this.context)) {
-            return false;
-        }
-
-        if(this.targets.includes(target)) {
             return false;
         }
 
@@ -181,9 +179,12 @@ class Effect {
                 return;
             }
 
-            if(!oldCondition && newCondition) {
+            if(newCondition) {
+                let invalidTargets = _.filter(this.targets, target => !this.isValidTarget(target));
+                _.each(invalidTargets, target => {
+                    this.removeTarget(target);
+                });
                 this.addTargets(newTargets);
-                return;
             }
         }
 

--- a/test/server/cards/agendas/02060-thelordofthecrossing.spec.js
+++ b/test/server/cards/agendas/02060-thelordofthecrossing.spec.js
@@ -1,0 +1,117 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('The Lord of the Crossing', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck = this.buildDeck('baratheon', [
+                'The Lord of the Crossing',
+                'A Noble Cause',
+                'Selyse Baratheon', 'Bastard in Hiding', 'Fiery Followers'
+            ]);
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.selyse = this.player1.findCardByName('Selyse Baratheon', 'hand');
+            this.bastard = this.player1.findCardByName('Bastard in Hiding', 'hand');
+            this.followers = this.player1.findCardByName('Fiery Followers', 'hand');
+
+            this.player1.clickCard(this.selyse);
+            this.player1.clickCard(this.bastard);
+            this.player1.clickCard(this.followers);
+
+            this.completeSetup();
+
+            this.player1.selectPlot('A Noble Cause');
+            this.player2.selectPlot('A Noble Cause');
+            this.selectFirstPlayer(this.player1);
+
+            this.completeMarshalPhase();
+        });
+
+        describe('on challenge 1', function() {
+            beforeEach(function() {
+                this.skipActionWindow();
+
+                this.player1.clickPrompt('Military');
+                this.player1.clickCard(this.followers);
+                this.player1.clickPrompt('Done');
+            });
+
+            it('should reduce the strength of attacking characters by 1', function() {
+                expect(this.followers.getStrength()).toBe(1);
+            });
+        });
+
+        describe('on challenge 2', function() {
+            beforeEach(function() {
+                this.skipActionWindow();
+                this.player1.clickPrompt('Military');
+                this.player1.clickCard(this.followers);
+                this.player1.clickPrompt('Done');
+                this.skipActionWindow();
+                this.player2.clickPrompt('Done');
+                this.skipActionWindow();
+                this.skipActionWindow();
+                this.player1.clickPrompt('Apply Claim');
+                this.player2.clickPrompt('Done');
+
+                this.player1.clickPrompt('Intrigue');
+                this.player1.clickCard(this.selyse);
+                this.player1.clickPrompt('Done');
+            });
+
+            it('should not modify the strength of attacking characters', function() {
+                expect(this.selyse.getStrength()).toBe(2);
+            });
+        });
+
+        describe('on challenge 3', function() {
+            beforeEach(function() {
+                this.skipActionWindow();
+                this.player1.clickPrompt('Military');
+                this.player1.clickCard(this.followers);
+                this.player1.clickPrompt('Done');
+                this.skipActionWindow();
+                this.player2.clickPrompt('Done');
+                this.skipActionWindow();
+                this.skipActionWindow();
+                this.player1.clickPrompt('Apply Claim');
+                this.player2.clickPrompt('Done');
+
+                this.player1.clickPrompt('Intrigue');
+                this.player1.clickCard(this.selyse);
+                this.player1.clickPrompt('Done');
+                this.skipActionWindow();
+                this.player2.clickPrompt('Done');
+                this.skipActionWindow();
+                this.skipActionWindow();
+                this.player1.clickPrompt('Apply Claim');
+
+                this.player1.clickPrompt('Power');
+                this.player1.clickCard(this.bastard);
+                this.player1.clickPrompt('Done');
+            });
+
+            it('should increase the strength of attacking characters by 2', function() {
+                expect(this.bastard.getStrength()).toBe(4);
+            });
+
+            describe('when the player wins', function() {
+                beforeEach(function() {
+                    this.skipActionWindow();
+                    this.player2.clickPrompt('Done');
+                    this.skipActionWindow();
+                    this.skipActionWindow();
+                });
+
+                it('should grant power when the won', function() {
+                    // 3 from unopposed challenges, 1 from LotC
+                    expect(this.player1Object.getTotalPower()).toBe(4);
+                });
+            });
+        });
+    });
+});

--- a/test/server/effect.spec.js
+++ b/test/server/effect.spec.js
@@ -640,23 +640,31 @@ describe('Effect', function () {
                 });
             });
 
-            describe('when the condition goes from false to true', function() {
+            describe('when the condition is true', function() {
                 beforeEach(function() {
-                    this.effect.targets = [];
+                    this.matchingTarget = { target: 3, location: 'play area' };
+                    this.effect.targets = [this.target, this.matchingTarget];
                     this.effect.active = true;
                     this.effect.currentCondition = false;
                     this.effect.condition.and.returnValue(true);
+                    this.properties.match.and.callFake(card => card !== this.target);
                     this.effect.reapply(this.newTargets);
                 });
 
                 it('should apply the effect to new targets', function() {
-                    expect(this.properties.effect.apply).toHaveBeenCalledWith(this.target, jasmine.any(Object));
                     expect(this.properties.effect.apply).toHaveBeenCalledWith(this.newTarget, jasmine.any(Object));
                 });
 
+                it('should not unapply the effect from targets that still match', function() {
+                    expect(this.properties.effect.unapply).not.toHaveBeenCalledWith(this.matchingTarget, jasmine.any(Object));
+                });
+
+                it('should unapply the effect from targets that no longer match', function() {
+                    expect(this.properties.effect.unapply).toHaveBeenCalledWith(this.target, jasmine.any(Object));
+                });
+
                 it('should update the target list', function() {
-                    expect(this.effect.targets).toContain(this.target);
-                    expect(this.effect.targets).toContain(this.newTarget);
+                    expect(this.effect.targets).toEqual([this.matchingTarget, this.newTarget]);
                 });
             });
 
@@ -686,8 +694,8 @@ describe('Effect', function () {
                 beforeEach(function() {
                     this.effect.targets = [this.target];
                     this.effect.active = true;
-                    this.effect.currentCondition = true;
-                    this.effect.condition.and.returnValue(true);
+                    this.effect.currentCondition = false;
+                    this.effect.condition.and.returnValue(false);
                     this.effect.reapply(this.newTargets);
                 });
 


### PR DESCRIPTION
The previous change to how conditional effects are recalculated broke
effects such as Lords of the Crossing, whose targets can change while
the condition value remains the same. Now the target list is updated as
new targets come in, and targets that are no longer matching are
removed.