### PR TITLE
Fix effects when condition changes on enter play.

### DIFF
--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -53,7 +53,6 @@ class Effect {
         this.recalculateWhen = properties.recalculateWhen || [];
         this.isConditional = !!properties.condition;
         this.isStateDependent = properties.condition || this.effect.isStateDependent;
-        this.currentCondition = false;
     }
 
     buildEffect(effect) {
@@ -64,13 +63,8 @@ class Effect {
         return effect;
     }
 
-    checkCondition() {
-        this.currentCondition = this.condition();
-        return this.currentCondition;
-    }
-
     addTargets(targets) {
-        if(!this.checkCondition()) {
+        if(!this.condition()) {
             return;
         }
 
@@ -171,10 +165,9 @@ class Effect {
         }
 
         if(this.isConditional) {
-            let oldCondition = this.currentCondition;
-            let newCondition = this.checkCondition();
+            let newCondition = this.condition();
 
-            if(oldCondition && !newCondition) {
+            if(!newCondition) {
                 this.cancel();
                 return;
             }

--- a/test/server/cards/plots/03/03050-asongofsummer.spec.js
+++ b/test/server/cards/plots/03/03050-asongofsummer.spec.js
@@ -1,0 +1,45 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('A Song of Summer', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck = this.buildDeck('lannister', [
+                'A Song of Summer', 'Winter Festival',
+                'Ser Jaime Lannister (Core)'
+            ]);
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.jaime = this.player1.findCardByName('Ser Jaime Lannister', 'hand');
+
+            this.player1.clickCard(this.jaime);
+
+            this.completeSetup();
+        });
+
+        describe('when played against a non-Winter card', function() {
+            beforeEach(function() {
+                this.player1.selectPlot('A Song of Summer');
+                this.player2.selectPlot('A Song of Summer');
+            });
+
+            it('should increase strength of characters by 1', function() {
+                expect(this.jaime.getStrength()).toBe(6);
+            });
+        });
+
+        describe('when played against a Winter card', function() {
+            beforeEach(function() {
+                this.player1.selectPlot('A Song of Summer');
+                this.player2.selectPlot('Winter Festival');
+            });
+
+            it('should not increase strength of characters', function() {
+                expect(this.jaime.getStrength()).toBe(5);
+            });
+        });
+    });
+});

--- a/test/server/effect.spec.js
+++ b/test/server/effect.spec.js
@@ -56,6 +56,8 @@ describe('Effect', function () {
 
             describe('and the condition returns false', function() {
                 beforeEach(function() {
+                    this.existingTarget = { target: 1 };
+                    this.effect.targets = [this.existingTarget];
                     this.properties.condition.and.returnValue(false);
                     this.effect.addTargets([this.nonMatchingCard, this.matchingCard]);
                 });
@@ -645,7 +647,6 @@ describe('Effect', function () {
                     this.matchingTarget = { target: 3, location: 'play area' };
                     this.effect.targets = [this.target, this.matchingTarget];
                     this.effect.active = true;
-                    this.effect.currentCondition = false;
                     this.effect.condition.and.returnValue(true);
                     this.properties.match.and.callFake(card => card !== this.target);
                     this.effect.reapply(this.newTargets);
@@ -668,11 +669,10 @@ describe('Effect', function () {
                 });
             });
 
-            describe('when the condition goes from true to false', function() {
+            describe('when the condition is false', function() {
                 beforeEach(function() {
                     this.effect.targets = [this.target];
                     this.effect.active = true;
-                    this.effect.currentCondition = true;
                     this.effect.condition.and.returnValue(false);
                     this.effect.reapply(this.newTargets);
                 });
@@ -687,28 +687,6 @@ describe('Effect', function () {
 
                 it('should clear the target list', function() {
                     expect(this.effect.targets).toEqual([]);
-                });
-            });
-
-            describe('when the condition does not change', function() {
-                beforeEach(function() {
-                    this.effect.targets = [this.target];
-                    this.effect.active = true;
-                    this.effect.currentCondition = false;
-                    this.effect.condition.and.returnValue(false);
-                    this.effect.reapply(this.newTargets);
-                });
-
-                it('should not unapply the effect from existing targets', function() {
-                    expect(this.properties.effect.unapply).not.toHaveBeenCalled();
-                });
-
-                it('should not apply the effect to any targets', function() {
-                    expect(this.properties.effect.apply).not.toHaveBeenCalled();
-                });
-
-                it('should not update the target list', function() {
-                    expect(this.effect.targets).toEqual([this.target]);
                 });
             });
         });


### PR DESCRIPTION
When a condition changed from another card entering play (e.g. A Song of
Summer applying its effect, then a Winter plot being revealed), the
effect was no longer being cancelled. This was due to the change in the
reapply method as the condition was already false when reaching it. Now
reapply looks at the condition whether or not the result changed from
the last check.