### PR TITLE
Use correct event for unopposed win/loss

### DIFF
--- a/server/game/cards/characters/01/ashagreyjoy.js
+++ b/server/game/cards/characters/01/ashagreyjoy.js
@@ -4,7 +4,7 @@ class AshaGreyjoy extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onUnopposedWin: (event, challenge) => this.controller === challenge.winner && challenge.isParticipating(this)
+                afterChallenge: (event, challenge) => this.controller === challenge.winner && challenge.isParticipating(this) && challenge.isUnopposed()
             },
             handler: () => {
                 this.controller.standCard(this);

--- a/server/game/cards/characters/01/theongreyjoy.js
+++ b/server/game/cards/characters/01/theongreyjoy.js
@@ -4,7 +4,7 @@ class TheonGreyjoy extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onUnopposedWin: (event, challenge) => challenge.winner === this.controller && challenge.isParticipating(this)
+                afterChallenge: (event, challenge) => challenge.winner === this.controller && challenge.isParticipating(this) && challenge.isUnopposed()
             },
             handler: () => {
                 this.modifyPower(1);

--- a/server/game/cards/characters/02/thereader.js
+++ b/server/game/cards/characters/02/thereader.js
@@ -6,8 +6,9 @@ class TheReader extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onUnopposedWin: (event, challenge) => (
+                afterChallenge: (event, challenge) => (
                     challenge.winner === this.controller &&
+                    challenge.isUnopposed() &&
                     _.any(challenge.getWinnerCards(), card => card.isFaction('greyjoy') && card.isUnique())
                 )
             },

--- a/server/game/cards/characters/02/will.js
+++ b/server/game/cards/characters/02/will.js
@@ -4,7 +4,7 @@ class Will extends DrawCard {
     setupCardAbilities() {
         this.forcedReaction({
             when: {
-                onUnopposedWin: (e, challenge) => this.controller !== challenge.winner
+                afterChallenge: (e, challenge) => this.controller === challenge.loser && challenge.isUnopposed()
             },
             handler: () => {
                 this.game.promptForSelect(this.controller, {

--- a/server/game/cards/locations/01/greatkraken.js
+++ b/server/game/cards/locations/01/greatkraken.js
@@ -8,7 +8,7 @@ class GreatKraken extends DrawCard {
         });
         this.reaction({
             when: {
-                onUnopposedWin: (event, challenge) => this.controller === challenge.winner
+                afterChallenge: (event, challenge) => this.controller === challenge.winner && challenge.isUnopposed()
             },
             limit: ability.limit.perRound(2),
             choices: {

--- a/server/game/cards/locations/01/thewall.js
+++ b/server/game/cards/locations/01/thewall.js
@@ -4,7 +4,7 @@ class TheWall extends DrawCard {
     setupCardAbilities(ability) {
         this.forcedReaction({
             when: {
-                onUnopposedWin: (e, challenge) => this.controller !== challenge.winner && !this.kneeled
+                afterChallenge: (e, challenge) => this.controller === challenge.loser && !this.kneeled && challenge.isUnopposed()
             },
             handler: () => {
                 this.game.addMessage('{0} is forced to kneel {1} because they lost an unopposed challenge', this.controller, this);

--- a/test/server/cards/characters/05/05006-tywinlannister.spec.js
+++ b/test/server/cards/characters/05/05006-tywinlannister.spec.js
@@ -72,7 +72,6 @@ describe('Tywin Lannister (LoCR)', function() {
                 this.player1.clickPrompt('Done');
 
                 this.skipActionWindow();
-                this.skipActionWindow();
 
                 // Trigger The Reader
                 this.player2.clickPrompt('The Reader - Discard 3 cards');


### PR DESCRIPTION
Reactions and interrupts for winning or losing unopposed challenges
should have the same window as winning or losing normal challenges. Thus
they should use the `afterChallenge` event instead of `onUnopposedWin`.