### PR TITLE
Fix canMarshalFrom effect + Night Gathers.

### DIFF
--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -500,7 +500,7 @@ const Effects = {
                 player.marshalLocations.push(marshalLocation);
             },
             unapply: function(player) {
-                player.marshalLocations = _.reject(player.additionalMarshalLocations, l => l === marshalLocation);
+                player.marshalLocations = _.reject(player.marshalLocations, l => l === marshalLocation);
             }
         };
     },

--- a/test/server/effects/canmarshalfrom.spec.js
+++ b/test/server/effects/canmarshalfrom.spec.js
@@ -1,0 +1,45 @@
+/*global describe, it, beforeEach, expect, jasmine*/
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+const _ = require('underscore');
+
+const Effects = require('../../../server/game/effects.js');
+
+const MarshalLocation = require('../../../server/game/marshallocation.js');
+
+describe('Effects.canMarshalFrom', function() {
+    beforeEach(function() {
+        this.context = {};
+
+        this.player = { marshalLocations: [] };
+        this.playerHand = new MarshalLocation(this.player, 'hand');
+        this.player.marshalLocations.push(this.playerHand);
+
+        this.opponent = { opponent: 1 };
+
+        this.effect = Effects.canMarshalFrom(this.opponent, 'discard pile');
+    });
+
+    describe('apply()', function() {
+        beforeEach(function() {
+            this.effect.apply(this.player, this.context);
+        });
+
+        it('should add a marshal location', function() {
+            let marshalLocation = _.last(this.player.marshalLocations);
+            expect(marshalLocation.location).toBe('discard pile');
+            expect(marshalLocation.player).toBe(this.opponent);
+        });
+    });
+
+    describe('unapply()', function() {
+        beforeEach(function() {
+            this.effect.apply(this.player, this.context);
+            this.effect.unapply(this.player, this.context);
+        });
+
+        it('should remove the added marshal location', function() {
+            expect(this.player.marshalLocations).toEqual([this.playerHand]);
+        });
+    });
+});

--- a/test/server/effects/canmarshalfrom.spec.js
+++ b/test/server/effects/canmarshalfrom.spec.js
@@ -1,4 +1,4 @@
-/*global describe, it, beforeEach, expect, jasmine*/
+/*global describe, it, beforeEach, expect*/
 /* eslint camelcase: 0, no-invalid-this: 0 */
 
 const _ = require('underscore');


### PR DESCRIPTION
Previously, cards that used the `canMarshalFrom` effect such as Night
Gathers would improperly clear the valid marshal locations for a player
when the effect ended. This resulted in not being able to marshal cards
from the players hand after the effect was unapplied.