### PR TITLE
Allow first player to choose forced ability order.

### DIFF
--- a/server/game/cards/plots/02/pullingthestrings.js
+++ b/server/game/cards/plots/02/pullingthestrings.js
@@ -27,10 +27,12 @@ class PullingTheStrings extends PlotCard {
         this.resolving = true;
 
         this.game.addMessage('{0} uses {1} to initiate the when resolved effect of {2}', player, this, card);
-        card.controller = this.controller;
-        this.game.raiseEvent('onPlotRevealed', this.controller, () => {
+        card.controller = player;
+        this.controller = null;
+        this.game.raiseEvent('onPlotRevealed', player, () => {
             card.controller = card.owner;
             card.moveTo('revealed plots');
+            this.controller = player;
 
             this.resolving = false;
         });

--- a/server/game/cards/plots/04/varyssriddle.js
+++ b/server/game/cards/plots/04/varyssriddle.js
@@ -4,23 +4,26 @@ class VaryssRiddle extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
             handler: () => {
-                var otherPlayer = this.game.getOtherPlayer(this.controller);
+                let player = this.controller;
+                let otherPlayer = this.game.getOtherPlayer(player);
                 if(this.resolving || !otherPlayer) {
                     return;
                 }
 
-                var plot = otherPlayer.activePlot;
+                let plot = otherPlayer.activePlot;
                 if(plot.hasTrait('Riddle')) {
                     return;
                 }
 
-                this.game.addMessage('{0} uses {1} to initiate the when resolved effect of {2}', this.controller, this, plot);
-                plot.controller = this.controller;
+                this.game.addMessage('{0} uses {1} to initiate the when resolved effect of {2}', player, this, plot);
+                this.controller = null;
+                plot.controller = player;
                 this.resolving = true;
 
-                this.game.raiseEvent('onPlotRevealed', this.controller, () => {
+                this.game.raiseEvent('onPlotRevealed', player, () => {
                     this.resolving = false;
                     plot.controller = plot.owner;
+                    this.controller = player;
                 });
             }
         });

--- a/server/game/forcedtriggeredability.js
+++ b/server/game/forcedtriggeredability.js
@@ -27,7 +27,7 @@ class ForcedTriggeredAbility extends TriggeredAbility {
     }
 
     executeReaction(context) {
-        this.game.resolveAbility(this, context);
+        this.game.registerAbility(this, context);
     }
 
     executeHandler(context) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -21,6 +21,7 @@ const MenuPrompt = require('./gamesteps/menuprompt.js');
 const SelectCardPrompt = require('./gamesteps/selectcardprompt.js');
 const EventWindow = require('./gamesteps/eventwindow.js');
 const AbilityResolver = require('./gamesteps/abilityresolver.js');
+const ForcedTriggeredAbilityWindow = require('./gamesteps/forcedtriggeredabilitywindow.js');
 const TriggeredAbilityWindow = require('./gamesteps/triggeredabilitywindow.js');
 
 class Game extends EventEmitter {
@@ -546,7 +547,8 @@ class Game extends EventEmitter {
     }
 
     openAbilityWindow(properties) {
-        let window = new TriggeredAbilityWindow(this, { abilityType: properties.abilityType, event: properties.event });
+        let windowClass = ['forcedreaction', 'forcedinterrupt'].includes(properties.abilityType) ? ForcedTriggeredAbilityWindow : TriggeredAbilityWindow;
+        let window = new windowClass(this, { abilityType: properties.abilityType, event: properties.event });
         this.abilityWindowStack.push(window);
         this.emit(properties.event.name + ':' + properties.abilityType, ...properties.event.params);
         this.queueStep(window);

--- a/server/game/gamesteps/eventwindow.js
+++ b/server/game/gamesteps/eventwindow.js
@@ -58,7 +58,10 @@ class EventWindow extends BaseStep {
             return;
         }
 
-        this.game.emit(this.eventName + ':forcedinterrupt', ...this.event.params);
+        this.game.openAbilityWindow({
+            abilityType: 'forcedinterrupt',
+            event: this.event
+        });
     }
 
     interrupts() {
@@ -92,7 +95,10 @@ class EventWindow extends BaseStep {
             return;
         }
 
-        this.game.emit(this.eventName + ':forcedreaction', ...this.event.params);
+        this.game.openAbilityWindow({
+            abilityType: 'forcedreaction',
+            event: this.event
+        });
     }
 
     reactions() {

--- a/server/game/gamesteps/forcedtriggeredabilitywindow.js
+++ b/server/game/gamesteps/forcedtriggeredabilitywindow.js
@@ -4,7 +4,7 @@ const uuid = require('uuid');
 const BaseStep = require('./basestep.js');
 const TriggeredAbilityWindowTitles = require('./triggeredabilitywindowtitles.js');
 
-class TriggeredAbilityWindow extends BaseStep {
+class ForcedTriggeredAbilityWindow extends BaseStep {
     constructor(game, properties) {
         super(game);
         this.abilityChoices = [];
@@ -70,4 +70,4 @@ class TriggeredAbilityWindow extends BaseStep {
     }
 }
 
-module.exports = TriggeredAbilityWindow;
+module.exports = ForcedTriggeredAbilityWindow;

--- a/server/game/gamesteps/forcedtriggeredabilitywindow.js
+++ b/server/game/gamesteps/forcedtriggeredabilitywindow.js
@@ -1,0 +1,73 @@
+const _ = require('underscore');
+const uuid = require('uuid');
+
+const BaseStep = require('./basestep.js');
+const TriggeredAbilityWindowTitles = require('./triggeredabilitywindowtitles.js');
+
+class TriggeredAbilityWindow extends BaseStep {
+    constructor(game, properties) {
+        super(game);
+        this.abilityChoices = [];
+        this.event = properties.event;
+        this.abilityType = properties.abilityType;
+    }
+
+    registerAbility(ability, context) {
+        let player = ability.card.controller;
+        this.abilityChoices.push({
+            id: uuid.v1(),
+            player: player,
+            ability: ability,
+            card: ability.card,
+            context: context
+        });
+    }
+
+    continue() {
+        this.abilityChoices = _.filter(this.abilityChoices, abilityChoice => abilityChoice.ability.meetsRequirements(abilityChoice.context));
+
+        if(this.abilityChoices.length > 1) {
+            this.promptPlayer();
+            return false;
+        }
+
+        _.each(this.abilityChoices, abilityChoice => {
+            this.game.resolveAbility(abilityChoice.ability, abilityChoice.context);
+        });
+
+        return true;
+    }
+
+    promptPlayer() {
+        let buttons = _.chain(this.abilityChoices)
+            .map(abilityChoice => {
+                let title = abilityChoice.player.name + ' - ' + abilityChoice.card.name;
+                return { text: title, method: 'chooseAbility', arg: abilityChoice.id, card: abilityChoice.card.getSummary(true) };
+            })
+            .sortBy('text')
+            .value();
+
+        this.game.promptWithMenu(this.game.getFirstPlayer(), this, {
+            activePrompt: {
+                menuTitle: TriggeredAbilityWindowTitles.getTitle(this.abilityType, this.event),
+                buttons: buttons
+            },
+            waitingPromptTitle: 'Waiting for opponents to resolve forced abilities'
+        });
+    }
+
+    chooseAbility(player, id) {
+        let choice = _.find(this.abilityChoices, ability => ability.id === id);
+
+        if(!choice) {
+            return false;
+        }
+
+        this.game.resolveAbility(choice.ability, choice.context);
+        this.abilityChoices = _.reject(this.abilityChoices, ability => ability.card === choice.card);
+
+        return true;
+    }
+}
+
+module.exports = TriggeredAbilityWindow;

--- a/server/game/gamesteps/triggeredabilitywindowtitles.js
+++ b/server/game/gamesteps/triggeredabilitywindowtitles.js
@@ -9,13 +9,23 @@ const EventToTitleFunc = {
 const AbilityTypeToWord = {
     cancelinterrupt: 'interrupt',
     interrupt: 'interrupt',
-    reaction: 'reaction'
+    reaction: 'reaction',
+    forcedreaction: 'forced reaction',
+    forcedinterrupt: 'forced interrupt'
 };
 
 const AbilityWindowTitles = {
     getTitle: function(abilityType, event) {
         let abilityWord = AbilityTypeToWord[abilityType] || abilityType;
         let titleFunc = EventToTitleFunc[event.name];
+
+        if(['forcedreaction', 'forcedinterrupt'].includes(abilityType)) {
+            if(titleFunc) {
+                return 'Choose ' + abilityWord + ' order for ' + titleFunc(event);
+            }
+
+            return 'Choose ' + abilityWord + ' order';
+        }
 
         if(titleFunc) {
             return 'Any ' + abilityWord + 's to ' + titleFunc(event) + '?';

--- a/test/server/card/cardforcedreaction.spec.js
+++ b/test/server/card/cardforcedreaction.spec.js
@@ -6,7 +6,7 @@ const Event = require('../../../server/game/event.js');
 
 describe('CardForcedReaction', function () {
     beforeEach(function () {
-        this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener', 'resolveAbility']);
+        this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener', 'registerAbility']);
         this.cardSpy = jasmine.createSpyObj('card', ['isBlank']);
         this.limitSpy = jasmine.createSpyObj('limit', ['increment', 'isAtMax', 'registerEvents', 'unregisterEvents']);
 
@@ -44,8 +44,8 @@ describe('CardForcedReaction', function () {
                 this.executeEventHandler(1, 2, 3);
             });
 
-            it('should not resolve the ability', function() {
-                expect(this.gameSpy.resolveAbility).not.toHaveBeenCalled();
+            it('should not register the ability', function() {
+                expect(this.gameSpy.registerAbility).not.toHaveBeenCalled();
             });
         });
 
@@ -55,8 +55,8 @@ describe('CardForcedReaction', function () {
                 this.executeEventHandler(1, 2, 3);
             });
 
-            it('should not resolve the ability', function() {
-                expect(this.gameSpy.resolveAbility).not.toHaveBeenCalled();
+            it('should not register the ability', function() {
+                expect(this.gameSpy.registerAbility).not.toHaveBeenCalled();
             });
         });
 
@@ -66,8 +66,8 @@ describe('CardForcedReaction', function () {
                 this.executeEventHandler(1, 2, 3);
             });
 
-            it('should not resolve the ability', function() {
-                expect(this.gameSpy.resolveAbility).not.toHaveBeenCalled();
+            it('should not register the ability', function() {
+                expect(this.gameSpy.registerAbility).not.toHaveBeenCalled();
             });
         });
 
@@ -82,8 +82,8 @@ describe('CardForcedReaction', function () {
                     this.executeEventHandler(1, 2, 3);
                 });
 
-                it('should not resolve the ability', function() {
-                    expect(this.gameSpy.resolveAbility).not.toHaveBeenCalled();
+                it('should not register the ability', function() {
+                    expect(this.gameSpy.registerAbility).not.toHaveBeenCalled();
                 });
             });
 
@@ -93,8 +93,8 @@ describe('CardForcedReaction', function () {
                     this.executeEventHandler(1, 2, 3);
                 });
 
-                it('should resolve the ability', function() {
-                    expect(this.gameSpy.resolveAbility).toHaveBeenCalledWith(this.reaction, jasmine.any(Object));
+                it('should register the ability', function() {
+                    expect(this.gameSpy.registerAbility).toHaveBeenCalledWith(this.reaction, jasmine.any(Object));
                 });
             });
         });

--- a/test/server/gamesteps/eventwindow.spec.js
+++ b/test/server/gamesteps/eventwindow.spec.js
@@ -20,10 +20,10 @@ describe('EventWindow', function() {
 
             it('should emit all of the interrupt/reaction events', function() {
                 expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'cancelinterrupt', event: jasmine.any(Event) });
-                expect(this.gameSpy.emit).toHaveBeenCalledWith('myevent:forcedinterrupt', jasmine.any(Event), 'foo', 'bar');
+                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'forcedinterrupt', event: jasmine.any(Event) });
                 expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'interrupt', event: jasmine.any(Event) });
                 expect(this.gameSpy.emit).toHaveBeenCalledWith('myevent', jasmine.any(Event), 'foo', 'bar');
-                expect(this.gameSpy.emit).toHaveBeenCalledWith('myevent:forcedreaction', jasmine.any(Event), 'foo', 'bar');
+                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'forcedreaction', event: jasmine.any(Event) });
                 expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'reaction', event: jasmine.any(Event) });
             });
 
@@ -39,10 +39,10 @@ describe('EventWindow', function() {
 
             it('should not emit the post-cancel interrupt/reaction events', function() {
                 this.eventWindow.continue();
-                expect(this.gameSpy.emit).not.toHaveBeenCalledWith('myevent:forcedinterrupt', jasmine.any(Event), jasmine.any(String), jasmine.any(String));
+                expect(this.gameSpy.openAbilityWindow).not.toHaveBeenCalledWith({ abilityType: 'forcedinterrupt', event: jasmine.any(Event) });
                 expect(this.gameSpy.openAbilityWindow).not.toHaveBeenCalledWith({ abilityType: 'interrupt', event: jasmine.any(Event) });
                 expect(this.gameSpy.emit).not.toHaveBeenCalledWith('myevent', jasmine.any(Event), jasmine.any(String), jasmine.any(String));
-                expect(this.gameSpy.emit).not.toHaveBeenCalledWith('myevent:forcedreaction', jasmine.any(Event), jasmine.any(String), jasmine.any(String));
+                expect(this.gameSpy.openAbilityWindow).not.toHaveBeenCalledWith({ abilityType: 'forcedreaction', event: jasmine.any(Event) });
                 expect(this.gameSpy.openAbilityWindow).not.toHaveBeenCalledWith({ abilityType: 'reaction', event: jasmine.any(Event) });
             });
 
@@ -72,10 +72,10 @@ describe('EventWindow', function() {
 
             it('should emit all of the interrupt/reaction events', function() {
                 expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'cancelinterrupt', event: jasmine.any(Event) });
-                expect(this.gameSpy.emit).toHaveBeenCalledWith('myevent:forcedinterrupt', jasmine.any(Event), 'foo', 'bar');
+                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'forcedinterrupt', event: jasmine.any(Event) });
                 expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'interrupt', event: jasmine.any(Event) });
                 expect(this.gameSpy.emit).toHaveBeenCalledWith('myevent', jasmine.any(Event), 'foo', 'bar');
-                expect(this.gameSpy.emit).toHaveBeenCalledWith('myevent:forcedreaction', jasmine.any(Event), 'foo', 'bar');
+                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'forcedreaction', event: jasmine.any(Event) });
                 expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'reaction', event: jasmine.any(Event) });
             });
 
@@ -92,13 +92,13 @@ describe('EventWindow', function() {
 
             it('should emit all of the interrupt events', function() {
                 expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'cancelinterrupt', event: jasmine.any(Event) });
-                expect(this.gameSpy.emit).toHaveBeenCalledWith('myevent:forcedinterrupt', jasmine.any(Event), 'foo', 'bar');
+                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'forcedinterrupt', event: jasmine.any(Event) });
                 expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'interrupt', event: jasmine.any(Event) });
             });
 
             it('should not emit the post-cancel  events', function() {
                 expect(this.gameSpy.emit).not.toHaveBeenCalledWith('myevent', jasmine.any(Event), jasmine.any(String), jasmine.any(String));
-                expect(this.gameSpy.emit).not.toHaveBeenCalledWith('myevent:forcedreaction', jasmine.any(Event), jasmine.any(String), jasmine.any(String));
+                expect(this.gameSpy.openAbilityWindow).not.toHaveBeenCalledWith({ abilityType: 'forcedreaction', event: jasmine.any(Event) });
                 expect(this.gameSpy.openAbilityWindow).not.toHaveBeenCalledWith({ abilityType: 'reaction', event: jasmine.any(Event) });
             });
         });

--- a/test/server/gamesteps/forcedtriggeredabilitywindow.spec.js
+++ b/test/server/gamesteps/forcedtriggeredabilitywindow.spec.js
@@ -1,0 +1,207 @@
+/*global describe, it, beforeEach, expect, jasmine*/
+/* eslint no-invalid-this: 0 */
+
+const _ = require('underscore');
+
+const ForcedTriggeredAbilityWindow = require('../../../server/game/gamesteps/forcedtriggeredabilitywindow.js');
+
+describe('ForcedTriggeredAbilityWindow', function() {
+    beforeEach(function() {
+        this.player1Spy = jasmine.createSpyObj('player', ['setPrompt', 'cancelPrompt']);
+        this.player1Spy.name = 'player1';
+        this.player2Spy = jasmine.createSpyObj('player', ['setPrompt', 'cancelPrompt']);
+        this.player2Spy.name = 'player2';
+
+        this.gameSpy = jasmine.createSpyObj('game', ['getFirstPlayer', 'promptWithMenu', 'resolveAbility']);
+        this.gameSpy.getFirstPlayer.and.returnValue(this.player1Spy);
+
+        this.event = { name: 'onFoo', params: [] };
+
+        this.window = new ForcedTriggeredAbilityWindow(this.gameSpy, {
+            event: this.event,
+            abilityType: 'forcedinterrupt'
+        });
+
+        this.setupWindowChoices = () => {
+            function createCard(properties) {
+                let cardSpy = jasmine.createSpyObj('card', ['getSummary']);
+                _.extend(cardSpy, properties);
+                return cardSpy;
+            }
+
+            this.abilityCard1 = createCard({ card: 1, name: 'The Card', controller: this.player1Spy });
+            this.ability1Spy = jasmine.createSpyObj('ability', ['meetsRequirements']);
+            this.ability1Spy.meetsRequirements.and.returnValue(true);
+            this.context1 = { context: 1 };
+
+            this.abilityCard2 = createCard({ card: 2, name: 'The Card 2', controller: this.player1Spy });
+            this.ability2Spy = jasmine.createSpyObj('ability', ['meetsRequirements']);
+            this.ability2Spy.meetsRequirements.and.returnValue(true);
+            this.context2 = { context: 2 };
+
+            this.abilityCard3 = createCard({ card: 3, name: 'Their Card', controller: this.player2Spy });
+            this.ability3Spy = jasmine.createSpyObj('ability', ['meetsRequirements']);
+            this.ability3Spy.meetsRequirements.and.returnValue(true);
+            this.context3 = { context: 3 };
+
+            this.window.abilityChoices = [
+                { id: '1', ability: this.ability1Spy, card: this.abilityCard1, context: this.context1, player: this.player1Spy },
+                { id: '2', ability: this.ability2Spy, card: this.abilityCard2, context: this.context2, player: this.player1Spy },
+                { id: '3', ability: this.ability3Spy, card: this.abilityCard3, context: this.context3, player: this.player2Spy }
+            ];
+        };
+
+    });
+
+    describe('registerAbility()', function() {
+        beforeEach(function() {
+            this.abilityCard = { card: 1, name: 'The Card', controller: this.player1Spy };
+            this.abilitySpy = { card: this.abilityCard };
+            this.context = { context: 1 };
+
+            this.window.registerAbility(this.abilitySpy, this.context);
+        });
+
+        it('should add the ability to the list of choices', function() {
+            expect(this.window.abilityChoices.length).toBe(1);
+            expect(this.window.abilityChoices).toContain(jasmine.objectContaining({
+                ability: this.abilitySpy,
+                card: this.abilityCard,
+                context: this.context,
+                player: this.player1Spy
+            }));
+        });
+    });
+
+    describe('continue()', function() {
+        beforeEach(function() {
+            this.setupWindowChoices();
+        });
+
+        describe('when there are no remaining choices', function() {
+            beforeEach(function() {
+                this.window.abilityChoices = [];
+                this.result = this.window.continue();
+            });
+
+            it('should not prompt', function() {
+                expect(this.gameSpy.promptWithMenu).not.toHaveBeenCalled();
+            });
+
+            it('should complete the prompt', function() {
+                expect(this.result).toBe(true);
+            });
+        });
+
+        describe('when there is only 1 choice', function() {
+            beforeEach(function() {
+                this.window.abilityChoices = [_.first(this.window.abilityChoices)];
+                this.result = this.window.continue();
+            });
+
+            it('should resolve the ability', function() {
+                expect(this.gameSpy.resolveAbility).toHaveBeenCalledWith(this.ability1Spy, this.context1);
+            });
+
+            it('should not prompt', function() {
+                expect(this.gameSpy.promptWithMenu).not.toHaveBeenCalled();
+            });
+
+            it('should complete the prompt', function() {
+                expect(this.result).toBe(true);
+            });
+        });
+
+        describe('when there are multiple choices', function() {
+            describe('and all ability requirements have been met', function() {
+                beforeEach(function() {
+                    this.result = this.window.continue();
+                });
+
+                it('should prompt the first player', function() {
+                    expect(this.gameSpy.promptWithMenu).toHaveBeenCalledWith(this.player1Spy, this.window, jasmine.objectContaining({
+                        activePrompt: {
+                            menuTitle: jasmine.any(String),
+                            buttons: [
+                                jasmine.objectContaining({ text: 'player1 - The Card', arg: '1', method: 'chooseAbility' }),
+                                jasmine.objectContaining({ text: 'player1 - The Card 2', arg: '2', method: 'chooseAbility' }),
+                                jasmine.objectContaining({ text: 'player2 - Their Card', arg: '3', method: 'chooseAbility' })
+                            ]
+                        }
+                    }));
+                });
+
+                it('should continue to prompt', function() {
+                    expect(this.result).toBe(false);
+                });
+            });
+
+            describe('and an ability requirement has not been met', function() {
+                beforeEach(function() {
+                    this.ability1Spy.meetsRequirements.and.returnValue(false);
+                    this.window.continue();
+                });
+
+                it('should filter out that ability', function() {
+                    expect(this.gameSpy.promptWithMenu).toHaveBeenCalledWith(this.player1Spy, this.window, jasmine.objectContaining({
+                        activePrompt: {
+                            menuTitle: jasmine.any(String),
+                            buttons: [
+                                jasmine.objectContaining({ text: 'player1 - The Card 2', arg: '2', method: 'chooseAbility' }),
+                                jasmine.objectContaining({ text: 'player2 - Their Card', arg: '3', method: 'chooseAbility' })
+                            ]
+                        }
+                    }));
+                });
+            });
+
+            describe('and all abilities are not eligible', function() {
+                beforeEach(function() {
+                    this.ability1Spy.meetsRequirements.and.returnValue(false);
+                    this.ability2Spy.meetsRequirements.and.returnValue(false);
+                    this.ability3Spy.meetsRequirements.and.returnValue(false);
+                    this.result = this.window.continue();
+                });
+
+                it('should not prompt', function() {
+                    expect(this.gameSpy.promptWithMenu).not.toHaveBeenCalled();
+                });
+
+                it('should complete the prompt', function() {
+                    expect(this.result).toBe(true);
+                });
+            });
+        });
+    });
+
+    describe('chooseAbility()', function() {
+        beforeEach(function() {
+            this.setupWindowChoices();
+        });
+
+        describe('when the player select a non-existent choice', function() {
+            beforeEach(function() {
+                this.window.chooseAbility(this.player1Spy, 'foo');
+            });
+
+            it('should not resolve an ability', function() {
+                expect(this.gameSpy.resolveAbility).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('when the player selects a valid choice', function() {
+            beforeEach(function() {
+                this.window.chooseAbility(this.player1Spy, '1');
+            });
+
+            it('should resolve the ability', function() {
+                expect(this.gameSpy.resolveAbility).toHaveBeenCalledWith(this.ability1Spy, this.context1);
+            });
+
+            it('should remove all choices for that card', function() {
+                let remainingIds = _.pluck(this.window.abilityChoices, 'id');
+                expect(remainingIds).toEqual(['2', '3']);
+            });
+        });
+    });
+});

--- a/test/server/integration/forcedreactionorder.spec.js
+++ b/test/server/integration/forcedreactionorder.spec.js
@@ -1,0 +1,79 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('forced reaction order', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck1 = this.buildDeck('lannister', [
+                'Trading with the Pentoshi',
+                'The Hound', 'The Hound'
+            ]);
+            const deck2 = this.buildDeck('thenightswatch', [
+                'Trading with the Pentoshi',
+                'The Wall', 'Will'
+            ]);
+            this.player1.selectDeck(deck1);
+            this.player2.selectDeck(deck2);
+            this.startGame();
+            this.keepStartingHands();
+            this.player1.clickCard('The Hound', 'hand');
+            this.player2.clickCard('The Wall', 'hand');
+            this.player2.clickCard('Will', 'hand');
+            this.completeSetup();
+
+            this.player1.selectPlot('Trading with the Pentoshi');
+            this.player2.selectPlot('Trading with the Pentoshi');
+            this.selectFirstPlayer(this.player1);
+
+            // Resolve plot order
+            this.player1.clickPrompt('player1');
+
+            this.completeMarshalPhase();
+
+            this.skipActionWindow();
+            this.player1.clickPrompt('Power');
+            this.player1.clickCard('The Hound', 'play area');
+            this.player1.clickPrompt('Done');
+            this.skipActionWindow();
+            this.player2.clickPrompt('Done');
+            this.skipActionWindow();
+        });
+
+        it('should prompt the first player', function() {
+            expect(this.player1).toHavePromptButton('player1 - The Hound');
+            expect(this.player1).toHavePromptButton('player2 - The Wall');
+            expect(this.player1).toHavePromptButton('player2 - Will');
+        });
+
+        it('should allow the abilities to be triggered', function() {
+            let hound = this.player1.findCardByName('The Hound', 'play area');
+            let wall = this.player2.findCardByName('The Wall', 'play area');
+            let will = this.player2.findCardByName('Will', 'play area');
+
+            expect(hound.location).toBe('play area');
+            expect(will.location).toBe('play area');
+            expect(wall.kneeled).toBe(false);
+
+            this.player1.clickPrompt('player2 - Will');
+            this.player2.clickCard(will);
+
+            expect(hound.location).toBe('play area');
+            expect(will.location).toBe('discard pile');
+            expect(wall.kneeled).toBe(false);
+
+            this.player1.clickPrompt('player2 - The Wall');
+
+            expect(hound.location).toBe('play area');
+            expect(will.location).toBe('discard pile');
+            expect(wall.kneeled).toBe(true);
+
+            expect(this.player1).toHavePrompt('Discard 1 card at random for The Hound?');
+
+            this.player1.clickPrompt('No');
+
+            expect(hound.location).toBe('hand');
+            expect(will.location).toBe('discard pile');
+            expect(wall.kneeled).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
Per the rules, when there are more than one forced reactions /
interrupts in the same window, the first player gets to choose the order
that they are resolved.