### PR TITLE
Default location and cost for event card actions.

### DIFF
--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -1,6 +1,7 @@
 const _ = require('underscore');
 
 const BaseAbility = require('./baseability.js');
+const Costs = require('./costs.js');
 const EventRegistrar = require('./eventregistrar.js');
 
 /**
@@ -36,6 +37,7 @@ class CardAction extends BaseAbility {
         super(properties);
 
         const DefaultLocationForType = {
+            event: 'hand',
             agenda: 'agenda',
             plot: 'active plot'
         };
@@ -53,6 +55,10 @@ class CardAction extends BaseAbility {
         this.activationContexts = [];
 
         this.handler = this.buildHandler(card, properties);
+
+        if(card.getType() === 'event') {
+            this.cost.push(Costs.playEvent());
+        }
     }
 
     buildHandler(card, properties) {

--- a/server/game/cards/events/01/hearmeroar.js
+++ b/server/game/cards/events/01/hearmeroar.js
@@ -1,34 +1,24 @@
 const DrawCard = require('../../../drawcard.js');
 
 class HearMeRoar extends DrawCard {
-    canPlay(player, card) {
-        if(player !== this.controller || this !== card) {
-            return false;
-        }
+    setupCardAbilities() {
+        this.action({
+            title: 'Put card into play',
+            target: {
+                activePromptTitle: 'Select character',
+                cardCondition: card => card.location === 'hand' && card.controller === this.controller && card.getType() === 'character' && card.isFaction('lannister')
+            },
+            handler: context => {
+                context.player.putIntoPlay(context.target);
 
-        return super.canPlay(player, card);
-    }
+                this.atEndOfPhase(ability => ({
+                    match: context.target,
+                    effect: ability.effects.discardIfStillInPlay(false)
+                }));
 
-    play(player) {
-        this.game.promptForSelect(player, {
-            activePromptTitle: 'Select character',
-            source: this,
-            cardCondition: card => card.location === 'hand' && card.controller === this.controller && card.getType() === 'character' && card.isFaction('lannister'),
-            onSelect: (player, card) => this.onCardSelected(player, card)
+                this.game.addMessage('{0} uses {1} to put {2} into play from their hand', context.player, this, context.target);
+            }
         });
-    }
-
-    onCardSelected(player, card) {
-        player.putIntoPlay(card);
-
-        this.atEndOfPhase(ability => ({
-            match: card,
-            effect: ability.effects.discardIfStillInPlay(false)
-        }));
-
-        this.game.addMessage('{0} uses {1} to put {2} into play from their hand', player, this, card);
-
-        return true;
     }
 }
 

--- a/server/game/playcardaction.js
+++ b/server/game/playcardaction.js
@@ -16,6 +16,7 @@ class PlayCardAction extends BaseAbility {
         return (
             context.game.currentPhase !== 'setup' &&
             context.source.getType() === 'event' &&
+            context.source.abilities.actions.length === 0 &&
             !context.source.cannotPlay &&
             context.player.hand.contains(context.source) &&
             context.source.canPlay(context.player, context.source)

--- a/test/server/card/cardaction.spec.js
+++ b/test/server/card/cardaction.spec.js
@@ -79,10 +79,30 @@ describe('CardAction', function () {
                 expect(this.action.location).toBe('active plot');
             });
 
+            it('should default to hand for cards with type event', function() {
+                this.cardSpy.getType.and.returnValue('event');
+                this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+                expect(this.action.location).toBe('hand');
+            });
+
             it('should use the location sent via properties', function() {
                 this.properties.location = 'foo';
                 this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
                 expect(this.action.location).toBe('foo');
+            });
+        });
+
+        describe('cost', function() {
+            describe('when the card type is event', function() {
+                beforeEach(function() {
+                    this.cardSpy.getType.and.returnValue('event');
+                    this.properties.cost = ['foo'];
+                    this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
+                });
+
+                it('should add the play event cost', function() {
+                    expect(this.action.cost.length).toBe(2);
+                });
             });
         });
     });

--- a/test/server/integration/marshalphase.spec.js
+++ b/test/server/integration/marshalphase.spec.js
@@ -7,7 +7,7 @@ describe('marshal phase', function() {
             beforeEach(function() {
                 const deck = this.buildDeck('stark', [
                     'Trading with the Pentoshi', 'Sneak Attack',
-                    'Arya Stark (Core)', 'Eddard Stark (Core)', 'Eddard Stark (Core)', 'Eddard Stark (WotN)', 'The Kingsroad', 'Hear Me Roar!'
+                    'Arya Stark (Core)', 'Eddard Stark (Core)', 'Eddard Stark (Core)', 'Eddard Stark (WotN)', 'The Kingsroad', 'Hear Me Roar!', 'Gold Cloaks'
                 ]);
                 this.player1.selectDeck(deck);
                 this.player2.selectDeck(deck);

--- a/test/server/playcardaction.spec.js
+++ b/test/server/playcardaction.spec.js
@@ -25,7 +25,7 @@ describe('PlayCardAction', function () {
             this.playerSpy.hand = _([this.cardSpy]);
             this.cardSpy.getType.and.returnValue('event');
             this.cardSpy.canPlay.and.returnValue(true);
-            this.cardSpy.abilities = {};
+            this.cardSpy.abilities = { actions: [] };
         });
 
         describe('when all conditions are met', function() {


### PR DESCRIPTION
It is now possible to define actions for event cards through the ability
API. By default, each event card with an action is playable from hand
(assuming requirements and costs are met) and they will automatically
have the standard event costs specified.

Hear Me Roar has been converted as an example.