### PR TITLE
Require participating characters to win challenges

### DIFF
--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -120,7 +120,7 @@ class Challenge {
 
         this.calculateStrength();
 
-        if(this.attackerStrength === 0 && this.defenderStrength === 0 || this.attackerStrength >= this.defenderStrength && this.attackingPlayer.cannotWinChallenge) {
+        if(this.hasNoWinnerOrLoser()) {
             this.loser = undefined;
             this.winner = undefined;
             this.loserStrength = this.winnerStrength = 0;
@@ -144,6 +144,16 @@ class Challenge {
         this.winner.winChallenge(this.challengeType, this.attackingPlayer === this.winner);
         this.loser.loseChallenge(this.challengeType, this.attackingPlayer === this.loser);
         this.strengthDifference = this.winnerStrength - this.loserStrength;
+    }
+
+    hasNoWinnerOrLoser() {
+        return (
+            this.attackerStrength === 0 && this.defenderStrength === 0 ||
+            this.attackerStrength >= this.defenderStrength && this.attackingPlayer.cannotWinChallenge ||
+            this.attackerStrength >= this.defenderStrength && this.attackers.length === 0 ||
+            this.defenderStrength > this.attackerStrength && this.defendingPlayer.cannotWinChallenge ||
+            this.defenderStrength > this.attackerStrength && this.defenders.length === 0
+        );
     }
 
     isAttackerTheWinner() {

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -22,7 +22,6 @@ class ChallengeFlow extends BaseStep {
             new SimpleStep(this.game, () => this.announceDefenderStrength()),
             new ActionWindow(this.game, 'After defenders declared'),
             new SimpleStep(this.game, () => this.determineWinner()),
-            new ActionWindow(this.game, 'After winner determined'),
             new SimpleStep(this.game, () => this.unopposedPower()),
             new SimpleStep(this.game, () => this.beforeClaim()),
             new SimpleStep(this.game, () => this.applyKeywords()),
@@ -134,6 +133,11 @@ class ChallengeFlow extends BaseStep {
         }
 
         this.game.raiseEvent('afterChallenge', this.challenge);
+
+        // Only open a winner action window if a winner / loser was determined.
+        if(this.challenge.winner) {
+            this.game.queueStep(new ActionWindow(this.game, 'After winner determined'));
+        }
     }
 
     unopposedPower() {

--- a/test/server/integration/challengesphase.spec.js
+++ b/test/server/integration/challengesphase.spec.js
@@ -1,0 +1,54 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('challenges phase', function() {
+    integration(function() {
+        describe('when a side has higher strength but no participating characters', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('thenightswatch', [
+                    'Sneak Attack',
+                    'Steward at the Wall', 'The Haunted Forest', 'The Haunted Forest', 'The Shadow Tower'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+                this.player1.clickCard('Steward at the Wall', 'hand');
+                this.player2.clickCard('The Haunted Forest', 'hand');
+                this.player2.clickCard('The Haunted Forest', 'hand');
+                this.player2.clickCard('The Shadow Tower', 'hand');
+                this.completeSetup();
+
+                this.player1.selectPlot('Sneak Attack');
+                this.player2.selectPlot('Sneak Attack');
+                this.selectFirstPlayer(this.player1);
+
+                this.completeMarshalPhase();
+
+                this.skipActionWindow();
+
+                this.player1.clickPrompt('Intrigue');
+                this.player1.clickCard('Steward at the Wall', 'play area');
+                this.player1.clickPrompt('Done');
+
+                // Skip attackers declared window
+                this.skipActionWindow();
+
+                this.player2.clickPrompt('Done');
+
+                // Skip defenders declared window
+                this.skipActionWindow();
+            });
+
+            it('should not trigger any win reactions for the defender', function() {
+                expect(this.player2).not.toHavePromptButton('The Shadow Tower');
+            });
+
+            it('should complete the challenge', function() {
+                expect(this.player1).toHavePromptButton('Military');
+                expect(this.player1).toHavePromptButton('Intrigue');
+                expect(this.player1).toHavePromptButton('Power');
+            });
+        });
+    });
+});


### PR DESCRIPTION
Per the rules, if either the attacker or defender has higher strength,
but has no participating characters, then neither player wins or loses
the challenge. This is most applicable when something like The Haunted
Forest ends up with higher strength than the attacking player.

Fixes #730.