### PR TITLE
Implement The Prince's Plan.

### DIFF
--- a/docs/implementing-cards.md
+++ b/docs/implementing-cards.md
@@ -668,6 +668,17 @@ this.reaction({
 });
 ```
 
+#### Abilities outside of play
+
+Certain abilities, such as those for The Prince's Plan, can only be activated in non-play locations. Such reactions should be defined by specifying the `location` property with the location from which the ability may be activated. The player can then activate the ability when prompted.
+
+```javascript
+this.reaction({
+    location: 'discard pile',
+    // Implementation for The Prince's Plan
+})
+```
+
 #### When revealed abilities
 
 When implementing plot cards that have a **When Revealed** ability, use the `whenRevealed` method. It will automatically listen to the correct event for you and all that must be provided is a `handler` method.

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -292,21 +292,24 @@ class BaseCard {
     moveTo(targetLocation) {
         if(LocationsWithEventHandling.includes(targetLocation) && !LocationsWithEventHandling.includes(this.location)) {
             this.events.register(this.eventsForRegistration);
-            _.each(this.abilities.actions, action => {
-                action.registerEvents();
-            });
-            _.each(this.abilities.reactions, reaction => {
-                reaction.registerEvents();
-            });
         } else if(LocationsWithEventHandling.includes(this.location) && !LocationsWithEventHandling.includes(targetLocation)) {
             this.events.unregisterAll();
-            _.each(this.abilities.actions, action => {
-                action.unregisterEvents();
-            });
-            _.each(this.abilities.reactions, reaction => {
-                reaction.unregisterEvents();
-            });
         }
+
+        _.each(this.abilities.actions, action => {
+            if(action.isEventListeningLocation(targetLocation) && !action.isEventListeningLocation(this.location)) {
+                action.registerEvents();
+            } else if(action.isEventListeningLocation(this.location) && !action.isEventListeningLocation(targetLocation)) {
+                action.unregisterEvents();
+            }
+        });
+        _.each(this.abilities.reactions, reaction => {
+            if(reaction.isEventListeningLocation(targetLocation) && !reaction.isEventListeningLocation(this.location)) {
+                reaction.registerEvents();
+            } else if(reaction.isEventListeningLocation(this.location) && !reaction.isEventListeningLocation(targetLocation)) {
+                reaction.unregisterEvents();
+            }
+        });
 
         if(targetLocation !== 'play area') {
             this.facedown = false;

--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -168,6 +168,10 @@ class CardAction extends BaseAbility {
         this.activationContexts = [];
     }
 
+    isEventListeningLocation(location) {
+        return this.location === location;
+    }
+
     registerEvents() {
         this.events.register(['onBeginRound']);
         if(this.limit) {

--- a/server/game/cards/events/06/theprincesplan.js
+++ b/server/game/cards/events/06/theprincesplan.js
@@ -1,0 +1,55 @@
+const DrawCard = require('../../../drawcard.js');
+
+class ThePrincesPlan extends DrawCard {
+    setupCardAbilities(ability) {
+        this.action({
+            title: 'Give +1 STR per used plot + icon',
+            target: {
+                activePromptTitle: 'Select a character',
+                cardCondition: card => card.location === 'play area' && card.getType() === 'character'
+            },
+            handler: context => {
+                this.targetCharacter = context.target;
+                this.game.promptWithMenu(context.player, this, {
+                    activePrompt: {
+                        menuTitle: 'Choose an icon to gain',
+                        buttons: [
+                            { text: 'Military', method: 'addStrengthAndIcon', arg: 'military' },
+                            { text: 'Intrigue', method: 'addStrengthAndIcon', arg: 'intrigue' },
+                            { text: 'Power', method: 'addStrengthAndIcon', arg: 'power' }
+                        ]
+                    },
+                    source: this
+                });
+            }
+        });
+
+        this.reaction({
+            location: 'discard pile',
+            when: {
+                afterChallenge: (event, challenge) => challenge.loser === this.controller
+            },
+            cost: ability.costs.payGold(1),
+            handler: () => {
+                this.game.addMessage('{0} pays 1 gold to move {1} back to their hand', this.controller, this);
+                this.controller.moveCard(this, 'hand');
+            }
+        });
+    }
+
+    addStrengthAndIcon(player, icon) {
+        this.game.addMessage('{0} uses {1} to give {2} +1 STR per used plot and a {3} icon until the end of the phase', player, this, this.targetCharacter, icon);
+        this.untilEndOfPhase(ability => ({
+            match: this.targetCharacter,
+            effect: [
+                ability.effects.dynamicStrength(() => this.controller.getNumberOfUsedPlots()),
+                ability.effects.addIcon(icon)
+            ]
+        }));
+        return true;
+    }
+}
+
+ThePrincesPlan.code = '06016';
+
+module.exports = ThePrincesPlan;

--- a/server/game/forcedtriggeredability.js
+++ b/server/game/forcedtriggeredability.js
@@ -18,6 +18,8 @@ const TriggeredAbility = require('./triggeredability.js');
  *           choice, use the choices sub object instead.
  * limit   - optional AbilityLimit object that represents the max number of uses
  *           for the reaction as well as when it resets.
+ * location - string indicating the location the card should be in in order
+ *            to activate the reaction. Defaults to 'play area'.
  */
 class ForcedTriggeredAbility extends TriggeredAbility {
     constructor(game, card, type, properties) {

--- a/server/game/promptedtriggeredability.js
+++ b/server/game/promptedtriggeredability.js
@@ -26,6 +26,8 @@ const TriggeredAbility = require('./triggeredability.js');
  *           are handlers when the player chooses it from the prompt.
  * limit   - optional AbilityLimit object that represents the max number of uses
  *           for the reaction as well as when it resets.
+ * location - string indicating the location the card should be in in order
+ *            to activate the reaction. Defaults to 'play area'.
  */
 class PromptedTriggeredAbility extends TriggeredAbility {
     constructor(game, card, type, properties) {

--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -23,11 +23,18 @@ class TriggeredAbility extends BaseAbility {
     constructor(game, card, eventType, properties) {
         super(properties);
 
+        const DefaultLocationForType = {
+            event: 'hand',
+            agenda: 'agenda',
+            plot: 'active plot'
+        };
+
         this.game = game;
         this.card = card;
         this.limit = properties.limit;
         this.when = properties.when;
         this.eventType = eventType;
+        this.location = properties.location || DefaultLocationForType[card.getType()] || 'play area';
     }
 
     eventHandler(event) {
@@ -65,6 +72,10 @@ class TriggeredAbility extends BaseAbility {
     }
 
     executeReaction() {
+    }
+
+    isEventListeningLocation(location) {
+        return this.location === location;
     }
 
     registerEvents() {

--- a/test/server/card/cardforcedreaction.spec.js
+++ b/test/server/card/cardforcedreaction.spec.js
@@ -7,7 +7,7 @@ const Event = require('../../../server/game/event.js');
 describe('CardForcedReaction', function () {
     beforeEach(function () {
         this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener', 'registerAbility']);
-        this.cardSpy = jasmine.createSpyObj('card', ['isBlank']);
+        this.cardSpy = jasmine.createSpyObj('card', ['getType', 'isBlank']);
         this.limitSpy = jasmine.createSpyObj('limit', ['increment', 'isAtMax', 'registerEvents', 'unregisterEvents']);
 
         this.properties = {

--- a/test/server/card/cardreaction.spec.js
+++ b/test/server/card/cardreaction.spec.js
@@ -7,7 +7,7 @@ const Event = require('../../../server/game/event.js');
 describe('CardReaction', function () {
     beforeEach(function () {
         this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener', 'registerAbility']);
-        this.cardSpy = jasmine.createSpyObj('card', ['isBlank']);
+        this.cardSpy = jasmine.createSpyObj('card', ['getType', 'isBlank']);
         this.limitSpy = jasmine.createSpyObj('limit', ['increment', 'isAtMax', 'registerEvents', 'unregisterEvents']);
 
         this.properties = {
@@ -22,6 +22,39 @@ describe('CardReaction', function () {
         this.createReaction = () => {
             return new CardReaction(this.gameSpy, this.cardSpy, this.properties);
         };
+    });
+
+    describe('constructor', function() {
+        describe('location', function() {
+            it('should default to play area', function() {
+                this.action = new CardReaction(this.gameSpy, this.cardSpy, this.properties);
+                expect(this.action.location).toBe('play area');
+            });
+
+            it('should default to agenda for cards with type agenda', function() {
+                this.cardSpy.getType.and.returnValue('agenda');
+                this.action = new CardReaction(this.gameSpy, this.cardSpy, this.properties);
+                expect(this.action.location).toBe('agenda');
+            });
+
+            it('should default to active plot for cards with type plot', function() {
+                this.cardSpy.getType.and.returnValue('plot');
+                this.action = new CardReaction(this.gameSpy, this.cardSpy, this.properties);
+                expect(this.action.location).toBe('active plot');
+            });
+
+            it('should default to hand for cards with type event', function() {
+                this.cardSpy.getType.and.returnValue('event');
+                this.action = new CardReaction(this.gameSpy, this.cardSpy, this.properties);
+                expect(this.action.location).toBe('hand');
+            });
+
+            it('should use the location sent via properties', function() {
+                this.properties.location = 'foo';
+                this.action = new CardReaction(this.gameSpy, this.cardSpy, this.properties);
+                expect(this.action.location).toBe('foo');
+            });
+        });
     });
 
     describe('eventHandler()', function() {


### PR DESCRIPTION
Allows reactions to be defined for locations other than 'play area' and implements The Prince's Plan.

**Note:** It is now technically possible to define in-hand reactions for event cards. However, the cost is not currently defaulted like it is for in-hand event card actions, and (more importantly), such reactions are still blocking prompts, which could reveal information about the player's hand. So while you could start defining event card reactions using the API, I wouldn't recommend it yet.