### PR TITLE
Undelete target condition for Offer a Peach.

### DIFF
--- a/server/game/cards/events/04/offerofapeach.js
+++ b/server/game/cards/events/04/offerofapeach.js
@@ -18,6 +18,10 @@ class OfferOfAPeach extends DrawCard {
             }
         });
     }
+
+    cardCondition(card) {
+        return card.location === 'play area' && this.game.currentChallenge.isAttacking(card);
+    }
 }
 
 OfferOfAPeach.code = '04084';


### PR DESCRIPTION
Got a little too overzealous deleting code when converting event cards
to use `action`.