### PR TITLE
Choose stealth targets before challenge initiated.

### DIFF
--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -15,7 +15,6 @@ class ChallengeFlow extends BaseStep {
             new SimpleStep(this.game, () => this.resetCards()),
             new SimpleStep(this.game, () => this.announceChallenge()),
             new SimpleStep(this.game, () => this.promptForAttackers()),
-            () => new ChooseStealthTargets(this.game, this.challenge, this.challenge.getStealthAttackers()),
             new SimpleStep(this.game, () => this.announceAttackerStrength()),
             new ActionWindow(this.game, 'After attackers declared'),
             new SimpleStep(this.game, () => this.promptForDefenders()),
@@ -60,6 +59,8 @@ class ChallengeFlow extends BaseStep {
 
     chooseAttackers(player, attackers) {
         this.challenge.addAttackers(attackers);
+
+        this.game.queueStep(new ChooseStealthTargets(this.game, this.challenge, this.challenge.getStealthAttackers()));
 
         this.game.raiseEvent('onChallenge', this.challenge, () => {
             this.challenge.initiateChallenge();

--- a/test/server/integration/challengesphase.spec.js
+++ b/test/server/integration/challengesphase.spec.js
@@ -3,6 +3,45 @@
 
 describe('challenges phase', function() {
     integration(function() {
+        describe('when a character has stealth', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('lannister', [
+                    'Sneak Attack',
+                    'Tyrion Lannister (Core)', 'Joffrey Baratheon (Core)'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+                this.player1.clickCard('Tyrion Lannister', 'hand');
+                this.player2.clickCard('Joffrey Baratheon', 'hand');
+                this.completeSetup();
+
+                this.player1.selectPlot('Sneak Attack');
+                this.player2.selectPlot('Sneak Attack');
+                this.selectFirstPlayer(this.player1);
+
+                this.completeMarshalPhase();
+
+                this.skipActionWindow();
+
+                this.player1.clickPrompt('Intrigue');
+                this.player1.clickCard('Tyrion Lannister', 'play area');
+                this.player1.clickPrompt('Done');
+            });
+
+            it('should prompt for stealth targets before reactions', function() {
+                let stealthTarget = this.player2.findCardByName('Joffrey Baratheon', 'play area');
+
+                expect(this.player1).toHavePrompt('Select stealth target for Tyrion Lannister');
+
+                this.player1.clickCard(stealthTarget);
+
+                expect(this.player1).toHavePromptButton('Tyrion Lannister');
+                expect(stealthTarget.stealth).toBe(true);
+            });
+        });
+
         describe('when a side has higher strength but no participating characters', function() {
             beforeEach(function() {
                 const deck = this.buildDeck('thenightswatch', [


### PR DESCRIPTION
Per the rules, stealth targets must be chosen prior to any reactions or
interrupts firing for the challenge initiation.

Fixes #450.