### PR TITLE
Prevent reactions from firing from wrong location.

### DIFF
--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -64,6 +64,10 @@ class TriggeredAbility extends BaseAbility {
             return false;
         }
 
+        if(this.card.location !== this.location) {
+            return false;
+        }
+
         if(!this.canPayCosts(context) || !this.canResolveTargets(context)) {
             return false;
         }

--- a/test/server/card/cardforcedreaction.spec.js
+++ b/test/server/card/cardforcedreaction.spec.js
@@ -8,6 +8,7 @@ describe('CardForcedReaction', function () {
     beforeEach(function () {
         this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener', 'registerAbility']);
         this.cardSpy = jasmine.createSpyObj('card', ['getType', 'isBlank']);
+        this.cardSpy.location = 'play area';
         this.limitSpy = jasmine.createSpyObj('limit', ['increment', 'isAtMax', 'registerEvents', 'unregisterEvents']);
 
         this.properties = {
@@ -63,6 +64,17 @@ describe('CardForcedReaction', function () {
         describe('when the when condition returns false', function() {
             beforeEach(function() {
                 this.properties.when.onSomething.and.returnValue(false);
+                this.executeEventHandler(1, 2, 3);
+            });
+
+            it('should not register the ability', function() {
+                expect(this.gameSpy.registerAbility).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('when the card is not in the proper location', function() {
+            beforeEach(function() {
+                this.cardSpy.location = 'foo';
                 this.executeEventHandler(1, 2, 3);
             });
 

--- a/test/server/card/cardreaction.spec.js
+++ b/test/server/card/cardreaction.spec.js
@@ -8,6 +8,7 @@ describe('CardReaction', function () {
     beforeEach(function () {
         this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener', 'registerAbility']);
         this.cardSpy = jasmine.createSpyObj('card', ['getType', 'isBlank']);
+        this.cardSpy.location = 'play area';
         this.limitSpy = jasmine.createSpyObj('limit', ['increment', 'isAtMax', 'registerEvents', 'unregisterEvents']);
 
         this.properties = {
@@ -96,6 +97,17 @@ describe('CardReaction', function () {
         describe('when the when condition returns false', function() {
             beforeEach(function() {
                 this.properties.when.onSomething.and.returnValue(false);
+                this.executeEventHandler(1, 2, 3);
+            });
+
+            it('should not register the ability', function() {
+                expect(this.gameSpy.registerAbility).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('when the card is not in the proper location', function() {
+            beforeEach(function() {
+                this.cardSpy.location = 'foo';
                 this.executeEventHandler(1, 2, 3);
             });
 

--- a/test/server/cards/locations/04/04082-harrenhal.spec.js
+++ b/test/server/cards/locations/04/04082-harrenhal.spec.js
@@ -1,0 +1,48 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('Harrenhal (GoH)', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck = this.buildDeck('stark', [
+                'Sneak Attack',
+                'Harrenhal (GoH)', 'Littlefinger'
+            ]);
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.harrenhal = this.player1.findCardByName('Harrenhal', 'hand');
+
+            this.player1.clickCard(this.harrenhal);
+            this.completeSetup();
+
+            this.player1.selectPlot('Sneak Attack');
+            this.player2.selectPlot('Sneak Attack');
+            this.selectFirstPlayer(this.player1);
+        });
+
+        describe('when a character is put into play', function() {
+            beforeEach(function() {
+                this.littlefinger = this.player2.findCardByName('Littlefinger', 'hand');
+                this.player1.clickPrompt('Done');
+                this.player2.clickCard(this.littlefinger);
+            });
+
+            it('should prompt to kill the character', function() {
+                this.player1.clickPrompt('Harrenhal');
+
+                expect(this.harrenhal.location).toBe('discard pile');
+                expect(this.player1Object.faction.kneeled).toBe(true);
+                expect(this.littlefinger.location).toBe('dead pile');
+            });
+
+            it('should not prompt to trigger the ability of the character that was killed', function() {
+                this.player1.clickPrompt('Harrenhal');
+
+                expect(this.player2).not.toHavePromptButton('Littlefinger');
+            });
+        });
+    });
+});


### PR DESCRIPTION
Previously, if an interrupt or reaction ended up removing another card
from play (e.g. Harrenhal kills Littlefinger when he enters play), then
the player would still be prompted to trigger the removed card's
abilities. Now reactions check that the card is still in the proper area
to be eligible to activate.

Fixes #640.