### PR TITLE
Recycle plots after "when revealed" has resolved.

### DIFF
--- a/server/game/gamesteps/plotphase.js
+++ b/server/game/gamesteps/plotphase.js
@@ -16,7 +16,8 @@ class PlotPhase extends Phase {
             () => new FirstPlayerPrompt(game, this.initiativeWinner),
             () => new ResolvePlots(game, this.getPlayersWithRevealEffects()),
             new SimpleStep(game, () => this.resolveRemainingPlots()),
-            new SimpleStep(game, () => this.completePlotReveal())
+            new SimpleStep(game, () => this.completePlotReveal()),
+            new SimpleStep(game, () => this.recyclePlots())
         ]);
     }
 
@@ -91,6 +92,12 @@ class PlotPhase extends Phase {
 
     completePlotReveal() {
         this.game.raiseEvent('onPlotRevealCompleted');
+    }
+
+    recyclePlots() {
+        _.each(this.game.getPlayers(), player => {
+            player.recyclePlots();
+        });
     }
 }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -477,6 +477,12 @@ class Player extends Spectator {
         this.selectedPlot.play();
         this.moveCard(this.selectedPlot, 'active plot');
 
+        this.game.raiseEvent('onCardEntersPlay', this.activePlot);
+
+        this.selectedPlot = undefined;
+    }
+
+    recyclePlots() {
         if(this.plotDeck.isEmpty()) {
             this.plotDiscard.each(plot => {
                 this.moveCard(plot, 'plot deck');
@@ -484,10 +490,6 @@ class Player extends Spectator {
 
             this.game.raiseEvent('onPlotsRecycled', this);
         }
-
-        this.game.raiseEvent('onCardEntersPlay', this.activePlot);
-
-        this.selectedPlot = undefined;
     }
 
     removeActivePlot(targetLocation) {


### PR DESCRIPTION
Previously, plots were being recycled immediately upon the 7th plot
becoming active. This prevented Pulling the Strings from replicating the
ability of the 6th plot played by the opponent. Per the rules, plots
should be recycled after all active plots have been resolved.