### PR TITLE
Add `cardType` property to select card prompts.

### DIFF
--- a/server/game/cards/plots/02/pullingthestrings.js
+++ b/server/game/cards/plots/02/pullingthestrings.js
@@ -10,6 +10,7 @@ class PullingTheStrings extends PlotCard {
 
                 this.game.promptForSelect(this.controller, {
                     cardCondition: card => this.cardCondition(card),
+                    cardType: 'plot',
                     activePromptTitle: 'Select a plot',
                     source: this,
                     onSelect: (player, card) => this.onCardSelected(player, card)
@@ -19,7 +20,7 @@ class PullingTheStrings extends PlotCard {
     }
 
     cardCondition(card) {
-        return card.getType() === 'plot' && card.location === 'revealed plots' && card.controller !== this.controller && (card.hasTrait('Edict') || card.hasTrait('Kingdom') || card.hasTrait('Scheme'));
+        return card.location === 'revealed plots' && card.controller !== this.controller && (card.hasTrait('Edict') || card.hasTrait('Kingdom') || card.hasTrait('Scheme'));
     }
 
     onCardSelected(player, card) {

--- a/server/game/gamesteps/selectcardprompt.js
+++ b/server/game/gamesteps/selectcardprompt.js
@@ -17,6 +17,9 @@ const UiPrompt = require('./uiprompt.js');
  *                      opponent players.
  * cardCondition      - a function that takes a card and should return a boolean
  *                      on whether that card is elligible to be selected.
+ * cardType           - a string or array of strings listing which types of
+ *                      cards can be selected. Defaults to the list of draw
+ *                      card types.
  * onSelect           - a callback that is called once all cards have been
  *                      selected. On single card prompts this is called as soon
  *                      as an elligible card is clicked. On multi-select prompts
@@ -41,6 +44,9 @@ class SelectCardPrompt extends UiPrompt {
 
         this.properties = properties;
         _.defaults(this.properties, this.defaultProperties());
+        if(!_.isArray(this.properties.cardType)) {
+            this.properties.cardType = [this.properties.cardType];
+        }
         this.selectedCards = [];
         this.savePreviouslySelectedCards();
     }
@@ -50,6 +56,7 @@ class SelectCardPrompt extends UiPrompt {
             numCards: 1,
             additionalButtons: [],
             cardCondition: () => true,
+            cardType: ['attachment', 'character', 'event', 'location'],
             onSelect: () => true,
             onMenuCommand: () => true,
             onCancel: () => true
@@ -81,7 +88,7 @@ class SelectCardPrompt extends UiPrompt {
 
     highlightSelectableCards() {
         this.game.allCards.each(card => {
-            if(['character', 'attachment', 'location', 'event'].includes(card.getType())) {
+            if(this.properties.cardType.includes(card.getType())) {
                 card.selectable = !!this.properties.cardCondition(card);
             }
         });
@@ -115,7 +122,7 @@ class SelectCardPrompt extends UiPrompt {
             return false;
         }
 
-        if(!this.properties.cardCondition(card)) {
+        if(!this.checkCardCondition(card)) {
             return false;
         }
 
@@ -126,6 +133,10 @@ class SelectCardPrompt extends UiPrompt {
         if(this.properties.numCards === 1 && this.selectedCards.length === 1 && !this.properties.multiSelect) {
             this.fireOnSelect();
         }
+    }
+
+    checkCardCondition(card) {
+        return this.properties.cardType.includes(card.getType()) && this.properties.cardCondition(card);
     }
 
     selectCard(card) {


### PR DESCRIPTION
Select card prompts can now filter cards by their type. Most card
conditions written have assumed they're operating on draw cards, leading
to errors if the player happens to click a non-draw card. Prompts are
now limited to draw card types unless explicitly specified using the
`cardType` property (e.g. Pulling the Strings for plot cards).

Fixes #770.