### PR TITLE
"When Revealed" should fire per card not player.

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -175,7 +175,7 @@ class BaseCard {
     whenRevealed(properties) {
         var whenClause = {
             when: {
-                onPlotRevealed: (e, player) => player === this.controller
+                onPlotRevealed: (e, player, plot) => plot === this
             }
         };
         this.forcedInterrupt(_.extend(whenClause, properties));

--- a/server/game/cards/agendas/therainsofcastamere.js
+++ b/server/game/cards/agendas/therainsofcastamere.js
@@ -91,7 +91,7 @@ class TheRainsOfCastamere extends AgendaCard {
 
         player.selectedPlot = scheme;
         player.flipPlotFaceup();
-        this.game.raiseEvent('onPlotRevealed', player);
+        this.game.raiseEvent('onPlotRevealed', player, scheme);
 
         player.kneelCard(player.faction);
 

--- a/server/game/cards/plots/02/pullingthestrings.js
+++ b/server/game/cards/plots/02/pullingthestrings.js
@@ -28,11 +28,9 @@ class PullingTheStrings extends PlotCard {
 
         this.game.addMessage('{0} uses {1} to initiate the when resolved effect of {2}', player, this, card);
         card.controller = player;
-        this.controller = null;
-        this.game.raiseEvent('onPlotRevealed', player, () => {
+        this.game.raiseEvent('onPlotRevealed', player, card, () => {
             card.controller = card.owner;
             card.moveTo('revealed plots');
-            this.controller = player;
 
             this.resolving = false;
         });

--- a/server/game/cards/plots/04/varyssriddle.js
+++ b/server/game/cards/plots/04/varyssriddle.js
@@ -16,14 +16,12 @@ class VaryssRiddle extends PlotCard {
                 }
 
                 this.game.addMessage('{0} uses {1} to initiate the when resolved effect of {2}', player, this, plot);
-                this.controller = null;
                 plot.controller = player;
                 this.resolving = true;
 
-                this.game.raiseEvent('onPlotRevealed', player, () => {
+                this.game.raiseEvent('onPlotRevealed', player, plot, () => {
                     this.resolving = false;
                     plot.controller = plot.owner;
-                    this.controller = player;
                 });
             }
         });

--- a/server/game/gamesteps/plot/resolveplots.js
+++ b/server/game/gamesteps/plot/resolveplots.js
@@ -15,7 +15,7 @@ class ResolvePlots extends BaseStep {
         }
 
         _.each(this.playersWithRevealEffects, player => {
-            this.game.raiseEvent('onPlotRevealed', player);
+            this.game.raiseEvent('onPlotRevealed', player, player.activePlot);
         });
 
         return true;
@@ -41,7 +41,7 @@ class ResolvePlots extends BaseStep {
         }
 
         this.playersWithRevealEffects = _.reject(this.playersWithRevealEffects, p => p === player);
-        this.game.raiseEvent('onPlotRevealed', player);
+        this.game.raiseEvent('onPlotRevealed', player, player.activePlot);
 
         return true;
     }

--- a/server/game/gamesteps/plotphase.js
+++ b/server/game/gamesteps/plotphase.js
@@ -86,7 +86,7 @@ class PlotPhase extends Phase {
     resolveRemainingPlots() {
         var playersWithoutRevealEffects = _.reject(this.game.getPlayers(), player => player.activePlot.hasRevealEffect());
         _.each(playersWithoutRevealEffects, player => {
-            this.game.raiseEvent('onPlotRevealed', player);
+            this.game.raiseEvent('onPlotRevealed', player, player.activePlot);
         });
     }
 

--- a/test/server/cards/agendas/05045-therainsofcastamere.spec.js
+++ b/test/server/cards/agendas/05045-therainsofcastamere.spec.js
@@ -172,7 +172,7 @@ describe('The Rains of Castamere', function() {
             });
 
             it('should not reveal a plot', function() {
-                expect(this.gameSpy.raiseEvent).not.toHaveBeenCalledWith('onPlotRevealed', jasmine.any(Object));
+                expect(this.gameSpy.raiseEvent).not.toHaveBeenCalledWith('onPlotRevealed', jasmine.any(Object), jasmine.any(Object));
             });
 
             it('should return false', function() {
@@ -201,7 +201,7 @@ describe('The Rains of Castamere', function() {
                 });
 
                 it('should reveal the plot', function() {
-                    expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onPlotRevealed', this.player);
+                    expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onPlotRevealed', this.player, this.scheme1);
                 });
 
                 it('should return true', function() {
@@ -229,7 +229,7 @@ describe('The Rains of Castamere', function() {
                 });
 
                 it('should reveal the plot', function() {
-                    expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onPlotRevealed', this.player);
+                    expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onPlotRevealed', this.player, this.scheme1);
                 });
 
                 it('should return true', function() {
@@ -261,7 +261,7 @@ describe('The Rains of Castamere', function() {
                 });
 
                 it('should reveal the plot', function() {
-                    expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onPlotRevealed', this.player);
+                    expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onPlotRevealed', this.player, this.scheme1);
                 });
 
                 it('should return true', function() {

--- a/test/server/cards/plots/04/04020-varyssriddle.spec.js
+++ b/test/server/cards/plots/04/04020-varyssriddle.spec.js
@@ -5,10 +5,35 @@ describe('Varys\'s Riddle', function() {
     integration(function() {
         beforeEach(function() {
             const deck1 = this.buildDeck('greyjoy', [
-                'Varys\'s Riddle'
+                'Varys\'s Riddle',
+                'The Roseroad'
             ]);
 
             this.player1.selectDeck(deck1);
+        });
+
+        describe('when there are plot modifiers out', function() {
+            beforeEach(function() {
+                const deck2 = this.buildDeck('lannister', [
+                    'Wildfire Assault'
+                ]);
+
+                this.player2.selectDeck(deck2);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.player1.clickCard('The Roseroad', 'hand');
+                this.completeSetup();
+            });
+
+            it('should not crash', function() {
+                expect(() => {
+                    this.player1.selectPlot('Varys\'s Riddle');
+                    this.player2.selectPlot('Wildfire Assault');
+                    this.selectFirstPlayer(this.player1);
+                    this.selectPlotOrder(this.player1);
+                }).not.toThrow();
+            });
         });
 
         describe('when played against Wraiths in Their Midst', function() {

--- a/test/server/gamesteps/plot/resolveplots.spec.js
+++ b/test/server/gamesteps/plot/resolveplots.spec.js
@@ -8,6 +8,10 @@ describe('the ResolvePlots', function() {
         this.game = jasmine.createSpyObj('game', ['getPlayerByName', 'getFirstPlayer', 'promptWithMenu', 'raiseEvent']);
         this.player = jasmine.createSpyObj('player', ['setPrompt', 'cancelPrompt']);
         this.otherPlayer = jasmine.createSpyObj('player', ['setPrompt', 'cancelPrompt']);
+        this.playerPlot = { plot: 1 };
+        this.player.activePlot = this.playerPlot;
+        this.otherPlayerPlot = { plot: 2 };
+        this.otherPlayer.activePlot = this.otherPlayerPlot;
 
         this.game.getFirstPlayer.and.returnValue(this.otherPlayer);
     });
@@ -40,7 +44,7 @@ describe('the ResolvePlots', function() {
 
             it('should reveal the plot', function() {
                 this.prompt.continue();
-                expect(this.game.raiseEvent).toHaveBeenCalledWith('onPlotRevealed', this.player);
+                expect(this.game.raiseEvent).toHaveBeenCalledWith('onPlotRevealed', this.player, this.playerPlot);
             });
 
             it('should return true', function() {
@@ -60,8 +64,8 @@ describe('the ResolvePlots', function() {
 
             it('should not reveal any plot', function() {
                 this.prompt.continue();
-                expect(this.game.raiseEvent).not.toHaveBeenCalledWith('onPlotRevealed', this.player);
-                expect(this.game.raiseEvent).not.toHaveBeenCalledWith('onPlotRevealed', this.otherPlayer);
+                expect(this.game.raiseEvent).not.toHaveBeenCalledWith('onPlotRevealed', this.player, this.playerPlot);
+                expect(this.game.raiseEvent).not.toHaveBeenCalledWith('onPlotRevealed', this.otherPlayer, this.otherPlayerPlot);
             });
 
             it('should return false', function() {
@@ -99,7 +103,7 @@ describe('the ResolvePlots', function() {
 
             it('should reveal the plot', function() {
                 this.prompt.resolvePlayer(this.player, this.otherPlayer.name);
-                expect(this.game.raiseEvent).toHaveBeenCalledWith('onPlotRevealed', this.otherPlayer);
+                expect(this.game.raiseEvent).toHaveBeenCalledWith('onPlotRevealed', this.otherPlayer, this.otherPlayerPlot);
             });
 
             it('should remove the resolved player from the list', function() {


### PR DESCRIPTION
Previously, the onPlotRevealed event used to trigger "When Revealed"
abilities was only passing the player object. This made it necessary to
set controller to null on Varys's Riddle and Pulling the Strings because
they fire the onPlotRevealed event to replicate the opponent plot. This
would lead to them triggering themselves and prompting the player to
choose order of resolution. However, by setting the controller to null,
any cards that modified the current plot (including simple ones like the
+1 gold from Roseroad) would start to produce errors.

By sending the plot card that is firing with the onPlotRevealed event,
it is now possible to trigger only that specific card's "When Revealed"
ability and is no longer necessary to disown cards that replicate other
plots.

Fixes #769.