### PR TITLE
Encapsulate `Player.cardsInPlay`

### DIFF
--- a/server/game/cards/attachments/04/beggarking.js
+++ b/server/game/cards/attachments/04/beggarking.js
@@ -21,7 +21,7 @@ class BeggarKing extends DrawCard {
                 var gold = 1;
 
                 var otherPlayer = this.game.getOtherPlayer(this.controller);
-                if(!otherPlayer || !otherPlayer.cardsInPlay.any(card => card.hasTrait('King'))) {
+                if(!otherPlayer || !otherPlayer.anyCardsInPlay(card => card.hasTrait('King'))) {
                     gold = 2;
                 }
 

--- a/server/game/cards/attachments/04/motherofdragons.js
+++ b/server/game/cards/attachments/04/motherofdragons.js
@@ -6,7 +6,7 @@ class MotherOfDragons extends DrawCard {
             title: 'Kneel Mother of Dragons to add attached character to challenge',
             condition: () =>
                 this.game.currentChallenge
-                && this.controller.cardsInPlay.any(
+                && this.controller.anyCardsInPlay(
                     card => this.game.currentChallenge.isParticipating(card)
                         && card.hasTrait('Dragon')),
             cost: ability.costs.kneelSelf(),

--- a/server/game/cards/attachments/04/redgodsblessing.js
+++ b/server/game/cards/attachments/04/redgodsblessing.js
@@ -11,15 +11,7 @@ class RedGodsBlessing extends DrawCard {
     }
 
     getNumberOfCardsWithRhllor() {
-        var cardsWithRhllor = this.controller.cardsInPlay.reduce((runningTotal, c) => {
-            if(c.hasTrait('R\'hllor') && c.getType() === 'character') {
-                return runningTotal + 1;
-            }
-
-            return runningTotal;
-        }, 0);
-
-        return cardsWithRhllor;
+        return this.controller.getNumberOfCardsInPlay(c => c.hasTrait('R\'hllor') && c.getType() === 'character');
     }
 }
 

--- a/server/game/cards/attachments/05/shieldoflannisport.js
+++ b/server/game/cards/attachments/05/shieldoflannisport.js
@@ -15,7 +15,7 @@ class ShieldOfLannisport extends DrawCard {
     }
 
     noOtherLordsOrLadies() {
-        return !this.controller.cardsInPlay.any(card => (
+        return !this.controller.anyCardsInPlay(card => (
             card !== this.parent &&
             (card.hasTrait('Lord') || card.hasTrait('Lady')) &&
             card.getCost() >= 4

--- a/server/game/cards/characters/01/direwolfpup.js
+++ b/server/game/cards/characters/01/direwolfpup.js
@@ -4,24 +4,12 @@ class DirewolfPup extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             match: card => card === this,
-            effect: ability.effects.dynamicStrength(() => this.calculateStrength(this.controller.cardsInPlay))
+            effect: ability.effects.dynamicStrength(() => this.getNumberOfOtherDirewolves())
         });
     }
 
-    isOtherDirewolf(card) {
-        return card.uuid === this.uuid || !card.hasTrait('Direwolf');
-    }
-
-    calculateStrength(list) {
-        return list.reduce((counter, card) => {
-            var attachmentStr = this.calculateStrength(card.attachments);
-
-            if(this.isOtherDirewolf(card)) {
-                return counter + attachmentStr;
-            }
-
-            return counter + attachmentStr + 1;
-        }, 0);
+    getNumberOfOtherDirewolves() {
+        return this.controller.getNumberOfCardsInPlay(card => card !== this && card.hasTrait('Direwolf'));
     }
 }
 

--- a/server/game/cards/characters/01/drownedmen.js
+++ b/server/game/cards/characters/01/drownedmen.js
@@ -9,7 +9,7 @@ class DrownedMen extends DrawCard {
     }
 
     calculateStrength() {
-        var cards = this.controller.cardsInPlay.filter(card => {
+        var cards = this.controller.filterCardsInPlay(card => {
             return card.getType() === 'location' && card.hasTrait('Warship');
         });
 

--- a/server/game/cards/characters/01/greywind.js
+++ b/server/game/cards/characters/01/greywind.js
@@ -18,7 +18,7 @@ class GreyWind extends DrawCard {
     }
 
     cardCondition(card) {
-        var str = this.controller.findCardByName(this.controller.cardsInPlay, 'Robb Stark') ? 2 : 1;
+        var str = this.controller.anyCardsInPlay(card => card.name === 'Robb Stark') ? 2 : 1;
 
         return card.getStrength() <= str && card.location === 'play area' && card.getType() === 'character';
     }

--- a/server/game/cards/characters/01/kingshuntingparty.js
+++ b/server/game/cards/characters/01/kingshuntingparty.js
@@ -15,7 +15,7 @@ class KingsHuntingParty extends DrawCard {
             return false;
         }
 
-        if(otherPlayer.cardsInPlay.any(card => {
+        if(otherPlayer.anyCardsInPlay(card => {
             return card.getType() === 'character' && card.hasTrait('King');
         })) {
             return true;

--- a/server/game/cards/characters/01/left.js
+++ b/server/game/cards/characters/01/left.js
@@ -3,7 +3,7 @@ const DrawCard = require('../../../drawcard.js');
 class Left extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            condition: () => this.controller.findCardByName(this.controller.cardsInPlay, 'Right'),
+            condition: () => this.controller.anyCardsInPlay(card => card.name === 'Right'),
             match: this,
             effect: [
                 ability.effects.modifyStrength(1),

--- a/server/game/cards/characters/01/oldbearmormont.js
+++ b/server/game/cards/characters/01/oldbearmormont.js
@@ -3,7 +3,7 @@ const DrawCard = require('../../../drawcard.js');
 class OldBearMormont extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            condition: () => this.controller.cardsInPlay.any(card => card.name === 'The Wall'),
+            condition: () => this.controller.anyCardsInPlay(card => card.name === 'The Wall'),
             match: this,
             effect: ability.effects.doesNotKneelAsDefender()
         });

--- a/server/game/cards/characters/01/right.js
+++ b/server/game/cards/characters/01/right.js
@@ -3,7 +3,7 @@ const DrawCard = require('../../../drawcard.js');
 class Right extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            condition: () => this.controller.findCardByName(this.controller.cardsInPlay, 'Left'),
+            condition: () => this.controller.anyCardsInPlay(card => card.name === 'Left'),
             match: this,
             effect: [
                 ability.effects.modifyStrength(1),

--- a/server/game/cards/characters/01/robbstark.js
+++ b/server/game/cards/characters/01/robbstark.js
@@ -1,3 +1,5 @@
+const _ = require('underscore');
+
 const DrawCard = require('../../../drawcard.js');
 
 class RobbStark extends DrawCard {
@@ -9,10 +11,9 @@ class RobbStark extends DrawCard {
             },
             limit: ability.limit.perRound(1),
             handler: () => {
-                this.controller.cardsInPlay.each(card => {
-                    if(card.getType() === 'character') {
-                        card.controller.standCard(card);
-                    }
+                let characters = this.controller.filterCardsInPlay(card => card.getType() === 'character');
+                _.each(characters, card => {
+                    card.controller.standCard(card);
                 });
 
                 this.game.addMessage('{0} uses {1} to stand each {2} character they control', this.controller, this, 'stark');

--- a/server/game/cards/characters/01/varys.js
+++ b/server/game/cards/characters/01/varys.js
@@ -11,10 +11,9 @@ class Varys extends DrawCard {
             cost: ability.costs.removeSelfFromGame(),
             handler: () => {
                 _.each(this.game.getPlayers(), player => {
-                    player.cardsInPlay.each(card => {
-                        if(card.getType() === 'character') {
-                            player.discardCard(card);
-                        }
+                    let characters = player.filterCardsInPlay(card => card.getType() === 'character');
+                    _.each(characters, card => {
+                        player.discardCard(card);
                     });
                 });
 

--- a/server/game/cards/characters/01/wardensofthereach.js
+++ b/server/game/cards/characters/01/wardensofthereach.js
@@ -9,13 +9,7 @@ class WardensOfTheReach extends DrawCard {
     }
 
     calculateStrength() {
-        return this.controller.cardsInPlay.reduce((counter, card) => {
-            if(card.getType() !== 'location' || !card.hasTrait('The Reach')) {
-                return counter;
-            }
-
-            return counter + 1;
-        }, 0);
+        return this.controller.getNumberOfCardsInPlay(card => card.getType() === 'location' && card.hasTrait('The Reach'));
     }
 }
 

--- a/server/game/cards/characters/02/hedgeknight.js
+++ b/server/game/cards/characters/02/hedgeknight.js
@@ -13,15 +13,7 @@ class HedgeKnight extends DrawCard {
     }
 
     isControlAnotherKnight() {
-        var numOtherKnights = this.controller.cardsInPlay.reduce((counter, card) => {
-            if(this.isBlank() || !card.hasTrait('Knight') || card === this) {
-                return counter;
-            }
-
-            return counter + 1;
-        }, 0);
-
-        return numOtherKnights >= 1;
+        return this.controller.anyCardsInPlay(card => card.hasTrait('Knight') && card !== this);
     }
 }
 

--- a/server/game/cards/characters/02/hodor.js
+++ b/server/game/cards/characters/02/hodor.js
@@ -3,7 +3,7 @@ const DrawCard = require('../../../drawcard.js');
 class Hodor extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            condition: () => !this.controller.findCardByName(this.controller.cardsInPlay, 'Bran Stark'),
+            condition: () => !this.controller.anyCardsInPlay(card => card.name === 'Bran Stark'),
             match: this,
             effect: ability.effects.allowAsAttacker(false)
         });

--- a/server/game/cards/characters/02/jhogo.js
+++ b/server/game/cards/characters/02/jhogo.js
@@ -15,15 +15,7 @@ class Jhogo extends DrawCard {
     }
 
     getNumberOfBloodriders() {
-        var cards = this.controller.cardsInPlay.reduce((runningTotal, card) => {
-            if(!this.isBlank() && card.hasTrait('Bloodrider') && card.getType() === 'character' && card !== this) {
-                return runningTotal + 1;
-            }
-
-            return runningTotal;
-        }, 0);
-
-        return cards;
+        return this.controller.getNumberOfCardsInPlay(card => card.hasTrait('Bloodrider') && card.getType() === 'character' && card !== this);
     }
 
     getNumberOfDeadDefendingCharacters() {

--- a/server/game/cards/characters/02/ladyinwaiting.js
+++ b/server/game/cards/characters/02/ladyinwaiting.js
@@ -20,7 +20,7 @@ class LadyInWaiting extends DrawCard {
             this.game.currentPhase === 'marshal' &&
             !this.cannotMarshal &&
             this.controller.isCardInMarshalLocation(this) &&
-            this.controller.cardsInPlay.any(card => card.getType() === 'character' && card.hasTrait('Lady'))
+            this.controller.anyCardsInPlay(card => card.getType() === 'character' && card.hasTrait('Lady'))
         );
     }
 

--- a/server/game/cards/characters/02/winterfellkennelmaster.js
+++ b/server/game/cards/characters/02/winterfellkennelmaster.js
@@ -22,7 +22,7 @@ class WinterfellKennelMaster extends DrawCard {
     }
 
     isStarkCardParticipatingInChallenge() {
-        return this.game.currentChallenge && this.controller.cardsInPlay.any(card => {
+        return this.game.currentChallenge && this.controller.anyCardsInPlay(card => {
             return this.game.currentChallenge.isParticipating(card) && card.isFaction('stark');
         });
     }

--- a/server/game/cards/characters/04/brienneoftarth.js
+++ b/server/game/cards/characters/04/brienneoftarth.js
@@ -3,7 +3,7 @@ const DrawCard = require('../../../drawcard.js');
 class BrienneOfTarth extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            condition: () => this.controller.cardsInPlay.any(card => card.hasTrait('King') || card.name === 'Catelyn Stark'),
+            condition: () => this.controller.anyCardsInPlay(card => card.hasTrait('King') || card.name === 'Catelyn Stark'),
             match: this,
             effect: ability.effects.doesNotKneelAsDefender()
         });

--- a/server/game/cards/characters/04/myrcellabaratheon.js
+++ b/server/game/cards/characters/04/myrcellabaratheon.js
@@ -21,7 +21,7 @@ class MyrcellaBaratheon extends DrawCard {
 
     areNoKingsInPlay() {
         return !_.any(this.game.getPlayers(), player => {
-            return player.cardsInPlay.any(card => card.getType() === 'character' && card.hasTrait('King'));
+            return player.anyCardsInPlay(card => card.getType() === 'character' && card.hasTrait('King'));
         });
     }
 }

--- a/server/game/cards/characters/04/robbstark.js
+++ b/server/game/cards/characters/04/robbstark.js
@@ -53,7 +53,7 @@ class RobbStark extends DrawCard {
     }
 
     numberOfLoyalChars () {
-        var cards = this.controller.cardsInPlay.filter(card => {
+        var cards = this.controller.filterCardsInPlay(card => {
             return card.isLoyal() && card.getType() === 'character';
         });
 

--- a/server/game/cards/characters/04/seramorylorch.js
+++ b/server/game/cards/characters/04/seramorylorch.js
@@ -11,16 +11,12 @@ class SerAmoryLorch extends DrawCard {
 
     opponentHasThreeOrFewerChars() {
         var otherPlayer = this.game.getOtherPlayer(this.controller);
- 
+
         if(!otherPlayer) {
             return true;
         }
 
-        var cards = otherPlayer.cardsInPlay.filter(card => {
-            return card.getType() === 'character';
-        });
-
-        return cards.length <= 3;
+        return otherPlayer.getNumberOfCardsInPlay(card => card.getType() === 'character') <= 3;
     }
 }
 

--- a/server/game/cards/characters/05/moonbrothers.js
+++ b/server/game/cards/characters/05/moonbrothers.js
@@ -22,7 +22,7 @@ class MoonBrothers extends DrawCard {
     }
 
     hasAttackingClansman() {
-        var cards = this.controller.cardsInPlay.filter(card => {
+        var cards = this.controller.filterCardsInPlay(card => {
             return card.hasTrait('Clansman') && card.getType() === 'character' && this.game.currentChallenge.isAttacking(card);
         });
 

--- a/server/game/cards/characters/05/serlancellannister.js
+++ b/server/game/cards/characters/05/serlancellannister.js
@@ -10,7 +10,7 @@ class SerLancelLannister extends DrawCard {
     }
 
     getSingleOtherLannisterLordOrLady() {
-        var cards = this.controller.cardsInPlay.filter(card => {
+        var cards = this.controller.filterCardsInPlay(card => {
             return card.isFaction('lannister') && (card.hasTrait('Lord') || card.hasTrait('Lady')) && card.getType() === 'character' && card !== this;
         });
 

--- a/server/game/cards/characters/05/shaggasonofdolf.js
+++ b/server/game/cards/characters/05/shaggasonofdolf.js
@@ -35,10 +35,10 @@ class ShaggaSonOfDolf extends DrawCard {
     }
 
     hasClansmanOrTyrion() {
-        var cards = this.controller.cardsInPlay.filter(card => {
+        var cards = this.controller.filterCardsInPlay(card => {
             return (card.hasTrait('Clansman') && card.getType() === 'character') || card.name === 'Tyrion Lannister';
         });
-        
+
         return cards.length > 0;
     }
 }

--- a/server/game/cards/characters/05/timettsonoftimett.js
+++ b/server/game/cards/characters/05/timettsonoftimett.js
@@ -23,7 +23,7 @@ class TimettSonOfTimett extends DrawCard {
     }
 
     getNumberOfClansmen() {
-        var cards = this.controller.cardsInPlay.filter(card => {
+        var cards = this.controller.filterCardsInPlay(card => {
             return card.hasTrait('Clansman') && card.getType() === 'character';
         });
 

--- a/server/game/cards/characters/06/eastwatchcarpenter.js
+++ b/server/game/cards/characters/06/eastwatchcarpenter.js
@@ -16,7 +16,7 @@ class EastwatchCarpenter extends DrawCard {
     }
 
     numberOfNWLocations() {
-        var cards = this.controller.cardsInPlay.filter(card => {
+        var cards = this.controller.filterCardsInPlay(card => {
             return card.isFaction('thenightswatch') && card.getType() === 'location';
         });
 

--- a/server/game/cards/characters/07/jonsnow.js
+++ b/server/game/cards/characters/07/jonsnow.js
@@ -1,3 +1,5 @@
+const _ = require('underscore');
+
 const DrawCard = require('../../../drawcard.js');
 
 class JonSnow extends DrawCard {
@@ -9,19 +11,19 @@ class JonSnow extends DrawCard {
             limit: ability.limit.perPhase(1),
             choices: {
                 'Stand Wildlings': () => {
-                    this.controller.cardsInPlay.each(card => {
-                        if(this.game.currentChallenge.isAttacking(card) && card.hasTrait('Wildling') && card.getType() === 'character') {
-                            card.controller.standCard(card);
-                        }
+                    let attackingWildlings = this.controller.filterCardsInPlay(card => this.game.currentChallenge.isAttacking(card) && card.hasTrait('Wildling') && card.getType() === 'character');
+
+                    _.each(attackingWildlings, card => {
+                        card.controller.standCard(card);
                     });
 
                     this.game.addMessage('{0} uses {1} to stand each attacking Wildling character', this.controller, this);
                 },
                 'Stand Nights Watch': () => {
-                    this.controller.cardsInPlay.each(card => {
-                        if(this.game.currentChallenge.isDefending(card) && card.isFaction('thenightswatch') && card.getType() === 'character') {
-                            card.controller.standCard(card);
-                        }
+                    let defendingWatch = this.controller.filterCardsInPlay(card => this.game.currentChallenge.isDefending(card) && card.isFaction('thenightswatch') && card.getType() === 'character');
+
+                    _.each(defendingWatch, card => {
+                        card.controller.standCard(card);
                     });
 
                     this.game.addMessage('{0} uses {1} to stand each defending {2} character', this.controller, this, 'thenightswatch');

--- a/server/game/cards/characters/07/lostranger.js
+++ b/server/game/cards/characters/07/lostranger.js
@@ -14,7 +14,7 @@ class LostRanger extends DrawCard {
     }
 
     hasNoOtherRanger() {
-        var rangers = this.controller.cardsInPlay.filter(card => {
+        var rangers = this.controller.filterCardsInPlay(card => {
             return card !== this && card.hasTrait('Ranger') && card.getType() === 'character';
         });
 

--- a/server/game/cards/events/01/seeninflames.js
+++ b/server/game/cards/events/01/seeninflames.js
@@ -6,7 +6,7 @@ class SeenInFlames extends DrawCard {
             title: 'Discard from opponent\'s hand',
             phase: 'challenge',
             condition: () => (
-                this.controller.cardsInPlay.any(card => card.hasTrait('R\'hllor')) &&
+                this.controller.anyCardsInPlay(card => card.hasTrait('R\'hllor')) &&
                 this.opponentHasCards()
             ),
             handler: context => {

--- a/server/game/cards/events/01/thethingsidoforlove.js
+++ b/server/game/cards/events/01/thethingsidoforlove.js
@@ -4,7 +4,7 @@ class TheThingsIDoForLove extends DrawCard {
     setupCardAbilities(ability) {
         this.action({
             title: 'Return card to owners hand',
-            condition: () => this.controller.cardsInPlay.any(card => card.hasTrait('Lord') || card.hasTrait('Lady')),
+            condition: () => this.controller.anyCardsInPlay(card => card.hasTrait('Lord') || card.hasTrait('Lady')),
             phase: 'challenge',
             cost: ability.costs.kneelFactionCard(),
             target: {

--- a/server/game/cards/events/02/thewatcheronthewalls.js
+++ b/server/game/cards/events/02/thewatcheronthewalls.js
@@ -9,7 +9,7 @@ class TheWatcherOnTheWalls extends ChallengeEvent {
     }
 
     canPlay(player, card) {
-        var standingRangers = this.controller.cardsInPlay.filter(
+        var standingRangers = this.controller.filterCardsInPlay(
             card =>
                 !card.kneeled
                 && card.hasTrait('Ranger'));

--- a/server/game/cards/events/03/evenhandedjustice.js
+++ b/server/game/cards/events/03/evenhandedjustice.js
@@ -14,9 +14,7 @@ class EvenHandedJustice extends DrawCard {
     }
 
     hasStandingCharacters(player) {
-        return (player.cardsInPlay
-                .filter(card => card.getType() === 'character' && !card.kneeled)
-                .length > 0);
+        return player.anyCardsInPlay(card => card.getType() === 'character' && !card.kneeled);
     }
 
     play(player) {

--- a/server/game/cards/events/04/offerofapeach.js
+++ b/server/game/cards/events/04/offerofapeach.js
@@ -4,7 +4,7 @@ class OfferOfAPeach extends DrawCard {
     setupCardAbilities() {
         this.action({
             title: 'Remove character from challenge',
-            condition: () => this.game.currentChallenge && this.controller.cardsInPlay.any(card => card.hasTrait('Lady') || card.name === 'Renly Baratheon'),
+            condition: () => this.game.currentChallenge && this.controller.anyCardsInPlay(card => card.hasTrait('Lady') || card.name === 'Renly Baratheon'),
             phase: 'challenge',
             target: {
                 activePromptTitle: 'Select a character',

--- a/server/game/cards/plots/01/callingthebanners.js
+++ b/server/game/cards/plots/01/callingthebanners.js
@@ -4,21 +4,13 @@ class CallingTheBanners extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
             handler: () => {
-                var otherPlayer = this.game.getOtherPlayer(this.controller);
+                let otherPlayer = this.game.getOtherPlayer(this.controller);
 
                 if(!otherPlayer) {
                     return;
                 }
 
-                var characterCount = otherPlayer.cardsInPlay.reduce((memo, card) => {
-                    var count = memo;
-
-                    if(card.getType() === 'character') {
-                        count++;
-                    }
-
-                    return count;
-                }, 0);
+                let characterCount = otherPlayer.getNumberOfCardsInPlay(card => card.getType() === 'character');
 
                 if(characterCount <= 0) {
                     return;

--- a/server/game/cards/plots/01/wildfireassault.js
+++ b/server/game/cards/plots/01/wildfireassault.js
@@ -32,7 +32,7 @@ class WildfireAssault extends PlotCard {
     doDiscard() {
         _.each(this.selections, selection => {
             var player = selection.player;
-            var toKill = _.difference(player.cardsInPlay.filter(card => card.getType() === 'character'), selection.cards);
+            var toKill = _.difference(player.filterCardsInPlay(card => card.getType() === 'character'), selection.cards);
 
             _.each(toKill, card => {
                 player.killCharacter(card, false);

--- a/server/game/cards/plots/02/politicaldisaster.js
+++ b/server/game/cards/plots/02/politicaldisaster.js
@@ -27,7 +27,7 @@ class PoliticalDisaster extends PlotCard {
     doDiscard() {
         _.each(this.selections, selection => {
             var player = selection.player;
-            var toDiscard = _.difference(player.cardsInPlay.filter(card => card.getType() === 'location'), selection.cards);
+            var toDiscard = _.difference(player.filterCardsInPlay(card => card.getType() === 'location'), selection.cards);
 
             _.each(toDiscard, card => {
                 player.discardCard(card);

--- a/server/game/cards/plots/02/thefirstsnowofwinter.js
+++ b/server/game/cards/plots/02/thefirstsnowofwinter.js
@@ -17,10 +17,9 @@ class TheFirstSnowOfWinter extends PlotCard {
     }
 
     returnCardsToHand(player) {
-        player.cardsInPlay.each(card => {
-            if(card.getType() === 'character' && card.getCost() <= 3) {
-                player.returnCardToHand(card);
-            }
+        let characters = player.filterCardsInPlay(card => card.getType() === 'character' && card.getCost() <= 3);
+        _.each(characters, card => {
+            player.returnCardToHand(card);
         });
     }
 }

--- a/server/game/cards/plots/02/wardensofthenorth.js
+++ b/server/game/cards/plots/02/wardensofthenorth.js
@@ -22,7 +22,7 @@ class WardensOfTheNorth extends PlotCard {
     }
 
     isStarkCardParticipatingInChallenge() {
-        return this.game.currentChallenge && this.controller.cardsInPlay.any(card => {
+        return this.game.currentChallenge && this.controller.anyCardsInPlay(card => {
             return this.game.currentChallenge.isParticipating(card) && card.isFaction('stark');
         });
     }

--- a/server/game/cards/plots/04/battleoftheblackwater.js
+++ b/server/game/cards/plots/04/battleoftheblackwater.js
@@ -14,7 +14,7 @@ class BattleOfTheBlackwater extends PlotCard {
     }
 
     removeAllDupes(player) {
-        var characters = player.cardsInPlay.filter(card => card.dupes.size() > 0);
+        var characters = player.filterCardsInPlay(card => card.dupes.size() > 0);
         _.each(characters, character => {
             while(character.dupes.size() > 0) {
                 player.removeDuplicate(character);

--- a/server/game/cards/plots/04/valarmorghulis.js
+++ b/server/game/cards/plots/04/valarmorghulis.js
@@ -14,7 +14,7 @@ class ValarMorghulis extends PlotCard {
     }
 
     killAllCharacters(player) {
-        var characters = player.cardsInPlay.filter(card => card.getType() === 'character');
+        var characters = player.filterCardsInPlay(card => card.getType() === 'character');
 
         _.each(characters, character => {
             player.killCharacter(character);

--- a/server/game/cards/plots/07/namedaytourney.js
+++ b/server/game/cards/plots/07/namedaytourney.js
@@ -26,7 +26,7 @@ class NameDayTourney extends PlotCard {
     }
 
     hasParticipatingKnight() {
-        var cards = this.controller.cardsInPlay.filter(card => {
+        var cards = this.controller.filterCardsInPlay(card => {
             return (this.game.currentChallenge.isParticipating(card) &&
                     card.hasTrait('Knight') && 
                     card.getType() === 'character');

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -59,7 +59,7 @@ const Costs = {
         );
         return {
             canPay: function(context) {
-                return context.player.cardsInPlay.any(card => fullCondition(card, context));
+                return context.player.anyCardsInPlay(card => fullCondition(card, context));
             },
             resolve: function(context) {
                 var result = {
@@ -128,7 +128,7 @@ const Costs = {
         );
         return {
             canPay: function(context) {
-                return context.player.cardsInPlay.any(card => fullCondition(card, context));
+                return context.player.anyCardsInPlay(card => fullCondition(card, context));
             },
             resolve: function(context) {
                 var result = {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -592,7 +592,9 @@ class Game extends EventEmitter {
         }
 
         oldController.removeCardFromPile(card);
+        oldController.allCards = _(oldController.allCards.reject(c => c === card));
         newController.cardsInPlay.push(card);
+        newController.allCards.push(card);
         card.controller = newController;
 
         if(card.location !== 'play area') {

--- a/server/game/gamesteps/challenge/fulfillmilitaryclaim.js
+++ b/server/game/gamesteps/challenge/fulfillmilitaryclaim.js
@@ -32,7 +32,7 @@ class FulfillMilitaryClaim extends BaseStep {
             cards = [cards];
         }
 
-        var charactersAvailable = this.player.cardsInPlay.filter(c => c.getType() === 'character').length;
+        var charactersAvailable = this.player.getNumberOfCardsInPlay(c => c.getType() === 'character');
         var maxAppliedClaim = Math.min(this.claim, charactersAvailable);
 
         if(cards.length < maxAppliedClaim) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -116,6 +116,20 @@ class Player extends Spectator {
         return this.cardsInPlay.any(predicate);
     }
 
+    filterCardsInPlay(predicate) {
+        return this.cardsInPlay.filter(predicate);
+    }
+
+    getNumberOfCardsInPlay(predicate) {
+        return this.cardsInPlay.reduce((num, card) => {
+            if(predicate(card)) {
+                return num + 1;
+            }
+
+            return num;
+        }, 0);
+    }
+
     isCardInMarshalLocation(card) {
         return _.any(this.marshalLocations, location => location.contains(card));
     }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -113,16 +113,16 @@ class Player extends Spectator {
     }
 
     anyCardsInPlay(predicate) {
-        return this.cardsInPlay.any(predicate);
+        return this.allCards.any(card => card.location === 'play area' && predicate(card));
     }
 
     filterCardsInPlay(predicate) {
-        return this.cardsInPlay.filter(predicate);
+        return this.allCards.filter(card => card.location === 'play area' && predicate(card));
     }
 
     getNumberOfCardsInPlay(predicate) {
-        return this.cardsInPlay.reduce((num, card) => {
-            if(predicate(card)) {
+        return this.allCards.reduce((num, card) => {
+            if(card.location === 'play area' && predicate(card)) {
                 return num + 1;
             }
 

--- a/test/server/gamesteps/fulfillmilitaryclaim.spec.js
+++ b/test/server/gamesteps/fulfillmilitaryclaim.spec.js
@@ -1,15 +1,13 @@
 /*global describe, it, beforeEach, expect, jasmine*/
 /* eslint camelcase: 0, no-invalid-this: 0 */
 
-const _ = require('underscore');
-
 const FulfillMilitaryClaim = require('../../../server/game/gamesteps/challenge/fulfillmilitaryclaim.js');
 
 describe('FulfillMilitaryClaim', function() {
     beforeEach(function() {
         this.game = jasmine.createSpyObj('game', ['promptForSelect', 'addMessage']);
-        this.loser = jasmine.createSpyObj('loser', ['killCharacter']);
-        this.loser.cardsInPlay = _([]);
+        this.loser = jasmine.createSpyObj('loser', ['killCharacter', 'getNumberOfCardsInPlay']);
+        this.loser.getNumberOfCardsInPlay.and.returnValue(0);
 
         this.step = new FulfillMilitaryClaim(this.game, this.loser, 1);
     });
@@ -40,9 +38,7 @@ describe('FulfillMilitaryClaim', function() {
             this.card2 = makeCard(this.loser, 'character');
             this.card3 = makeCard(this.loser, 'location');
 
-            this.loser.cardsInPlay.push(this.card1);
-            this.loser.cardsInPlay.push(this.card2);
-            this.loser.cardsInPlay.push(this.card3);
+            this.loser.getNumberOfCardsInPlay.and.returnValue(2);
         });
 
         describe('when the claim is 1', function() {


### PR DESCRIPTION
Removes all usages of `player.cardsInPlay` from card implementations in favor of new helper methods.