### PR TITLE
Add a deck search prompt.

### DIFF
--- a/server/game/cards/characters/02/serhobberredwyne.js
+++ b/server/game/cards/characters/02/serhobberredwyne.js
@@ -1,5 +1,4 @@
 const DrawCard = require('../../../drawcard.js');
-const _ = require('underscore');
 
 class SerHobberRedwyne extends DrawCard {
     setupCardAbilities() {
@@ -8,39 +7,24 @@ class SerHobberRedwyne extends DrawCard {
                 onCardEntersPlay: (event, card) => card === this && this.game.currentPhase === 'marshal'
             },
             handler: () => {
-                var characters = this.controller.searchDrawDeck(this.controller.drawDeck.length, card => {
-                    return card.hasTrait('Lady');
-                });
-                var buttons = _.map(characters, card => {
-                    return { text: card.name, method: 'cardSelected', arg: card.uuid, card: card.getSummary(true) };
-                });
-                buttons.push({ text: 'Done', method: 'doneSelecting' });
-                this.game.promptWithMenu(this.controller, this, {
-                    activePrompt: {
-                        menuTitle: 'Select a card to add to your hand',
-                        buttons: buttons
-                    },
+                this.game.promptForDeckSearch(this.controller, {
+                    activePromptTitle: 'Select a card to add to your hand',
+                    cardCondition: card => card.getType() === 'character' && card.hasTrait('Lady'),
+                    onSelect: (player, card) => this.cardSelected(player, card),
+                    onCancel: player => this.doneSelecting(player),
                     source: this
                 });
             }
         });
     }
 
-    cardSelected(player, cardId) {
-        var card = player.findCardByUuid(player.drawDeck, cardId);
-        if(!card) {
-            return false;
-        }
+    cardSelected(player, card) {
         player.moveCard(card, 'hand');
-        player.shuffleDrawDeck();
         this.game.addMessage('{0} uses {1} to reveal {2} and add it to their hand', player, this, card);
-        return true;
     }
 
     doneSelecting(player) {
-        player.shuffleDrawDeck();
         this.game.addMessage('{0} does not use {1} to add a card to their hand', player, this);
-        return true;
     }
 }
 

--- a/server/game/cards/characters/04/pyatpree.js
+++ b/server/game/cards/characters/04/pyatpree.js
@@ -1,5 +1,3 @@
-const _ = require('underscore');
-
 const DrawCard = require('../../../drawcard.js');
 
 class PyatPree extends DrawCard {
@@ -9,47 +7,25 @@ class PyatPree extends DrawCard {
                 afterChallenge: (event, challenge) => challenge.winner === this.controller && challenge.isParticipating(this)
             },
             handler: () => {
-                var cards = this.controller.searchDrawDeck(this.game.currentChallenge.strengthDifference, card => {
-                    return (card.getType() === 'attachment' || card.getType() === 'event') && card.isFaction('targaryen');
-                });
-
-                var buttons = _.map(cards, card => {
-                    return { text: card.name, method: 'cardSelected', arg: card.uuid, card: card.getSummary(true) };
-                });
-                buttons.push({ text: 'Done', method: 'doneSelecting' });
-
-                this.game.promptWithMenu(this.controller, this, {
-                    activePrompt: {
-                        menuTitle: 'Select a card add to your hand',
-                        buttons: buttons
-                    },
+                this.game.promptForDeckSearch(this.controller, {
+                    numCards: this.game.currentChallenge.strengthDifference,
+                    activePromptTitle: 'Select a card to add to your hand',
+                    cardCondition: card => (card.getType() === 'attachment' || card.getType() === 'event') && card.isFaction('targaryen'),
+                    onSelect: (player, card) => this.cardSelected(player, card),
+                    onCancel: player => this.doneSelecting(player),
                     source: this
                 });
             }
         });
     }
 
-    cardSelected(player, cardId) {
-        var card = player.findCardByUuid(player.drawDeck, cardId);
-
-        if(!card) {
-            return false;
-        }
-
+    cardSelected(player, card) {
         player.moveCard(card, 'hand');
-        player.shuffleDrawDeck();
-
         this.game.addMessage('{0} uses {1} to reveal {2} and add it to their hand', player, this, card);
-
-        return true;
     }
 
     doneSelecting(player) {
-        player.shuffleDrawDeck();
-
         this.game.addMessage('{0} does not use {1} to add a card to their hand', player, this);
-
-        return true;
     }
 }
 

--- a/server/game/cards/characters/05/alerietyrell.js
+++ b/server/game/cards/characters/05/alerietyrell.js
@@ -1,5 +1,3 @@
-const _ = require('underscore');
-
 const DrawCard = require('../../../drawcard.js');
 
 class AlerieTyrell extends DrawCard {
@@ -9,47 +7,25 @@ class AlerieTyrell extends DrawCard {
                 onCardEntersPlay: (event, card) => card === this
             },
             handler: () => {
-                var characters = this.controller.searchDrawDeck(10, card => {
-                    return card.getType() === 'character' && card.isFaction('tyrell') && card.getCost() <= 3;
-                });
-
-                var buttons = _.map(characters, card => {
-                    return { text: card.name, method: 'cardSelected', arg: card.uuid, card: card.getSummary(true) };
-                });
-                buttons.push({ text: 'Done', method: 'doneSelecting' });
-
-                this.game.promptWithMenu(this.controller, this, {
-                    activePrompt: {
-                        menuTitle: 'Select a card to add to your hand',
-                        buttons: buttons
-                    },
+                this.game.promptForDeckSearch(this.controller, {
+                    numCards: 10,
+                    activePromptTitle: 'Select a card to add to your hand',
+                    cardCondition: card => card.getType() === 'character' && card.isFaction('tyrell') && card.getCost() <= 3,
+                    onSelect: (player, card) => this.cardSelected(player, card),
+                    onCancel: player => this.doneSelecting(player),
                     source: this
                 });
             }
         });
     }
 
-    cardSelected(player, cardId) {
-        var card = player.findCardByUuid(player.drawDeck, cardId);
-
-        if(!card) {
-            return false;
-        }
-
+    cardSelected(player, card) {
         player.moveCard(card, 'hand');
-        player.shuffleDrawDeck();
-
         this.game.addMessage('{0} uses {1} to search the top 10 cards of their deck and reveal {2} and add it to their hand', player, this, card);
-
-        return true;
     }
 
     doneSelecting(player) {
-        player.shuffleDrawDeck();
-
         this.game.addMessage('{0} does not use {1} to add a card to their hand', player, this);
-
-        return true;
     }
 }
 

--- a/server/game/cards/characters/06/margaerytyrell.js
+++ b/server/game/cards/characters/06/margaerytyrell.js
@@ -1,5 +1,3 @@
-const _ = require('underscore');
-
 const DrawCard = require('../../../drawcard.js');
 
 class MargaeryTyrell extends DrawCard {
@@ -12,52 +10,24 @@ class MargaeryTyrell extends DrawCard {
             },
             limit: ability.limit.perRound(1),
             handler: () => {
-                var characters = this.controller.searchDrawDeck(card => {
-                    return card.isUnique() && (card.hasTrait('king') || card.hasTrait('lord')) && this.controller.deadPile.filter(c => {
-                        return c.name === card.name;
-                    }).length === 0;
-                   
-                });
-                var uniqueCardsByTitle = [];
-                var selectableCharacters = _.filter(characters, (char) => {
-                    if(uniqueCardsByTitle.indexOf(char.cardData.label) >= 0) {
-                        return false;
-                    }
-
-                    uniqueCardsByTitle.push(char.cardData.label);
-                    return true;
-                });
-                var buttons = _.map(selectableCharacters, card => {
-                    return { text: card.cardData.label, method: 'cardSelected', arg: card.uuid, card: card.getSummary(true) };
-                });
-
-                buttons.push({ text: 'Done', method: 'doneSelecting' });
-                this.game.promptWithMenu(this.controller, this, {
-                    activePrompt: {
-                        menuTitle: 'Select a card to put into play',
-                        buttons: buttons
-                    },
+                this.game.promptForDeckSearch(this.controller, {
+                    activePromptTitle: 'Select a card to put into play',
+                    cardCondition: card => card.isUnique() && (card.hasTrait('king') || card.hasTrait('lord')) && this.controller.canPutIntoPlay(card),
+                    onSelect: (player, card) => this.cardSelected(player, card),
+                    onCancel: player => this.doneSelecting(player),
                     source: this
                 });
             }
         });
     }
 
-    cardSelected(player, cardId) {
-        var card = player.findCardByUuid(player.drawDeck, cardId);
-        if(!card) {
-            return false;
-        }
+    cardSelected(player, card) {
         player.putIntoPlay(card);
-        player.shuffleDrawDeck();
         this.game.addMessage('{0} uses {1} to search their deck and put {2} into play', player, this, card);
-        return true;
     }
 
     doneSelecting(player) {
-        player.shuffleDrawDeck();
         this.game.addMessage('{0} does not use {1} to put a card into play', player, this);
-        return true;
     }
 }
 

--- a/server/game/cards/events/01/olennascunning.js
+++ b/server/game/cards/events/01/olennascunning.js
@@ -1,5 +1,3 @@
-const _ = require('underscore');
-
 const DrawCard = require('../../../drawcard.js');
 
 class OlennasCunning extends DrawCard {
@@ -35,47 +33,24 @@ class OlennasCunning extends DrawCard {
     }
 
     typeSelected(player, type) {
-        var cards = this.controller.searchDrawDeck(card => {
-            return card.getType() !== type;
-        });
-
-        var buttons = _.map(cards, card => {
-            return { text: card.name, method: 'cardSelected', arg: card.uuid, card: card.getSummary(true) };
-        });
-        buttons.push({ text: 'Done', method: 'doneSelecting' });
-
-        this.game.promptWithMenu(this.controller, this, {
-            activePrompt: {
-                menuTitle: 'Select a card add to your hand',
-                buttons: buttons
-            },
+        this.game.promptForDeckSearch(this.controller, {
+            activePromptTitle: 'Select a card add to your hand',
+            cardCondition: card => card.getType() !== type,
+            onSelect: (player, card) => this.cardSelected(player, card),
+            onCancel: player => this.doneSelecting(player),
             source: this
         });
 
         return true;
     }
 
-    cardSelected(player, cardId) {
-        var card = player.findCardByUuid(player.drawDeck, cardId);
-
-        if(!card) {
-            return false;
-        }
-
+    cardSelected(player, card) {
         player.moveCard(card, 'hand');
-        player.shuffleDrawDeck();
-
         this.game.addMessage('{0} uses {1} to reveal {2} and add it to their hand', player, this, card);
-
-        return true;
     }
 
     doneSelecting(player) {
-        player.shuffleDrawDeck();
-
         this.game.addMessage('{0} does not use {1} to add a card to their hand', player, this);
-
-        return true;
     }
 }
 

--- a/server/game/cards/locations/02/shadowblacklane.js
+++ b/server/game/cards/locations/02/shadowblacklane.js
@@ -1,5 +1,3 @@
-const _ = require('underscore');
-
 const DrawCard = require('../../../drawcard.js');
 
 class ShadowblackLane extends DrawCard {
@@ -10,45 +8,25 @@ class ShadowblackLane extends DrawCard {
             },
             cost: ability.costs.kneelFactionCard(),
             handler: () => {
-                var events = this.controller.searchDrawDeck(10, card => {
-                    return card.getType() === 'event' && card.isFaction(this.controller.faction.getPrintedFaction());
-                });
-
-                var buttons = _.map(events, card => {
-                    return { text: card.name, method: 'cardSelected', arg: card.uuid, card: card.getSummary(true) };
-                });
-                buttons.push({ text: 'Done', method: 'doneSelecting' });
-
-                this.game.promptWithMenu(this.controller, this, {
-                    activePrompt: {
-                        menuTitle: 'Select a card to add to your hand',
-                        buttons: buttons
-                    },
+                this.game.promptForDeckSearch(this.controller, {
+                    numCards: 10,
+                    activePromptTitle: 'Select a card to add to your hand',
+                    cardCondition: card => card.getType() === 'event' && card.isFaction(this.controller.faction.getPrintedFaction()),
+                    onSelect: (player, card) => this.cardSelected(player, card),
+                    onCancel: player => this.doneSelecting(player),
                     source: this
                 });
             }
         });
     }
 
-    cardSelected(player, cardId) {
-        var card = player.findCardByUuid(player.drawDeck, cardId);
-
-        if(!card) {
-            return false;
-        }
-
+    cardSelected(player, card) {
         player.moveCard(card, 'hand');
-        player.shuffleDrawDeck();
         this.game.addMessage('{0} uses {1} to reveal {2} and add it to their hand', player, this, card);
-
-        return true;
     }
 
     doneSelecting(player) {
-        player.shuffleDrawDeck();
         this.game.addMessage('{0} does not use {1} to add a card to their hand', player, this);
-
-        return true;
     }
 }
 

--- a/server/game/cards/locations/02/streetofsilk.js
+++ b/server/game/cards/locations/02/streetofsilk.js
@@ -10,20 +10,12 @@ class StreetOfSilk extends DrawCard {
             },
             cost: ability.costs.kneelFactionCard(),
             handler: () => {
-                var events = this.controller.searchDrawDeck(5, card => {
-                    return card.hasTrait('Ally') || card.hasTrait('Companion');
-                });
-
-                var buttons = _.map(events, card => {
-                    return { text: card.name, method: 'cardSelected', arg: card.uuid, card: card.getSummary(true) };
-                });
-                buttons.push({ text: 'Done', method: 'doneSelecting' });
-
-                this.game.promptWithMenu(this.controller, this, {
-                    activePrompt: {
-                        menuTitle: 'Select a card to add to your hand',
-                        buttons: buttons
-                    },
+                this.game.promptForDeckSearch(this.controller, {
+                    numCards: 5,
+                    activePromptTitle: 'Select a card to add to your hand',
+                    cardCondition: card => card.getType() === 'character' && (card.hasTrait('Ally') || card.hasTrait('Companion')),
+                    onSelect: (player, card) => this.cardSelected(player, card),
+                    onCancel: player => this.doneSelecting(player),
                     source: this
                 });
             }
@@ -40,25 +32,13 @@ class StreetOfSilk extends DrawCard {
         return _.any(ourCards, card => card.hasTrait('Lord') || card.hasTrait('Lady'));
     }
 
-    cardSelected(player, cardId) {
-        var card = player.findCardByUuid(player.drawDeck, cardId);
-
-        if(!card) {
-            return false;
-        }
-
+    cardSelected(player, card) {
         player.moveCard(card, 'hand');
-        player.shuffleDrawDeck();
         this.game.addMessage('{0} uses {1} to reveal {2} and add it to their hand', player, this, card);
-
-        return true;
     }
 
     doneSelecting(player) {
-        player.shuffleDrawDeck();
         this.game.addMessage('{0} does not use {1} to add a card to their hand', player, this);
-
-        return true;
     }
 }
 

--- a/server/game/cards/locations/02/streetofsteel.js
+++ b/server/game/cards/locations/02/streetofsteel.js
@@ -1,5 +1,3 @@
-const _ = require('underscore');
-
 const DrawCard = require('../../../drawcard.js');
 
 class StreetOfSteel extends DrawCard {
@@ -10,45 +8,25 @@ class StreetOfSteel extends DrawCard {
             },
             cost: ability.costs.kneelFactionCard(),
             handler: () => {
-                var events = this.controller.searchDrawDeck(10, card => {
-                    return card.getType() === 'attachment' && (card.hasTrait('Weapon') || card.hasTrait('Item'));
-                });
-
-                var buttons = _.map(events, card => {
-                    return { text: card.name, method: 'cardSelected', arg: card.uuid, card: card.getSummary(true) };
-                });
-                buttons.push({ text: 'Done', method: 'doneSelecting' });
-
-                this.game.promptWithMenu(this.controller, this, {
-                    activePrompt: {
-                        menuTitle: 'Select a card to add to your hand',
-                        buttons: buttons
-                    },
+                this.game.promptForDeckSearch(this.controller, {
+                    numCards: 10,
+                    activePromptTitle: 'Select a card to add to your hand',
+                    cardCondition: card => card.getType() === 'attachment' && (card.hasTrait('Weapon') || card.hasTrait('Item')),
+                    onSelect: (player, card) => this.cardSelected(player, card),
+                    onCancel: player => this.doneSelecting(player),
                     source: this
                 });
             }
         });
     }
 
-    cardSelected(player, cardId) {
-        var card = player.findCardByUuid(player.drawDeck, cardId);
-
-        if(!card) {
-            return false;
-        }
-
+    cardSelected(player, card) {
         player.moveCard(card, 'hand');
-        player.shuffleDrawDeck();
         this.game.addMessage('{0} uses {1} to reveal {2} and add it to their hand', player, this, card);
-
-        return true;
     }
 
     doneSelecting(player) {
-        player.shuffleDrawDeck();
         this.game.addMessage('{0} does not use {1} to add a card to their hand', player, this);
-
-        return true;
     }
 }
 

--- a/server/game/cards/plots/01/buildingorders.js
+++ b/server/game/cards/plots/01/buildingorders.js
@@ -1,50 +1,28 @@
-const _ = require('underscore');
-
 const PlotCard = require('../../../plotcard.js');
 
 class BuildingOrders extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
             handler: () => {
-                var attachmentsAndLocations = this.controller.searchDrawDeck(10, card => {
-                    return card.getType() === 'attachment' || card.getType() === 'location';
-                });
-
-                var buttons = _.map(attachmentsAndLocations, card => {
-                    return { text: card.name, method: 'cardSelected', arg: card.uuid, card: card.getSummary(true) };
-                });
-                buttons.push({ text: 'Done', method: 'doneSelecting' });
-
-                this.game.promptWithMenu(this.controller, this, {
-                    activePrompt: {
-                        menuTitle: 'Select a card to add to your hand',
-                        buttons: buttons
-                    },
+                this.game.promptForDeckSearch(this.controller, {
+                    numCards: 10,
+                    activePromptTitle: 'Select a card to add to your hand',
+                    cardType: ['attachment', 'location'],
+                    onSelect: (player, card) => this.cardSelected(player, card),
+                    onCancel: player => this.doneSelecting(player),
                     source: this
                 });
             }
         });
     }
 
-    cardSelected(player, cardId) {
-        var card = player.findCardByUuid(player.drawDeck, cardId);
-
-        if(!card) {
-            return false;
-        }
-
+    cardSelected(player, card) {
         player.moveCard(card, 'hand');
-        player.shuffleDrawDeck();
-
         this.game.addMessage('{0} uses {1} to reveal {2} and add it to their hand', player, this, card);
-
-        return true;
     }
 
     doneSelecting(player) {
-        player.shuffleDrawDeck();
         this.game.addMessage('{0} does not use {1} to add a card to their hand', player, this);
-        return true;
     }
 }
 

--- a/server/game/cards/plots/01/summons.js
+++ b/server/game/cards/plots/01/summons.js
@@ -1,51 +1,28 @@
-const _ = require('underscore');
-
 const PlotCard = require('../../../plotcard.js');
 
 class Summons extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
             handler: () => {
-                var characters = this.controller.searchDrawDeck(10, card => {
-                    return card.getType() === 'character';
-                });
-
-                var buttons = _.map(characters, card => {
-                    return { text: card.name, method: 'cardSelected', arg: card.uuid, card: card.getSummary(true) };
-                });
-                buttons.push({ text: 'Done', method: 'doneSelecting' });
-
-                this.game.promptWithMenu(this.controller, this, {
-                    activePrompt: {
-                        menuTitle: 'Select a card to add to your hand',
-                        buttons: buttons
-                    },
+                this.game.promptForDeckSearch(this.controller, {
+                    numCards: 10,
+                    activePromptTitle: 'Select a card to add to your hand',
+                    cardType: 'character',
+                    onSelect: (player, card) => this.cardSelected(player, card),
+                    onCancel: player => this.doneSelecting(player),
                     source: this
                 });
             }
         });
     }
 
-    cardSelected(player, cardId) {
-        var card = player.findCardByUuid(player.drawDeck, cardId);
-
-        if(!card) {
-            return false;
-        }
-
+    cardSelected(player, card) {
         player.moveCard(card, 'hand');
-        player.shuffleDrawDeck();
-
         this.game.addMessage('{0} uses {1} to reveal {2} and add it to their hand', player, this, card);
-
-        return true;
     }
 
     doneSelecting(player) {
-        player.shuffleDrawDeck();
         this.game.addMessage('{0} does not use {1} to add a card to their hand', player, this);
-
-        return true;
     }
 }
 

--- a/server/game/cards/plots/02/heretoserve.js
+++ b/server/game/cards/plots/02/heretoserve.js
@@ -1,51 +1,27 @@
-const _ = require('underscore');
-
 const PlotCard = require('../../../plotcard.js');
 
 class HereToServe extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
             handler: () => {
-                var maesterCards = this.controller.searchDrawDeck(card => {
-                    return (card.hasTrait('Maester') && card.getCost() <= 3);
-                });
-
-                var buttons = _.map(maesterCards, card => {
-                    return { text: card.name, method: 'cardSelected', arg: card.uuid, card: card.getSummary(true) };
-                });
-
-                buttons.push({ text: 'Done', method: 'doneSelecting' });
-
-                this.game.promptWithMenu(this.controller, this, {
-                    activePrompt: {
-                        menuTitle: 'Select a card to put in play',
-                        buttons: buttons
-                    },
+                this.game.promptForDeckSearch(this.controller, {
+                    activePromptTitle: 'Select a card to put in play',
+                    cardCondition: card => card.hasTrait('Maester') && card.getCost() <= 3 && this.controller.canPutIntoPlay(card),
+                    onSelect: (player, card) => this.cardSelected(player, card),
+                    onCancel: player => this.doneSelecting(player),
                     source: this
                 });
             }
         });
     }
 
-    cardSelected(player, cardId) {
-        var card = player.findCardByUuid(player.drawDeck, cardId);
-
-        if(!card) {
-            return false;
-        }
-
-        player.shuffleDrawDeck();
+    cardSelected(player, card) {
         this.game.addMessage('{0} uses {1} to put {2} into play', player, this, card);
         player.putIntoPlay(card);
-
-        return true;
     }
 
     doneSelecting(player) {
-        player.shuffleDrawDeck();
         this.game.addMessage('{0} does not use {1} to find a card', player, this);
-
-        return true;
     }
 }
 

--- a/server/game/cards/plots/03/atimeforwolves.js
+++ b/server/game/cards/plots/03/atimeforwolves.js
@@ -1,45 +1,26 @@
-const _ = require('underscore');
-
 const PlotCard = require('../../../plotcard.js');
 
 class ATimeForWolves extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
             handler: () => {
-                var direwolfCards = this.controller.searchDrawDeck(card => {
-                    return card.hasTrait('Direwolf');
-                });
-
-                var buttons = _.map(direwolfCards, card => {
-                    return { text: card.name, method: 'cardSelected', arg: card.uuid, card: card.getSummary(true) };
-                });
-
-                buttons.push({ text: 'Done', method: 'doneSelecting' });
-
-                this.game.promptWithMenu(this.controller, this, {
-                    activePrompt: {
-                        menuTitle: 'Select a card to add to your hand',
-                        buttons: buttons
-                    },
+                this.game.promptForDeckSearch(this.controller, {
+                    activePromptTitle: 'Select a card to add to your hand',
+                    cardCondition: card => card.hasTrait('Direwolf'),
+                    onSelect: (player, card) => this.cardSelected(player, card),
+                    onCancel: player => this.doneSelecting(player),
                     source: this
                 });
             }
         });
     }
 
-    cardSelected(player, cardId) {
-        var card = player.findCardByUuid(player.drawDeck, cardId);
-
-        if(!card) {
-            return false;
-        }
-
+    cardSelected(player, card) {
         player.moveCard(card, 'hand');
-        player.shuffleDrawDeck();
 
         if(card.getCost() > 3) {
             this.game.addMessage('{0} uses {1} to reveal {2} and add it to their hand', player, this, card);
-            return true;
+            return;
         }
 
         this.revealedCard = card;
@@ -57,8 +38,6 @@ class ATimeForWolves extends PlotCard {
 
             source: this
         });
-
-        return true;
     }
 
     keepInHand(player) {
@@ -85,9 +64,7 @@ class ATimeForWolves extends PlotCard {
     }
 
     doneSelecting(player) {
-        player.shuffleDrawDeck();
         this.game.addMessage('{0} does not use {1} to find a card', player, this);
-        return true;
     }
 }
 

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -17,6 +17,7 @@ const DominancePhase = require('./gamesteps/dominancephase.js');
 const StandingPhase = require('./gamesteps/standingphase.js');
 const TaxationPhase = require('./gamesteps/taxationphase.js');
 const SimpleStep = require('./gamesteps/simplestep.js');
+const DeckSearchPrompt = require('./gamesteps/decksearchprompt.js');
 const MenuPrompt = require('./gamesteps/menuprompt.js');
 const SelectCardPrompt = require('./gamesteps/selectcardprompt.js');
 const EventWindow = require('./gamesteps/eventwindow.js');
@@ -479,6 +480,10 @@ class Game extends EventEmitter {
 
     promptForSelect(player, properties) {
         this.queueStep(new SelectCardPrompt(this, player, properties));
+    }
+
+    promptForDeckSearch(player, properties) {
+        this.queueStep(new DeckSearchPrompt(this, player, properties));
     }
 
     menuButton(playerName, arg, method) {

--- a/server/game/gamesteps/decksearchprompt.js
+++ b/server/game/gamesteps/decksearchprompt.js
@@ -1,0 +1,124 @@
+const _ = require('underscore');
+const UiPrompt = require('./uiprompt.js');
+
+/**
+ * Prompt that will search the player's deck, present them with matching cards,
+ * them do something with the chosen card. Whether the player chooses a card or
+ * cancels the prompt, their deck will be shuffled.
+ *
+ * The properties option object has the following properties:
+ * numCards           - an integer specifying the number of cards that will be
+ *                      searched within the player's deck. If not specified, the
+ *                      entire deck will be searched.
+ * activePromptTitle  - the title that should be used in the prompt for the
+ *                      choosing player.
+ * waitingPromptTitle - the title that should be used in the prompt for the
+ *                      opponent players.
+ * cardCondition      - a function that takes a card and should return a boolean
+ *                      on whether that card is elligible to be selected.
+ * cardType           - a string or array of strings listing which types of
+ *                      cards can be selected. Defaults to the list of draw
+ *                      card types.
+ * onSelect           - a callback that is called once the player chooses a
+ *                      card.
+ * onCancel           - a callback that is called when the player clicks the
+ *                      done button without choosing a card.
+ * source             - what is at the origin of the user prompt, usually a card;
+ *                      used to provide a default waitingPromptTitle, if missing
+ */
+class DeckSearchPrompt extends UiPrompt {
+    constructor(game, choosingPlayer, properties) {
+        super(game);
+
+        this.choosingPlayer = choosingPlayer;
+        if(properties.source && !properties.waitingPromptTitle) {
+            this.waitingPromptTitle = 'Waiting for opponent to use ' + properties.source.name;
+        }
+
+        this.properties = properties;
+        _.defaults(this.properties, this.defaultProperties());
+        if(!_.isArray(this.properties.cardType)) {
+            this.properties.cardType = [this.properties.cardType];
+        }
+    }
+
+    defaultProperties() {
+        return {
+            cardCondition: () => true,
+            cardType: ['attachment', 'character', 'event', 'location'],
+            onSelect: () => true,
+            onCancel: () => true
+        };
+    }
+
+    activeCondition(player) {
+        return player === this.choosingPlayer;
+    }
+
+    activePrompt() {
+        return {
+            menuTitle: this.properties.activePromptTitle || 'Choose a card',
+            buttons: this.buttons(),
+            promptTitle: this.properties.source ? this.properties.source.name : undefined
+        };
+    }
+
+    buttons() {
+        let uniqueCardsByTitle = _.uniq(this.searchCards(), card => card.cardData.label);
+        let buttons = _.map(uniqueCardsByTitle, card => {
+            return { text: card.cardData.label, arg: card.uuid, card: card.getSummary(true) };
+        });
+        buttons.push({ text: 'Done', arg: 'done' });
+        return buttons;
+    }
+
+    searchCards() {
+        if(this.properties.numCards) {
+            return this.choosingPlayer.searchDrawDeck(this.properties.numCards, card => this.checkCardCondition(card));
+        }
+        return this.choosingPlayer.searchDrawDeck(card => this.checkCardCondition(card));
+    }
+
+    waitingPrompt() {
+        return { menuTitle: this.properties.waitingPromptTitle || 'Waiting for opponent' };
+    }
+
+    checkCardCondition(card) {
+        return this.properties.cardType.includes(card.getType()) && this.properties.cardCondition(card);
+    }
+
+    onMenuCommand(player, arg) {
+        if(player !== this.choosingPlayer) {
+            return false;
+        }
+
+        if(arg === 'done') {
+            this.cancelAndShuffle(player);
+            return;
+        }
+
+        let card = player.findCardByUuid(player.drawDeck, arg);
+
+        if(!card) {
+            return false;
+        }
+
+        this.selectAndShuffle(player, card);
+    }
+
+    cancelAndShuffle(player) {
+        this.properties.onCancel(player);
+        player.shuffleDrawDeck();
+        this.game.addMessage('{0} shuffles their deck', player);
+        this.complete();
+    }
+
+    selectAndShuffle(player, card) {
+        this.properties.onSelect(player, card);
+        player.shuffleDrawDeck();
+        this.game.addMessage('{0} shuffles their deck', player);
+        this.complete();
+    }
+}
+
+module.exports = DeckSearchPrompt;

--- a/test/server/gamesteps/decksearchprompt.spec.js
+++ b/test/server/gamesteps/decksearchprompt.spec.js
@@ -1,0 +1,203 @@
+/*global describe, it, beforeEach, expect, jasmine*/
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+const _ = require('underscore');
+const DeckSearchPrompt = require('../../../server/game/gamesteps/decksearchprompt.js');
+
+describe('DeckSearchPrompt', function() {
+    function createCardSpy(properties = {}) {
+        let card = jasmine.createSpyObj('card', ['getSummary', 'getType']);
+        _.extend(card, properties);
+        return card;
+    }
+
+    beforeEach(function() {
+        this.game = jasmine.createSpyObj('game', ['addMessage', 'getPlayers']);
+
+        this.player = jasmine.createSpyObj('player1', ['cancelPrompt', 'setPrompt', 'findCardByUuid', 'searchDrawDeck', 'shuffleDrawDeck']);
+        this.player.drawDeck = _([]);
+        this.otherPlayer = jasmine.createSpyObj('player2', ['setPrompt', 'cancelPrompt']);
+
+        this.properties = {
+            cardCondition: jasmine.createSpy('cardCondition'),
+            onSelect: jasmine.createSpy('onSelect'),
+            onCancel: jasmine.createSpy('onCancel')
+        };
+        this.properties.cardCondition.and.returnValue(true);
+    });
+
+    describe('constructor', function() {
+        describe('cardType', function() {
+            it('should default to a list of draw card types', function() {
+                let prompt = new DeckSearchPrompt(this.game, this.player, this.properties);
+                expect(prompt.properties.cardType).toEqual(['attachment', 'character', 'event', 'location']);
+            });
+
+            it('should let a custom array be set', function() {
+                this.properties.cardType = ['foo'];
+                let prompt = new DeckSearchPrompt(this.game, this.player, this.properties);
+                expect(prompt.properties.cardType).toEqual(['foo']);
+            });
+
+            it('should let a non-array be set', function() {
+                this.properties.cardType = 'foo';
+                let prompt = new DeckSearchPrompt(this.game, this.player, this.properties);
+                expect(prompt.properties.cardType).toEqual(['foo']);
+            });
+        });
+    });
+
+    describe('for a finite search', function() {
+        beforeEach(function() {
+            this.properties.numCards = 10;
+            this.prompt = new DeckSearchPrompt(this.game, this.player, this.properties);
+        });
+
+        describe('activePrompt()', function() {
+            beforeEach(function() {
+                this.player.searchDrawDeck.and.returnValue([
+                    createCardSpy({ uuid: '1111', cardData: { label: 'Foo' } }),
+                    createCardSpy({ uuid: '2222', cardData: { label: 'Bar' } }),
+                    createCardSpy({ uuid: '3333', cardData: { label: 'Foo' } })
+                ]);
+                this.result = this.prompt.activePrompt();
+            });
+
+            it('should search the deck with appropriate parameters', function() {
+                expect(this.player.searchDrawDeck).toHaveBeenCalledWith(10, jasmine.any(Function));
+            });
+
+            it('should generate buttons for each unique card by title', function() {
+                expect(this.result.buttons).toContain(jasmine.objectContaining({ text: 'Foo', arg: '1111' }));
+                expect(this.result.buttons).toContain(jasmine.objectContaining({ text: 'Bar', arg: '2222' }));
+                expect(this.result.buttons).not.toContain(jasmine.objectContaining({ arg: '3333' }));
+            });
+
+            it('should include a Done button', function() {
+                expect(this.result.buttons).toContain(jasmine.objectContaining({ text: 'Done', arg: 'done' }));
+            });
+        });
+
+        describe('onMenuCommand()', function() {
+            beforeEach(function() {
+                this.card = { uuid: '1111' };
+                this.player.findCardByUuid.and.returnValue(this.card);
+            });
+
+            describe('when receiving input from the opponent', function() {
+                beforeEach(function() {
+                    this.result = this.prompt.onMenuCommand(this.otherPlayer, '1111');
+                });
+
+                it('should return false', function() {
+                    expect(this.result).toBe(false);
+                });
+
+                it('should not complete the prompt', function() {
+                    expect(this.prompt.isComplete()).toBe(false);
+                });
+
+                it('should not call any of the callbacks', function() {
+                    expect(this.properties.onSelect).not.toHaveBeenCalled();
+                    expect(this.properties.onCancel).not.toHaveBeenCalled();
+                });
+
+                it('should not shuffle the deck', function() {
+                    expect(this.player.shuffleDrawDeck).not.toHaveBeenCalled();
+                });
+            });
+
+            describe('when clicking Done', function() {
+                beforeEach(function() {
+                    this.prompt.onMenuCommand(this.player, 'done');
+                });
+
+                it('should complete the prompt', function() {
+                    expect(this.prompt.isComplete()).toBe(true);
+                });
+
+                it('should call the onCancel callback', function() {
+                    expect(this.properties.onCancel).toHaveBeenCalled();
+                });
+
+                it('should shuffle the deck', function() {
+                    expect(this.player.shuffleDrawDeck).toHaveBeenCalled();
+                });
+            });
+
+            describe('when choosing a card not in the deck', function() {
+                beforeEach(function() {
+                    this.player.findCardByUuid.and.returnValue(undefined);
+                    this.result = this.prompt.onMenuCommand(this.player, '2222');
+                });
+
+                it('should return false', function() {
+                    expect(this.result).toBe(false);
+                });
+
+                it('should not complete the prompt', function() {
+                    expect(this.prompt.isComplete()).toBe(false);
+                });
+
+                it('should not call any of the callbacks', function() {
+                    expect(this.properties.onSelect).not.toHaveBeenCalled();
+                    expect(this.properties.onCancel).not.toHaveBeenCalled();
+                });
+
+                it('should not shuffle the deck', function() {
+                    expect(this.player.shuffleDrawDeck).not.toHaveBeenCalled();
+                });
+            });
+
+            describe('when choosing a card', function() {
+                beforeEach(function() {
+                    this.prompt.onMenuCommand(this.player, '1111');
+                });
+
+                it('should complete the prompt', function() {
+                    expect(this.prompt.isComplete()).toBe(true);
+                });
+
+                it('should call the onSelect callback', function() {
+                    expect(this.properties.onSelect).toHaveBeenCalledWith(this.player, this.card);
+                });
+
+                it('should shuffle the deck', function() {
+                    expect(this.player.shuffleDrawDeck).toHaveBeenCalled();
+                });
+            });
+        });
+    });
+
+    describe('for a full deck search', function() {
+        beforeEach(function() {
+            delete this.properties.numCards;
+            this.prompt = new DeckSearchPrompt(this.game, this.player, this.properties);
+        });
+
+        describe('activePrompt()', function() {
+            beforeEach(function() {
+                this.player.searchDrawDeck.and.returnValue([
+                    createCardSpy({ uuid: '1111', cardData: { label: 'Foo' } }),
+                    createCardSpy({ uuid: '2222', cardData: { label: 'Bar' } }),
+                    createCardSpy({ uuid: '3333', cardData: { label: 'Foo' } })
+                ]);
+                this.result = this.prompt.activePrompt();
+            });
+
+            it('should search the deck with appropriate parameters', function() {
+                expect(this.player.searchDrawDeck).toHaveBeenCalledWith(jasmine.any(Function));
+            });
+
+            it('should generate buttons for each unique card by title', function() {
+                expect(this.result.buttons).toContain(jasmine.objectContaining({ text: 'Foo', arg: '1111' }));
+                expect(this.result.buttons).toContain(jasmine.objectContaining({ text: 'Bar', arg: '2222' }));
+                expect(this.result.buttons).not.toContain(jasmine.objectContaining({ arg: '3333' }));
+            });
+
+            it('should include a Done button', function() {
+                expect(this.result.buttons).toContain(jasmine.objectContaining({ text: 'Done', arg: 'done' }));
+            });
+        });
+    });
+});


### PR DESCRIPTION
Implements a `promptForDeckSearch` method on `Game` to simplify the deck
searching process. The new prompt asks the player to choose a card based
on the number of cards and card condition matcher, then calls an
onSelect callback when they've chosen. Whether they choose a card or
cancel the prompt, the player's draw deck is automatically shuffled.

Converts all existing "search" cards to use the new prompt. "Look at X top/bottom cards" should NOT use this prompt and will need their own version.