### PR TITLE
Implement simultaneous kill event

### DIFF
--- a/server/game/cards/attachments/01/bodyguard.js
+++ b/server/game/cards/attachments/01/bodyguard.js
@@ -4,7 +4,7 @@ class BodyGuard extends DrawCard {
     setupCardAbilities() {
         this.interrupt({
             when: {
-                onCharacterKilled: (event, player, card, allowSave) => this.parent === card && allowSave,
+                onCharacterKilled: event => this.parent === event.card && event.allowSave,
                 onCardDiscarded: event => event.card === this.parent && event.allowSave
             },
             canCancel: true,

--- a/server/game/cards/attachments/04/theboyking.js
+++ b/server/game/cards/attachments/04/theboyking.js
@@ -7,7 +7,7 @@ class TheBoyKing extends DrawCard {
         });
         this.reaction({
             when: {
-                onCharacterKilled: (event, player, card) => card.getCost() <= 3
+                onCharacterKilled: event => event.card.getCost() <= 3
             },
             cost: ability.costs.kneelSelf(),
             handler: () => {

--- a/server/game/cards/characters/01/benjenstark.js
+++ b/server/game/cards/characters/01/benjenstark.js
@@ -8,7 +8,7 @@ class BenjenStark extends DrawCard {
         });
         this.interrupt({
             when: {
-                onCharacterKilled: (event, player, card) => card === this
+                onCharacterKilled: event => event.card === this
             },
             handler: (context) => {
                 context.skipHandler();

--- a/server/game/cards/characters/01/joffreybaratheon.js
+++ b/server/game/cards/characters/01/joffreybaratheon.js
@@ -4,7 +4,7 @@ class JoffreyBaratheon extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onCharacterKilled: (event, player, card) => card.getType() === 'character' && (card.hasTrait('Lord') || card.hasTrait('Lady'))
+                onCharacterKilled: event => event.card.getType() === 'character' && (event.card.hasTrait('Lord') || event.card.hasTrait('Lady'))
             },
             limit: ability.limit.perRound(3),
             handler: () => {

--- a/server/game/cards/characters/01/maesteraemon.js
+++ b/server/game/cards/characters/01/maesteraemon.js
@@ -4,17 +4,17 @@ class MaesterAemon extends DrawCard {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onCharacterKilled: (event, player, card, allowSaves) => (
-                    allowSaves &&
-                    card.isFaction('thenightswatch') &&
-                    card.controller === this.controller
+                onCharacterKilled: event => (
+                    event.allowSave &&
+                    event.card.isFaction('thenightswatch') &&
+                    event.card.controller === this.controller
                 )
             },
             cost: ability.costs.kneelSelf(),
             canCancel: true,
             handler: context => {
                 context.cancel();
-                this.game.addMessage('{0} kneels {1} to save {2}', this.controller, this, context.event.params[2]);
+                this.game.addMessage('{0} kneels {1} to save {2}', this.controller, this, context.event.card);
             }
         });
     }

--- a/server/game/cards/characters/01/robbstark.js
+++ b/server/game/cards/characters/01/robbstark.js
@@ -6,7 +6,7 @@ class RobbStark extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onCharacterKilled: (e, player, card) => this.isStarkCharacter(card),
+                onCharacterKilled: event => this.isStarkCharacter(event.card),
                 onSacrificed: (e, player, card) => this.isStarkCharacter(card)
             },
             limit: ability.limit.perRound(1),

--- a/server/game/cards/characters/01/serdavosseaworth.js
+++ b/server/game/cards/characters/01/serdavosseaworth.js
@@ -4,7 +4,7 @@ class SerDavosSeaworth extends DrawCard {
     setupCardAbilities() {
         this.interrupt({
             when: {
-                onCharacterKilled: (event, player, card) => card === this
+                onCharacterKilled: event => event.card === this
             },
             handler: (context) => {
                 context.skipHandler();

--- a/server/game/cards/characters/01/serwaymarroyce.js
+++ b/server/game/cards/characters/01/serwaymarroyce.js
@@ -4,13 +4,7 @@ class SerWaymarRoyce extends DrawCard {
     setupCardAbilities() {
         this.interrupt({
             when: {
-                onCharacterKilled: (event, player, card) => {
-                    if(card !== this || player !== card.controller) {
-                        return false;
-                    }
-
-                    return true;
-                }
+                onCharacterKilled: event => event.card === this
             },
             handler: () => {
                 var otherPlayer = this.game.getOtherPlayer(this.controller);

--- a/server/game/cards/characters/01/shireenbaratheon.js
+++ b/server/game/cards/characters/01/shireenbaratheon.js
@@ -4,7 +4,7 @@ class ShireenBaratheon extends DrawCard {
     setupCardAbilities() {
         this.interrupt({
             when: {
-                onCharacterKilled: (event, player, card) => card === this
+                onCharacterKilled: event => event.card === this
             },
             handler: () => {
                 this.game.promptForSelect(this.controller, {

--- a/server/game/cards/characters/02/bastarddaughter.js
+++ b/server/game/cards/characters/02/bastarddaughter.js
@@ -4,9 +4,9 @@ class BastardDaughter extends DrawCard {
     setupCardAbilities() {
         this.interrupt({
             when: {
-                onCharacterKilled: (event, player, card) => (
-                    this.controller === card.controller &&
-                    (card === this || card.name === 'The Red Viper')
+                onCharacterKilled: event => (
+                    this.controller === event.card.controller &&
+                    (event.card === this || event.card.name === 'The Red Viper')
                 )
             },
             handler: () => {

--- a/server/game/cards/characters/02/serbarristanselmy.js
+++ b/server/game/cards/characters/02/serbarristanselmy.js
@@ -4,10 +4,10 @@ class SerBarristanSelmy extends DrawCard {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onCharacterKilled: (event, player, card, allowSave) => (
-                    allowSave
-                    && (card.hasTrait('Lord') || card.hasTrait('Lady'))
-                    && card.controller === this.controller
+                onCharacterKilled: event => (
+                    event.allowSave
+                    && (event.card.hasTrait('Lord') || event.card.hasTrait('Lady'))
+                    && event.card.controller === this.controller
                 )
             },
             cost: ability.costs.standSelf(),
@@ -16,7 +16,7 @@ class SerBarristanSelmy extends DrawCard {
                 context.cancel();
 
                 this.game.addMessage('{0} stands {1} to save {2}',
-                                     this.controller, this, context.event.params[2]);
+                                     this.controller, this, context.event.card);
             }
         });
     }

--- a/server/game/cards/characters/03/aryastark.js
+++ b/server/game/cards/characters/03/aryastark.js
@@ -4,15 +4,15 @@ class AryaStark extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onCharacterKilled: (event, player, card) => (
-                    this.controller === card.controller &&
-                    card.isFaction('stark'))
+                onCharacterKilled: event => (
+                    this.controller === event.card.controller &&
+                    event.card.isFaction('stark'))
             },
             cost: ability.costs.sacrificeSelf(),
             handler: () => {
                 this.game.promptForSelect(this.controller, {
                     cardCondition: card => (
-                        card.location === 'play area' && 
+                        card.location === 'play area' &&
                         card.getType() === 'character' &&
                         card.getStrength() <= 3),
                     activePromptTitle: 'Select a character',

--- a/server/game/cards/characters/03/catelynstark.js
+++ b/server/game/cards/characters/03/catelynstark.js
@@ -4,8 +4,8 @@ class CatelynStark extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onSacrificed: (event, player, card) => this.starkCharacterSacrificedOrKilled(event, player, card),
-                onCharacterKilled: (event, player, card) => this.starkCharacterSacrificedOrKilled(event, player, card)
+                onSacrificed: (event, player, card) => this.starkCharacterSacrificedOrKilled(event, card),
+                onCharacterKilled: event => this.starkCharacterSacrificedOrKilled(event, event.card)
             },
             limit: ability.limit.perRound(2),
             handler: () => {
@@ -19,9 +19,9 @@ class CatelynStark extends DrawCard {
         });
     }
 
-    starkCharacterSacrificedOrKilled(event, player, card) {
+    starkCharacterSacrificedOrKilled(event, card) {
         return (
-            this.controller === player &&
+            this.controller === card.controller &&
             card !== this &&
             card.isFaction('stark') &&
             card.getType() === 'character'

--- a/server/game/cards/characters/03/crossroadssellsword.js
+++ b/server/game/cards/characters/03/crossroadssellsword.js
@@ -4,9 +4,9 @@ class CrossroadsSellsword extends DrawCard {
     setupCardAbilities() {
         this.interrupt({
             when: {
-                onCharacterKilled: (event, player, card) => (
-                    card === this &&
-                    this.controller === card.controller &&
+                onCharacterKilled: event => (
+                    event.card === this &&
+                    this.controller === event.card.controller &&
                     this.game.currentPhase === 'challenge')
             },
             handler: () => {

--- a/server/game/cards/characters/03/jorycassel.js
+++ b/server/game/cards/characters/03/jorycassel.js
@@ -6,18 +6,18 @@ class JoryCassel extends DrawCard {
     setupCardAbilities() {
         this.interrupt({
             when: {
-                onCharacterKilled: (event, player, card, allowSave) => (
-                    allowSave &&
-                    card.controller === this.controller &&
-                    card.isUnique() &&
-                    card.isFaction('stark')
+                onCharacterKilled: event => (
+                    event.allowSave &&
+                    event.card.controller === this.controller &&
+                    event.card.isUnique() &&
+                    event.card.isFaction('stark')
                 )
             },
             canCancel: true,
             handler: context => {
                 context.cancel();
                 var message = '{0} uses {1} to save {2}';
-                var toKill = context.event.params[2];
+                var toKill = context.event.card;
 
                 this.controller.sacrificeCard(this);
 

--- a/server/game/cards/characters/03/quentynmartell.js
+++ b/server/game/cards/characters/03/quentynmartell.js
@@ -12,7 +12,7 @@ class QuentynMartell extends DrawCard {
         });
         this.interrupt({
             when: {
-                onCharacterKilled: (event, player, card) => card === this
+                onCharacterKilled: event => event.card === this
             },
             handler: () => {
                 this.game.promptForSelect(this.controller, {

--- a/server/game/cards/characters/05/chelladaughterofcheyk.js
+++ b/server/game/cards/characters/05/chelladaughterofcheyk.js
@@ -18,7 +18,7 @@ class ChellaDaughterOfCheyk extends DrawCard {
 
         this.reaction({
             when: {
-                onCharacterKilled: (event, player, card) => this.game.currentChallenge && this.game.currentChallenge.isAttacking(this) && card !== this
+                onCharacterKilled: event => this.game.currentChallenge && this.game.currentChallenge.isAttacking(this) && event.card !== this
             },
             handler: () => {
                 this.addToken('ear', 1);

--- a/server/game/cards/characters/05/victariongreyjoy.js
+++ b/server/game/cards/characters/05/victariongreyjoy.js
@@ -4,9 +4,9 @@ class VictarionGreyjoy extends DrawCard {
     setupCardAbilities() {
         this.interrupt({
             when: {
-                onCharacterKilled: (event, player, card, allowSave) => (
-                    allowSave &&
-                    card === this &&
+                onCharacterKilled: event => (
+                    event.allowSave &&
+                    event.card === this &&
                     this.power >= 2
                 )
             },

--- a/server/game/cards/characters/06/margaerytyrell.js
+++ b/server/game/cards/characters/06/margaerytyrell.js
@@ -4,8 +4,8 @@ class MargaeryTyrell extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onCharacterKilled: (event, player, card) => {
-                    return card.isUnique() && (card.hasTrait('king') || card.hasTrait('lord')) && card.controller === this.controller;
+                onCharacterKilled: event => {
+                    return event.card.isUnique() && (event.card.hasTrait('king') || event.card.hasTrait('lord')) && event.card.controller === this.controller;
                 }
             },
             limit: ability.limit.perRound(1),

--- a/server/game/cards/events/02/thewatcheronthewalls.js
+++ b/server/game/cards/events/02/thewatcheronthewalls.js
@@ -34,10 +34,7 @@ class TheWatcherOnTheWalls extends ChallengeEvent {
 
     onSelect(player, cards) {
         _.each(cards, card => player.kneelCard(card));
-        _.each(this.game.currentChallenge.attackers, attacker => {
-            attacker.controller.killCharacter(attacker);
-        });
-
+        this.game.killCharacters(this.game.currentChallenge.attackers);
         this.game.addMessage('{0} uses {1} to kill each attacking character',
                              player, this);
 

--- a/server/game/cards/locations/02/ironmines.js
+++ b/server/game/cards/locations/02/ironmines.js
@@ -4,12 +4,12 @@ class IronMines extends DrawCard {
     setupCardAbilities() {
         this.interrupt({
             when: {
-                onCharacterKilled: (event, player, card, allowSave) => card.controller === this.controller && allowSave
+                onCharacterKilled: event => event.card.controller === this.controller && event.allowSave
             },
             canCancel: true,
             handler: (context) => {
                 context.cancel();
-                this.game.addMessage('{0} sacrifices {1} to save {2}', this.controller, this, context.event.params[2]);
+                this.game.addMessage('{0} sacrifices {1} to save {2}', this.controller, this, context.event.card);
 
                 this.controller.sacrificeCard(this);
             }

--- a/server/game/cards/locations/04/vaestolorro.js
+++ b/server/game/cards/locations/04/vaestolorro.js
@@ -4,23 +4,17 @@ class VaesTolorro extends DrawCard {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onCharacterKilled: (event, player, card) => {
-                    if(!card.getPower() >= 1) {
-                        return false;
-                    }
-                    this.pendingCard = card;
-                    
-                    return true;
-                }
+                onCharacterKilled: event => event.card.getPower() >= 1
             },
             cost: ability.costs.kneelSelf(),
-            handler: () => {
-                var power = this.pendingCard.getPower() >= 2 && this.pendingCard.getStrength() === 0 ? 2 : 1;
+            handler: context => {
+                let pendingCard = context.event.card;
+                var power = pendingCard.getPower() >= 2 && pendingCard.getStrength() === 0 ? 2 : 1;
 
-                this.pendingCard.modifyPower(-power);
+                pendingCard.modifyPower(-power);
                 this.modifyPower(power);
-                this.game.addMessage('{0} kneels {1} to move {2} power from {3} to {1}', 
-                                      this.controller, this, power, this.pendingCard);
+                this.game.addMessage('{0} kneels {1} to move {2} power from {3} to {1}',
+                                      this.controller, this, power, pendingCard);
             }
         });
     }

--- a/server/game/cards/plots/01/wildfireassault.js
+++ b/server/game/cards/plots/01/wildfireassault.js
@@ -30,13 +30,13 @@ class WildfireAssault extends PlotCard {
     }
 
     doDiscard() {
-        _.each(this.selections, selection => {
-            var player = selection.player;
-            var toKill = _.difference(player.filterCardsInPlay(card => card.getType() === 'character'), selection.cards);
+        let characters = [];
 
-            _.each(toKill, card => {
-                player.killCharacter(card, false);
-            });
+        _.each(this.selections, selection => {
+            let player = selection.player;
+            let toKill = _.difference(player.filterCardsInPlay(card => card.getType() === 'character'), selection.cards);
+
+            characters = characters.concat(toKill);
 
             if(_.isEmpty(toKill)) {
                 this.game.addMessage('{0} does not kill any characters with {1}', player, this);
@@ -44,6 +44,8 @@ class WildfireAssault extends PlotCard {
                 this.game.addMessage('{0} uses {1} to kill {2}', player, this, toKill);
             }
         });
+
+        this.game.killCharacters(characters, false);
 
         this.selections = [];
     }

--- a/server/game/cards/plots/04/valarmorghulis.js
+++ b/server/game/cards/plots/04/valarmorghulis.js
@@ -6,18 +6,12 @@ class ValarMorghulis extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
             handler: () => {
-                _.each(this.game.getPlayersInFirstPlayerOrder(), player => {
-                    this.killAllCharacters(player);
-                });
+                let characters = _.chain(this.game.getPlayersInFirstPlayerOrder())
+                    .map(player => player.filterCardsInPlay(card => card.getType() === 'character'))
+                    .flatten()
+                    .value();
+                this.game.killCharacters(characters);
             }
-        });
-    }
-
-    killAllCharacters(player) {
-        var characters = player.filterCardsInPlay(card => card.getType() === 'character');
-
-        _.each(characters, character => {
-            player.killCharacter(character);
         });
     }
 }

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -21,6 +21,7 @@ const DeckSearchPrompt = require('./gamesteps/decksearchprompt.js');
 const MenuPrompt = require('./gamesteps/menuprompt.js');
 const SelectCardPrompt = require('./gamesteps/selectcardprompt.js');
 const EventWindow = require('./gamesteps/eventwindow.js');
+const SimultaneousEventWindow = require('./gamesteps/simultaneouseventwindow.js');
 const AbilityResolver = require('./gamesteps/abilityresolver.js');
 const ForcedTriggeredAbilityWindow = require('./gamesteps/forcedtriggeredabilitywindow.js');
 const TriggeredAbilityWindow = require('./gamesteps/triggeredabilitywindow.js');
@@ -587,6 +588,10 @@ class Game extends EventEmitter {
         }
 
         this.queueStep(new EventWindow(this, eventName, params, handler, true));
+    }
+
+    raiseSimultaneousEvent(cards, properties) {
+        this.queueStep(new SimultaneousEventWindow(this, cards, properties));
     }
 
     takeControl(player, card) {

--- a/server/game/gamesteps/challenge/fulfillmilitaryclaim.js
+++ b/server/game/gamesteps/challenge/fulfillmilitaryclaim.js
@@ -41,9 +41,7 @@ class FulfillMilitaryClaim extends BaseStep {
 
         this.game.addMessage('{0} chooses {1} for claim', this.player, cards);
 
-        _.each(cards, card => {
-            card.controller.killCharacter(card);
-        });
+        this.game.killCharacters(cards);
 
         return true;
     }

--- a/server/game/gamesteps/simultaneouseventwindow.js
+++ b/server/game/gamesteps/simultaneouseventwindow.js
@@ -1,0 +1,121 @@
+const _ = require('underscore');
+
+const BaseStep = require('./basestep.js');
+const GamePipeline = require('../gamepipeline.js');
+const SimpleStep = require('./simplestep.js');
+const Event = require('../event.js');
+
+class SimultaneousEventWindow extends BaseStep {
+    constructor(game, cards, properties) {
+        super(game);
+
+        this.handler = properties.handler || (() => true);
+
+        this.event = new Event(properties.eventName, _.extend({ cards: cards }, properties.params), true);
+        this.perCardEvents = this.buildPerCardEvents(cards, properties);
+        this.perCardHandler = properties.perCardHandler || (() => true);
+        this.pipeline = new GamePipeline();
+        this.pipeline.initialise([
+            new SimpleStep(game, () => this.openWindow('cancelinterrupt')),
+            new SimpleStep(game, () => this.perCardWindow('cancelinterrupt')),
+            new SimpleStep(game, () => this.openWindow('forcedinterrupt')),
+            new SimpleStep(game, () => this.perCardWindow('forcedinterrupt')),
+            new SimpleStep(game, () => this.openWindow('interrupt')),
+            new SimpleStep(game, () => this.perCardWindow('interrupt')),
+            new SimpleStep(game, () => this.executeHandler()),
+            new SimpleStep(game, () => this.openWindow('forcedreaction')),
+            new SimpleStep(game, () => this.perCardWindow('forcedreaction')),
+            new SimpleStep(game, () => this.openWindow('reaction')),
+            new SimpleStep(game, () => this.perCardWindow('reaction'))
+        ]);
+    }
+
+    buildPerCardEvents(cards, properties) {
+        return _.map(cards, card => {
+            let perCardParams = _.extend({ card: card }, properties.params);
+            return new Event(properties.perCardEventName, perCardParams, true);
+        });
+    }
+
+    queueStep(step) {
+        this.pipeline.queueStep(step);
+    }
+
+    isComplete() {
+        return this.pipeline.length === 0;
+    }
+
+    onCardClicked(player, card) {
+        return this.pipeline.handleCardClicked(player, card);
+    }
+
+    onMenuCommand(player, arg, method) {
+        return this.pipeline.handleMenuCommand(player, arg, method);
+    }
+
+    cancelStep() {
+        this.pipeline.cancelStep();
+    }
+
+    continue() {
+        return this.pipeline.continue();
+    }
+
+    openWindow(abilityType) {
+        if(this.event.cancelled) {
+            return;
+        }
+
+        this.game.openAbilityWindow({
+            abilityType: abilityType,
+            event: this.event
+        });
+    }
+
+    perCardWindow(abilityType) {
+        if(this.event.cancelled) {
+            return;
+        }
+
+        this.filterOutCancelledEvents();
+        _.each(this.perCardEvents, event => {
+            this.game.openAbilityWindow({
+                abilityType: abilityType,
+                event: event
+            });
+        });
+    }
+
+    filterOutCancelledEvents() {
+        this.perCardEvents = _.filter(this.perCardEvents, event => this.event.cards.includes(event.card) && !event.cancelled);
+    }
+
+    executeHandler() {
+        if(this.event.cancelled) {
+            return;
+        }
+
+        this.executeEventHandler(this.event, this.handler);
+
+        this.filterOutCancelledEvents();
+
+        _.each(this.perCardEvents, event => {
+            this.game.queueSimpleStep(() => {
+                this.executeEventHandler(event, this.perCardHandler);
+            });
+        });
+    }
+
+    executeEventHandler(event, handler) {
+        if(!event.shouldSkipHandler) {
+            handler(...event.params);
+
+            if(event.cancelled) {
+                return;
+            }
+        }
+        this.game.emit(event.name, ...event.params);
+    }
+}
+
+module.exports = SimultaneousEventWindow;

--- a/server/game/gamesteps/triggeredabilitywindowtitles.js
+++ b/server/game/gamesteps/triggeredabilitywindowtitles.js
@@ -1,6 +1,6 @@
 const EventToTitleFunc = {
     onCardPowerChanged: event => event.params[1].name + ' gaining power',
-    onCharacterKilled: event => event.params[2].name + ' being killed',
+    onCharacterKilled: event => event.card.name + ' being killed',
     onPhaseEnded: event => event.params[1] + ' phase ending',
     onPhaseStarted: event => event.params[1] + ' phase starting',
     onSacrificed: event => event.params[2].name + ' being sacrificed'

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -830,7 +830,12 @@ class Player extends Spectator {
                 this.game.addMessage('{0} discards a duplicate to save {1}', this, character);
             }
         } else {
-            this.game.raiseEvent('onCharacterKilled', this, character, allowSave, event => {
+            let params = {
+                player: this,
+                card: character,
+                allowSave: allowSave
+            };
+            this.game.raiseMergedEvent('onCharacterKilled', params, event => {
                 if(character.location !== 'play area') {
                     event.cancel();
                     return;

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -813,38 +813,11 @@ class Player extends Spectator {
         }
     }
 
+    /**
+     * @deprecated Use `Game.killCharacter` instead.
+     */
     killCharacter(card, allowSave = true) {
-        var character = this.findCardInPlayByUuid(card.uuid);
-
-        if(!character || character.location !== 'play area') {
-            return;
-        }
-
-        if(!character.canBeKilled()) {
-            this.game.addMessage('{0} controlled by {1} cannot be killed',
-                                 character, this);
-        } else if(!character.dupes.isEmpty() && allowSave) {
-            if(!this.removeDuplicate(character)) {
-                this.moveCard(card, 'dead pile');
-            } else {
-                this.game.addMessage('{0} discards a duplicate to save {1}', this, character);
-            }
-        } else {
-            let params = {
-                player: this,
-                card: character,
-                allowSave: allowSave
-            };
-            this.game.raiseMergedEvent('onCharacterKilled', params, event => {
-                if(character.location !== 'play area') {
-                    event.cancel();
-                    return;
-                }
-
-                this.moveCard(card, 'dead pile');
-                this.game.addMessage('{0} kills {1}', this, character);
-            });
-        }
+        this.game.killCharacter(card, allowSave);
     }
 
     getDominance() {

--- a/test/server/cards/plots/04/04080-valarmorghulis.spec.js
+++ b/test/server/cards/plots/04/04080-valarmorghulis.spec.js
@@ -1,0 +1,62 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('Valar Morghulis', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck1 = this.buildDeck('tyrell', [
+                'Valar Morghulis',
+                'Margaery Tyrell (AMAF)', 'Margaery Tyrell (AMAF)', 'Rickon Stark', 'Eddard Stark (Core)'
+            ]);
+            const deck2 = this.buildDeck('thenightswatch', [
+                'A Noble Cause',
+                'Samwell Tarly (Core)', 'Maester Aemon (Core)'
+            ]);
+
+            this.player1.selectDeck(deck1);
+            this.player2.selectDeck(deck2);
+            this.startGame();
+            this.keepStartingHands();
+
+            [this.marg1, this.marg2] = this.player1.filterCardsByName('Margaery Tyrell', 'hand');
+            this.rickon = this.player1.findCardByName('Rickon Stark', 'hand');
+            this.eddard = this.player1.findCardByName('Eddard Stark', 'hand');
+
+            this.samwell = this.player2.findCardByName('Samwell Tarly', 'hand');
+            this.aemon = this.player2.findCardByName('Maester Aemon', 'hand');
+
+            this.player1.clickCard(this.marg1);
+            this.player1.clickCard(this.marg2);
+            this.player1.clickCard(this.rickon);
+
+            this.player2.clickCard(this.samwell);
+            this.player2.clickCard(this.aemon);
+
+            this.completeSetup();
+
+            this.player1Object.moveCard(this.eddard, 'draw deck');
+
+            this.player1.selectPlot('Valar Morghulis');
+            this.player2.selectPlot('A Noble Cause');
+
+            this.selectFirstPlayer(this.player1);
+        });
+
+        it('should prompt interrupts and reactions in the proper order', function() {
+            expect(this.player1).not.toHavePromptButton('Margaery Tyrell');
+            expect(this.player2).toHavePromptButton('Maester Aemon');
+
+            // Aemon saves Sam but dies
+            this.player2.clickPrompt('Maester Aemon');
+            expect(this.samwell.location).toBe('play area');
+            expect(this.aemon.location).toBe('dead pile');
+
+            // Marg's dupe saves her but Rickon dies
+            expect(this.marg1.location).toBe('play area');
+            expect(this.marg2.location).toBe('discard pile');
+            expect(this.rickon.location).toBe('dead pile');
+
+            expect(this.player1).toHavePromptButton('Margaery Tyrell');
+        });
+    });
+});

--- a/test/server/gamesteps/fulfillmilitaryclaim.spec.js
+++ b/test/server/gamesteps/fulfillmilitaryclaim.spec.js
@@ -5,8 +5,8 @@ const FulfillMilitaryClaim = require('../../../server/game/gamesteps/challenge/f
 
 describe('FulfillMilitaryClaim', function() {
     beforeEach(function() {
-        this.game = jasmine.createSpyObj('game', ['promptForSelect', 'addMessage']);
-        this.loser = jasmine.createSpyObj('loser', ['killCharacter', 'getNumberOfCardsInPlay']);
+        this.game = jasmine.createSpyObj('game', ['killCharacters', 'promptForSelect', 'addMessage']);
+        this.loser = jasmine.createSpyObj('loser', ['getNumberOfCardsInPlay']);
         this.loser.getNumberOfCardsInPlay.and.returnValue(0);
 
         this.step = new FulfillMilitaryClaim(this.game, this.loser, 1);
@@ -47,7 +47,7 @@ describe('FulfillMilitaryClaim', function() {
             });
 
             it('should kill the character', function() {
-                expect(this.loser.killCharacter).toHaveBeenCalledWith(this.card1);
+                expect(this.game.killCharacters).toHaveBeenCalledWith([this.card1]);
             });
 
             it('should return true', function() {
@@ -67,7 +67,7 @@ describe('FulfillMilitaryClaim', function() {
                     });
 
                     it('should not kill the character', function() {
-                        expect(this.loser.killCharacter).not.toHaveBeenCalled();
+                        expect(this.game.killCharacters).not.toHaveBeenCalled();
                     });
 
                     it('should return false', function() {
@@ -81,8 +81,7 @@ describe('FulfillMilitaryClaim', function() {
                     });
 
                     it('should kill the characters', function() {
-                        expect(this.loser.killCharacter).toHaveBeenCalledWith(this.card1);
-                        expect(this.loser.killCharacter).toHaveBeenCalledWith(this.card2);
+                        expect(this.game.killCharacters).toHaveBeenCalledWith([this.card1, this.card2]);
                     });
 
                     it('should return true', function() {
@@ -103,7 +102,7 @@ describe('FulfillMilitaryClaim', function() {
                     });
 
                     it('should not kill the character', function() {
-                        expect(this.loser.killCharacter).not.toHaveBeenCalled();
+                        expect(this.game.killCharacters).not.toHaveBeenCalled();
                     });
 
                     it('should return false', function() {
@@ -117,8 +116,7 @@ describe('FulfillMilitaryClaim', function() {
                     });
 
                     it('should kill the characters', function() {
-                        expect(this.loser.killCharacter).toHaveBeenCalledWith(this.card1);
-                        expect(this.loser.killCharacter).toHaveBeenCalledWith(this.card2);
+                        expect(this.game.killCharacters).toHaveBeenCalledWith([this.card1, this.card2]);
                     });
 
                     it('should return true', function() {

--- a/test/server/gamesteps/simultaneouseventwindow.spec.js
+++ b/test/server/gamesteps/simultaneouseventwindow.spec.js
@@ -1,0 +1,164 @@
+/*global describe, it, beforeEach, expect, jasmine*/
+/* eslint no-invalid-this: 0 */
+
+const _ = require('underscore');
+
+const SimultaneousEventWindow = require('../../../server/game/gamesteps/simultaneouseventwindow.js');
+const Event = require('../../../server/game/event.js');
+
+describe('SimultaneousEventWindow', function() {
+    beforeEach(function() {
+        this.gameSpy = jasmine.createSpyObj('game', ['emit', 'openAbilityWindow', 'queueSimpleStep']);
+        this.gameSpy.queueSimpleStep.and.callFake(step => step());
+        this.cards = ['card1', 'card2'];
+        this.params = { foo: 'bar' };
+        this.handler = jasmine.createSpy('handler');
+        this.perCardHandler = jasmine.createSpy('perCardHandler');
+        this.eventWindow = new SimultaneousEventWindow(this.gameSpy, this.cards, {
+            eventName: 'myevent',
+            params: this.params,
+            handler: this.handler,
+            perCardEventName: 'percardevent',
+            perCardHandler: this.perCardHandler
+        });
+    });
+
+    describe('continue()', function() {
+        describe('during the normal flow', function() {
+            beforeEach(function() {
+                this.eventWindow.continue();
+            });
+
+            it('should emit all of the interrupt/reaction events', function() {
+                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'cancelinterrupt', event: jasmine.objectContaining({ name: 'myevent', cards: this.cards }) });
+                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'forcedinterrupt', event: jasmine.objectContaining({ name: 'myevent', cards: this.cards }) });
+                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'interrupt', event: jasmine.objectContaining({ name: 'myevent', cards: this.cards }) });
+                expect(this.gameSpy.emit).toHaveBeenCalledWith('myevent', jasmine.any(Event), { cards: this.cards, foo: 'bar' });
+                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'forcedreaction', event: jasmine.objectContaining({ name: 'myevent', cards: this.cards }) });
+                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'reaction', event: jasmine.objectContaining({ name: 'myevent', cards: this.cards }) });
+            });
+
+            it('should call the handler', function() {
+                expect(this.handler).toHaveBeenCalled();
+            });
+
+            it('should emit all of the interrupt/reaction events for each card', function() {
+                _.each(this.cards, card => {
+                    expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'cancelinterrupt', event: jasmine.objectContaining({ name: 'percardevent', card: card }) });
+                    expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'forcedinterrupt', event: jasmine.objectContaining({ name: 'percardevent', card: card }) });
+                    expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'interrupt', event: jasmine.objectContaining({ name: 'percardevent', card: card }) });
+                    expect(this.gameSpy.emit).toHaveBeenCalledWith('percardevent', jasmine.any(Event), { card: card, foo: 'bar' });
+                    expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'forcedreaction', event: jasmine.objectContaining({ name: 'percardevent', card: card }) });
+                    expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'reaction', event: jasmine.objectContaining({ name: 'percardevent', card: card }) });
+                });
+            });
+
+            it('should call the handlers for each card', function() {
+                expect(this.perCardHandler).toHaveBeenCalledWith(jasmine.objectContaining({ card: 'card1' }), jasmine.any(Object));
+                expect(this.perCardHandler).toHaveBeenCalledWith(jasmine.objectContaining({ card: 'card2' }), jasmine.any(Object));
+            });
+        });
+
+        describe('when the event is cancelled', function() {
+            beforeEach(function() {
+                this.eventWindow.event.cancel();
+            });
+
+            it('should not emit the post-cancel interrupt/reaction events', function() {
+                this.eventWindow.continue();
+                expect(this.gameSpy.openAbilityWindow).not.toHaveBeenCalledWith({ abilityType: 'forcedinterrupt', event: jasmine.objectContaining({ name: 'myevent', cards: this.cards }) });
+                expect(this.gameSpy.openAbilityWindow).not.toHaveBeenCalledWith({ abilityType: 'interrupt', event: jasmine.objectContaining({ name: 'myevent', cards: this.cards }) });
+                expect(this.gameSpy.emit).not.toHaveBeenCalledWith('myevent', jasmine.any(Event), jasmine.any(Object));
+                expect(this.gameSpy.openAbilityWindow).not.toHaveBeenCalledWith({ abilityType: 'forcedreaction', event: jasmine.objectContaining({ name: 'myevent', cards: this.cards }) });
+                expect(this.gameSpy.openAbilityWindow).not.toHaveBeenCalledWith({ abilityType: 'reaction', event: jasmine.objectContaining({ name: 'myevent', cards: this.cards }) });
+            });
+
+            it('should not call the handler', function() {
+                this.eventWindow.continue();
+                expect(this.handler).not.toHaveBeenCalled();
+            });
+
+            it('should not emit all of the interrupt/reaction events for each card', function() {
+                this.eventWindow.continue();
+                expect(this.gameSpy.openAbilityWindow).not.toHaveBeenCalledWith(jasmine.objectContaining({ event: jasmine.objectContaining({ name: 'percardevent' }) }));
+                expect(this.gameSpy.emit).not.toHaveBeenCalledWith('percardevent', jasmine.any(Event), jasmine.any(Object));
+            });
+
+            it('should not call the handlers for each card', function() {
+                expect(this.perCardHandler).not.toHaveBeenCalled();
+            });
+
+            describe('and another step has been queued on the event', function() {
+                beforeEach(function() {
+                    this.anotherStep = jasmine.createSpyObj('step', ['continue']);
+                    this.eventWindow.queueStep(this.anotherStep);
+                });
+
+                it('should still call the step', function() {
+                    this.eventWindow.continue();
+                    expect(this.anotherStep.continue).toHaveBeenCalled();
+                });
+            });
+        });
+
+        describe('when an event has its handler skipped', function() {
+            beforeEach(function() {
+                this.eventWindow.event.skipHandler();
+                this.eventWindow.continue();
+            });
+
+            it('should emit all of the interrupt/reaction events', function() {
+                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'cancelinterrupt', event: jasmine.objectContaining({ name: 'myevent', cards: this.cards }) });
+                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'forcedinterrupt', event: jasmine.objectContaining({ name: 'myevent', cards: this.cards }) });
+                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'interrupt', event: jasmine.objectContaining({ name: 'myevent', cards: this.cards }) });
+                expect(this.gameSpy.emit).toHaveBeenCalledWith('myevent', jasmine.any(Event), { cards: this.cards, foo: 'bar' });
+                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'forcedreaction', event: jasmine.objectContaining({ name: 'myevent', cards: this.cards }) });
+                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'reaction', event: jasmine.objectContaining({ name: 'myevent', cards: this.cards }) });
+            });
+
+            it('should not call the handler', function() {
+                expect(this.handler).not.toHaveBeenCalled();
+            });
+        });
+
+        describe('when an event handler cancels the event', function() {
+            beforeEach(function() {
+                this.handler.and.callFake(event => event.cancel());
+                this.eventWindow.continue();
+            });
+
+            it('should emit all of the interrupt events', function() {
+                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'cancelinterrupt', event: jasmine.objectContaining({ name: 'myevent', cards: this.cards }) });
+                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'forcedinterrupt', event: jasmine.objectContaining({ name: 'myevent', cards: this.cards }) });
+                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'interrupt', event: jasmine.objectContaining({ name: 'myevent', cards: this.cards }) });
+            });
+
+            it('should not emit the post-cancel events', function() {
+                expect(this.gameSpy.emit).not.toHaveBeenCalledWith('myevent', jasmine.any(Event), jasmine.any(Object));
+                expect(this.gameSpy.openAbilityWindow).not.toHaveBeenCalledWith({ abilityType: 'forcedreaction', event: jasmine.objectContaining({ name: 'myevent', cards: this.cards }) });
+                expect(this.gameSpy.openAbilityWindow).not.toHaveBeenCalledWith({ abilityType: 'reaction', event: jasmine.objectContaining({ name: 'myevent', cards: this.cards }) });
+            });
+        });
+
+        describe('when an individual card event is cancelled', function() {
+            beforeEach(function() {
+                this.eventWindow.perCardEvents[0].cancel();
+                this.eventWindow.continue();
+            });
+
+            it('should not emit the interrupt/reaction events for the cancelled card', function() {
+                expect(this.gameSpy.openAbilityWindow).not.toHaveBeenCalledWith(jasmine.objectContaining({ event: jasmine.objectContaining({ name: 'percardevent', card: 'card1' }) }));
+            });
+
+            it('should emit all of the interrupt/reaction events for the non-cancelled cards', function() {
+                let card = 'card2';
+                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'cancelinterrupt', event: jasmine.objectContaining({ name: 'percardevent', card: card }) });
+                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'forcedinterrupt', event: jasmine.objectContaining({ name: 'percardevent', card: card }) });
+                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'interrupt', event: jasmine.objectContaining({ name: 'percardevent', card: card }) });
+                expect(this.gameSpy.emit).toHaveBeenCalledWith('percardevent', jasmine.any(Event), { card: card, foo: 'bar' });
+                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'forcedreaction', event: jasmine.objectContaining({ name: 'percardevent', card: card }) });
+                expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'reaction', event: jasmine.objectContaining({ name: 'percardevent', card: card }) });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Previously, cards like Valar that killed multiple characters simultaneously would fire events as follows:
```
Interrupts for card1 being killed
card1 is killed
Reaction to card1 being killed
Interrupts for card2 being killed
card2 is killed
Reaction to card2 being killed
```

This was obviously incorrect and allowed interrupts for cards being killed to fire after reactions to other cards being killed within the same kill window.

Now, when cards are killed simultaneously, events are fired as follows:
```
Interrupts for card1 being killed
Interrupts for card2 being killed
card1 is killed
card2 is killed
Reaction to card1 being killed
Reaction to card2 being killed
```

It was necessary to convert the `onCharacterKilled` to the new merged event style to get this to work. An additional `onCharactersKilled` event (note the plural) has been introduced which can be used to improve saving cards after this PR is merged (prompt with all possible save choices instead of one at a time).

This PR also ends up changing how saving with dupes works. As an example, previously if a character with a dupe also had Bodyguard attached, the dupe would be automatically discarded to save the character without asking to use the Bodyguard. Now, Bodyguard will prompt first, allowing the player to chose whether to use it or rely on the dupe. As before, if there are no other available saves, the dupe will be discarded automatically to save.