### PR TITLE
Simplify prompt buttons representing cards.

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -443,6 +443,15 @@ class BaseCard {
         return false;
     }
 
+    getShortSummary() {
+        return {
+            code: this.cardData.code,
+            label: this.cardData.label,
+            name: this.cardData.name,
+            type: this.getType()
+        };
+    }
+
     getSummary(isActivePlayer, hideWhenFaceup) {
         return isActivePlayer || (!this.facedown && !hideWhenFaceup) ? {
             code: this.cardData.code,

--- a/server/game/cards/agendas/therainsofcastamere.js
+++ b/server/game/cards/agendas/therainsofcastamere.js
@@ -70,7 +70,7 @@ class TheRainsOfCastamere extends AgendaCard {
 
     menuButtons() {
         var buttons = _.map(this.schemes, scheme => {
-            return { text: scheme.name, method: 'revealScheme', arg: scheme.uuid, card: scheme.getSummary(true) };
+            return { method: 'revealScheme', card: scheme };
         });
 
         buttons.push({ text: 'Done', method: 'cancelScheme' });

--- a/server/game/cards/attachments/03/greendreams.js
+++ b/server/game/cards/attachments/03/greendreams.js
@@ -14,8 +14,8 @@ class GreenDreams extends DrawCard {
                     activePrompt: {
                         menuTitle: 'Put ' + this.topCard.name + ' on bottom of your deck?',
                         buttons: [
-                            { text: 'Yes', method: 'placeOnBottom', arg: 'yes', card: this.topCard.getSummary(true) },
-                            { text: 'No', method: 'placeOnBottom', arg: 'no', card: this.topCard.getSummary(true) }
+                            { text: 'Yes', method: 'placeOnBottom', arg: 'yes', card: this.topCard },
+                            { text: 'No', method: 'placeOnBottom', arg: 'no', card: this.topCard }
                         ]
                     },
                     source: this

--- a/server/game/cards/characters/01/greenbloodtrader.js
+++ b/server/game/cards/characters/01/greenbloodtrader.js
@@ -12,7 +12,7 @@ class GreenbloodTrader extends DrawCard {
                 this.top2Cards = this.controller.drawDeck.first(2);
 
                 var buttons = _.map(this.top2Cards, card => {
-                    return { text: card.name, method: 'cardSelected', arg: card.uuid, card: card.getSummary(true) };
+                    return { method: 'cardSelected', card: card };
                 });
 
                 buttons.push({ text: 'Continue', method: 'continueWithoutSelecting' });
@@ -76,7 +76,7 @@ class GreenbloodTrader extends DrawCard {
 
     continueWithoutSelecting(player) {
         var buttons = _.map(this.top2Cards, card => {
-            return { text: card.name, method: 'moveToBottom', arg: card.uuid, card: card.getSummary(true) };
+            return { method: 'moveToBottom', card: card };
         });
 
         buttons.push({ text: 'Cancel', method: 'cancel' });

--- a/server/game/cards/characters/05/tywinlannister.js
+++ b/server/game/cards/characters/05/tywinlannister.js
@@ -14,7 +14,7 @@ class TywinLannister extends DrawCard {
 
                 var top2Cards = this.discardingPlayer.drawDeck.first(2);
                 var buttons = _.map(top2Cards, card => {
-                    return { text: card.name, method: 'cardSelected', arg: card.uuid, card: card.getSummary(true) };
+                    return { method: 'cardSelected', card: card };
                 });
 
                 this.game.promptWithMenu(this.controller, this, {

--- a/server/game/cards/characters/06/melisandre.js
+++ b/server/game/cards/characters/06/melisandre.js
@@ -26,7 +26,7 @@ class Melisandre extends DrawCard {
     revealHand() {
         let otherPlayer = this.game.getOtherPlayer(this.controller);
         let buttons = otherPlayer.hand.map(card => {
-            return { text: card.name, method: 'cardSelected', arg: card.uuid, card: card.getSummary(true) };
+            return { method: 'cardSelected', card: card };
         });
 
         buttons.push({ text: 'Cancel', method: 'cancel' });

--- a/server/game/cards/events/01/seeninflames.js
+++ b/server/game/cards/events/01/seeninflames.js
@@ -37,7 +37,7 @@ class SeenInFlames extends DrawCard {
     revealHand() {
         var otherPlayer = this.game.getOtherPlayer(this.controller);
         var buttons = otherPlayer.hand.map(card => {
-            return { text: card.name, method: 'cardSelected', arg: card.uuid, card: card.getSummary(true) };
+            return { method: 'cardSelected', card: card };
         });
 
         buttons.push({ text: 'Cancel', method: 'cancel' });

--- a/server/game/cards/events/01/thebearandthemaidenfair.js
+++ b/server/game/cards/events/01/thebearandthemaidenfair.js
@@ -41,7 +41,7 @@ class TheBearAndTheMaidenFair extends DrawCard {
 
     promptToPlaceNextCard() {
         var buttons = _.map(this.remainingCards, card => ({
-            text: card.name, method: 'selectCard', arg: card.uuid, card: card.getSummary(true)
+            method: 'selectCard', card: card
         }));
 
         if(this.mode === 'bottom') {

--- a/server/game/cards/events/02/agiftofarborred.js
+++ b/server/game/cards/events/02/agiftofarborred.js
@@ -20,7 +20,7 @@ class AGiftOfArborRed extends DrawCard {
                 }
 
                 var buttons = _.map(this.thisPlayerCards, card => ({
-                    text: card.name, method: 'selectThisPlayerCardForHand', arg: card.uuid, card: card.getSummary(true)
+                    method: 'selectThisPlayerCardForHand', card: card
                 }));
 
                 this.game.promptWithMenu(this.controller, this, {
@@ -46,7 +46,7 @@ class AGiftOfArborRed extends DrawCard {
         }
 
         var buttons = _.map(this.otherPlayerCards, card => ({
-            text: card.name, method: 'selectOtherPlayerCardForHand', arg: card.uuid, card: card.getSummary(true)
+            method: 'selectOtherPlayerCardForHand', card: card
         }));
 
         this.game.promptWithMenu(this.controller, this, {

--- a/server/game/cards/events/02/ineverbetagainstmyfamily.js
+++ b/server/game/cards/events/02/ineverbetagainstmyfamily.js
@@ -26,7 +26,7 @@ class INeverBetAgainstMyFamily extends DrawCard {
 
     promptToChooseCharacter() {
         var buttons = _.map(this.uniqueCharacters, card => ({
-            text: card.name, method: 'selectCharacter', arg: card.uuid, card: card.getSummary(true)
+            method: 'selectCharacter', card: card
         }));
 
         buttons.push({ text: 'None', method: 'promptToPlaceNextCard' });
@@ -67,7 +67,7 @@ class INeverBetAgainstMyFamily extends DrawCard {
         }
 
         var buttons = _.map(this.remainingCards, card => ({
-            text: card.name, method: 'selectCardForBottom', arg: card.uuid, card: card.getSummary(true)
+            method: 'selectCardForBottom', card: card
         }));
 
         this.game.promptWithMenu(this.controller, this, {

--- a/server/game/cards/events/03/hisvipereyes.js
+++ b/server/game/cards/events/03/hisvipereyes.js
@@ -39,7 +39,7 @@ class HisViperEyes extends DrawCard {
     revealHand() {
         var otherPlayer = this.game.getOtherPlayer(this.controller);
         var buttons = otherPlayer.hand.map(card => {
-            return { text: card.name, method: 'cardSelected', arg: card.uuid, card: card.getSummary(true) };
+            return { method: 'cardSelected', card: card };
         });
 
         buttons.push({ text: 'Cancel', method: 'cancel' });

--- a/server/game/cards/events/05/aroseofgold.js
+++ b/server/game/cards/events/05/aroseofgold.js
@@ -13,7 +13,7 @@ class ARoseOfGold extends DrawCard {
                 this.remainingCards = this.controller.searchDrawDeck(3);
 
                 var buttons = _.map(this.remainingCards, card => ({
-                    text: card.name, method: 'selectCardForHand', arg: card.uuid, card: card.getSummary(true)
+                    method: 'selectCardForHand', card: card
                 }));
 
                 this.game.promptWithMenu(this.controller, this, {
@@ -44,7 +44,7 @@ class ARoseOfGold extends DrawCard {
 
     promptToPlaceNextCard() {
         var buttons = _.map(this.remainingCards, card => ({
-            text: card.name, method: 'selectCardForBottom', arg: card.uuid, card: card.getSummary(true)
+            method: 'selectCardForBottom', card: card
         }));
 
         this.game.promptWithMenu(this.controller, this, {

--- a/server/game/cards/locations/04/caswellskeep.js
+++ b/server/game/cards/locations/04/caswellskeep.js
@@ -36,7 +36,7 @@ class CaswellsKeep extends DrawCard {
         this.topCards = this.selectedPlayer.searchDrawDeck(2);
 
         var buttons = _.map(this.topCards, card => ({
-            text: card.name, method: 'selectCard', arg: card.uuid, card: card.getSummary(true)
+            method: 'selectCard', card: card
         }));
 
         this.game.promptWithMenu(this.controller, this, {

--- a/server/game/cards/locations/07/queenscrown.js
+++ b/server/game/cards/locations/07/queenscrown.js
@@ -29,7 +29,7 @@ class Queenscrown extends DrawCard {
 
     promptToDiscardCharacter(characters) {
         let buttons = _.map(characters, card => {
-            return { text: card.name, method: 'placeCharacterInDiscard', arg: card.uuid, card: card.getSummary(true) };
+            return { method: 'placeCharacterInDiscard', card: card };
         });
         buttons.push({ text: 'Done', method: 'promptToPlaceOnBottom' });
         this.game.promptWithMenu(this.controller, this, {
@@ -63,7 +63,7 @@ class Queenscrown extends DrawCard {
         }
 
         let buttons = _.map(this.remainingCards, card => {
-            return { text: card.name, method: 'placeCardOnBottom', arg: card.uuid, card: card.getSummary(true) };
+            return { method: 'placeCardOnBottom', card: card };
         });
 
         this.game.promptWithMenu(this.controller, this, {

--- a/server/game/cards/plots/05/summonedtocourt.js
+++ b/server/game/cards/plots/05/summonedtocourt.js
@@ -73,7 +73,7 @@ class SummonedToCourt extends PlotCard {
             activePrompt: {
                 menuTitle: 'Put ' + card.name + ' into play?',
                 buttons: [
-                    { text: 'Yes', method: 'putChoiceIntoPlay', arg: card.uuid, card: card.getSummary(true) },
+                    { text: 'Yes', method: 'putChoiceIntoPlay', card: card },
                     { text: 'No', method: 'declinePutIntoPlay', arg: card.uuid }
                 ]
             },

--- a/server/game/gamesteps/decksearchprompt.js
+++ b/server/game/gamesteps/decksearchprompt.js
@@ -66,7 +66,7 @@ class DeckSearchPrompt extends UiPrompt {
     buttons() {
         let uniqueCardsByTitle = _.uniq(this.searchCards(), card => card.cardData.label);
         let buttons = _.map(uniqueCardsByTitle, card => {
-            return { text: card.cardData.label, arg: card.uuid, card: card.getSummary(true) };
+            return { text: card.cardData.label, card: card };
         });
         buttons.push({ text: 'Done', arg: 'done' });
         return buttons;

--- a/server/game/gamesteps/forcedtriggeredabilitywindow.js
+++ b/server/game/gamesteps/forcedtriggeredabilitywindow.js
@@ -42,7 +42,7 @@ class ForcedTriggeredAbilityWindow extends BaseStep {
         let buttons = _.chain(this.abilityChoices)
             .map(abilityChoice => {
                 let title = abilityChoice.player.name + ' - ' + abilityChoice.card.name;
-                return { text: title, method: 'chooseAbility', arg: abilityChoice.id, card: abilityChoice.card.getSummary(true) };
+                return { text: title, method: 'chooseAbility', arg: abilityChoice.id, card: abilityChoice.card };
             })
             .sortBy('text')
             .value();

--- a/server/game/gamesteps/triggeredabilitywindow.js
+++ b/server/game/gamesteps/triggeredabilitywindow.js
@@ -56,7 +56,7 @@ class TriggeredAbilityWindow extends BaseStep {
             if(abilityChoice.text !== 'default') {
                 title += ' - ' + abilityChoice.text;
             }
-            return { text: title, method: 'chooseAbility', arg: abilityChoice.id, card: abilityChoice.card.getSummary(true) };
+            return { text: title, method: 'chooseAbility', arg: abilityChoice.id, card: abilityChoice.card };
         });
         buttons.push({ text: 'Pass', method: 'pass' });
         this.game.promptWithMenu(player, this, {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -1073,7 +1073,15 @@ class Player extends Spectator {
         this.selectCard = prompt.selectCard || false;
         this.menuTitle = prompt.menuTitle || '';
         this.promptTitle = prompt.promptTitle;
-        this.buttons = prompt.buttons || [];
+        this.buttons = _.map(prompt.buttons || [], button => {
+            if(button.card) {
+                let card = button.card;
+                let properties = _.omit(button, 'card');
+                return _.extend({ text: card.name, arg: card.uuid, card: card.getShortSummary() }, properties);
+            }
+
+            return button;
+        });
     }
 
     cancelPrompt() {

--- a/test/server/gamesteps/decksearchprompt.spec.js
+++ b/test/server/gamesteps/decksearchprompt.spec.js
@@ -68,9 +68,9 @@ describe('DeckSearchPrompt', function() {
             });
 
             it('should generate buttons for each unique card by title', function() {
-                expect(this.result.buttons).toContain(jasmine.objectContaining({ text: 'Foo', arg: '1111' }));
-                expect(this.result.buttons).toContain(jasmine.objectContaining({ text: 'Bar', arg: '2222' }));
-                expect(this.result.buttons).not.toContain(jasmine.objectContaining({ arg: '3333' }));
+                expect(this.result.buttons).toContain(jasmine.objectContaining({ text: 'Foo', card: jasmine.objectContaining({ uuid: '1111' }) }));
+                expect(this.result.buttons).toContain(jasmine.objectContaining({ text: 'Bar', card: jasmine.objectContaining({ uuid: '2222' }) }));
+                expect(this.result.buttons).not.toContain(jasmine.objectContaining({ card: jasmine.objectContaining({ uuid: '3333' }) }));
             });
 
             it('should include a Done button', function() {
@@ -190,9 +190,9 @@ describe('DeckSearchPrompt', function() {
             });
 
             it('should generate buttons for each unique card by title', function() {
-                expect(this.result.buttons).toContain(jasmine.objectContaining({ text: 'Foo', arg: '1111' }));
-                expect(this.result.buttons).toContain(jasmine.objectContaining({ text: 'Bar', arg: '2222' }));
-                expect(this.result.buttons).not.toContain(jasmine.objectContaining({ arg: '3333' }));
+                expect(this.result.buttons).toContain(jasmine.objectContaining({ text: 'Foo', card: jasmine.objectContaining({ uuid: '1111' }) }));
+                expect(this.result.buttons).toContain(jasmine.objectContaining({ text: 'Bar', card: jasmine.objectContaining({ uuid: '2222' }) }));
+                expect(this.result.buttons).not.toContain(jasmine.objectContaining({ card: jasmine.objectContaining({ uuid: '3333' }) }));
             });
 
             it('should include a Done button', function() {


### PR DESCRIPTION
Previously, when a menu prompt button was associated with a card, there
was a lot of repetition in that the text, argument and card summary were
almost always the same. Now, it is possible to just specify the card and
the other arguments are automatically filled in. If the `text` or `arg`
properties are specified, they will override the default card-generated
values.

Additionally, instead of sending the full card summary, only the
information used for card previews is sent to the client.