### PR TITLE
Add support for "up to X stat" selection prompts.

### DIFF
--- a/server/game/cards/attachments/02/kingrobertswarhammer.js
+++ b/server/game/cards/attachments/02/kingrobertswarhammer.js
@@ -4,8 +4,6 @@ const DrawCard = require('../../../drawcard.js');
 
 class KingRobertsWarhammer extends DrawCard {
     setupCardAbilities(ability) {
-        this.selectedStrength = 0;
-
         this.whileAttached({
             effect: ability.effects.modifyStrength(1)
         });
@@ -18,16 +16,9 @@ class KingRobertsWarhammer extends DrawCard {
                     numCards: 99,
                     activePromptTitle: 'Select characters',
                     source: this,
-                    cardCondition: card => {
-                        return !card.kneeled && (card.getStrength() + this.selectedStrength <= this.parent.getStrength() || card.opponentSelected);
-                    },
-                    onCardToggle: (player, card) => {
-                        if(card.opponentSelected) {
-                            this.selectedStrength += card.getStrength();
-                        } else {
-                            this.selectedStrength -= card.getStrength();
-                        }
-                    },
+                    maxStat: () => this.parent.getStrength(),
+                    cardStat: card => card.getStrength(),
+                    cardCondition: card => card.location === 'play area' && card.getType() === 'character' && !card.kneeled,
                     onSelect: (player, cards) => this.onSelect(player, cards),
                     onCancel: (player) => this.cancelSelection(player)
                 });
@@ -41,17 +32,12 @@ class KingRobertsWarhammer extends DrawCard {
         });
 
         this.game.addMessage('{0} sacrifices {1} to kneel {2}', player, this, cards);
-
-        this.selectedStrength = 0;
-
         this.controller.sacrificeCard(this);
 
         return true;
     }
 
     cancelSelection(player) {
-        this.selectedStrength = 0;
-
         this.game.addMessage('{0} cancels the resolution of {1}', player, this);
     }
 }

--- a/server/game/cards/characters/04/roosebolton.js
+++ b/server/game/cards/characters/04/roosebolton.js
@@ -4,8 +4,6 @@ const DrawCard = require('../../../drawcard.js');
 
 class RooseBolton extends DrawCard {
     setupCardAbilities() {
-        this.selectedStrength = 0;
-
         this.reaction({
             when: {
                 afterChallenge: (event, challenge) => challenge.winner === this.controller && challenge.isAttacking(this)
@@ -15,16 +13,10 @@ class RooseBolton extends DrawCard {
                     numCards: 99,
                     activePromptTitle: 'Select characters',
                     source: this,
+                    maxStat: () => this.getStrength(),
+                    cardStat: card => card.getStrength(),
                     cardCondition: card => {
-                        return card.getType() === 'character' && card.controller !== this.controller &&
-                            (card.getStrength() + this.selectedStrength <= this.getStrength() || card.opponentSelected);
-                    },
-                    onCardToggle: (player, card) => {
-                        if(card.opponentSelected) {
-                            this.selectedStrength += card.getStrength();
-                        } else {
-                            this.selectedStrength -= card.getStrength();
-                        }
+                        return card.location === 'play area' && card.getType() === 'character' && card.controller !== this.controller;
                     },
                     onSelect: (player, cards) => this.onSelect(player, cards),
                     onCancel: (player) => this.cancelSelection(player)
@@ -39,17 +31,12 @@ class RooseBolton extends DrawCard {
         });
 
         this.game.addMessage('{0} sacrifices {1} to kill {2}', player, this, cards);
-
-        this.selectedStrength = 0;
-
         this.controller.sacrificeCard(this);
 
         return true;
     }
 
     cancelSelection(player) {
-        this.selectedStrength = 0;
-
         this.game.addMessage('{0} cancels the resolution of {1}', player, this);
     }
 }

--- a/server/game/cards/events/01/consolidationofpower.js
+++ b/server/game/cards/events/01/consolidationofpower.js
@@ -16,22 +16,13 @@ class ConsolidationOfPower extends DrawCard {
     }
 
     play(player) {
-        this.selectedStrength = 0;
-
         this.game.promptForSelect(player, {
             numCards: 99,
             activePromptTitle: 'Select characters',
             source: this,
-            cardCondition: card => {
-                return !card.kneeled && (card.getStrength() + this.selectedStrength <= 4 || card.opponentSelected || card.selected);
-            },
-            onCardToggle: (player, card) => {
-                if(card.opponentSelected || card.selected) {
-                    this.selectedStrength += card.getStrength();
-                } else {
-                    this.selectedStrength -= card.getStrength();
-                }
-            },
+            maxStat: () => 4,
+            cardStat: card => card.getStrength(),
+            cardCondition: card => card.location === 'play area' && card.getType() === 'character' && !card.kneeled,
             onSelect: (player, cards) => this.onSelect(player, cards),
             onCancel: (player) => this.cancelSelection(player)
         });
@@ -63,14 +54,10 @@ class ConsolidationOfPower extends DrawCard {
         this.game.addMessage('{0} uses {1} to kneel {2}', player, this, this.cards);
         this.game.addMessage('{0} uses {1} to have {2} gain 1 power', player, this, card);
 
-        this.selectedStrength = 0;
-
         return true;
     }
 
     cancelSelection(player) {
-        this.selectedStrength = 0;
-
         this.game.addMessage('{0} cancels the resolution of {1}', player, this);
     }
 }

--- a/test/server/gamesteps/selectcardprompt.spec.js
+++ b/test/server/gamesteps/selectcardprompt.spec.js
@@ -496,4 +496,74 @@ describe('the SelectCardPrompt', function() {
             });
         });
     });
+
+    describe('for stat-based prompts', function() {
+        beforeEach(function() {
+            this.maxStatSpy = jasmine.createSpy('maxStat');
+            this.maxStatSpy.and.returnValue(1);
+            this.cardStatSpy = jasmine.createSpy('cardStat');
+            this.properties.maxStat = this.maxStatSpy;
+            this.properties.cardStat = this.cardStatSpy;
+            this.prompt = new SelectCardPrompt(this.game, this.player, this.properties);
+        });
+
+        describe('checkCardCondition()', function() {
+            beforeEach(function() {
+                this.properties.cardCondition.and.returnValue(true);
+                this.card.getType.and.returnValue('character');
+            });
+
+            describe('when the card is not selected', function() {
+                beforeEach(function() {
+                    this.prompt.selectedCards = [];
+                });
+
+                describe('and the card will not put it past the max', function() {
+                    beforeEach(function() {
+                        this.cardStatSpy.and.returnValue(1);
+                    });
+
+                    it('should return true', function() {
+                        expect(this.prompt.checkCardCondition(this.card)).toBe(true);
+                    });
+                });
+
+                describe('and the card will put it past the max', function() {
+                    beforeEach(function() {
+                        this.cardStatSpy.and.returnValue(2);
+                    });
+
+                    it('should return false', function() {
+                        expect(this.prompt.checkCardCondition(this.card)).toBe(false);
+                    });
+                });
+            });
+
+            describe('when the card is already selected and is therefore being unselected', function() {
+                beforeEach(function() {
+                    this.prompt.selectedCards = [this.card];
+                });
+
+                describe('and the card will not put it past the max', function() {
+                    beforeEach(function() {
+                        this.cardStatSpy.and.returnValue(1);
+                    });
+
+                    it('should return true', function() {
+                        expect(this.prompt.checkCardCondition(this.card)).toBe(true);
+                    });
+                });
+
+                describe('and the card will put it past the max', function() {
+                    beforeEach(function() {
+                        this.cardStatSpy.and.returnValue(2);
+                    });
+
+                    it('should return true', function() {
+                        expect(this.prompt.checkCardCondition(this.card)).toBe(true);
+                    });
+                });
+            });
+        });
+    });
 });


### PR DESCRIPTION
Previously, cards that had a mechanism to select cards up to a combined
strength or cost (e.g. King Robert's Warhammer) were manually tracking
the sum by monitoring card selection being toggled. Now the select card
prompt supports this natively, allowing a `maxStat` function to be
passed to indicate what the maximum stat value is, and a `cardStat`
function to take a card and get the appropriate stat value for it (e.g.
strength).