### PR TITLE
Properly implement "when marshalled" abilities.

### DIFF
--- a/server/game/cards/attachments/04/venomousblade.js
+++ b/server/game/cards/attachments/04/venomousblade.js
@@ -8,7 +8,7 @@ class VenomousBlade extends DrawCard {
 
         this.reaction({
             when: {
-                onCardEntersPlay: (event, card) => card === this
+                onCardEntersPlay: event => event.card === this
             },
             handler: () => {
                 this.game.promptForSelect(this.controller, {

--- a/server/game/cards/characters/01/areohotah.js
+++ b/server/game/cards/characters/01/areohotah.js
@@ -4,8 +4,8 @@ class AreoHotah extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onCardEntersPlay: (event, card) => (
-                    card === this &&
+                onCardEntersPlay: event => (
+                    event.card === this &&
                     this.game.currentChallenge &&
                     this.game.currentPhase === 'challenge'
                 )

--- a/server/game/cards/characters/01/aryastark.js
+++ b/server/game/cards/characters/01/aryastark.js
@@ -9,7 +9,7 @@ class AryaStark extends DrawCard {
         });
         this.reaction({
             when: {
-                onCardEntersPlay: (event, card) => card === this
+                onCardEntersPlay: event => event.card === this
             },
             handler: () => {
                 var dupe = this.controller.drawDeck.first();

--- a/server/game/cards/characters/01/greenbloodtrader.js
+++ b/server/game/cards/characters/01/greenbloodtrader.js
@@ -6,7 +6,7 @@ class GreenbloodTrader extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onCardEntersPlay: (e, card) => card === this
+                onCardEntersPlay: event => event.card === this
             },
             handler: () => {
                 this.top2Cards = this.controller.drawDeck.first(2);

--- a/server/game/cards/characters/01/littlefinger.js
+++ b/server/game/cards/characters/01/littlefinger.js
@@ -4,7 +4,7 @@ class LittleFinger extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onCardEntersPlay: (e, card) => card === this && this.game.currentPhase === 'marshal'
+                onCardEntersPlay: event => event.card === this && event.playingType === 'marshal'
             },
             handler: () => {
                 this.controller.drawCardsToHand(2);

--- a/server/game/cards/characters/01/melisandre.js
+++ b/server/game/cards/characters/01/melisandre.js
@@ -4,8 +4,8 @@ class Melisandre extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onCardEntersPlay: (event, card) =>
-                    card.controller === this.controller && card.hasTrait('R\'hllor'),
+                onCardEntersPlay: event =>
+                    event.playingType === 'marshal' && event.card.controller === this.controller && event.card.hasTrait('R\'hllor'),
                 onCardPlayed: (event, player, card) =>
                     card.controller === this.controller && card.hasTrait('R\'hllor')
             },

--- a/server/game/cards/characters/01/olennasinformant.js
+++ b/server/game/cards/characters/01/olennasinformant.js
@@ -4,7 +4,7 @@ class OlennasInformant extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onCardEntersPlay: (e, card) => card === this && this.game.currentPhase === 'challenge'
+                onCardEntersPlay: event => event.card === this && this.game.currentPhase === 'challenge'
             },
             handler: () => {
                 this.game.promptWithMenu(this.controller, this, {

--- a/server/game/cards/characters/01/sansastark.js
+++ b/server/game/cards/characters/01/sansastark.js
@@ -7,8 +7,8 @@ class SansaStark extends DrawCard {
         this.registerEvents(['onCardEntersPlay']);
     }
 
-    onCardEntersPlay(event, card) {
-        if(card !== this || this.controller.phase === 'setup') {
+    onCardEntersPlay(event) {
+        if(event.card !== this || this.controller.phase === 'setup') {
             return;
         }
 

--- a/server/game/cards/characters/01/summer.js
+++ b/server/game/cards/characters/01/summer.js
@@ -9,9 +9,7 @@ class Summer extends DrawCard {
 
         this.reaction({
             when: {
-                onCardEntersPlay: (event, card) => {
-                    return card === this;
-                }
+                onCardEntersPlay: event => event.card === this
             },
             handler: () => {
                 this.game.promptForSelect(this.controller, {

--- a/server/game/cards/characters/01/thequeensassassin.js
+++ b/server/game/cards/characters/01/thequeensassassin.js
@@ -4,9 +4,7 @@ class TheQueensAssassin extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onCardEntersPlay: (event, card) => {
-                    return this.wasAmbush && this === card;
-                }
+                onCardEntersPlay: event => event.card === this && event.playingType === 'ambush'
             },
             handler: () => {
                 var otherPlayer = this.game.getOtherPlayer(this.controller);

--- a/server/game/cards/characters/01/vanguardlancer.js
+++ b/server/game/cards/characters/01/vanguardlancer.js
@@ -4,7 +4,7 @@ class VanguardLancer extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onCardEntersPlay: (event, card) => card === this
+                onCardEntersPlay: event => event.card === this
             },
             handler: () => {
                 this.game.promptForSelect(this.controller, {

--- a/server/game/cards/characters/01/yoren.js
+++ b/server/game/cards/characters/01/yoren.js
@@ -4,7 +4,7 @@ class Yoren extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onCardEntersPlay: (event, card) => card === this && card.controller.phase !== 'setup'
+                onCardEntersPlay: event => event.card === this && event.playingType === 'marshal'
             },
             handler: () => {
                 this.game.promptForSelect(this.controller, {

--- a/server/game/cards/characters/02/newly-madelord.js
+++ b/server/game/cards/characters/02/newly-madelord.js
@@ -4,7 +4,7 @@ class NewlyMadeLord extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onCardEntersPlay: (e, card) => card === this
+                onCardEntersPlay: event => event.card === this && event.playingType === 'marshal'
             },
             handler: () => {
                 this.game.promptForSelect(this.controller, {

--- a/server/game/cards/characters/02/serhobberredwyne.js
+++ b/server/game/cards/characters/02/serhobberredwyne.js
@@ -4,7 +4,7 @@ class SerHobberRedwyne extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onCardEntersPlay: (event, card) => card === this && this.game.currentPhase === 'marshal'
+                onCardEntersPlay: event => event.card === this && event.playingType === 'marshal'
             },
             handler: () => {
                 this.game.promptForDeckSearch(this.controller, {

--- a/server/game/cards/characters/03/houseflorentknight.js
+++ b/server/game/cards/characters/03/houseflorentknight.js
@@ -5,7 +5,7 @@ class HouseFlorentKnight extends DrawCard {
     setupCardAbilities() {
         this.forcedReaction({
             when: {
-                onCardEntersPlay: (event, card) => card === this
+                onCardEntersPlay: event => event.card === this
             },
             target: {
                 activePromptTitle: 'Select a character with the lowest strength in play',

--- a/server/game/cards/characters/03/riverrunminstrel.js
+++ b/server/game/cards/characters/03/riverrunminstrel.js
@@ -4,7 +4,7 @@ class RiverrunMinstrel extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onCardEntersPlay: (e, card) => card === this
+                onCardEntersPlay: event => event.card === this
             },
             handler: () => {
                 this.game.promptForSelect(this.controller, {

--- a/server/game/cards/characters/04/asshaipriestess.js
+++ b/server/game/cards/characters/04/asshaipriestess.js
@@ -4,7 +4,7 @@ class AsshaiPriestess extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onCardEntersPlay: (event, card) => card === this && this.game.currentPhase === 'marshal'
+                onCardEntersPlay: event => event.card === this && event.playingType === 'marshal'
             },
             handler: () => {
                 this.game.promptForSelect(this.controller, {

--- a/server/game/cards/characters/04/captainsdaughter.js
+++ b/server/game/cards/characters/04/captainsdaughter.js
@@ -4,7 +4,8 @@ class CaptainsDaughter extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onCardEntersPlay: (event, card) => {
+                onCardEntersPlay: event => {
+                    let card = event.card;
                     if(this.controller === card.controller || this.controller.phase === 'setup' || card.isLoyal() || card.getType() !== 'character') {
                         return false;
                     }

--- a/server/game/cards/characters/04/esgred.js
+++ b/server/game/cards/characters/04/esgred.js
@@ -14,7 +14,8 @@ class Esgred extends DrawCard {
         });
     }
 
-    onCardEntersPlay(event, card) {
+    onCardEntersPlay(event) {
+        let card = event.card;
         if(card !== this && card.name !== 'Asha Greyjoy') {
             return;
         }

--- a/server/game/cards/characters/04/jaqenhghar.js
+++ b/server/game/cards/characters/04/jaqenhghar.js
@@ -6,7 +6,7 @@ class JaqenHGhar extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onCardEntersPlay: (event, card) => card === this
+                onCardEntersPlay: event => event.card === this
             },
             handler: () => {
                 this.game.promptForSelect(this.controller, {

--- a/server/game/cards/characters/04/joffreybaratheon.js
+++ b/server/game/cards/characters/04/joffreybaratheon.js
@@ -4,8 +4,9 @@ class JoffreyBaratheon extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onCardEntersPlay: (event, card) => {
-                    if(this.controller !== card.controller || this.controller.phase !== 'marshal' || card.getType() !== 'character' || !card.isLoyal()) {
+                onCardEntersPlay: event => {
+                    let card = event.card;
+                    if(this.controller !== card.controller || event.playingType !== 'marshal' || card.getType() !== 'character' || !card.isLoyal()) {
                         return false;
                     }
 

--- a/server/game/cards/characters/04/lordsportfisherman.js
+++ b/server/game/cards/characters/04/lordsportfisherman.js
@@ -4,7 +4,7 @@ class LordsportFisherman extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onCardEntersPlay: (e, card) => card === this && this.game.currentPhase === 'marshal'
+                onCardEntersPlay: event => event.card === this && event.playingType === 'marshal'
             },
             handler: () => {
                 var bottomCard = this.controller.drawDeck.last();

--- a/server/game/cards/characters/04/quaitheoftheshadow.js
+++ b/server/game/cards/characters/04/quaitheoftheshadow.js
@@ -5,8 +5,8 @@ class QuaitheOfTheShadow extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onCardEntersPlay: (event, card) => (
-                    card === this &&
+                onCardEntersPlay: event => (
+                    event.card === this &&
                     this.game.currentChallenge &&
                     this.game.currentPhase === 'challenge'
                 )

--- a/server/game/cards/characters/04/serarysoakheart.js
+++ b/server/game/cards/characters/04/serarysoakheart.js
@@ -4,7 +4,7 @@ class SerArysOakheart extends DrawCard {
     setupCardAbilities() {  
         this.reaction({
             when: {
-                onCardEntersPlay: (e, card) => card === this && this.controller.gold >= 2
+                onCardEntersPlay: event => event.card === this && this.controller.gold >= 2
             },
             handler: () => {
                 this.game.promptForSelect(this.controller, {

--- a/server/game/cards/characters/04/starfallcavalry.js
+++ b/server/game/cards/characters/04/starfallcavalry.js
@@ -4,7 +4,7 @@ class StarfallCavalry extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onCardEntersPlay: (event, card) => card === this
+                onCardEntersPlay: event => event.card === this
             },
             handler: () => {
                 var numCards = this.controller.getNumberOfUsedPlots() >= 3 ? 3 : 1;

--- a/server/game/cards/characters/04/tandastokeworth.js
+++ b/server/game/cards/characters/04/tandastokeworth.js
@@ -5,7 +5,7 @@ class TandaStokeworth extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onCardEntersPlay: (e, card) => card === this && this.game.currentPhase === 'marshal'
+                onCardEntersPlay: event => event.card === this && event.playingType === 'marshal'
             },
             handler: () => {
                 _.each(this.game.getPlayers(), player => {

--- a/server/game/cards/characters/04/xaroxhoandaxos.js
+++ b/server/game/cards/characters/04/xaroxhoandaxos.js
@@ -5,7 +5,7 @@ class XaroXhoanDaxos extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onCardEntersPlay: (event, card) => card.getType() === 'attachment' && card.isUnique() && this.game.currentPhase === 'marshal'
+                onCardEntersPlay: event => event.card.getType() === 'attachment' && event.card.isUnique() && event.playingType === 'marshal'
             },
             limit: AbilityLimit.perPhase(1),
             handler: () => {

--- a/server/game/cards/characters/05/alerietyrell.js
+++ b/server/game/cards/characters/05/alerietyrell.js
@@ -4,7 +4,7 @@ class AlerieTyrell extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onCardEntersPlay: (event, card) => card === this
+                onCardEntersPlay: event => event.card === this
             },
             handler: () => {
                 this.game.promptForDeckSearch(this.controller, {

--- a/server/game/cards/characters/05/lannisportguard.js
+++ b/server/game/cards/characters/05/lannisportguard.js
@@ -5,7 +5,7 @@ class LannisportGuard extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onCardEntersPlay: (e, card) => card === this && this.game.currentPhase === 'marshal'
+                onCardEntersPlay: event => event.card === this && event.playingType === 'marshal'
             },
             handler: () => {
                 _.each(this.game.getPlayers(), player => {

--- a/server/game/cards/characters/05/redkeepspy.js
+++ b/server/game/cards/characters/05/redkeepspy.js
@@ -4,9 +4,9 @@ class RedKeepSpy extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onCardEntersPlay: (event, card) => (
-                    this.wasAmbush && 
-                    this === card &&
+                onCardEntersPlay: event => (
+                    event.playingType === 'ambush' &&
+                    this === event.card &&
                     this.hasMoreCardsInHand()
                 )
             },

--- a/server/game/cards/characters/05/serkevanlannister.js
+++ b/server/game/cards/characters/05/serkevanlannister.js
@@ -4,7 +4,7 @@ class SerKevanLannister extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onCardEntersPlay: (e, card) => card === this && this.game.currentPhase === 'marshal'
+                onCardEntersPlay: event => event.card === this && event.playingType === 'marshal'
             },
             handler: () => {
                 this.game.promptForSelect(this.controller, {

--- a/server/game/cards/characters/05/shaggasonofdolf.js
+++ b/server/game/cards/characters/05/shaggasonofdolf.js
@@ -8,7 +8,7 @@ class ShaggaSonOfDolf extends DrawCard {
             phase: 'challenge',
             condition: () => this.hasClansmanOrTyrion(),
             handler: () => {
-                this.controller.putIntoPlay(this);
+                this.controller.putIntoPlay(this, 'ambush');
                 this.wasAmbush = true;
                 this.game.addMessage('{0} ambushes {1} into play for free', this.controller, this);
             }
@@ -16,7 +16,7 @@ class ShaggaSonOfDolf extends DrawCard {
 
         this.forcedReaction({
             when: {
-                onCardEntersPlay: (event, card) => card === this && this.wasAmbush
+                onCardEntersPlay: event => event.card === this && event.playingType === 'ambush'
             },
             target: {
                 activePromptTitle: 'Select a character to kill',

--- a/server/game/cards/characters/07/dalla.js
+++ b/server/game/cards/characters/07/dalla.js
@@ -4,7 +4,7 @@ class Dalla extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onCardEntersPlay: (event, card) => card.controller === this.controller && card.hasTrait('Wildling') && card.getType() === 'character'
+                onCardEntersPlay: event => event.card.controller === this.controller && event.card.hasTrait('Wildling') && event.card.getType() === 'character'
             },
             limit: ability.limit.perPhase(1),
             handler: () => {

--- a/server/game/cards/characters/07/southronmessenger.js
+++ b/server/game/cards/characters/07/southronmessenger.js
@@ -4,7 +4,7 @@ class SouthronMessenger extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onCardEntersPlay: (event, card) => card === this && this.game.currentChallenge
+                onCardEntersPlay: event => event.card === this && this.game.currentChallenge
             },
             target: {
                 activePromptTitle: 'Select participating character',

--- a/server/game/cards/characters/07/ulfsonofumar.js
+++ b/server/game/cards/characters/07/ulfsonofumar.js
@@ -4,7 +4,8 @@ class UlfSonOfUmar extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onCardEntersPlay: (event, card) => {
+                onCardEntersPlay: event => {
+                    let card = event.card;
                     if(!card.hasTrait('Clansman') || card.getType() !== 'character' || card.controller !== this.controller || card.getStrength(true) === 0) {
                         return false;
                     }

--- a/server/game/cards/locations/02/brandonsgift.js
+++ b/server/game/cards/locations/02/brandonsgift.js
@@ -4,12 +4,12 @@ class BrandonsGift extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onCardEntersPlay: (event, card) => (
-                    card.controller === this.controller && 
-                    this.game.currentPhase === 'marshal' &&
-                    card.hasTrait('Builder') && 
-                    card.getType() === 'character')
-                    
+                onCardEntersPlay: event => (
+                    event.card.controller === this.controller &&
+                    event.playingType === 'marshal' &&
+                    event.card.hasTrait('Builder') &&
+                    event.card.getType() === 'character')
+
             },
             limit: ability.limit.perPhase(3),
             handler: () => {

--- a/server/game/cards/locations/02/northernrookery.js
+++ b/server/game/cards/locations/02/northernrookery.js
@@ -7,7 +7,7 @@ class NorthernRookery extends DrawCard {
         });
         this.reaction({
             when: {
-                onCardEntersPlay: (e, card) => card === this && this.game.currentPhase === 'marshal'
+                onCardEntersPlay: event => event.card === this && event.playingType === 'marshal'
             },
             handler: () => {
                 this.game.addMessage('{0} uses {1} to draw 1 card.', this.controller, this);

--- a/server/game/cards/locations/02/pleasurebarge.js
+++ b/server/game/cards/locations/02/pleasurebarge.js
@@ -6,10 +6,10 @@ class PleasureBarge extends DrawCard {
         this.plotModifiers({
             gold: -1
         });
-        
+
         this.reaction({
             when: {
-                onCardEntersPlay: (e, card) => card === this && this.game.currentPhase === 'marshal'
+                onCardEntersPlay: event => event.card === this && event.playingType === 'marshal'
             },
             handler: () => {
                 this.controller.drawCardsToHand(3);

--- a/server/game/cards/locations/04/bearisland.js
+++ b/server/game/cards/locations/04/bearisland.js
@@ -4,7 +4,7 @@ class BearIsland extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onCardEntersPlay: (event, card) => card.getType() !== 'plot' && card.controller === this.controller && card.isLoyal() && this.game.currentPhase === 'marshal'
+                onCardEntersPlay: event => event.card.getType() !== 'plot' && event.card.controller === this.controller && event.card.isLoyal() && event.playingType === 'marshal'
             },
             limit: ability.limit.perPhase(2),
             handler: () => {

--- a/server/game/cards/locations/04/harrenhal.js
+++ b/server/game/cards/locations/04/harrenhal.js
@@ -4,7 +4,8 @@ class Harrenhal extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onCardEntersPlay: (event, card) => {
+                onCardEntersPlay: event => {
+                    let card = event.card;
                     if(this.controller === card.controller || this.controller.phase === 'setup' || card.getType() !== 'character') {
                         return false;
                     }

--- a/server/game/cards/locations/04/thefrostfangs.js
+++ b/server/game/cards/locations/04/thefrostfangs.js
@@ -4,7 +4,7 @@ class TheFrostfangs extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onCardEntersPlay: (event, card) => card === this && card.controller.phase !== 'setup'
+                onCardEntersPlay: event => event.card === this
             },
             handler: () => {
                 var otherPlayer = this.game.getOtherPlayer(this.controller);

--- a/server/game/cards/locations/05/mountainsofthemoon.js
+++ b/server/game/cards/locations/05/mountainsofthemoon.js
@@ -6,7 +6,8 @@ class MountainsOfTheMoon extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onCardEntersPlay: (event, card) => {
+                onCardEntersPlay: event => {
+                    let card = event.card;
                     if(!card.hasTrait('Clansman') || !card.getType() === 'character') {
                         return false;
                     }

--- a/server/game/cards/plots/07/whispercampaign.js
+++ b/server/game/cards/plots/07/whispercampaign.js
@@ -4,7 +4,8 @@ class WhisperCampaign extends PlotCard {
     setupCardAbilities() {
         this.forcedReaction({
             when: {
-                onCardEntersPlay: (event, card) => {
+                onCardEntersPlay: event => {
+                    let card = event.card;
                     if(card.getType() !== 'character' || card.hasIcon('intrigue')) {
                         return false;
                     }

--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -30,8 +30,8 @@ class EffectEngine {
         });
     }
 
-    onCardEntersPlay(e, card) {
-        this.addTargetForPersistentEffects(card, 'play area');
+    onCardEntersPlay(event) {
+        this.addTargetForPersistentEffects(event.card, 'play area');
     }
 
     onCardLeftPlay(e, player, card) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -606,7 +606,7 @@ class Game extends EventEmitter {
         if(card.location !== 'play area') {
             card.play(newController, false);
             card.moveTo('play area');
-            this.raiseEvent('onCardEntersPlay', card);
+            this.raiseMergedEvent('onCardEntersPlay', { card: card, playingType: 'play' });
         }
 
         this.raiseEvent('onCardTakenControl', card);

--- a/server/game/gamesteps/attachmentprompt.js
+++ b/server/game/gamesteps/attachmentprompt.js
@@ -1,10 +1,11 @@
 const UiPrompt = require('./uiprompt.js');
 
 class AttachmentPrompt extends UiPrompt {
-    constructor(game, player, attachmentCard) {
+    constructor(game, player, attachmentCard, playingType) {
         super(game);
         this.player = player;
         this.attachmentCard = attachmentCard;
+        this.playingType = playingType;
     }
 
     activeCondition(player) {
@@ -24,7 +25,7 @@ class AttachmentPrompt extends UiPrompt {
         }
 
         var targetPlayer = this.game.getPlayerByName(targetCard.controller.name);
-        targetPlayer.attach(player, attachment, targetCard.uuid);
+        targetPlayer.attach(player, attachment, targetCard.uuid, this.playingType);
 
         player.selectCard = false;
         this.complete();

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -424,7 +424,7 @@ class Player extends Spectator {
         var dupeCard = this.getDuplicateInPlay(card);
 
         if(card.getType() === 'attachment' && playingType !== 'setup' && !dupeCard) {
-            this.promptForAttachment(card);
+            this.promptForAttachment(card, playingType);
             return;
         }
 
@@ -445,7 +445,7 @@ class Player extends Spectator {
                 this.game.queueStep(new BestowPrompt(this.game, this, card));
             }
 
-            this.game.raiseEvent('onCardEntersPlay', card);
+            this.game.raiseMergedEvent('onCardEntersPlay', { card: card, playingType: playingType });
         }
     }
 
@@ -503,7 +503,7 @@ class Player extends Spectator {
         this.selectedPlot.play();
         this.moveCard(this.selectedPlot, 'active plot');
 
-        this.game.raiseEvent('onCardEntersPlay', this.activePlot);
+        this.game.raiseMergedEvent('onCardEntersPlay', { card: this.activePlot, playingType: 'plot' });
 
         this.selectedPlot = undefined;
     }
@@ -564,7 +564,7 @@ class Player extends Spectator {
         return attachment.canAttach(this, card);
     }
 
-    attach(player, attachment, cardId) {
+    attach(player, attachment, cardId, playingType) {
         var card = this.findCardInPlayByUuid(cardId);
 
         if(!card || !attachment) {
@@ -575,7 +575,7 @@ class Player extends Spectator {
 
         attachment.parent = card;
         attachment.moveTo('play area');
-        this.game.raiseEvent('onCardEntersPlay', attachment);
+        this.game.raiseMergedEvent('onCardEntersPlay', { card: attachment, playingType: playingType });
         card.attachments.push(attachment);
 
         attachment.attach(player, card);
@@ -721,9 +721,9 @@ class Player extends Spectator {
         return true;
     }
 
-    promptForAttachment(card) {
+    promptForAttachment(card, playingType) {
         // TODO: Really want to move this out of here.
-        this.game.queueStep(new AttachmentPrompt(this.game, this, card));
+        this.game.queueStep(new AttachmentPrompt(this.game, this, card, playingType));
     }
 
     beginChallenge() {

--- a/test/server/effectengine.spec.js
+++ b/test/server/effectengine.spec.js
@@ -83,7 +83,7 @@ describe('EffectEngine', function () {
             beforeEach(function() {
                 this.effectSpy.duration = 'persistent';
                 this.cardEnteringPlay = { location: 'play area' };
-                this.engine.onCardEntersPlay({}, this.cardEnteringPlay);
+                this.engine.onCardEntersPlay({ card: this.cardEnteringPlay });
             });
 
             it('should add the card entering play as a target', function() {
@@ -95,7 +95,7 @@ describe('EffectEngine', function () {
             beforeEach(function() {
                 this.effectSpy.duration = 'untilEndOfChallenge';
                 this.cardEnteringPlay = { location: 'play area' };
-                this.engine.onCardEntersPlay({}, this.cardEnteringPlay);
+                this.engine.onCardEntersPlay({ card: this.cardEnteringPlay });
             });
 
             it('should not add the card entering play as a target', function() {

--- a/test/server/player/flipplotfaceup.spec.js
+++ b/test/server/player/flipplotfaceup.spec.js
@@ -6,7 +6,7 @@ const Player = require('../../../server/game/player.js');
 
 describe('Player', function() {
     beforeEach(function() {
-        this.gameSpy = jasmine.createSpyObj('game', ['on', 'getOtherPlayer', 'raiseEvent', 'playerDecked']);
+        this.gameSpy = jasmine.createSpyObj('game', ['on', 'getOtherPlayer', 'raiseEvent', 'raiseMergedEvent', 'playerDecked']);
 
         this.player = new Player('1', 'Player 1', true, this.gameSpy);
         this.player.initialise();

--- a/test/server/player/putintoplay.spec.js
+++ b/test/server/player/putintoplay.spec.js
@@ -7,7 +7,7 @@ const Player = require('../../../server/game/player.js');
 
 describe('Player', function() {
     beforeEach(function() {
-        this.gameSpy = jasmine.createSpyObj('game', ['queueStep', 'raiseEvent', 'playerDecked']);
+        this.gameSpy = jasmine.createSpyObj('game', ['queueStep', 'raiseEvent', 'raiseMergedEvent', 'playerDecked']);
         this.player = new Player('1', 'Player 1', true, this.gameSpy);
         this.player.initialise();
 
@@ -148,7 +148,7 @@ describe('Player', function() {
                 });
 
                 it('should raise the onCardEntersPlay event', function() {
-                    expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onCardEntersPlay', this.cardSpy);
+                    expect(this.gameSpy.raiseMergedEvent).toHaveBeenCalledWith('onCardEntersPlay', jasmine.objectContaining({ card: this.cardSpy, playingType: 'marshal' }));
                 });
 
                 describe('when it has the Bestow keyword', function() {
@@ -179,7 +179,7 @@ describe('Player', function() {
                 });
 
                 it('should not raise the onCardEntersPlay event', function() {
-                    expect(this.gameSpy.raiseEvent).not.toHaveBeenCalledWith('onCardEntersPlay', this.cardSpy);
+                    expect(this.gameSpy.raiseMergedEvent).not.toHaveBeenCalledWith('onCardEntersPlay', jasmine.objectContaining({ card: this.cardSpy }));
                 });
 
                 it('should add as a duplicate', function() {
@@ -270,7 +270,7 @@ describe('Player', function() {
                 });
 
                 it('should raise the onCardEntersPlay event', function() {
-                    expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onCardEntersPlay', this.cardSpy);
+                    expect(this.gameSpy.raiseMergedEvent).toHaveBeenCalledWith('onCardEntersPlay', jasmine.objectContaining({ card: this.cardSpy, playingType: 'setup' }));
                 });
 
                 describe('when it has the Bestow keyword', function() {
@@ -309,7 +309,7 @@ describe('Player', function() {
                 });
 
                 it('should raise the onCardEntersPlay event', function() {
-                    expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onCardEntersPlay', this.cardSpy);
+                    expect(this.gameSpy.raiseMergedEvent).toHaveBeenCalledWith('onCardEntersPlay', jasmine.objectContaining({ card: this.cardSpy, playingType: 'setup' }));
                 });
 
                 it('should not add as a duplicate', function() {
@@ -342,7 +342,7 @@ describe('Player', function() {
                 });
 
                 it('should raise the onCardEntersPlay event', function() {
-                    expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onCardEntersPlay', this.cardSpy);
+                    expect(this.gameSpy.raiseMergedEvent).toHaveBeenCalledWith('onCardEntersPlay', jasmine.objectContaining({ card: this.cardSpy, playingType: 'ambush' }));
                 });
             });
 
@@ -361,7 +361,7 @@ describe('Player', function() {
                 });
 
                 it('should not raise the onCardEntersPlay event', function() {
-                    expect(this.gameSpy.raiseEvent).not.toHaveBeenCalledWith('onCardEntersPlay', this.cardSpy);
+                    expect(this.gameSpy.raiseMergedEvent).not.toHaveBeenCalledWith('onCardEntersPlay', jasmine.objectContaining({ card: this.cardSpy }));
                 });
 
                 it('should add as a duplicate', function() {


### PR DESCRIPTION
Previously, "when marshalled" abilities were checking to see if the
current phase was marshal. This was not correct, as there are
potentially card effects that can put a card into play during the
marshal phase which should not be considered marshalling the card.

Now, the `playingType` parameter is checked to make sure that the card
has been marshalled. The `onCardEntersPlay` event has been converted to
the new event style.

This fixes bugs with Yoren, Newly Made Lord, and Melisandre where the
phase / playing type wasn't being checked at all.

Fixes #714.