### PR TITLE
Fix selectable card state when selecting opponent cards.

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -452,7 +452,8 @@ class BaseCard {
         };
     }
 
-    getSummary(isActivePlayer, hideWhenFaceup) {
+    getSummary(activePlayer, hideWhenFaceup) {
+        let isActivePlayer = activePlayer === this.owner;
         return isActivePlayer || (!this.facedown && !hideWhenFaceup) ? {
             code: this.cardData.code,
             controlled: this.owner !== this.controller,

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -461,8 +461,10 @@ class BaseCard {
             menu: this.getMenu(),
             name: this.cardData.label,
             new: this.new,
-            selected: (isActivePlayer && this.selected) || this.opponentSelected,
-            selectable: (isActivePlayer && this.selectable),
+            // The `this.selected` property here is a hack for plot selection,
+            // which we do differently from normal card selection.
+            selected: this.selected || activePlayer.isCardSelected(this),
+            selectable: activePlayer.isCardSelectable(this),
             tokens: this.tokens,
             type: this.getType(),
             uuid: this.uuid

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -307,13 +307,13 @@ class DrawCard extends BaseCard {
         return !this.cannotBeKilled;
     }
 
-    getSummary(isActivePlayer, hideWhenFaceup) {
-        var baseSummary = super.getSummary(isActivePlayer, hideWhenFaceup);
+    getSummary(activePlayer, hideWhenFaceup) {
+        let baseSummary = super.getSummary(activePlayer, hideWhenFaceup);
 
         return _.extend(baseSummary, {
             attached: !!this.parent,
             attachments: this.attachments.map(attachment => {
-                return attachment.getSummary(isActivePlayer, hideWhenFaceup);
+                return attachment.getSummary(activePlayer, hideWhenFaceup);
             }),
             baseStrength: _.isNull(this.cardData.strength) ? 0 : this.cardData.strength,
             dupes: this.dupes.map(dupe => {
@@ -321,7 +321,7 @@ class DrawCard extends BaseCard {
                     throw new Error('A dupe should not have dupes! ' + dupe.name);
                 }
 
-                return dupe.getSummary(isActivePlayer, hideWhenFaceup);
+                return dupe.getSummary(activePlayer, hideWhenFaceup);
             }),
             iconsAdded: this.getIconsAdded(),
             iconsRemoved: this.getIconsRemoved(),

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -275,7 +275,6 @@ class DrawCard extends BaseCard {
         this.power = 0;
         this.wasAmbush = false;
         this.inChallenge = false;
-        this.selected = this.opponentSelected = false;
 
         super.leavesPlay();
     }

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -791,12 +791,13 @@ class Game extends EventEmitter {
         };
     }
 
-    getState(activePlayer) {
-        var playerState = {};
+    getState(activePlayerName) {
+        let activePlayer = this.playersAndSpectators[activePlayerName];
+        let playerState = {};
 
         if(this.started) {
             _.each(this.getPlayers(), player => {
-                playerState[player.name] = player.getState(activePlayer === player.name);
+                playerState[player.name] = player.getState(activePlayer);
             });
 
             return {
@@ -816,10 +817,10 @@ class Game extends EventEmitter {
             };
         }
 
-        return this.getSummary(activePlayer);
+        return this.getSummary(activePlayerName);
     }
 
-    getSummary(activePlayer) {
+    getSummary(activePlayerName) {
         var playerSummaries = {};
 
         _.each(this.getPlayers(), player => {
@@ -828,7 +829,7 @@ class Game extends EventEmitter {
                 return;
             }
 
-            if(activePlayer === player.name && player.deck) {
+            if(activePlayerName === player.name && player.deck) {
                 deck = { name: player.deck.name, selected: player.deck.selected };
             } else if(player.deck) {
                 deck = { selected: player.deck.selected };

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -37,6 +37,8 @@ class Player extends Spectator {
         this.costReducers = [];
         this.playableLocations = _.map(['marshal', 'play', 'ambush'], playingType => new PlayableLocation(playingType, this, 'hand'));
         this.usedPlotsModifier = 0;
+        this.selectedCards = [];
+        this.selectableCards = [];
 
         this.createAdditionalPile('out of game', { title: 'Out of Game', area: 'player row' });
     }
@@ -1031,6 +1033,30 @@ class Player extends Spectator {
 
     isBelowReserve() {
         return this.hand.size() <= this.getTotalReserve();
+    }
+
+    isCardSelected(card) {
+        return this.selectedCards.includes(card);
+    }
+
+    setSelectedCards(cards) {
+        this.selectedCards = cards;
+    }
+
+    clearSelectedCards() {
+        this.selectedCards = [];
+    }
+
+    isCardSelectable(card) {
+        return this.selectableCards.includes(card);
+    }
+
+    setSelectableCards(cards) {
+        this.selectableCards = cards;
+    }
+
+    clearSelectableCards() {
+        this.selectableCards = [];
     }
 
     getSummaryForCardList(list, activePlayer, hideWhenFaceup) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -1033,9 +1033,9 @@ class Player extends Spectator {
         return this.hand.size() <= this.getTotalReserve();
     }
 
-    getSummaryForCardList(list, isActivePlayer, hideWhenFaceup) {
+    getSummaryForCardList(list, activePlayer, hideWhenFaceup) {
         return list.map(card => {
-            return card.getSummary(isActivePlayer, hideWhenFaceup);
+            return card.getSummary(activePlayer, hideWhenFaceup);
         });
     }
 
@@ -1068,26 +1068,27 @@ class Player extends Spectator {
         this.buttons = [];
     }
 
-    getState(isActivePlayer) {
-        var state = {
-            activePlot: this.activePlot ? this.activePlot.getSummary(isActivePlayer) : undefined,
+    getState(activePlayer) {
+        let isActivePlayer = activePlayer === this;
+        let state = {
+            activePlot: this.activePlot ? this.activePlot.getSummary(activePlayer) : undefined,
             additionalPiles: _.mapObject(this.additionalPiles, pile => ({
                 title: pile.title,
                 area: pile.area,
                 isPrivate: pile.isPrivate,
-                cards: this.getSummaryForCardList(pile.cards, isActivePlayer, pile.isPrivate)
+                cards: this.getSummaryForCardList(pile.cards, activePlayer, pile.isPrivate)
             })),
-            agenda: this.agenda ? this.agenda.getSummary() : undefined,
+            agenda: this.agenda ? this.agenda.getSummary(activePlayer) : undefined,
             buttons: isActivePlayer ? this.buttons : undefined,
-            cardsInPlay: this.getSummaryForCardList(this.cardsInPlay, isActivePlayer),
+            cardsInPlay: this.getSummaryForCardList(this.cardsInPlay, activePlayer),
             claim: this.getClaim(),
-            deadPile: this.getSummaryForCardList(this.deadPile, isActivePlayer),
-            discardPile: this.getSummaryForCardList(this.discardPile, isActivePlayer),
+            deadPile: this.getSummaryForCardList(this.deadPile, activePlayer),
+            discardPile: this.getSummaryForCardList(this.discardPile, activePlayer),
             disconnected: this.disconnected,
-            faction: this.faction.getSummary(),
+            faction: this.faction.getSummary(activePlayer),
             firstPlayer: this.firstPlayer,
             gold: !isActivePlayer && this.phase === 'setup' ? 0 : this.gold,
-            hand: this.getSummaryForCardList(this.hand, isActivePlayer, true),
+            hand: this.getSummaryForCardList(this.hand, activePlayer, true),
             id: this.id,
             left: this.left,
             menuTitle: isActivePlayer ? this.menuTitle : undefined,
@@ -1095,8 +1096,8 @@ class Player extends Spectator {
             name: this.name,
             numPlotCards: this.plotDeck.size(),
             phase: this.phase,
-            plotDeck: this.getSummaryForCardList(this.plotDeck, isActivePlayer, true),
-            plotDiscard: this.getSummaryForCardList(this.plotDiscard, isActivePlayer),
+            plotDeck: this.getSummaryForCardList(this.plotDeck, activePlayer, true),
+            plotDiscard: this.getSummaryForCardList(this.plotDiscard, activePlayer),
             plotSelected: !!this.selectedPlot,
             promptTitle: isActivePlayer ? this.promptTitle : undefined,
             reserve: this.getTotalReserve(),
@@ -1107,7 +1108,7 @@ class Player extends Spectator {
 
         if(this.showDeck) {
             state.showDeck = true;
-            state.drawDeck = this.getSummaryForCardList(this.drawDeck, isActivePlayer);
+            state.drawDeck = this.getSummaryForCardList(this.drawDeck, activePlayer);
         }
 
         return state;

--- a/server/game/spectator.js
+++ b/server/game/spectator.js
@@ -8,6 +8,14 @@ class Spectator {
         this.buttons = [];
         this.menuTitle = 'Spectator mode';
     }
+
+    isCardSelected() {
+        return false;
+    }
+
+    isCardSelectable() {
+        return false;
+    }
 }
 
 module.exports = Spectator;

--- a/test/server/card/basecard.spec.js
+++ b/test/server/card/basecard.spec.js
@@ -8,7 +8,8 @@ describe('BaseCard', function () {
         this.testCard = { code: '111', label: 'test 1(some pack)', name: 'test 1' };
         this.limitedCard = { code: '1234', text: 'Limited.' };
         this.nonLimitedCard = { code: '2222', text: 'Stealth.' };
-        this.card = new BaseCard({}, this.testCard);
+        this.owner = { owner: 1 };
+        this.card = new BaseCard(this.owner, this.testCard);
     });
 
     describe('when new instance created', function() {
@@ -51,7 +52,7 @@ describe('BaseCard', function () {
     describe('getSummary', function() {
         describe('when is active player', function() {
             beforeEach(function () {
-                this.summary = this.card.getSummary(true);
+                this.summary = this.card.getSummary(this.owner);
             });
 
             describe('and card is faceup', function() {
@@ -69,7 +70,7 @@ describe('BaseCard', function () {
             describe('and card is facedown', function() {
                 beforeEach(function () {
                     this.card.facedown = true;
-                    this.summary = this.card.getSummary(true);
+                    this.summary = this.card.getSummary(this.owner);
                 });
 
                 it('should return card data', function() {
@@ -86,13 +87,14 @@ describe('BaseCard', function () {
 
         describe('when is not active player', function() {
             beforeEach(function () {
-                this.summary = this.card.getSummary(false);
+                this.anotherPlayer = { player: 2 };
+                this.summary = this.card.getSummary(this.anotherPlayer);
             });
 
             describe('and card is faceup', function() {
                 describe('and hiding facedown cards', function() {
                     beforeEach(function() {
-                        this.summary = this.card.getSummary(false, true);
+                        this.summary = this.card.getSummary(this.anotherPlayer, true);
                     });
 
                     it('should return no card data', function () {
@@ -120,7 +122,7 @@ describe('BaseCard', function () {
             describe('and card is facedown', function() {
                 beforeEach(function () {
                     this.card.facedown = true;
-                    this.summary = this.card.getSummary(false);
+                    this.summary = this.card.getSummary(this.anotherPlayer);
                 });
 
                 it('should return no card data', function() {

--- a/test/server/card/basecard.spec.js
+++ b/test/server/card/basecard.spec.js
@@ -8,7 +8,7 @@ describe('BaseCard', function () {
         this.testCard = { code: '111', label: 'test 1(some pack)', name: 'test 1' };
         this.limitedCard = { code: '1234', text: 'Limited.' };
         this.nonLimitedCard = { code: '2222', text: 'Stealth.' };
-        this.owner = { owner: 1 };
+        this.owner = jasmine.createSpyObj('owner', ['isCardSelectable', 'isCardSelected']);
         this.card = new BaseCard(this.owner, this.testCard);
     });
 
@@ -87,7 +87,7 @@ describe('BaseCard', function () {
 
         describe('when is not active player', function() {
             beforeEach(function () {
-                this.anotherPlayer = { player: 2 };
+                this.anotherPlayer = jasmine.createSpyObj('owner', ['isCardSelectable', 'isCardSelected']);
                 this.summary = this.card.getSummary(this.anotherPlayer);
             });
 


### PR DESCRIPTION
Previously, the `selected` and `selectable` state for cards was stored directly on the card. This made it difficult to hide selection state from the opponent when their cards were selected or selectable (hence the `opponentSelected` flag). In the case of `selectable`, it was impossible to show the selecting player which opponent cards were selectable without also showing the opponent.

Now, the list of selected and selectable cards is stored directly on the player object doing the selection. This made it easy to only show selection state to that player, though it did require passing the full player object in the serializers instead of a boolean flag indicating 'active' player.