### PR TITLE
Protect against loops when removing duplicates.

### DIFF
--- a/server/game/cards/plots/04/battleoftheblackwater.js
+++ b/server/game/cards/plots/04/battleoftheblackwater.js
@@ -14,10 +14,14 @@ class BattleOfTheBlackwater extends PlotCard {
     }
 
     removeAllDupes(player) {
-        var characters = player.filterCardsInPlay(card => card.dupes.size() > 0);
+        // TODO: This implementation only works for 2 player games. The wording
+        // of the card is that you discard each duplicate you and your opponent
+        // control, not discarding the dupes on cards you or the opponent
+        // control. But for 2 player, discarding each dupe is fine.
+        let characters = player.filterCardsInPlay(card => card.dupes.size() > 0);
         _.each(characters, character => {
             while(character.dupes.size() > 0) {
-                player.removeDuplicate(character);
+                player.removeDuplicate(character, true);
             }
         });
     }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -867,11 +867,13 @@ class Player extends Spectator {
     }
 
     removeAttachment(attachment, allowSave = true) {
+        if(allowSave && !attachment.dupes.isEmpty() && this.removeDuplicate(attachment)) {
+            this.game.addMessage('{0} discards a duplicate to save {1}', this, attachment);
+            return;
+        }
+
         while(attachment.dupes.size() > 0) {
-            var dupeRemoved = this.removeDuplicate(attachment);
-            if(dupeRemoved && allowSave) {
-                return;
-            }
+            this.removeDuplicate(attachment, true);
         }
 
         if(attachment.isTerminal()) {

--- a/test/server/player/removeattachment.spec.js
+++ b/test/server/player/removeattachment.spec.js
@@ -6,7 +6,7 @@ const DrawCard = require('../../../server/game/drawcard.js');
 
 describe('Player', function() {
     beforeEach(function() {
-        this.gameSpy = jasmine.createSpyObj('game', ['raiseEvent', 'raiseMergedEvent', 'getOtherPlayer', 'playerDecked']);
+        this.gameSpy = jasmine.createSpyObj('game', ['addMessage', 'raiseEvent', 'raiseMergedEvent', 'getOtherPlayer', 'playerDecked']);
         this.player = new Player('1', 'Player 1', true, this.gameSpy);
         this.player.deck = {};
         this.player.initialise();


### PR DESCRIPTION
Battle of the Blackwater could trigger an infinite loop if the character
that has the dupe had been taken control from the opponent.

When removing attachments, if the dupe's owner is not the same as the
attachment's owner an infinite loop could occur. There's no scenario
under the current rules where this should be able to happen but we
should still protect against it.