### PR TITLE
Fix return to hand ability for The Prince's Plan.

### DIFF
--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -48,6 +48,8 @@ class TriggeredAbility extends BaseAbility {
     }
 
     meetsRequirements(context) {
+        let isPlayableEventAbility = this.card.getType() === 'event' && this.location === 'hand';
+
         if(this.game.currentPhase === 'setup') {
             return false;
         }
@@ -64,11 +66,11 @@ class TriggeredAbility extends BaseAbility {
             return false;
         }
 
-        if(this.card.getType() === 'event' && !context.player.isCardInPlayableLocation(this.card, 'play')) {
+        if(isPlayableEventAbility && !context.player.isCardInPlayableLocation(this.card, 'play')) {
             return false;
         }
 
-        if(this.card.getType() !== 'event' && this.card.location !== this.location) {
+        if(!isPlayableEventAbility && this.card.location !== this.location) {
             return false;
         }
 

--- a/test/server/cards/events/06/06016-theprincesplan.spec.js
+++ b/test/server/cards/events/06/06016-theprincesplan.spec.js
@@ -1,0 +1,61 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('The Prince\'s Plan', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck = this.buildDeck('martell', [
+                'A Noble Cause',
+                'The Prince\'s Plan', 'Obara Sand', 'The Red Viper (Core)'
+            ]);
+
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.player1.clickCard('Obara Sand', 'hand');
+            this.player2.clickCard('The Red Viper', 'hand');
+
+            this.completeSetup();
+            this.player1.selectPlot('A Noble Cause');
+            this.player2.selectPlot('A Noble Cause');
+            this.selectFirstPlayer(this.player1);
+
+            this.skipActionWindow();
+
+            this.completeMarshalPhase();
+
+            this.event = this.player1.findCardByName('The Prince\'s Plan');
+        });
+
+        describe('when in the discard pile and a challenge is lost', function() {
+            beforeEach(function() {
+                this.player1Object.moveCard(this.event, 'discard pile');
+
+                this.skipActionWindow();
+                this.player1.clickPrompt('Military');
+                this.player1.clickCard('Obara Sand', 'play area');
+                this.player1.clickPrompt('Done');
+
+                this.skipActionWindow();
+
+                this.player2.clickCard('The Red Viper', 'play area');
+                this.player2.clickPrompt('Done');
+
+                this.skipActionWindow();
+            });
+
+            it('should prompt to return the event back to hand', function() {
+                expect(this.player1).toHavePromptButton('The Prince\'s Plan');
+            });
+
+            it('should allow the event to be returned to hand for 1 gold', function() {
+                this.player1.clickPrompt('The Prince\'s Plan');
+
+                expect(this.event.location).toBe('hand');
+                expect(this.player1Object.gold).toBe(4);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Non-hand event card abilities were broken when implementing the Annals
of Castle Black, as it was always checking that the event card was in a
playable locations. This prevented cards like The Prince's Plan from
triggering properly from discard pile.