### PR TITLE
Ensure player object always sent to serializers

### DIFF
--- a/client/Application.jsx
+++ b/client/Application.jsx
@@ -100,6 +100,10 @@ class App extends React.Component {
             this.props.receiveGameState(game, this.props.username);
         });
 
+        socket.on('cleargamestate', () => {
+            this.props.clearGameState();
+        });
+
         socket.on('lobbychat', message => {
             this.props.receiveLobbyMessage(message);
         });
@@ -161,6 +165,10 @@ class App extends React.Component {
 
             gameSocket.on('gamestate', game => {
                 this.props.receiveGameState(game, this.props.username);
+            });
+
+            gameSocket.on('cleargamestate', () => {
+                this.props.clearGameState();
             });
         });
 
@@ -254,6 +262,7 @@ App.displayName = 'Application';
 App.propTypes = {
     agendas: React.PropTypes.array,
     cards: React.PropTypes.array,
+    clearGameState: React.PropTypes.func,
     currentGame: React.PropTypes.object,
     fetchCards: React.PropTypes.func,
     fetchPacks: React.PropTypes.func,

--- a/client/actions.js
+++ b/client/actions.js
@@ -127,6 +127,12 @@ export function receiveGameState(game, username) {
     };
 }
 
+export function clearGameState() {
+    return {
+        type: 'CLEAR_GAMESTATE'
+    };
+}
+
 export function receiveLobbyMessage(message) {
     return {
         type: 'RECEIVE_LOBBY_MSG',

--- a/client/reducers/games.js
+++ b/client/reducers/games.js
@@ -3,6 +3,7 @@ import _ from 'underscore';
 function games(state = {
     games: []
 }, action) {
+    let retState = {};
     switch(action.type) {
         case 'START_NEWGAME':
             return Object.assign({}, state, {
@@ -31,7 +32,7 @@ function games(state = {
                 newGame: false
             });
         case 'RECEIVE_GAMESTATE':
-            var retState = Object.assign({}, state, {
+            retState = Object.assign({}, state, {
                 currentGame: action.currentGame
             });
 
@@ -78,6 +79,10 @@ function games(state = {
                 passwordError: undefined,
                 passwordJoinType: undefined
             });
+        case 'CLEAR_GAMESTATE':
+            retState = _.omit(state, 'currentGame');
+            retState.newGame = false;
+            return retState;
         default:
             return state;
     }

--- a/server/game/anonymousspectator.js
+++ b/server/game/anonymousspectator.js
@@ -1,0 +1,19 @@
+class AnonymousSpectator {
+    constructor() {
+        this.name = 'Anonymous';
+        this.emailHash = '';
+
+        this.buttons = [];
+        this.menuTitle = 'Spectator mode';
+    }
+
+    isCardSelected() {
+        return false;
+    }
+
+    isCardSelectable() {
+        return false;
+    }
+}
+
+module.exports = AnonymousSpectator;

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -463,11 +463,11 @@ class BaseCard {
             new: this.new,
             // The `this.selected` property here is a hack for plot selection,
             // which we do differently from normal card selection.
-            selected: this.selected || (activePlayer && activePlayer.isCardSelected(this)),
-            selectable: activePlayer && activePlayer.isCardSelectable(this),
+            selected: this.selected || activePlayer.isCardSelected(this),
+            selectable: activePlayer.isCardSelectable(this),
             tokens: this.tokens,
             type: this.getType(),
-            unselectable: activePlayer && activePlayer.selectCard && !activePlayer.isCardSelectable(this),
+            unselectable: activePlayer.selectCard && !activePlayer.isCardSelectable(this),
             uuid: this.uuid
         } : { facedown: true };
     }

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -7,6 +7,7 @@ const EffectEngine = require('./effectengine.js');
 const Effect = require('./effect.js');
 const Player = require('./player.js');
 const Spectator = require('./spectator.js');
+const AnonymousSpectator = require('./anonymousspectator.js');
 const GamePipeline = require('./gamepipeline.js');
 const SetupPhase = require('./gamesteps/setupphase.js');
 const PlotPhase = require('./gamesteps/plotphase.js');
@@ -811,7 +812,7 @@ class Game extends EventEmitter {
     }
 
     getState(activePlayerName) {
-        let activePlayer = this.playersAndSpectators[activePlayerName];
+        let activePlayer = this.playersAndSpectators[activePlayerName] || new AnonymousSpectator();
         let playerState = {};
 
         if(this.started) {

--- a/server/gamenode/gameserver.js
+++ b/server/gamenode/gameserver.js
@@ -307,7 +307,7 @@ class GameServer {
             spectator: isSpectator
         });
 
-        socket.send('gamestate', game.getState(socket.user.username));
+        socket.send('cleargamestate');
         socket.leaveChannel(game.id);
 
         if(game.isEmpty()) {

--- a/server/lobby.js
+++ b/server/lobby.js
@@ -400,7 +400,7 @@ class Lobby {
         }
 
         game.leave(socket.user.username);
-        socket.send('gamestate', game.getSummary(socket.user.username));
+        socket.send('cleargamestate');
         socket.leaveChannel(game.id);
 
         if(game.isEmpty()) {


### PR DESCRIPTION
* Ensures a player object is always sent to serializers, opening up the possibility of anonymous spectators in the future.
* No longer sends full game state when leaving a game - instead, sends a more targeted 'clear game state' command to that specific socket.