### PR TITLE
Allow actions to be restricted per card.

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -46,6 +46,7 @@ class BaseCard {
             initiative: true,
             reserve: true
         };
+        this.abilityRestrictions = [];
         this.menu = _([]);
         this.events = new EventRegistrar(this.game, this);
 
@@ -355,6 +356,19 @@ class BaseCard {
         if(!before && after) {
             this.game.raiseEvent('onCardBlankToggled', this, after);
         }
+    }
+
+    allowGameAction(actionType) {
+        let currentAbilityContext = this.game.currentAbilityContext;
+        return !_.any(this.abilityRestrictions, restriction => restriction.isMatch(actionType, currentAbilityContext));
+    }
+
+    addAbilityRestriction(restriction) {
+        this.abilityRestrictions.push(restriction);
+    }
+
+    removeAbilityRestriction(restriction) {
+        this.abilityRestrictions = _.reject(this.abilityRestrictions, r => r === restriction);
     }
 
     addKeyword(keyword) {

--- a/server/game/gamesteps/abilityresolver.js
+++ b/server/game/gamesteps/abilityresolver.js
@@ -13,12 +13,16 @@ class AbilityResolver extends BaseStep {
         this.pipeline = new GamePipeline();
         this.pipeline.initialise([
             new SimpleStep(game, () => this.markActionAsTaken()),
+            new SimpleStep(game, () => this.game.pushAbilityContext('card', context.source, 'cost')),
             new SimpleStep(game, () => this.resolveCosts()),
             new SimpleStep(game, () => this.waitForCostResolution()),
             new SimpleStep(game, () => this.payCosts()),
+            new SimpleStep(game, () => this.game.popAbilityContext()),
+            new SimpleStep(game, () => this.game.pushAbilityContext('card', context.source, 'effect')),
             new SimpleStep(game, () => this.resolveTargets()),
             new SimpleStep(game, () => this.waitForTargetResolution()),
-            new SimpleStep(game, () => this.executeHandler())
+            new SimpleStep(game, () => this.executeHandler()),
+            new SimpleStep(game, () => this.game.popAbilityContext())
         ]);
     }
 

--- a/test/server/challenge/determinewinner.spec.js
+++ b/test/server/challenge/determinewinner.spec.js
@@ -7,7 +7,11 @@ const DrawCard = require('../../../server/game/drawcard.js');
 
 describe('Challenge', function() {
     beforeEach(function() {
-        this.gameSpy = jasmine.createSpyObj('game', ['on', 'raiseEvent']);
+        this.gameSpy = jasmine.createSpyObj('game', ['applyGameAction', 'on', 'raiseEvent']);
+        this.gameSpy.applyGameAction.and.callFake((type, card, handler) => {
+            handler(card);
+        });
+
         this.attackingPlayer = new Player('1', 'Player 1', true, this.gameSpy);
         spyOn(this.attackingPlayer, 'winChallenge');
         spyOn(this.attackingPlayer, 'loseChallenge');

--- a/test/server/challenge/removefromchallenge.spec.js
+++ b/test/server/challenge/removefromchallenge.spec.js
@@ -7,7 +7,10 @@ const DrawCard = require('../../../server/game/drawcard.js');
 
 describe('Challenge', function() {
     beforeEach(function() {
-        this.gameSpy = jasmine.createSpyObj('game', ['on', 'raiseEvent']);
+        this.gameSpy = jasmine.createSpyObj('game', ['applyGameAction', 'on', 'raiseEvent']);
+        this.gameSpy.applyGameAction.and.callFake((type, card, handler) => {
+            handler(card);
+        });
 
         this.attackingPlayer = new Player('1', 'Player 1', true, this.gameSpy);
         spyOn(this.attackingPlayer, 'winChallenge');

--- a/test/server/game/applygameaction.spec.js
+++ b/test/server/game/applygameaction.spec.js
@@ -1,0 +1,93 @@
+/*global describe, it, beforeEach, expect, jasmine*/
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+const Game = require('../../../server/game/game.js');
+
+describe('Game', function() {
+    beforeEach(function() {
+        this.gameRepository = jasmine.createSpyObj('gameRepository', ['save']);
+        this.game = new Game('1', 'Test Game', { gameRepository: this.gameRepository });
+
+        this.card1 = jasmine.createSpyObj('card', ['allowGameAction']);
+        this.card2 = jasmine.createSpyObj('card', ['allowGameAction']);
+        this.handler = jasmine.createSpy('handler');
+    });
+
+    describe('applyGameAction()', function() {
+        describe('when passed a single card', function() {
+            describe('and the action is allowed', function() {
+                beforeEach(function() {
+                    this.card1.allowGameAction.and.returnValue(true);
+
+                    this.game.applyGameAction('kill', this.card1, this.handler);
+                });
+
+                it('should check that the action is allowed on the card', function() {
+                    expect(this.card1.allowGameAction).toHaveBeenCalledWith('kill');
+                });
+
+                it('should call the handler callback with the card', function() {
+                    expect(this.handler).toHaveBeenCalledWith(this.card1);
+                });
+            });
+
+            describe('and the action is not allowed', function() {
+                beforeEach(function() {
+                    this.card1.allowGameAction.and.returnValue(false);
+
+                    this.game.applyGameAction('kill', this.card1, this.handler);
+                });
+
+                it('should not call the handler callback', function() {
+                    expect(this.handler).not.toHaveBeenCalled();
+                });
+            });
+        });
+
+        describe('when passed an array of cards', function() {
+            describe('and the action is allowed for all cards', function() {
+                beforeEach(function() {
+                    this.card1.allowGameAction.and.returnValue(true);
+                    this.card2.allowGameAction.and.returnValue(true);
+
+                    this.game.applyGameAction('kill', [this.card1, this.card2], this.handler);
+                });
+
+                it('should check that the action is allowed on the cards', function() {
+                    expect(this.card1.allowGameAction).toHaveBeenCalledWith('kill');
+                    expect(this.card2.allowGameAction).toHaveBeenCalledWith('kill');
+                });
+
+                it('should call the handler callback with the cards', function() {
+                    expect(this.handler).toHaveBeenCalledWith([this.card1, this.card2]);
+                });
+            });
+
+            describe('and the action is not allowed on some of the cards', function() {
+                beforeEach(function() {
+                    this.card1.allowGameAction.and.returnValue(false);
+                    this.card2.allowGameAction.and.returnValue(true);
+
+                    this.game.applyGameAction('kill', [this.card1, this.card2], this.handler);
+                });
+
+                it('should call the handler callback with the allowed cards', function() {
+                    expect(this.handler).toHaveBeenCalledWith([this.card2]);
+                });
+            });
+
+            describe('and the action is not allowed on any of the cards', function() {
+                beforeEach(function() {
+                    this.card1.allowGameAction.and.returnValue(false);
+                    this.card2.allowGameAction.and.returnValue(false);
+
+                    this.game.applyGameAction('kill', [this.card1, this.card2], this.handler);
+                });
+
+                it('should not call the handler callback', function() {
+                    expect(this.handler).not.toHaveBeenCalled();
+                });
+            });
+        });
+    });
+});

--- a/test/server/gamesteps/abilityresolver.spec.js
+++ b/test/server/gamesteps/abilityresolver.spec.js
@@ -5,7 +5,7 @@ const AbilityResolver = require('../../../server/game/gamesteps/abilityresolver.
 
 describe('AbilityResolver', function() {
     beforeEach(function() {
-        this.game = jasmine.createSpyObj('game', ['markActionAsTaken']);
+        this.game = jasmine.createSpyObj('game', ['markActionAsTaken', 'popAbilityContext', 'pushAbilityContext']);
         this.ability = jasmine.createSpyObj('ability', ['isAction', 'resolveCosts', 'payCosts', 'resolveTargets', 'executeHandler']);
         this.context = { foo: 'bar' };
         this.resolver = new AbilityResolver(this.game, this.ability, this.context);

--- a/test/server/player/discardcards.spec.js
+++ b/test/server/player/discardcards.spec.js
@@ -8,7 +8,7 @@ const Player = require('../../../server/game/player.js');
 describe('Player', function () {
 
     function createCardSpy(num, owner) {
-        var spy = jasmine.createSpyObj('card', ['moveTo', 'removeDuplicate']);
+        let spy = jasmine.createSpyObj('card', ['moveTo', 'removeDuplicate']);
         spy.num = num;
         spy.location = 'loc';
         spy.dupes = _([]);
@@ -17,7 +17,12 @@ describe('Player', function () {
     }
 
     beforeEach(function() {
-        this.gameSpy = jasmine.createSpyObj('game', ['raiseEvent', 'raiseMergedEvent', 'queueSimpleStep', 'addMessage']);
+        this.gameSpy = jasmine.createSpyObj('game', ['applyGameAction', 'raiseEvent', 'raiseMergedEvent', 'queueSimpleStep', 'addMessage']);
+        this.gameSpy.applyGameAction.and.callFake((type, cards, handler) => {
+            if(cards.length > 0) {
+                handler(cards);
+            }
+        });
 
         this.player = new Player('1', 'Test 1', true, this.gameSpy);
         spyOn(this.player, 'moveCard');


### PR DESCRIPTION
Provides infrastructure for #414 but does not implement immunity.

It is now possible to restrict an action from being taken on a card
based on restrictions placed on the card. As abilities are activated,
they are placed on a stack on `Game` to keep track of the current
ability's source card. When a game action is applied to a card (e.g.
being killed, discarded, knelt, etc), the card checks through the list
of restrictions to see if that particular action coming from the source
card is allowed. This provides the necessary infrastructure to implement
both immunity abilities as well as conditional 'cannot' effects (e.g.
Ygritte).

To make checking these restrictions more convenient, a `applyGameAction`
method is provided on `Game` that will only apply an action to eligible
cards.