### PR TITLE
Add conditional 'cannot' restrictions + Ygritte's ability

### DIFF
--- a/server/game/cannotrestriction.js
+++ b/server/game/cannotrestriction.js
@@ -1,0 +1,20 @@
+class CannotRestriction {
+    constructor(type, condition) {
+        this.type = type;
+        this.condition = condition;
+    }
+
+    isMatch(type, abilityContext) {
+        return this.type === type && this.checkCondition(abilityContext);
+    }
+
+    checkCondition(context) {
+        if(!this.condition) {
+            return true;
+        }
+
+        return this.condition(context);
+    }
+}
+
+module.exports = CannotRestriction;

--- a/server/game/cards/attachments/02/fishingnet.js
+++ b/server/game/cards/attachments/02/fishingnet.js
@@ -3,7 +3,7 @@ const DrawCard = require('../../../drawcard.js');
 class FishingNet extends DrawCard {
     setupCardAbilities(ability) {
         this.whileAttached({
-            effect: ability.effects.allowAsDefender(false)
+            effect: ability.effects.cannotBeDeclaredAsDefender()
         });
     }
     canAttach(player, card) {

--- a/server/game/cards/attachments/04/craven.js
+++ b/server/game/cards/attachments/04/craven.js
@@ -3,7 +3,7 @@ const DrawCard = require('../../../drawcard.js');
 class Craven extends DrawCard {
     setupCardAbilities(ability) {
         this.whileAttached({
-            effect: ability.effects.allowAsAttacker(false)
+            effect: ability.effects.cannotBeDeclaredAsAttacker()
         });
     }
 }

--- a/server/game/cards/characters/01/ghost.js
+++ b/server/game/cards/characters/01/ghost.js
@@ -16,7 +16,7 @@ class Ghost extends DrawCard {
                 this.game.addMessage('{0} uses {1} to make {2} unable to be declared as a defender', this.controller, this, this.bypassed);
                 this.untilEndOfPhase(ability => ({
                     match: this.bypassed,
-                    effect: ability.effects.allowAsDefender(false)
+                    effect: ability.effects.cannotBeDeclaredAsDefender()
                 }));
             }
         });

--- a/server/game/cards/characters/02/hodor.js
+++ b/server/game/cards/characters/02/hodor.js
@@ -5,7 +5,7 @@ class Hodor extends DrawCard {
         this.persistentEffect({
             condition: () => !this.controller.anyCardsInPlay(card => card.name === 'Bran Stark'),
             match: this,
-            effect: ability.effects.allowAsAttacker(false)
+            effect: ability.effects.cannotBeDeclaredAsAttacker()
         });
         this.persistentEffect({
             match: this,

--- a/server/game/cards/characters/02/ladyinwaiting.js
+++ b/server/game/cards/characters/02/ladyinwaiting.js
@@ -18,7 +18,7 @@ class LadyInWaiting extends DrawCard {
     canMarshalAsDupe() {
         return (
             this.game.currentPhase === 'marshal' &&
-            !this.cannotMarshal &&
+            this.canBeMarshaled() &&
             this.controller.isCardInPlayableLocation(this, 'marshal') &&
             this.controller.anyCardsInPlay(card => card.getType() === 'character' && card.hasTrait('Lady'))
         );

--- a/server/game/cards/characters/02/winterfellkennelmaster.js
+++ b/server/game/cards/characters/02/winterfellkennelmaster.js
@@ -7,7 +7,7 @@ class WinterfellKennelMaster extends DrawCard {
             phase: 'challenge',
             limit: ability.limit.perPhase(1),
             condition: () => this.isStarkCardParticipatingInChallenge(),
-            cost: ability.costs.kneel(card => this.isDirewolfOrHasAttachment(card) && !card.challengeOptions.cannotParticipate),
+            cost: ability.costs.kneel(card => this.isDirewolfOrHasAttachment(card) && card.canParticipateInChallenge()),
             handler: context => {
                 var card = context.kneelingCostCard;
                 if(this.game.currentChallenge.attackingPlayer === context.player) {

--- a/server/game/cards/characters/04/kingrenlyshost.js
+++ b/server/game/cards/characters/04/kingrenlyshost.js
@@ -13,7 +13,7 @@ class KingRenlySHost extends DrawCard {
         this.persistentEffect({  // cannot attack while Winter
             condition: () => this.anyPlotHasTrait('Winter'),
             match: this,
-            effect: ability.effects.allowAsAttacker(false)
+            effect: ability.effects.cannotBeDeclaredAsAttacker()
         });
     }
 

--- a/server/game/cards/characters/05/trystanemartell.js
+++ b/server/game/cards/characters/05/trystanemartell.js
@@ -18,7 +18,7 @@ class TrystaneMartell extends DrawCard {
                         this.game.addMessage('{0} uses {1} to make {2} unable to be declared as a defender', player, this, card);
                         this.untilEndOfPhase(ability => ({
                             match: card,
-                            effect: ability.effects.allowAsDefender(false)
+                            effect: ability.effects.cannotBeDeclaredAsDefender()
                         }));
 
                         return true;

--- a/server/game/cards/characters/06/wexpyke.js
+++ b/server/game/cards/characters/06/wexpyke.js
@@ -5,7 +5,7 @@ class WexPyke extends DrawCard {
         this.persistentEffect({
             condition: () => this.game.currentChallenge && this.game.currentChallenge.isAttacking(this),
             match: card => card.getType() === 'character' && card.getCost() === this.tokens['gold'],
-            effect: ability.effects.allowAsDefender(false)
+            effect: ability.effects.cannotBeDeclaredAsDefender()
         });
 
         this.action({

--- a/server/game/cards/characters/06/ygritte.js
+++ b/server/game/cards/characters/06/ygritte.js
@@ -2,7 +2,10 @@ const DrawCard = require('../../../drawcard.js');
 
 class Ygritte extends DrawCard {
     setupCardAbilities(ability) {
-        // TODO: Cannot be knelt by card effects.
+        this.persistentEffect({
+            match: this,
+            effect: ability.effects.cannotBeKneeled(context => context.stage === 'effect')
+        });
         this.persistentEffect({
             condition: () => this.controlsAnotherWildling(),
             match: this,

--- a/server/game/cards/characters/07/rattleshirt.js
+++ b/server/game/cards/characters/07/rattleshirt.js
@@ -11,7 +11,7 @@ class Rattleshirt extends DrawCard {
                 card.getType() === 'character'
                 && card.attachments.size() === 0,
             targetController: 'opponent',
-            effect: ability.effects.allowAsDefender(false)
+            effect: ability.effects.cannotBeDeclaredAsDefender()
         });
     }
 }

--- a/server/game/cards/characters/07/saltwife.js
+++ b/server/game/cards/characters/07/saltwife.js
@@ -13,7 +13,7 @@ class SaltWife extends DrawCard {
             handler: context => {
                 this.untilEndOfPhase(ability => ({
                     match: context.target,
-                    effect: ability.effects.allowAsDefender(false)
+                    effect: ability.effects.cannotBeDeclaredAsDefender()
                 }));
                 this.game.addMessage('{0} sacrifices {1} to make {2} unable to be declared as a defender', 
                                       context.player, this, context.target);

--- a/server/game/cards/locations/03/theshadowtower.js
+++ b/server/game/cards/locations/03/theshadowtower.js
@@ -16,9 +16,9 @@ class TheShadowTower extends DrawCard {
                         this.game.addMessage('{0} kneels {1} to make {2} unable to be declared as attacker', player, this, card);
                         this.untilEndOfPhase(ability => ({
                             match: card,
-                            effect: ability.effects.allowAsAttacker(false)
+                            effect: ability.effects.cannotBeDeclaredAsAttacker()
                         }));
-                        
+
                         return true;
                     }
                 });

--- a/server/game/cards/plots/02/wardensofthenorth.js
+++ b/server/game/cards/plots/02/wardensofthenorth.js
@@ -7,7 +7,7 @@ class WardensOfTheNorth extends PlotCard {
             phase: 'challenge',
             limit: ability.limit.perRound(2),
             condition: () => this.isStarkCardParticipatingInChallenge(),
-            cost: ability.costs.kneel(card => card.getType() === 'character' && card.isFaction('stark') && !card.challengeOptions.cannotParticipate),
+            cost: ability.costs.kneel(card => card.getType() === 'character' && card.isFaction('stark') && card.canParticipateInChallenge()),
             handler: context => {
                 var card = context.kneelingCostCard;
                 if(this.game.currentChallenge.attackingPlayer === context.player) {

--- a/server/game/cards/plots/04/battleofoxcross.js
+++ b/server/game/cards/plots/04/battleofoxcross.js
@@ -12,7 +12,7 @@ class BattleOfOxcross extends PlotCard {
                 card.getType() === 'character'
                 && card.getCost() >= 4,
             targetController: 'opponent',
-            effect: ability.effects.allowAsDefender(false)
+            effect: ability.effects.cannotBeDeclaredAsDefender()
         });
     }
 

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -231,7 +231,7 @@ const Costs = {
     expendEvent: function() {
         return {
             canPay: function(context) {
-                return context.player.isCardInPlayableLocation(context.source, 'play') && !context.source.cannotPlay;
+                return context.player.isCardInPlayableLocation(context.source, 'play') && context.source.canBePlayed();
             },
             pay: function(context) {
                 context.source.controller.moveCard(context.source, 'discard pile');

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -47,8 +47,6 @@ class DrawCard extends BaseCard {
         this.saved = false;
         this.standsDuringStanding = true;
         this.challengeOptions = {
-            allowAsAttacker: true,
-            allowAsDefender: true,
             doesNotKneelAs: {
                 attacker: false,
                 defender: false
@@ -296,15 +294,15 @@ class DrawCard extends BaseCard {
         this.inChallenge = false;
     }
 
-    canAddAsAttacker(challengeType) {
-        return this.challengeOptions.allowAsAttacker && this.canAddAsParticipant(challengeType);
+    canDeclareAsAttacker(challengeType) {
+        return this.allowGameAction('declareAsAttacker') && this.canDeclareAsParticipant(challengeType);
     }
 
-    canAddAsDefender(challengeType) {
-        return this.challengeOptions.allowAsDefender && this.canAddAsParticipant(challengeType);
+    canDeclareAsDefender(challengeType) {
+        return this.allowGameAction('declareAsDefender') && this.canDeclareAsParticipant(challengeType);
     }
 
-    canAddAsParticipant(challengeType) {
+    canDeclareAsParticipant(challengeType) {
         return (
             this.canParticipateInChallenge() &&
             this.location === 'play area' &&
@@ -315,11 +313,11 @@ class DrawCard extends BaseCard {
     }
 
     canParticipateInChallenge() {
-        return this.canBe('participateInChallenge');
+        return this.allowGameAction('participateInChallenge');
     }
 
     canBeBypassedByStealth() {
-        return !this.isStealth() && this.canBe('bypassedByStealth');
+        return !this.isStealth() && this.allowGameAction('bypassByStealth');
     }
 
     canBeKilled() {

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -55,7 +55,6 @@ class DrawCard extends BaseCard {
                 defender: false
             }
         };
-        this.cannotBeKilled = false;
         this.stealthLimit = 1;
     }
 
@@ -226,11 +225,7 @@ class DrawCard extends BaseCard {
     }
 
     canUseStealthToBypass(targetCard) {
-        if(!this.isStealth() || targetCard.isStealth() || targetCard.cannotBeBypassedByStealth) {
-            return false;
-        }
-
-        return true;
+        return this.isStealth() && targetCard.canBeBypassedByStealth();
     }
 
     useStealthToBypass(targetCard) {
@@ -319,8 +314,20 @@ class DrawCard extends BaseCard {
         );
     }
 
+    canBeBypassedByStealth() {
+        return !this.isStealth() && this.canBe('bypassedByStealth');
+    }
+
     canBeKilled() {
-        return !this.cannotBeKilled;
+        return this.allowGameAction('kill');
+    }
+
+    canBeMarshaled() {
+        return this.allowGameAction('marshal');
+    }
+
+    canBePlayed() {
+        return this.allowGameAction('play');
     }
 
     markAsInDanger() {

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -49,7 +49,6 @@ class DrawCard extends BaseCard {
         this.challengeOptions = {
             allowAsAttacker: true,
             allowAsDefender: true,
-            cannotParticipate: false,
             doesNotKneelAs: {
                 attacker: false,
                 defender: false
@@ -298,20 +297,25 @@ class DrawCard extends BaseCard {
     }
 
     canAddAsAttacker(challengeType) {
-        return this.challengeOptions.allowAsAttacker && !this.challengeOptions.cannotParticipate && this.canAddAsParticipant(challengeType);
+        return this.challengeOptions.allowAsAttacker && this.canAddAsParticipant(challengeType);
     }
 
     canAddAsDefender(challengeType) {
-        return this.challengeOptions.allowAsDefender && !this.challengeOptions.cannotParticipate && this.canAddAsParticipant(challengeType);
+        return this.challengeOptions.allowAsDefender && this.canAddAsParticipant(challengeType);
     }
 
     canAddAsParticipant(challengeType) {
         return (
+            this.canParticipateInChallenge() &&
             this.location === 'play area' &&
             !this.stealth &&
             (!this.kneeled || this.challengeOptions.canBeDeclaredWhileKneeling) &&
             (this.hasIcon(challengeType) || this.challengeOptions.canBeDeclaredWithoutIcon)
         );
+    }
+
+    canParticipateInChallenge() {
+        return this.canBe('participateInChallenge');
     }
 
     canBeBypassedByStealth() {

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -3,6 +3,21 @@ const _ = require('underscore');
 const AbilityLimit = require('./abilitylimit.js');
 const CostReducer = require('./costreducer.js');
 const PlayableLocation = require('./playablelocation.js');
+const CannotRestriction = require('./cannotrestriction.js');
+
+function cannotEffect(type) {
+    return function(predicate) {
+        let restriction = new CannotRestriction(type, predicate);
+        return {
+            apply: function(card) {
+                card.addAbilityRestriction(restriction);
+            },
+            unapply: function(card) {
+                card.removeAbilityRestriction(restriction);
+            }
+        };
+    };
+}
 
 const Effects = {
     all: function(effects) {
@@ -447,6 +462,7 @@ const Effects = {
             }
         };
     },
+    cannotBeKneeled: cannotEffect('kneel'),
     cannotBeKilled: function() {
         return {
             apply: function(card) {

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -68,16 +68,7 @@ const Effects = {
             }
         };
     },
-    cannotParticipate: function() {
-        return {
-            apply: function(card) {
-                card.challengeOptions.cannotParticipate = true;
-            },
-            unapply: function(card) {
-                card.challengeOptions.cannotParticipate = false;
-            }
-        };
-    },
+    cannotParticipate: cannotEffect('participateInChallenge'),
     doesNotKneelAsAttacker: function() {
         return {
             apply: function(card) {

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -42,32 +42,8 @@ const Effects = {
             isStateDependent: (stateDependentEffects.length !== 0)
         };
     },
-    allowAsAttacker: function(value) {
-        return {
-            apply: function(card, context) {
-                context.allowAsAttacker = context.allowAsAttacker || {};
-                context.allowAsAttacker[card.uuid] = card.challengeOptions.allowAsAttacker;
-                card.challengeOptions.allowAsAttacker = value;
-            },
-            unapply: function(card, context) {
-                card.challengeOptions.allowAsAttacker = context.allowAsAttacker[card.uuid];
-                delete context.allowAsAttacker[card.uuid];
-            }
-        };
-    },
-    allowAsDefender: function(value) {
-        return {
-            apply: function(card, context) {
-                context.allowAsDefender = context.allowAsDefender || {};
-                context.allowAsDefender[card.uuid] = card.challengeOptions.allowAsDefender;
-                card.challengeOptions.allowAsDefender = value;
-            },
-            unapply: function(card, context) {
-                card.challengeOptions.allowAsDefender = context.allowAsDefender[card.uuid];
-                delete context.allowAsDefender[card.uuid];
-            }
-        };
-    },
+    cannotBeDeclaredAsAttacker: cannotEffect('declareAsAttacker'),
+    cannotBeDeclaredAsDefender: cannotEffect('declareAsDefender'),
     cannotParticipate: cannotEffect('participateInChallenge'),
     doesNotKneelAsAttacker: function() {
         return {

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -432,47 +432,11 @@ const Effects = {
             }
         };
     },
-    cannotMarshal: function() {
-        return {
-            apply: function(card) {
-                card.cannotMarshal = true;
-            },
-            unapply: function(card) {
-                card.cannotMarshal = false;
-            }
-        };
-    },
-    cannotPlay: function() {
-        return {
-            apply: function(card) {
-                card.cannotPlay = true;
-            },
-            unapply: function(card) {
-                card.cannotPlay = false;
-            }
-        };
-    },
-    cannotBeBypassedByStealth: function() {
-        return {
-            apply: function(card) {
-                card.cannotBeBypassedByStealth = true;
-            },
-            unapply: function(card) {
-                card.cannotBeBypassedByStealth = false;
-            }
-        };
-    },
+    cannotMarshal: cannotEffect('marshal'),
+    cannotPlay: cannotEffect('play'),
+    cannotBeBypassedByStealth: cannotEffect('bypassByStealth'),
     cannotBeKneeled: cannotEffect('kneel'),
-    cannotBeKilled: function() {
-        return {
-            apply: function(card) {
-                card.cannotBeKilled = true;
-            },
-            unapply: function(card) {
-                card.cannotBeKilled = false;
-            }
-        };
-    },
+    cannotBeKilled: cannotEffect('kill'),
     cannotGainChallengeBonus: function() {
         return {
             apply: function(player) {

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -54,7 +54,7 @@ class ChallengeFlow extends BaseStep {
     }
 
     allowAsAttacker(card) {
-        return this.challenge.attackingPlayer === card.controller && card.canAddAsAttacker(this.challenge.challengeType);
+        return this.challenge.attackingPlayer === card.controller && card.canDeclareAsAttacker(this.challenge.challengeType);
     }
 
     chooseAttackers(player, attackers) {
@@ -98,7 +98,7 @@ class ChallengeFlow extends BaseStep {
     }
 
     allowAsDefender(card) {
-        return this.challenge.defendingPlayer === card.controller && card.canAddAsDefender(this.challenge.challengeType);
+        return this.challenge.defendingPlayer === card.controller && card.canDeclareAsDefender(this.challenge.challengeType);
     }
 
     chooseDefenders(defenders) {

--- a/server/game/marshalcardaction.js
+++ b/server/game/marshalcardaction.js
@@ -17,7 +17,7 @@ class MarshalCardAction extends BaseAbility {
 
         return (
             game.currentPhase === 'marshal' &&
-            !source.cannotMarshal &&
+            source.canBeMarshaled() &&
             source.getType() !== 'event' &&
             player.isCardInPlayableLocation(source, 'marshal') &&
             player.canPutIntoPlay(source)

--- a/server/game/playcardaction.js
+++ b/server/game/playcardaction.js
@@ -17,7 +17,7 @@ class PlayCardAction extends BaseAbility {
             context.game.currentPhase !== 'setup' &&
             context.source.getType() === 'event' &&
             context.source.abilities.actions.length === 0 &&
-            !context.source.cannotPlay &&
+            context.source.canBePlayed() &&
             context.player.isCardInPlayableLocation(context.source, 'play') &&
             context.source.canPlay(context.player, context.source)
         );

--- a/test/server/card/drawcard.usestealthtobypass.spec.js
+++ b/test/server/card/drawcard.usestealthtobypass.spec.js
@@ -1,14 +1,20 @@
-/*global describe, it, beforeEach, expect*/
+/*global describe, it, beforeEach, expect, spyOn*/
 /*eslint camelcase: 0, no-invalid-this: 0 */
 
 const DrawCard = require('../../../server/game/drawcard.js');
 
 describe('the DrawCard', function() {
     describe('the useStealthToBypass() function', function() {
+        function createCard() {
+            let card = new DrawCard({}, {});
+            spyOn(card, 'canBeBypassedByStealth').and.returnValue(true);
+            return card;
+        }
+
         describe('when the card does not have stealth', function() {
             beforeEach(function() {
-                this.source = new DrawCard({}, {});
-                this.target = new DrawCard({}, {});
+                this.source = createCard();
+                this.target = createCard();
             });
 
             it('should return false.', function() {
@@ -18,9 +24,9 @@ describe('the DrawCard', function() {
 
         describe('when the card has stealth and the target does not', function() {
             beforeEach(function() {
-                this.source = new DrawCard({}, {});
+                this.source = createCard();
                 this.source.addKeyword('Stealth');
-                this.target = new DrawCard({}, {});
+                this.target = createCard();
             });
 
             it('should return true.', function() {
@@ -38,12 +44,12 @@ describe('the DrawCard', function() {
             });
         });
 
-        describe('when both cards have stealth', function() {
+        describe('when the target cannot be bypassed', function() {
             beforeEach(function() {
-                this.source = new DrawCard({}, {});
+                this.source = createCard();
                 this.source.addKeyword('Stealth');
-                this.target = new DrawCard({}, {});
-                this.target.addKeyword('Stealth');
+                this.target = createCard();
+                this.target.canBeBypassedByStealth.and.returnValue(false);
             });
 
             it('should return false', function() {

--- a/test/server/cards/characters/06/06017-ygritte.spec.js
+++ b/test/server/cards/characters/06/06017-ygritte.spec.js
@@ -1,0 +1,62 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('Ygritte', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck = this.buildDeck('baratheon', [
+                'Sneak Attack',
+                'Ygritte', 'Melisandre (Core)', 'Chataya\'s Brothel'
+            ]);
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.ygritte = this.player1.findCardByName('Ygritte', 'hand');
+            this.brothel = this.player1.findCardByName('Chataya\'s Brothel', 'hand');
+            this.player1.clickCard(this.ygritte);
+            this.player1.clickCard(this.brothel);
+            this.completeSetup();
+
+            this.player1.selectPlot('Sneak Attack');
+            this.player2.selectPlot('Sneak Attack');
+            this.selectFirstPlayer(this.player1);
+
+            this.player1.clickPrompt('Done');
+        });
+
+        it('should not be knelt by card effects', function() {
+            this.player2.clickCard('Melisandre', 'hand');
+            this.player2.clickPrompt('Melisandre');
+
+            this.player2.clickCard(this.ygritte);
+
+            expect(this.ygritte.kneeled).toBe(false);
+        });
+
+        it('should be knelt by framework effects', function() {
+            this.player2.clickPrompt('Done');
+
+            this.player1.clickPrompt('Military');
+            this.player1.clickCard(this.ygritte);
+            this.player1.clickPrompt('Done');
+
+            expect(this.ygritte.kneeled).toBe(true);
+        });
+
+        it('should be knelt as a cost', function() {
+            this.player1.clickMenu(this.brothel, 'Kneel a character to gain gold');
+            this.player1.clickCard(this.ygritte);
+
+            expect(this.player1Object.gold).toBe(6);
+            expect(this.ygritte.kneeled).toBe(true);
+        });
+
+        it('should be knelt by player interaction', function() {
+            this.player1.clickCard(this.ygritte);
+
+            expect(this.ygritte.kneeled).toBe(true);
+        });
+    });
+});

--- a/test/server/marshalcardaction.spec.js
+++ b/test/server/marshalcardaction.spec.js
@@ -7,7 +7,8 @@ describe('MarshalCardAction', function () {
     beforeEach(function() {
         this.gameSpy = jasmine.createSpyObj('game', ['addMessage', 'on', 'removeListener']);
         this.playerSpy = jasmine.createSpyObj('player', ['canPutIntoPlay', 'isCardInPlayableLocation', 'putIntoPlay']);
-        this.cardSpy = jasmine.createSpyObj('card', ['getType']);
+        this.cardSpy = jasmine.createSpyObj('card', ['canBeMarshaled', 'getType']);
+        this.cardSpy.canBeMarshaled.and.returnValue(true);
         this.cardSpy.controller = this.playerSpy;
         this.cardSpy.owner = this.playerSpy;
         this.context = {
@@ -65,7 +66,7 @@ describe('MarshalCardAction', function () {
 
         describe('when the card is forbidden from being marshalled', function() {
             beforeEach(function() {
-                this.cardSpy.cannotMarshal = true;
+                this.cardSpy.canBeMarshaled.and.returnValue(false);
             });
 
             it('should return false', function() {

--- a/test/server/playcardaction.spec.js
+++ b/test/server/playcardaction.spec.js
@@ -7,7 +7,8 @@ describe('PlayCardAction', function () {
     beforeEach(function() {
         this.gameSpy = jasmine.createSpyObj('game', ['addMessage', 'on', 'raiseEvent', 'removeListener']);
         this.playerSpy = jasmine.createSpyObj('player', ['isCardInPlayableLocation', 'moveCard']);
-        this.cardSpy = jasmine.createSpyObj('card', ['canPlay', 'getType', 'play']);
+        this.cardSpy = jasmine.createSpyObj('card', ['canBePlayed', 'canPlay', 'getType', 'play']);
+        this.cardSpy.canBePlayed.and.returnValue(true);
         this.context = {
             costs: {},
             game: this.gameSpy,
@@ -64,7 +65,7 @@ describe('PlayCardAction', function () {
 
         describe('when the card is forbidden from being played', function() {
             beforeEach(function() {
-                this.cardSpy.cannotPlay = true;
+                this.cardSpy.canBePlayed.and.returnValue(false);
             });
 
             it('should return false', function() {


### PR DESCRIPTION
Continuing on #414, adding the ability to have conditional 'cannot's (e.g. Ygritte)

Reworks the rest of the card-level cannot effects to use restrictions instead of boolean flags.

Also renames the poorly named allowAsAttacker/Defender effects to cannotDeclareAsAttacker/Defender.