### PR TITLE
Implement immunity restriction and cards.

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -363,6 +363,11 @@ class BaseCard {
         return !_.any(this.abilityRestrictions, restriction => restriction.isMatch(actionType, currentAbilityContext));
     }
 
+    allowEffectFrom(sourceCard) {
+        let currentAbilityContext = { source: 'card', card: sourceCard, stage: 'effect' };
+        return !_.any(this.abilityRestrictions, restriction => restriction.isMatch('applyEffect', currentAbilityContext));
+    }
+
     addAbilityRestriction(restriction) {
         this.abilityRestrictions.push(restriction);
     }

--- a/server/game/cards/attachments/04/dragonglassdagger.js
+++ b/server/game/cards/attachments/04/dragonglassdagger.js
@@ -4,8 +4,10 @@ class DragonglassDagger extends DrawCard {
     setupCardAbilities(ability) {
         this.whileAttached({
             condition: () => this.game.currentChallenge && this.game.currentChallenge.isParticipating(this.parent),
-            //TO DO: Immune to opponents' character abilities
-            effect: ability.effects.modifyStrength(2)
+            effect: [
+                ability.effects.modifyStrength(2),
+                ability.effects.immuneTo(card => card.controller !== this.controller && card.getType() === 'character')
+            ]
         });
     }
 

--- a/server/game/cards/characters/02/maesterluwin.js
+++ b/server/game/cards/characters/02/maesterluwin.js
@@ -12,10 +12,10 @@ class MaesterLuwin extends DrawCard {
             effect: ability.effects.addKeyword('Stealth')
         });
 
-//      this.persistentEffect({
-//          match: (card) => card.name === 'Bran Stark',
-//          effect: //To do: immune to opponents' plot effects
-//      });
+        this.persistentEffect({
+            match: (card) => card.name === 'Bran Stark',
+            effect: ability.effects.immuneTo(card => card.controller !== this.controller && card.getType() === 'plot')
+        });
 
         this.persistentEffect({
             match: (card) => card.name === 'Rickon Stark',

--- a/server/game/cards/characters/02/septamordane.js
+++ b/server/game/cards/characters/02/septamordane.js
@@ -12,8 +12,10 @@ class SeptaMordane extends DrawCard {
 
         this.persistentEffect({
             match: (card) => card.name === 'Arya Stark',
-            effect: ability.effects.addIcon('intrigue')
-                    //To do: immune to opponents' plot effects
+            effect: [
+                ability.effects.addIcon('intrigue'),
+                ability.effects.immuneTo(card => card.controller !== this.controller && card.getType() === 'plot')
+            ]
         });
     }
 }

--- a/server/game/cards/characters/03/bearislandloyalist.js
+++ b/server/game/cards/characters/03/bearislandloyalist.js
@@ -1,0 +1,24 @@
+const DrawCard = require('../../../drawcard.js');
+
+class BearIslandLoyalist extends DrawCard {
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            condition: () => this.game.currentChallenge && this.game.currentChallenge.isParticipating(this),
+            match: card => this.isOtherParticipating(card),
+            effect: ability.effects.immuneTo(card => card.controller !== this.controller && card.getType() === 'event')
+        });
+    }
+
+    isOtherParticipatingStark(card) {
+        return (
+            this.game.currentChallenge.isParticipating(card) &&
+            card.controller === this.controller &&
+            card.isFaction('stark') &&
+            card !== this
+        );
+    }
+}
+
+BearIslandLoyalist.code = '03012';
+
+module.exports = BearIslandLoyalist;

--- a/server/game/cards/characters/04/craster.js
+++ b/server/game/cards/characters/04/craster.js
@@ -1,0 +1,15 @@
+const DrawCard = require('../../../drawcard.js');
+
+class Craster extends DrawCard {
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            match: this,
+            effect: ability.effects.immuneTo(card => card.hasTrait('Omen'))
+        });
+        // TODO: Sacrifice to put characters killed this phase back into play.
+    }
+}
+
+Craster.code = '04085';
+
+module.exports = Craster;

--- a/server/game/cards/locations/02/pleasurebarge.js
+++ b/server/game/cards/locations/02/pleasurebarge.js
@@ -1,12 +1,15 @@
 const DrawCard = require('../../../drawcard.js');
 
-// TODO: Immunity to card effects; "have not yet drawn cards this phase" check
+// TODO: "have not yet drawn cards this phase" check
 class PleasureBarge extends DrawCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.plotModifiers({
             gold: -1
         });
-
+        this.persistentEffect({
+            match: this,
+            effect: ability.effects.immuneTo(() => true)
+        });
         this.reaction({
             when: {
                 onCardEntersPlay: event => event.card === this && event.playingType === 'marshal'

--- a/server/game/cards/locations/02/smallcouncilchamber.js
+++ b/server/game/cards/locations/02/smallcouncilchamber.js
@@ -1,8 +1,11 @@
 const DrawCard = require('../../../drawcard.js');
 
 class SmallCouncilChamber extends DrawCard {
-    setupCardAbilities() {
-        // TODO: Immune to effects.
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            match: this,
+            effect: ability.effects.immuneTo(card => card.getType() === 'event')
+        });
         this.reaction({
             when: {
                 afterChallenge: (e, challenge) => challenge.winner === this.controller && challenge.challengeType === 'intrigue'

--- a/server/game/cards/locations/03/winterfellheartree.js
+++ b/server/game/cards/locations/03/winterfellheartree.js
@@ -1,0 +1,26 @@
+const DrawCard = require('../../../drawcard.js');
+
+class WinterfellHeartTree extends DrawCard {
+    setupCardAbilities(ability) {
+        this.reaction({
+            when: {
+                onPhaseStarted: () => true
+            },
+            cost: ability.costs.sacrificeSelf(),
+            target: {
+                activePromptTitle: 'Select character to grant immunity',
+                cardCondition: card => card.controller === this.controller && card.isFaction('stark')
+            },
+            handler: context => {
+                this.untilEndOfPhase(ability => ({
+                    match: context.target,
+                    effect: ability.effects.immuneTo(card => card.controller !== this.controller && card.getType() === 'plot')
+                }));
+            }
+        });
+    }
+}
+
+WinterfellHeartTree.code = '03018';
+
+module.exports = WinterfellHeartTree;

--- a/server/game/cards/plots/02/atourneyfortheking.js
+++ b/server/game/cards/plots/02/atourneyfortheking.js
@@ -1,0 +1,18 @@
+const PlotCard = require('../../../plotcard.js');
+
+class ATourneyForTheKing extends PlotCard {
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            match: card => card.getType() === 'character' && card.hasTrait('Knight'),
+            targetController: 'current',
+            effect: [
+                ability.effects.addKeyword('Renown'),
+                ability.effects.immuneTo(card => card.controller !== this.controller && card.getType() === 'event')
+            ]
+        });
+    }
+}
+
+ATourneyForTheKing.code = '02059';
+
+module.exports = ATourneyForTheKing;

--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -89,6 +89,10 @@ class Effect {
             if(this.targetLocation === 'hand' && target.location !== 'hand') {
                 return false;
             }
+
+            if(!target.allowEffectFrom(this.source)) {
+                return false;
+            }
         }
 
         if(!_.isFunction(this.match)) {

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -4,6 +4,7 @@ const AbilityLimit = require('./abilitylimit.js');
 const CostReducer = require('./costreducer.js');
 const PlayableLocation = require('./playablelocation.js');
 const CannotRestriction = require('./cannotrestriction.js');
+const ImmunityRestriction = require('./immunityrestriction.js');
 
 function cannotEffect(type) {
     return function(predicate) {
@@ -382,6 +383,17 @@ const Effects = {
             },
             unapply: function(card) {
                 card.standsDuringStanding = true;
+            }
+        };
+    },
+    immuneTo: function(cardCondition) {
+        let restriction = new ImmunityRestriction(cardCondition);
+        return {
+            apply: function(card) {
+                card.addAbilityRestriction(restriction);
+            },
+            unapply: function(card) {
+                card.removeAbilityRestriction(restriction);
             }
         };
     },

--- a/server/game/immunityrestriction.js
+++ b/server/game/immunityrestriction.js
@@ -1,0 +1,15 @@
+class ImmunityRestriction {
+    constructor(cardCondition) {
+        this.cardCondition = cardCondition;
+    }
+
+    isMatch(type, abilityContext) {
+        return (
+            abilityContext.stage === 'effect' &&
+            abilityContext.card &&
+            this.cardCondition(abilityContext.card)
+        );
+    }
+}
+
+module.exports = ImmunityRestriction;

--- a/test/server/effect.spec.js
+++ b/test/server/effect.spec.js
@@ -1,8 +1,17 @@
 /*global describe, it, beforeEach, expect, jasmine */
 /*eslint camelcase: 0, no-invalid-this: 0 */
 
+const _ = require('underscore');
+
 const Effect = require('../../server/game/effect.js');
 const Player = require('../../server/game/player.js');
+
+function createTarget(properties = {}) {
+    let card = jasmine.createSpyObj('card', ['allowEffectFrom']);
+    card.allowEffectFrom.and.returnValue(true);
+    _.extend(card, properties);
+    return card;
+}
 
 describe('Effect', function () {
     beforeEach(function () {
@@ -24,8 +33,8 @@ describe('Effect', function () {
 
     describe('addTargets()', function() {
         beforeEach(function() {
-            this.matchingCard = { good: true, location: 'play area' };
-            this.nonMatchingCard = { bad: true, location: 'play area' };
+            this.matchingCard = createTarget({ good: true, location: 'play area' });
+            this.nonMatchingCard = createTarget({ bad: true, location: 'play area' });
 
             this.properties.match.and.callFake((card) => card === this.matchingCard);
         });
@@ -124,6 +133,17 @@ describe('Effect', function () {
                 this.anotherPlayer = {};
                 this.sourceSpy.controller = this.player;
                 this.matchingCard.controller = this.player;
+            });
+
+            describe('when the source cannot apply an effect to the target', function() {
+                beforeEach(function() {
+                    this.matchingCard.allowEffectFrom.and.returnValue(false);
+                });
+
+                it('should reject the target', function() {
+                    this.effect.addTargets([this.matchingCard]);
+                    expect(this.effect.targets).not.toContain(this.matchingCard);
+                });
             });
 
             describe('when the target controller is current', function() {
@@ -345,7 +365,7 @@ describe('Effect', function () {
 
     describe('removeTarget()', function() {
         beforeEach(function() {
-            this.target = { good: true, location: 'play area' };
+            this.target = createTarget({ good: true, location: 'play area' });
 
             this.effect.addTargets([this.target]);
         });
@@ -505,8 +525,8 @@ describe('Effect', function () {
 
     describe('reapply()', function() {
         beforeEach(function() {
-            this.target = { target: 1, location: 'play area' };
-            this.newTarget = { target: 2, location: 'play area' };
+            this.target = createTarget({ target: 1, location: 'play area' });
+            this.newTarget = createTarget({ target: 2, location: 'play area' });
             this.effect.targets = [this.target];
             this.newTargets = [this.target, this.newTarget];
         });
@@ -644,7 +664,7 @@ describe('Effect', function () {
 
             describe('when the condition is true', function() {
                 beforeEach(function() {
-                    this.matchingTarget = { target: 3, location: 'play area' };
+                    this.matchingTarget = createTarget({ target: 3, location: 'play area' });
                     this.effect.targets = [this.target, this.matchingTarget];
                     this.effect.active = true;
                     this.effect.condition.and.returnValue(true);

--- a/test/server/integration/immunity.spec.js
+++ b/test/server/integration/immunity.spec.js
@@ -1,0 +1,57 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('immunity', function() {
+    integration(function() {
+        describe('when a card has immunity', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('lannister', [
+                    'Sneak Attack',
+                    'Small Council Chamber', 'Tywin Lannister (Core)', 'Nightmares', 'Put to the Torch'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.chamber = this.player1.findCardByName('Small Council Chamber', 'hand');
+                this.character = this.player2.findCardByName('Tywin Lannister', 'hand');
+
+                this.player1.clickCard(this.chamber);
+                this.player2.clickCard(this.character);
+
+                this.completeSetup();
+
+                this.player1.selectPlot('Sneak Attack');
+                this.player2.selectPlot('Sneak Attack');
+                this.selectFirstPlayer(this.player2);
+
+                this.completeMarshalPhase();
+            });
+
+            it('should not allow lasting effects to be applied to it', function() {
+                this.player2.clickCard('Nightmares', 'hand');
+                this.player2.clickCard(this.chamber);
+
+                expect(this.chamber.isBlank()).toBe(false);
+            });
+
+            it('should not allow actions to be applied to it', function() {
+                this.player2.clickPrompt('Military');
+                this.player2.clickCard(this.character);
+                this.player2.clickPrompt('Done');
+
+                this.skipActionWindow();
+
+                this.player1.clickPrompt('Done');
+
+                this.skipActionWindow();
+
+                this.player2.clickCard('Put to the Torch', 'hand');
+                this.player2.clickCard(this.chamber);
+
+                expect(this.chamber.location).toBe('play area');
+            });
+        });
+    });
+});


### PR DESCRIPTION
* Finishes implementations for cards that were just missing immunity.
* Adds full implementations of Winterfell Heart Tree, Bear Island
  Loyalist, A Tourney for the King.
* Adds a partial implementation of Craster for his immunity effect.

Completes #414.