### PR TITLE
Implement Red Keep and Haunted Forest using effects

### DIFF
--- a/server/game/cards/locations/01/theredkeep.js
+++ b/server/game/cards/locations/01/theredkeep.js
@@ -1,13 +1,17 @@
 const DrawCard = require('../../../drawcard.js');
 
 class TheRedKeep extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['onAttackersDeclared', 'onDefendersDeclared']);
-    }
-
     setupCardAbilities(ability) {
+        this.persistentEffect({
+            condition: () => (
+                this.game.currentChallenge &&
+                this.game.currentChallenge.challengeType === 'power' &&
+                this.game.currentChallenge.anyParticipants(card => card.controller === this.controller)
+            ),
+            targetType: 'player',
+            targetController: 'current',
+            effect: ability.effects.contributeChallengeStrength(2)
+        });
         this.interrupt({
             when: {
                 onPhaseEnded: (event, phase) => phase === 'challenge' &&

--- a/server/game/cards/locations/04/thehauntedforest.js
+++ b/server/game/cards/locations/04/thehauntedforest.js
@@ -1,22 +1,17 @@
 const DrawCard = require('../../../drawcard.js');
 
 class TheHauntedForest extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['onDefendersDeclared']);
-    }
-
-    onDefendersDeclared(event, challenge) {
-        if(challenge.defendingPlayer !== this.controller || this.isBlank() || this.kneeled) {
-            return;
-        }
-
-        challenge.modifyDefenderStrength(1);
-        this.game.addMessage('{0} uses {1} to add 1 to the strength of this {2} challenge', this.controller, this, challenge.challengeType);
-    }
-
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            condition: () => (
+                !this.kneeled &&
+                this.game.currentChallenge &&
+                this.game.currentChallenge.defendingPlayer === this.controller
+            ),
+            targetType: 'player',
+            targetController: 'current',
+            effect: ability.effects.contributeChallengeStrength(1)
+        });
         this.forcedReaction({
             when: {
                 afterChallenge: (e, challenge) => this.controller === challenge.loser && !this.kneeled

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -90,6 +90,11 @@ class Challenge {
         return this.isAttacking(card) || this.isDefending(card);
     }
 
+    anyParticipants(predicate) {
+        let participants = this.attackers.concat(this.defenders);
+        return _.any(participants, predicate);
+    }
+
     getNumberOfParticipants(predicate) {
         let participants = this.attackers.concat(this.defenders);
         return _.reduce(participants, (count, card) => {

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -457,6 +457,36 @@ const Effects = {
             }
         };
     },
+    modifyChallengeStrength: function(value) {
+        return {
+            apply: function(player, context) {
+                let challenge = context.game.currentChallenge;
+                if(!challenge) {
+                    return;
+                }
+
+                if(challenge.attackingPlayer === player) {
+                    challenge.modifyAttackerStrength(value);
+                    context.game.addMessage('{0} uses {1} to add {2} to the strength of this challenge for a total of {3}', player, context.source, value, challenge.attackerStrength);
+                } else if(challenge.defendingPlayer === player) {
+                    challenge.modifyDefenderStrength(value);
+                    context.game.addMessage('{0} uses {1} to add {2} to the strength of this challenge for a total of {3}', player, context.source, value, challenge.defenderStrength);
+                }
+            },
+            unapply: function(player, context) {
+                let challenge = context.game.currentChallenge;
+                if(!challenge) {
+                    return;
+                }
+
+                if(challenge.attackingPlayer === player) {
+                    challenge.modifyAttackerStrength(-value);
+                } else if(challenge.defendingPlayer === player) {
+                    challenge.modifyDefenderStrength(-value);
+                }
+            }
+        };
+    },
     setChallengerLimit: function(value) {
         return {
             apply: function(player, context) {

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -457,7 +457,7 @@ const Effects = {
             }
         };
     },
-    modifyChallengeStrength: function(value) {
+    contributeChallengeStrength: function(value) {
         return {
             apply: function(player, context) {
                 let challenge = context.game.currentChallenge;

--- a/test/server/cards/locations/01/01061-theredkeep.spec.js
+++ b/test/server/cards/locations/01/01061-theredkeep.spec.js
@@ -1,0 +1,61 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('The Red Keep', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck = this.buildDeck('stark', [
+                'Trading with the Pentoshi',
+                'The Red Keep', 'Areo Hotah', 'Maester Caleotte', 'Nightmares'
+            ]);
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.redKeep = this.player1.findCardByName('The Red Keep', 'hand');
+            this.character = this.player1.findCardByName('Maester Caleotte', 'hand');
+
+            this.player1.clickCard(this.character);
+            this.player1.clickCard(this.redKeep);
+            this.completeSetup();
+
+            this.player1.selectPlot('Trading with the Pentoshi');
+            this.player2.selectPlot('Trading with the Pentoshi');
+            this.selectFirstPlayer(this.player1);
+            this.selectPlotOrder(this.player1);
+
+            this.completeMarshalPhase();
+        });
+
+        describe('during a power challenge w/ at least one participating character', function() {
+            beforeEach(function() {
+                this.player1.clickPrompt('Power');
+                this.player1.clickCard(this.character);
+                this.player1.clickPrompt('Done');
+            });
+
+            it('should provide +2 strength', function() {
+                // 2 from Caleotte, 2 from the Red Keep.
+                expect(this.game.currentChallenge.attackerStrength).toBe(4);
+            });
+
+            it('should remove the strength bonus if blanked mid-challenge', function() {
+                this.player1.clickPrompt('Done');
+                this.player2.clickCard('Nightmares', 'hand');
+                this.player2.clickCard(this.redKeep);
+
+                expect(this.game.currentChallenge.attackerStrength).toBe(2);
+            });
+
+            it('should not keep the strength bonus if all characters removed from the challenge', function() {
+                this.player1.clickPrompt('Done');
+                this.player2.clickCard('Areo Hotah', 'hand');
+                this.player2.clickPrompt('Areo Hotah');
+                this.player2.clickCard(this.character);
+
+                expect(this.game.currentChallenge.attackerStrength).toBe(0);
+            });
+        });
+    });
+});


### PR DESCRIPTION
* Adds a `contributeChallengeStrength` effect.
* Converts The Red Keep and Haunted Forest to use the new effect to ensure blanking / removing characters from a challenge removes the effect where appropriate.

Fixes #858.
Fixes #697.