### PR TITLE
Make the onCardPlayed event more consistent.

### DIFF
--- a/server/game/baseability.js
+++ b/server/game/baseability.js
@@ -166,6 +166,10 @@ class BaseAbility {
     isAction() {
         return true;
     }
+
+    isPlayableEventAbility() {
+        return false;
+    }
 }
 
 module.exports = BaseAbility;

--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -139,17 +139,11 @@ class CardAction extends BaseAbility {
     }
 
     executeHandler(context) {
-        context.game.raiseMergedEvent('onBeforeCardPlayed', { player: context.player, source: context.source }, (event) => {
+        context.game.raiseMergedEvent('onBeforeCardPlayed', { player: context.player, source: context.source }, () => {
             var success = this.handler(context);
             if(success !== false && this.limit) {
                 this.limit.increment();
-            } else if(success !== false && context.source.getType() === 'event') {
-                context.game.raiseEvent('onCardPlayed', event.player, event.source);
             }
-        }, (event) => {
-            if(event.source.getType() === 'event') {
-                context.game.raiseEvent('onCardPlayed', event.player, event.source);
-            }            
         });
     }
 

--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -155,6 +155,10 @@ class CardAction extends BaseAbility {
         return this.clickToActivate;
     }
 
+    isPlayableEventAbility() {
+        return this.card.getType() === 'event' && this.location === 'hand';
+    }
+
     deactivate(player) {
         var context = _.last(this.activationContexts);
 

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -616,12 +616,12 @@ class Game extends EventEmitter {
         this.queueStep(new EventWindow(this, eventName, params, handler));
     }
 
-    raiseMergedEvent(eventName, params, handler, onCancelled) {
+    raiseMergedEvent(eventName, params, handler) {
         if(!handler) {
             handler = () => true;
         }
 
-        this.queueStep(new EventWindow(this, eventName, params, handler, onCancelled, true));
+        this.queueStep(new EventWindow(this, eventName, params, handler, true));
     }
 
     raiseSimultaneousEvent(cards, properties) {

--- a/server/game/gamesteps/abilityresolver.js
+++ b/server/game/gamesteps/abilityresolver.js
@@ -121,7 +121,7 @@ class AbilityResolver extends BaseStep {
         // with an interrupt to a card being played. If any are ever released,
         // then this event will need to wrap the execution of the entire
         // ability instead.
-        if(this.context.source.getType() === 'event') {
+        if(this.ability.isPlayableEventAbility()) {
             this.game.raiseEvent('onCardPlayed', this.context.player, this.context.source);
         }
     }

--- a/server/game/gamesteps/abilityresolver.js
+++ b/server/game/gamesteps/abilityresolver.js
@@ -22,6 +22,7 @@ class AbilityResolver extends BaseStep {
             new SimpleStep(game, () => this.resolveTargets()),
             new SimpleStep(game, () => this.waitForTargetResolution()),
             new SimpleStep(game, () => this.executeHandler()),
+            new SimpleStep(game, () => this.raiseCardPlayedIfEvent()),
             new SimpleStep(game, () => this.game.popAbilityContext())
         ]);
     }
@@ -111,6 +112,18 @@ class AbilityResolver extends BaseStep {
         }
 
         this.ability.executeHandler(this.context);
+    }
+
+    raiseCardPlayedIfEvent() {
+        // An event card is considered to be played even if it has been
+        // cancelled. Raising the event here will allow forced reactions and
+        // reactions to fire with the appropriate timing. There are no cards
+        // with an interrupt to a card being played. If any are ever released,
+        // then this event will need to wrap the execution of the entire
+        // ability instead.
+        if(this.context.source.getType() === 'event') {
+            this.game.raiseEvent('onCardPlayed', this.context.player, this.context.source);
+        }
     }
 }
 

--- a/server/game/gamesteps/eventwindow.js
+++ b/server/game/gamesteps/eventwindow.js
@@ -4,12 +4,11 @@ const SimpleStep = require('./simplestep.js');
 const Event = require('../event.js');
 
 class EventWindow extends BaseStep {
-    constructor(game, eventName, params, handler, onCancelled, merged = false) {
+    constructor(game, eventName, params, handler, merged = false) {
         super(game);
 
         this.eventName = eventName;
         this.handler = handler;
-        this.onCancelled = onCancelled;
 
         this.event = new Event(eventName, params, merged);
         this.pipeline = new GamePipeline();
@@ -78,10 +77,6 @@ class EventWindow extends BaseStep {
 
     executeHandler() {
         if(this.event.cancelled) {
-            if(this.onCancelled) {
-                this.onCancelled(...this.event.params);
-            }
-
             return;
         }
 

--- a/server/game/playcardaction.js
+++ b/server/game/playcardaction.js
@@ -30,6 +30,10 @@ class PlayCardAction extends BaseAbility {
             context.player.moveCard(event.source, 'discard pile');
         });
     }
+
+    isPlayableEventAbility() {
+        return true;
+    }
 }
 
 module.exports = PlayCardAction;

--- a/server/game/playcardaction.js
+++ b/server/game/playcardaction.js
@@ -28,7 +28,6 @@ class PlayCardAction extends BaseAbility {
             context.game.addMessage('{0} plays {1} costing {2}', event.player, event.source, context.costs.gold);
             context.source.play(event.player);
             context.player.moveCard(event.source, 'discard pile');
-            context.game.raiseEvent('onCardPlayed', event.player, event.source);
         });
     }
 }

--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -53,7 +53,7 @@ class TriggeredAbility extends BaseAbility {
     }
 
     meetsRequirements(context) {
-        let isPlayableEventAbility = this.card.getType() === 'event' && this.location === 'hand';
+        let isPlayableEventAbility = this.isPlayableEventAbility();
 
         if(this.game.currentPhase === 'setup') {
             return false;
@@ -95,6 +95,10 @@ class TriggeredAbility extends BaseAbility {
 
     isAction() {
         return false;
+    }
+
+    isPlayableEventAbility() {
+        return this.card.getType() === 'event' && this.location === 'hand';
     }
 
     registerEvents() {

--- a/test/server/gamesteps/abilityresolver.spec.js
+++ b/test/server/gamesteps/abilityresolver.spec.js
@@ -6,8 +6,8 @@ const AbilityResolver = require('../../../server/game/gamesteps/abilityresolver.
 describe('AbilityResolver', function() {
     beforeEach(function() {
         this.game = jasmine.createSpyObj('game', ['markActionAsTaken', 'popAbilityContext', 'pushAbilityContext', 'raiseEvent']);
-        this.ability = jasmine.createSpyObj('ability', ['isAction', 'resolveCosts', 'payCosts', 'resolveTargets', 'executeHandler']);
-        this.source = jasmine.createSpyObj('card', ['getType']);
+        this.ability = jasmine.createSpyObj('ability', ['isAction', 'isPlayableEventAbility', 'resolveCosts', 'payCosts', 'resolveTargets', 'executeHandler']);
+        this.source = { source: 1 };
         this.player = { player: 1 };
         this.context = { foo: 'bar', player: this.player, source: this.source };
         this.resolver = new AbilityResolver(this.game, this.ability, this.context);
@@ -44,10 +44,10 @@ describe('AbilityResolver', function() {
             });
         });
 
-        describe('when the source card is an event', function() {
+        describe('when the ability is an event being played', function() {
             beforeEach(function() {
                 this.ability.resolveCosts.and.returnValue([{ resolved: true, value: true }, { resolved: true, value: true }]);
-                this.source.getType.and.returnValue('event');
+                this.ability.isPlayableEventAbility.and.returnValue(true);
                 this.resolver.continue();
             });
 

--- a/test/server/integration/playingevents.spec.js
+++ b/test/server/integration/playingevents.spec.js
@@ -4,19 +4,25 @@
 describe('playing events', function() {
     integration(function() {
         beforeEach(function() {
-            const deck = this.buildDeck('baratheon', [
+            const deck1 = this.buildDeck('baratheon', [
                 'Trading with the Pentoshi',
-                'Melisandre (Core)', 'Seen In Flames', 'The Hand\'s Judgment', 'Tears of Lys', 'Hedge Knight'
+                'Melisandre (Core)', 'Seen In Flames'
             ]);
-            this.player1.selectDeck(deck);
-            this.player2.selectDeck(deck);
+            const deck2 = this.buildDeck('martell', [
+                'Trading with the Pentoshi',
+                'The Hand\'s Judgment', 'Hedge Knight', 'Tower of the Sun', 'The Prince\'s Plan'
+            ]);
+            this.player1.selectDeck(deck1);
+            this.player2.selectDeck(deck2);
             this.startGame();
             this.keepStartingHands();
 
             this.knight = this.player2.findCardByName('Hedge Knight', 'hand');
+            this.plan = this.player2.findCardByName('The Prince\'s Plan', 'hand');
 
             this.player1.clickCard('Melisandre', 'hand');
             this.player2.clickCard(this.knight);
+            this.player2.clickCard('Tower of the Sun', 'hand');
 
             this.completeSetup();
 
@@ -33,9 +39,9 @@ describe('playing events', function() {
                 this.player1.clickCard('Seen In Flames');
                 this.player2.clickPrompt('Pass');
 
-                // Discard Melisandre from the opponent's hand
+                // Discard Hand's Judgment from the opponent's hand
                 this.player2.clickPrompt('Yes');
-                this.player1.clickPrompt('Melisandre');
+                this.player1.clickPrompt('The Hand\'s Judgment');
             });
 
             it('should count as having played the event', function() {
@@ -52,6 +58,9 @@ describe('playing events', function() {
             beforeEach(function() {
                 this.player1.clickCard('Seen In Flames');
                 this.player2.clickPrompt('The Hand\'s Judgment');
+
+                // Pass on Tower of the Sun
+                this.player2.clickPrompt('Pass');
             });
 
             it('should still count as having played the event', function() {
@@ -61,6 +70,28 @@ describe('playing events', function() {
                 this.player1.clickCard(this.knight);
 
                 expect(this.knight.kneeled).toBe(true);
+            });
+        });
+
+        describe('when a return-from-discard event ability triggers', function() {
+            beforeEach(function() {
+                this.player2.dragCard(this.plan, 'discard pile');
+
+                this.player1.clickPrompt('Power');
+                this.player1.clickCard('Melisandre', 'play area');
+                this.player1.clickPrompt('Done');
+
+                this.skipActionWindow();
+
+                this.player2.clickPrompt('Done');
+
+                this.skipActionWindow();
+
+                this.player2.clickPrompt('The Prince\'s Plan');
+            });
+
+            it('should not count as playing an event', function() {
+                expect(this.player2).not.toHavePromptButton('Tower of the Sun');
             });
         });
     });

--- a/test/server/integration/playingevents.spec.js
+++ b/test/server/integration/playingevents.spec.js
@@ -1,0 +1,67 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('playing events', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck = this.buildDeck('baratheon', [
+                'Trading with the Pentoshi',
+                'Melisandre (Core)', 'Seen In Flames', 'The Hand\'s Judgment', 'Tears of Lys', 'Hedge Knight'
+            ]);
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.knight = this.player2.findCardByName('Hedge Knight', 'hand');
+
+            this.player1.clickCard('Melisandre', 'hand');
+            this.player2.clickCard(this.knight);
+
+            this.completeSetup();
+
+            this.player1.selectPlot('Trading with the Pentoshi');
+            this.player2.selectPlot('Trading with the Pentoshi');
+            this.selectFirstPlayer(this.player1);
+            this.selectPlotOrder(this.player1);
+
+            this.completeMarshalPhase();
+        });
+
+        describe('when playing an Action event', function() {
+            beforeEach(function() {
+                this.player1.clickCard('Seen In Flames');
+                this.player2.clickPrompt('Pass');
+
+                // Discard Melisandre from the opponent's hand
+                this.player2.clickPrompt('Yes');
+                this.player1.clickPrompt('Melisandre');
+            });
+
+            it('should count as having played the event', function() {
+                expect(this.player1).toHavePromptButton('Melisandre');
+
+                this.player1.clickPrompt('Melisandre');
+                this.player1.clickCard(this.knight);
+
+                expect(this.knight.kneeled).toBe(true);
+            });
+        });
+
+        describe('when cancelling the effects of an event', function() {
+            beforeEach(function() {
+                this.player1.clickCard('Seen In Flames');
+                this.player2.clickPrompt('The Hand\'s Judgment');
+            });
+
+            it('should still count as having played the event', function() {
+                expect(this.player1).toHavePromptButton('Melisandre');
+
+                this.player1.clickPrompt('Melisandre');
+                this.player1.clickCard(this.knight);
+
+                expect(this.knight.kneeled).toBe(true);
+            });
+        });
+    });
+});

--- a/test/server/playcardaction.spec.js
+++ b/test/server/playcardaction.spec.js
@@ -108,9 +108,5 @@ describe('PlayCardAction', function () {
         it('should place the card in discard', function() {
             expect(this.playerSpy.moveCard).toHaveBeenCalledWith(this.cardSpy, 'discard pile');
         });
-
-        it('should raise the onCardPlayed event', function() {
-            expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onCardPlayed', this.playerSpy, this.cardSpy);
-        });
     });
 });


### PR DESCRIPTION
* Ensures the onCardPlayed event is raised for events implemented via the legacy `play` method and through the ability API (including actions and reactions/interrupts).
* Ensures that additional event card abilities such as return-to-hand-from-discard do not count as playing an event.
* Removes the now unused onCanceled handler from the event window.