### PR TITLE
Fix unblanking conditional dynamic effects.

### DIFF
--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -64,7 +64,7 @@ class Effect {
     }
 
     addTargets(targets) {
-        if(!this.condition()) {
+        if(!this.active || !this.condition()) {
             return;
         }
 
@@ -73,9 +73,7 @@ class Effect {
         _.each(newTargets, target => {
             if(this.isValidTarget(target)) {
                 this.targets.push(target);
-                if(this.active) {
-                    this.effect.apply(target, this.context);
-                }
+                this.effect.apply(target, this.context);
             }
         });
     }
@@ -133,9 +131,7 @@ class Effect {
             return;
         }
 
-        if(this.active) {
-            this.effect.unapply(card, this.context);
-        }
+        this.effect.unapply(card, this.context);
 
         this.targets = _.reject(this.targets, target => target === card);
     }
@@ -144,22 +140,22 @@ class Effect {
         return this.targets.includes(card);
     }
 
-    setActive(newActive) {
-        if(this.active && !newActive) {
-            _.each(this.targets, target => this.effect.unapply(target, this.context));
-        }
-
-        if(!this.active && newActive) {
-            _.each(this.targets, target => this.effect.apply(target, this.context));
-        }
+    setActive(newActive, newTargets) {
+        let oldActive = this.active;
 
         this.active = newActive;
+
+        if(oldActive && !newActive) {
+            this.cancel();
+        }
+
+        if(!oldActive && newActive) {
+            this.addTargets(newTargets);
+        }
     }
 
     cancel() {
-        if(this.active) {
-            _.each(this.targets, target => this.effect.unapply(target, this.context));
-        }
+        _.each(this.targets, target => this.effect.unapply(target, this.context));
         this.targets = [];
     }
 

--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -76,9 +76,10 @@ class EffectEngine {
     }
 
     onCardBlankToggled(event, card, isBlank) {
-        var matchingEffects = _.filter(this.effects, effect => effect.duration === 'persistent' && effect.source === card);
+        let targets = this.getTargets();
+        let matchingEffects = _.filter(this.effects, effect => effect.duration === 'persistent' && effect.source === card);
         _.each(matchingEffects, effect => {
-            effect.setActive(!isBlank);
+            effect.setActive(!isBlank, targets);
         });
     }
 

--- a/test/server/effectengine.spec.js
+++ b/test/server/effectengine.spec.js
@@ -216,8 +216,8 @@ describe('EffectEngine', function () {
                     this.engine.onCardBlankToggled({}, this.cardBeingToggled, false);
                 });
 
-                it('should set the active value for the effect', function() {
-                    expect(this.effectSpy.setActive).toHaveBeenCalledWith(true);
+                it('should set the active value for the effect along with cards to target', function() {
+                    expect(this.effectSpy.setActive).toHaveBeenCalledWith(true, [this.handCard, this.playAreaCard]);
                 });
             });
 

--- a/test/server/integration/effects.spec.js
+++ b/test/server/integration/effects.spec.js
@@ -3,6 +3,64 @@
 
 describe('effects', function() {
     integration(function() {
+        describe('when blanking / unblanking a dynamically calculated conditional effect', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('targaryen', [
+                    'Sneak Attack',
+                    'Jhogo', 'Hedge Knight', 'Nightmares'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.jhogo = this.player1.findCardByName('Jhogo', 'hand');
+
+                this.player1.clickCard(this.jhogo);
+                this.completeSetup();
+
+                this.player1.selectPlot('Sneak Attack');
+                this.player2.selectPlot('Sneak Attack');
+                this.selectFirstPlayer(this.player1);
+
+                this.completeMarshalPhase();
+
+                // Move a character to the opponent's dead pile so Jhogo gets a
+                // strength boost
+                let character = this.player2.findCardByName('Hedge Knight', 'hand');
+                this.player2.dragCard(character, 'dead pile');
+
+                this.player1.clickPrompt('Power');
+                this.player1.clickCard(this.jhogo);
+                this.player1.clickPrompt('Done');
+
+                expect(this.jhogo.getStrength()).toBe(4);
+
+                this.player1.clickPrompt('Done');
+                this.player2.clickCard('Nightmares', 'hand');
+                this.player2.clickCard(this.jhogo);
+                this.player1.clickPrompt('Done');
+                this.player2.clickPrompt('Done');
+
+                expect(this.jhogo.getStrength()).toBe(3);
+
+                // Declare no defenders
+                this.player2.clickPrompt('Done');
+
+                this.skipActionWindow();
+                this.skipActionWindow();
+                this.player1.clickPrompt('Apply Claim');
+            });
+
+            it('should not crash when the blank wears off', function() {
+                expect(() => {
+                    // Complete challenges, so that Nightmares wears off.
+                    this.player1.clickPrompt('Done');
+                    this.player2.clickPrompt('Done');
+                }).not.toThrow();
+            });
+        });
+
         describe('when/until phase ends vs at end of phase', function() {
             beforeEach(function() {
                 const deck = this.buildDeck('stark', [


### PR DESCRIPTION
Previously, blanked effects continued to track the targets they were
applied to. However, it did not check the condition for the effect when
it was unblanked. This lead to crashes when unblanked while the
condition was no longer valid and the effect was dynamically calculated.
For example, it would try to apply Jhogo's strength bonus outside a
challenge if blanked during a challenge, leading to a crash.

Now, blanking is handled similar to conditional effects in that all
targets are removed when blanked, then targets are added back from
scratch when unblanked.

Fixes #771 
Fixes #689 