### PR TITLE
Automate targeting restrictions

### DIFF
--- a/server/game/cards/attachments/01/ice.js
+++ b/server/game/cards/attachments/01/ice.js
@@ -16,7 +16,8 @@ class Ice extends DrawCard {
             cost: ability.costs.sacrificeSelf(),
             target: {
                 activePromptTitle: 'Select a character to kill',
-                cardCondition: card => card.location === 'play area' && card.controller !== this.controller && card.getType() === 'character'
+                cardCondition: card => card.location === 'play area' && card.controller !== this.controller && card.getType() === 'character',
+                gameAction: 'kill'
             },
             handler: context => {
                 context.target.owner.killCharacter(context.target);

--- a/server/game/cards/attachments/01/throwingaxe.js
+++ b/server/game/cards/attachments/01/throwingaxe.js
@@ -12,6 +12,7 @@ class ThrowingAxe extends DrawCard {
                     activePromptTitle: 'Select a character to kill',
                     source: this,
                     cardCondition: card => card.location === 'play area' && this.game.currentChallenge.isDefending(card),
+                    gameAction: 'kill',
                     onSelect: (p, card) => this.onCardSelected(p, card)
                 });
             }

--- a/server/game/cards/attachments/02/kingrobertswarhammer.js
+++ b/server/game/cards/attachments/02/kingrobertswarhammer.js
@@ -19,6 +19,7 @@ class KingRobertsWarhammer extends DrawCard {
                     maxStat: () => this.parent.getStrength(),
                     cardStat: card => card.getStrength(),
                     cardCondition: card => card.location === 'play area' && card.getType() === 'character' && !card.kneeled,
+                    gameAction: 'kneel',
                     onSelect: (player, cards) => this.onSelect(player, cards),
                     onCancel: (player) => this.cancelSelection(player)
                 });

--- a/server/game/cards/characters/01/greywind.js
+++ b/server/game/cards/characters/01/greywind.js
@@ -8,7 +8,8 @@ class GreyWind extends DrawCard {
             phase: 'challenge',
             target: {
                 activePromptTitle: 'Select a character',
-                cardCondition: card => this.cardCondition(card)
+                cardCondition: card => this.cardCondition(card),
+                gameAction: 'kill'
             },
             handler: context => {
                 context.target.controller.killCharacter(context.target);

--- a/server/game/cards/characters/01/lordsportshipwright.js
+++ b/server/game/cards/characters/01/lordsportshipwright.js
@@ -15,6 +15,7 @@ class LordsportShipright extends DrawCard {
             cardCondition: card => this.cardCondition(card),
             activePromptTitle: 'Select location',
             source: this,
+            gameAction: 'kneel',
             onSelect: (player, card) => this.onCardSelected(player, card)
         });
 

--- a/server/game/cards/characters/01/melisandre.js
+++ b/server/game/cards/characters/01/melisandre.js
@@ -15,6 +15,7 @@ class Melisandre extends DrawCard {
                     cardCondition: card => this.cardCondition(card),
                     activePromptTitle: 'Select a character to kneel',
                     source: this,
+                    gameAction: 'kneel',
                     onSelect: (player, card) => this.onCardSelected(player, card)
                 });
             }

--- a/server/game/cards/characters/01/shireenbaratheon.js
+++ b/server/game/cards/characters/01/shireenbaratheon.js
@@ -11,6 +11,7 @@ class ShireenBaratheon extends DrawCard {
                     cardCondition: card => this.cardCondition(card),
                     activePromptTitle: 'Select a character to kneel',
                     source: this,
+                    gameAction: 'kneel',
                     onSelect: (player, card) => this.onCardSelected(player, card)
                 });
             }

--- a/server/game/cards/characters/01/thequeensassassin.js
+++ b/server/game/cards/characters/01/thequeensassassin.js
@@ -21,6 +21,7 @@ class TheQueensAssassin extends DrawCard {
                     activePromptTitle: 'Select a character to kill',
                     source: this,
                     cardCondition: card => card.location === 'play area' && card.controller !== this.controller && card.getType() === 'character',
+                    gameAction: 'kill',
                     onSelect: (p, card) => this.onCardSelected(p, card)
                 });
 

--- a/server/game/cards/characters/02/mirrimazduur.js
+++ b/server/game/cards/characters/02/mirrimazduur.js
@@ -16,6 +16,7 @@ class MirriMazDuur extends DrawCard {
                     activePromptTitle: 'Select a character to kill',
                     source: this,
                     cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.controller !== this.controller,
+                    gameAction: 'kill',
                     onSelect: (p, card) => this.onCardSelected(p, card)
                 });
             }

--- a/server/game/cards/characters/02/sergregorclegane.js
+++ b/server/game/cards/characters/02/sergregorclegane.js
@@ -19,6 +19,7 @@ class SerGregorClegane extends DrawCard {
                     cardCondition: card => this.cardCondition(discarded, card),
                     activePromptTitle: 'Select a character to kill',
                     source: this,
+                    gameAction: 'kill',
                     onSelect: (player, card) => this.onCardSelected(player, card)
                 });
             }

--- a/server/game/cards/characters/02/serilynpayne.js
+++ b/server/game/cards/characters/02/serilynpayne.js
@@ -18,6 +18,7 @@ class SerIlynPayne extends DrawCard {
             activePromptTitle: 'Select a character',
             source: this,
             cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.getCost() <= 3,
+            gameAction: 'kill',
             onSelect: (p, card) => this.onCardSelected(p, card)
         });
 

--- a/server/game/cards/characters/03/aryastark.js
+++ b/server/game/cards/characters/03/aryastark.js
@@ -17,6 +17,7 @@ class AryaStark extends DrawCard {
                         card.getStrength() <= 3),
                     activePromptTitle: 'Select a character',
                     source: this,
+                    gameAction: 'kill',
                     onSelect: (player, card) => this.onCardSelected(player, card)
                 });
             }

--- a/server/game/cards/characters/03/quentynmartell.js
+++ b/server/game/cards/characters/03/quentynmartell.js
@@ -19,6 +19,7 @@ class QuentynMartell extends DrawCard {
                     cardCondition: card => this.cardCondition(card),
                     activePromptTitle: 'Select a character to kill',
                     source: this,
+                    gameAction: 'kill',
                     onSelect: (player, card) => this.onCardSelected(player, card)
                 });
             }

--- a/server/game/cards/characters/04/asshaipriestess.js
+++ b/server/game/cards/characters/04/asshaipriestess.js
@@ -11,6 +11,7 @@ class AsshaiPriestess extends DrawCard {
                     cardCondition: card => this.cardCondition(card),
                     activePromptTitle: 'Select a character to kneel',
                     source: this,
+                    gameAction: 'kneel',
                     onSelect: (player, card) => this.onCardSelected(player, card)
                 });
             }

--- a/server/game/cards/characters/04/jaqenhghar.js
+++ b/server/game/cards/characters/04/jaqenhghar.js
@@ -39,7 +39,8 @@ class JaqenHGhar extends DrawCard {
             },
             target: {
                 activePromptTitle: 'Select a character to kill',
-                cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.hasToken('valarmorghulis')
+                cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.hasToken('valarmorghulis'),
+                gameAction: 'kill'
             },
             handler: context => {
                 this.game.killCharacter(context.target);

--- a/server/game/cards/characters/04/joffreybaratheon.js
+++ b/server/game/cards/characters/04/joffreybaratheon.js
@@ -30,6 +30,7 @@ class JoffreyBaratheon extends DrawCard {
                         !card.hasTrait('King') &&
                         card.getType() === 'character' && 
                         card.getCost() < this.pendingCard.getCost()),
+                    gameAction: 'kill',
                     onSelect: (p, card) => {
                         card.controller.killCharacter(card);
                         this.game.addMessage('{0} uses {1} to kneel {2} and their faction card to kill {3}', this.controller, this, this.pendingCard, card);

--- a/server/game/cards/characters/04/qhorinhalfhand.js
+++ b/server/game/cards/characters/04/qhorinhalfhand.js
@@ -20,6 +20,7 @@ class QhorinHalfhand extends DrawCard {
                         !card.isUnique() && 
                         card.getStrength() < this.getStrength() &&
                         card.controller !== this.controller),
+                    gameAction: 'kill',
                     onSelect: (p, card) => {
                         card.controller.killCharacter(card);
                         this.game.addMessage('{0} uses {1} to kill {2}', this.controller, this, card);

--- a/server/game/cards/characters/04/roosebolton.js
+++ b/server/game/cards/characters/04/roosebolton.js
@@ -18,6 +18,7 @@ class RooseBolton extends DrawCard {
                     cardCondition: card => {
                         return card.location === 'play area' && card.getType() === 'character' && card.controller !== this.controller;
                     },
+                    gameAction: 'kill',
                     onSelect: (player, cards) => this.onSelect(player, cards),
                     onCancel: (player) => this.cancelSelection(player)
                 });

--- a/server/game/cards/characters/05/shaggasonofdolf.js
+++ b/server/game/cards/characters/05/shaggasonofdolf.js
@@ -24,8 +24,8 @@ class ShaggaSonOfDolf extends DrawCard {
                     card.location === 'play area'
                     && card.controller === this.controller
                     && card.isFaction('lannister')
-                    && card.getType() === 'character'
-                    && card.canBeKilled()
+                    && card.getType() === 'character',
+                gameAction: 'kill'
             },
             handler: context => {
                 this.game.addMessage('{0} is forced by {1} to kill a character', this.controller, this);

--- a/server/game/cards/characters/05/timettsonoftimett.js
+++ b/server/game/cards/characters/05/timettsonoftimett.js
@@ -13,8 +13,9 @@ class TimettSonOfTimett extends DrawCard {
                 cardCondition: card => (
                     card.location === 'play area' &&
                     card.getType() === 'character' &&
-                    card.getCost() <= this.getNumberOfClansmen())
-            },            
+                    card.getCost() <= this.getNumberOfClansmen()),
+                gameAction: 'kill'
+            },
             handler: context => {
                 context.target.controller.killCharacter(context.target);
                 this.game.addMessage('{0} uses {1} to kill {2}', context.player, this, context.target);

--- a/server/game/cards/characters/06/stonecrows.js
+++ b/server/game/cards/characters/06/stonecrows.js
@@ -15,10 +15,10 @@ class StoneCrows extends DrawCard {
                 this.game.promptForSelect(otherPlayer, {
                     cardCondition: card => (
                         this.game.currentChallenge.isDefending(card) &&
-                        card.canBeKilled() &&
                         card.getType() === 'character'),
                     activePromptTitle: 'Select character to kill',
                     source: this,
+                    gameAction: 'kill',
                     onSelect: (player, card) => {
                         card.controller.killCharacter(card);
                         this.game.addMessage('{0} discards 1 gold from {1} to force {2} to kill {3}', this.controller, this, otherPlayer, card);

--- a/server/game/cards/events/01/consolidationofpower.js
+++ b/server/game/cards/events/01/consolidationofpower.js
@@ -23,6 +23,7 @@ class ConsolidationOfPower extends DrawCard {
             maxStat: () => 4,
             cardStat: card => card.getStrength(),
             cardCondition: card => card.location === 'play area' && card.getType() === 'character' && !card.kneeled,
+            gameAction: 'kneel',
             onSelect: (player, cards) => this.onSelect(player, cards),
             onCancel: (player) => this.cancelSelection(player)
         });

--- a/server/game/cards/events/01/puttothesword.js
+++ b/server/game/cards/events/01/puttothesword.js
@@ -25,6 +25,7 @@ class PutToTheSword extends DrawCard {
             activePromptTitle: 'Select a character to kill',
             source: this,
             cardCondition: card => card.location === 'play area' && card.controller !== player && card.getType() === 'character',
+            gameAction: 'kill',
             onSelect: (p, card) => this.onCardSelected(p, card)
         });
     }

--- a/server/game/cards/events/02/thewatcheronthewalls.js
+++ b/server/game/cards/events/02/thewatcheronthewalls.js
@@ -28,6 +28,7 @@ class TheWatcherOnTheWalls extends ChallengeEvent {
                 && !card.kneeled
                 && card.controller === this.controller
                 && card.hasTrait('Ranger'),
+            gameAction: 'kneel',
             onSelect: (player, cards) => this.onSelect(player, cards)
         });
     }

--- a/server/game/cards/events/03/evenhandedjustice.js
+++ b/server/game/cards/events/03/evenhandedjustice.js
@@ -28,6 +28,7 @@ class EvenHandedJustice extends DrawCard {
                 !card.kneeled
                 && card.getType() === 'character'
                 && card.controller !== this.controller,  // not event controller
+            gameAction: 'kneel',
             onSelect: (player, card) => this.onFirstCardSelected(player, card)
         });
 
@@ -45,6 +46,7 @@ class EvenHandedJustice extends DrawCard {
                 !card.kneeled
                 && card.getType() === 'character'
                 && card.controller === this.controller,  // event controller
+            gameAction: 'kneel',
             onSelect: (player, card) => this.onSecondCardSelected(player, card)
         });
 

--- a/server/game/cards/locations/02/theseastonechair.js
+++ b/server/game/cards/locations/02/theseastonechair.js
@@ -20,6 +20,7 @@ class TheSeastoneChair extends DrawCard {
                         card.getType() === 'character' && 
                         card.controller !== this.controller &&
                         card.attachments.size() === 0),
+                    gameAction: 'kill',
                     onSelect: (p, card) => this.onCardSelected(p, card)
                 });
             }

--- a/server/game/cards/plots/01/filthyaccusations.js
+++ b/server/game/cards/plots/01/filthyaccusations.js
@@ -8,6 +8,7 @@ class FilthyAccusations extends PlotCard {
                     cardCondition: card => this.cardCondition(card),
                     activePromptTitle: 'Select character to kneel',
                     source: this,
+                    gameAction: 'kneel',
                     onSelect: (player, card) => this.onCardSelected(player, card)
                 });
             }

--- a/server/game/chatcommands.js
+++ b/server/game/chatcommands.js
@@ -76,7 +76,8 @@ class ChatCommands {
         this.game.promptForSelect(player, {
             activePromptTitle: 'Select a character',
             waitingPromptTitle: 'Waiting for opponent to kill character',
-            cardCondition: card => card.location === 'play area' && card.controller === player,
+            cardCondition: card => card.location === 'play area' && card.controller === player && card.getType() === 'character',
+            gameAction: 'kill',
             onSelect: (p, card) => {
                 card.controller.killCharacter(card);
 

--- a/server/game/gamesteps/challenge/fulfillmilitaryclaim.js
+++ b/server/game/gamesteps/challenge/fulfillmilitaryclaim.js
@@ -18,8 +18,8 @@ class FulfillMilitaryClaim extends BaseStep {
             cardCondition: card =>
                 card.location === 'play area'
                 && card.controller === this.player
-                && card.getType() === 'character'
-                && card.canBeKilled(),
+                && card.getType() === 'character',
+            gameAction: 'kill',
             onSelect: (p, cards) => this.fulfillClaim(p, cards),
             onCancel: () => this.cancelClaim()
         });

--- a/server/game/gamesteps/selectcardprompt.js
+++ b/server/game/gamesteps/selectcardprompt.js
@@ -37,6 +37,8 @@ const UiPrompt = require('./uiprompt.js');
  *                      done button without selecting any cards.
  * source             - what is at the origin of the user prompt, usually a card;
  *                      used to provide a default waitingPromptTitle, if missing
+ * gameAction         - a string representing the game action to be checked on
+ *                      target cards.
  */
 class SelectCardPrompt extends UiPrompt {
     constructor(game, choosingPlayer, properties) {
@@ -67,6 +69,7 @@ class SelectCardPrompt extends UiPrompt {
             additionalButtons: [],
             cardCondition: () => true,
             cardType: ['attachment', 'character', 'event', 'location'],
+            gameAction: 'target',
             onSelect: () => true,
             onMenuCommand: () => true,
             onCancel: () => true
@@ -100,7 +103,7 @@ class SelectCardPrompt extends UiPrompt {
 
     highlightSelectableCards() {
         let selectableCards = this.game.allCards.filter(card => {
-            return this.properties.cardType.includes(card.getType()) && this.cardCondition(card);
+            return this.checkCardCondition(card);
         });
         this.choosingPlayer.setSelectableCards(selectableCards);
     }
@@ -147,7 +150,7 @@ class SelectCardPrompt extends UiPrompt {
     }
 
     checkCardCondition(card) {
-        return this.properties.cardType.includes(card.getType()) && this.cardCondition(card);
+        return this.properties.cardType.includes(card.getType()) && this.cardCondition(card) && card.allowGameAction(this.properties.gameAction);
     }
 
     selectCard(card) {

--- a/test/server/gamesteps/selectcardprompt.spec.js
+++ b/test/server/gamesteps/selectcardprompt.spec.js
@@ -6,8 +6,9 @@ const SelectCardPrompt = require('../../../server/game/gamesteps/selectcardpromp
 
 describe('the SelectCardPrompt', function() {
     function createCardSpy(properties = {}) {
-        let card = jasmine.createSpyObj('card', ['getType']);
+        let card = jasmine.createSpyObj('card', ['allowGameAction', 'getType']);
         card.getType.and.returnValue('character');
+        card.allowGameAction.and.returnValue(true);
         _.extend(card, properties);
         return card;
     }
@@ -87,6 +88,16 @@ describe('the SelectCardPrompt', function() {
             describe('when the card does not match the allowed condition', function() {
                 beforeEach(function() {
                     this.properties.cardCondition.and.returnValue(false);
+                });
+
+                it('should return false', function() {
+                    expect(this.prompt.onCardClicked(this.player, this.card)).toBe(false);
+                });
+            });
+
+            describe('when the specified game action is not allowed for the target', function() {
+                beforeEach(function() {
+                    this.card.allowGameAction.and.returnValue(false);
                 });
 
                 it('should return false', function() {


### PR DESCRIPTION
Adds a `gameAction` property to card select prompts. Setting this property will check that the specified game action type can be performed on the card. For instance, setting it to `'kill'` will only allow targeting of cards that can be killed. If the property is not specified, it will still exclude cards that are immune to the current ability.

Converts existing prompts to exclude cannot kill and cannot kneel where appropriate.