### PR TITLE
Make ability initiation event more consistent.

### DIFF
--- a/server/game/baseability.js
+++ b/server/game/baseability.js
@@ -170,6 +170,10 @@ class BaseAbility {
     isPlayableEventAbility() {
         return false;
     }
+
+    isCardAbility() {
+        return true;
+    }
 }
 
 module.exports = BaseAbility;

--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -139,12 +139,10 @@ class CardAction extends BaseAbility {
     }
 
     executeHandler(context) {
-        context.game.raiseMergedEvent('onBeforeCardPlayed', { player: context.player, source: context.source }, () => {
-            var success = this.handler(context);
-            if(success !== false && this.limit) {
-                this.limit.increment();
-            }
-        });
+        var success = this.handler(context);
+        if(success !== false && this.limit) {
+            this.limit.increment();
+        }
     }
 
     getMenuItem(arg) {

--- a/server/game/cards/characters/01/branstark.js
+++ b/server/game/cards/characters/01/branstark.js
@@ -5,7 +5,7 @@ class BranStark extends DrawCard {
         this.interrupt({
             canCancel: true,
             when: {
-                onBeforeCardPlayed: event => event.source.getType() === 'event' && event.player !== this.controller
+                onCardAbilityInitiated: event => event.source.getType() === 'event' && event.player !== this.controller
             },
             cost: ability.costs.sacrificeSelf(),
             handler: context => {

--- a/server/game/cards/events/01/thehandsjudgment.js
+++ b/server/game/cards/events/01/thehandsjudgment.js
@@ -5,7 +5,7 @@ class TheHandsJudgment extends DrawCard {
         this.interrupt({
             canCancel: true,
             when: {
-                onBeforeCardPlayed: event => {
+                onCardAbilityInitiated: event => {
                     if(event.source.getType() !== 'event' || event.player === this.controller) {
                         return false;
                     }

--- a/server/game/gamesteps/abilityresolver.js
+++ b/server/game/gamesteps/abilityresolver.js
@@ -111,7 +111,16 @@ class AbilityResolver extends BaseStep {
             return;
         }
 
-        this.ability.executeHandler(this.context);
+        // Check to make sure the ability is actually a card ability. For
+        // instance, marshaling does not count as initiating a card ability and
+        // thus is not subject to cancels such as Treachery.
+        if(this.ability.isCardAbility()) {
+            this.game.raiseMergedEvent('onCardAbilityInitiated', { player: this.context.player, source: this.context.source }, () => {
+                this.ability.executeHandler(this.context);
+            });
+        } else {
+            this.ability.executeHandler(this.context);
+        }
     }
 
     raiseCardPlayedIfEvent() {

--- a/server/game/marshalcardaction.js
+++ b/server/game/marshalcardaction.js
@@ -32,6 +32,10 @@ class MarshalCardAction extends BaseAbility {
         }
         context.player.putIntoPlay(context.source, 'marshal');
     }
+
+    isCardAbility() {
+        return false;
+    }
 }
 
 module.exports = MarshalCardAction;

--- a/server/game/playcardaction.js
+++ b/server/game/playcardaction.js
@@ -24,11 +24,9 @@ class PlayCardAction extends BaseAbility {
     }
 
     executeHandler(context) {
-        context.game.raiseMergedEvent('onBeforeCardPlayed', { player: context.player, source: context.source }, (event) => {
-            context.game.addMessage('{0} plays {1} costing {2}', event.player, event.source, context.costs.gold);
-            context.source.play(event.player);
-            context.player.moveCard(event.source, 'discard pile');
-        });
+        context.game.addMessage('{0} plays {1} costing {2}', context.player, context.source, context.costs.gold);
+        context.source.play(context.player);
+        context.player.moveCard(context.source, 'discard pile');
     }
 
     isPlayableEventAbility() {


### PR DESCRIPTION
Previously, only Action abilities and event cards implemented using the
legacy `play` method raised the event to indicate an ability effects
were being applied. Now, this event is raised for all card abilities
(pretty much everything except marshaling) when they are executed by the
AbilityResolver class. The event has been renamed from
onBeforeCardPlayed to onCardAbilityInitiated to better reflect what it
represents.