### PR TITLE
Implement challenge keywords as abilities.

### DIFF
--- a/server/game/gamekeywords.js
+++ b/server/game/gamekeywords.js
@@ -1,0 +1,13 @@
+const InsightKeyword = require('./insightkeyword.js');
+const IntimidateKeyword = require('./intimidatekeyword.js');
+const PillageKeyword = require('./pillagekeyword.js');
+const RenownKeyword = require('./renownkeyword.js');
+
+const GameKeywords = {
+    'insight': new InsightKeyword(),
+    'intimidate': new IntimidateKeyword(),
+    'pillage': new PillageKeyword(),
+    'renown': new RenownKeyword()
+};
+
+module.exports = GameKeywords;

--- a/server/game/insightkeyword.js
+++ b/server/game/insightkeyword.js
@@ -1,0 +1,21 @@
+const BaseAbility = require('./baseability.js');
+
+class InsightKeyword extends BaseAbility {
+    constructor() {
+        super({});
+        this.title = 'Insight';
+    }
+
+    meetsRequirements() {
+        return true;
+    }
+
+    executeHandler(context) {
+        let {game, challenge, source} = context;
+        let drawn = challenge.winner.drawCardsToHand(1);
+        game.raiseEvent('onInsight', challenge, source, drawn);
+        game.addMessage('{0} draws a card from Insight on {1}', challenge.winner, source);
+    }
+}
+
+module.exports = InsightKeyword;

--- a/server/game/intimidatekeyword.js
+++ b/server/game/intimidatekeyword.js
@@ -1,0 +1,36 @@
+const BaseAbility = require('./baseability.js');
+
+class IntimidateKeyword extends BaseAbility {
+    constructor() {
+        super({});
+        this.title = 'Intimidate';
+    }
+
+    meetsRequirements(context) {
+        return context.challenge.isAttackerTheWinner() && !context.challenge.appliedIntimidate;
+    }
+
+    executeHandler(context) {
+        let {game, challenge, source} = context;
+        let strength = challenge.strengthDifference;
+        game.promptForSelect(challenge.winner, {
+            activePromptTitle: 'Choose and kneel a character with ' + strength + ' strength or less',
+            cardCondition: card => this.canIntimidate(card, strength, challenge),
+            gameAction: 'kneel',
+            onSelect: (player, targetCard) => this.intimidate(game, source, targetCard)
+        });
+        challenge.appliedIntimidate = true;
+    }
+
+    canIntimidate(card, strength, challenge) {
+        return !card.kneeled && card.controller === challenge.loser && card.getStrength() <= strength;
+    }
+
+    intimidate(game, sourceCard, targetCard) {
+        targetCard.controller.kneelCard(targetCard);
+        game.addMessage('{0} uses intimidate from {1} to kneel {2}', sourceCard.controller, sourceCard, targetCard);
+        return true;
+    }
+}
+
+module.exports = IntimidateKeyword;

--- a/server/game/pillagekeyword.js
+++ b/server/game/pillagekeyword.js
@@ -1,0 +1,26 @@
+const BaseAbility = require('./baseability.js');
+
+class PillageKeyword extends BaseAbility {
+    constructor() {
+        super({});
+        this.title = 'Pillage';
+    }
+
+    meetsRequirements() {
+        return true;
+    }
+
+    executeHandler(context) {
+        let {game, challenge, source} = context;
+        game.queueSimpleStep(() => {
+            challenge.loser.discardFromDraw(1, cards => {
+                let discarded = cards[0];
+                game.raiseEvent('onPillage', challenge, source, discarded);
+
+                game.addMessage('{0} discards {1} from the top of their deck due to Pillage from {2}', challenge.loser, discarded, source);
+            });
+        });
+    }
+}
+
+module.exports = PillageKeyword;

--- a/server/game/renownkeyword.js
+++ b/server/game/renownkeyword.js
@@ -1,0 +1,21 @@
+const BaseAbility = require('./baseability.js');
+
+class RenownKeyword extends BaseAbility {
+    constructor() {
+        super({});
+        this.title = 'Renown';
+    }
+
+    meetsRequirements() {
+        return true;
+    }
+
+    executeHandler(context) {
+        let {game, challenge, source} = context;
+        source.modifyPower(1);
+        game.raiseEvent('onRenown', challenge, source);
+        game.addMessage('{0} gains 1 power on {1} from Renown', challenge.winner, source);
+    }
+}
+
+module.exports = RenownKeyword;


### PR DESCRIPTION
Separates out post-challenge keywords into ability classes. This will
allow more consistent handling of immunity to keywords (e.g. Dragonglass
Dagger vs intimidate) and clears the way for choosing the order of
keyword resolution and optional keywords.