### PR TITLE
Separate player prompt state to another class.

### DIFF
--- a/server/game/anonymousspectator.js
+++ b/server/game/anonymousspectator.js
@@ -7,12 +7,8 @@ class AnonymousSpectator {
         this.menuTitle = 'Spectator mode';
     }
 
-    isCardSelected() {
-        return false;
-    }
-
-    isCardSelectable() {
-        return false;
+    getCardSelectionState() {
+        return {};
     }
 }
 

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -473,22 +473,25 @@ class BaseCard {
 
     getSummary(activePlayer, hideWhenFaceup) {
         let isActivePlayer = activePlayer === this.owner;
-        return isActivePlayer || (!this.facedown && !hideWhenFaceup) ? {
+
+        if(!isActivePlayer && (this.facedown || hideWhenFaceup)) {
+            return { facedown: true };
+        }
+
+        let selectionState = activePlayer.getCardSelectionState(this);
+        let state = {
             code: this.cardData.code,
             controlled: this.owner !== this.controller,
             facedown: this.facedown,
             menu: this.getMenu(),
             name: this.cardData.label,
             new: this.new,
-            // The `this.selected` property here is a hack for plot selection,
-            // which we do differently from normal card selection.
-            selected: this.selected || activePlayer.isCardSelected(this),
-            selectable: activePlayer.isCardSelectable(this),
             tokens: this.tokens,
             type: this.getType(),
-            unselectable: activePlayer.selectCard && !activePlayer.isCardSelectable(this),
             uuid: this.uuid
-        } : { facedown: true };
+        };
+
+        return _.extend(state, selectionState);
     }
 }
 

--- a/server/game/playerpromptstate.js
+++ b/server/game/playerpromptstate.js
@@ -1,0 +1,75 @@
+const _ = require('underscore');
+
+class PlayerPromptState {
+    constructor() {
+        this.selectCard = false;
+        this.menuTitle = '';
+        this.promptTitle = '';
+        this.buttons = [];
+
+        this.selectableCards = [];
+        this.selectedCards = [];
+    }
+
+    setSelectedCards(cards) {
+        this.selectedCards = cards;
+    }
+
+    clearSelectedCards() {
+        this.selectedCards = [];
+    }
+
+    setSelectableCards(cards) {
+        this.selectableCards = cards;
+    }
+
+    clearSelectableCards() {
+        this.selectableCards = [];
+    }
+
+    setPrompt(prompt) {
+        this.selectCard = prompt.selectCard || false;
+        this.menuTitle = prompt.menuTitle || '';
+        this.promptTitle = prompt.promptTitle;
+        this.buttons = _.map(prompt.buttons || [], button => {
+            if(button.card) {
+                let card = button.card;
+                let properties = _.omit(button, 'card');
+                return _.extend({ text: card.name, arg: card.uuid, card: card.getShortSummary() }, properties);
+            }
+
+            return button;
+        });
+    }
+
+    cancelPrompt() {
+        this.selectCard = false;
+        this.menuTitle = '';
+        this.buttons = [];
+    }
+
+    getCardSelectionState(card) {
+        let selectable = this.selectableCards.includes(card);
+        let index = _.indexOf(this.selectedCards, card);
+        let result = {
+            // The `card.selected` property here is a hack for plot selection,
+            // which we do differently from normal card selection.
+            selected: card.selected || (index !== -1),
+            selectable: selectable,
+            unselectable: this.selectCard && !selectable
+        };
+
+        return result;
+    }
+
+    getState() {
+        return {
+            selectCard: this.selectCard,
+            menuTitle: this.menuTitle,
+            promptTitle: this.promptTitle,
+            buttons: this.buttons
+        };
+    }
+}
+
+module.exports = PlayerPromptState;

--- a/server/game/spectator.js
+++ b/server/game/spectator.js
@@ -9,12 +9,8 @@ class Spectator {
         this.menuTitle = 'Spectator mode';
     }
 
-    isCardSelected() {
-        return false;
-    }
-
-    isCardSelectable() {
-        return false;
+    getCardSelectionState() {
+        return {};
     }
 }
 

--- a/test/server/card/basecard.spec.js
+++ b/test/server/card/basecard.spec.js
@@ -9,7 +9,8 @@ describe('BaseCard', function () {
         this.limitedCard = { code: '1234', text: 'Limited.' };
         this.nonLimitedCard = { code: '2222', text: 'Stealth.' };
         this.game = {};
-        this.owner = jasmine.createSpyObj('owner', ['isCardSelectable', 'isCardSelected']);
+        this.owner = jasmine.createSpyObj('owner', ['getCardSelectionState']);
+        this.owner.getCardSelectionState.and.returnValue({});
         this.owner.game = this.game;
         this.card = new BaseCard(this.owner, this.testCard);
     });
@@ -89,7 +90,8 @@ describe('BaseCard', function () {
 
         describe('when is not active player', function() {
             beforeEach(function () {
-                this.anotherPlayer = jasmine.createSpyObj('owner', ['isCardSelectable', 'isCardSelected']);
+                this.anotherPlayer = jasmine.createSpyObj('owner', ['getCardSelectionState']);
+                this.anotherPlayer.getCardSelectionState.and.returnValue({});
                 this.summary = this.card.getSummary(this.anotherPlayer);
             });
 


### PR DESCRIPTION
Consolidates selection state to a single `getCardSelectionState` method
instead of individual methods checking for pieces of selection state.
Also extracts player prompt state logic to its own class.

(This is prep work for ordering prompts, which is going to add another property - `order` - to selection state)