### PR TITLE
bug fix: avoid null discarded card in Plaza of Pride message

### DIFF
--- a/server/game/cards/locations/07/plazaofpride.js
+++ b/server/game/cards/locations/07/plazaofpride.js
@@ -18,7 +18,7 @@ class PlazaOfPride extends DrawCard {
                         && card.getType() === 'character'
                         && card.kneeled
                         && card.getCost() <= context.discardCostCard.getCost() + 3,
-                    onSelect: (player, card) => this.onCardSelected(player, card, context.discardCardCost)
+                    onSelect: (player, card) => this.onCardSelected(player, card, context.discardCostCard)
                 });
             }
         });


### PR DESCRIPTION
Due to a typo in the used attribute name, before this change the message of
Plaza of Pride did not log the name of the card that was discarded to pay its
cost.