### PR TITLE
Prompt for dead pile order when multiple characters killed.

### DIFF
--- a/client/GameComponents/Card.jsx
+++ b/client/GameComponents/Card.jsx
@@ -208,6 +208,14 @@ class Card extends React.Component {
         return dupes;
     }
 
+    getCardOrder() {
+        if(!this.props.card.order) {
+            return null;
+        }
+
+        return (<div className='card-order'>{this.props.card.order}</div>);
+    }
+
     showMenu() {
         if(!this.isAllowedMenuSource()) {
             return false;
@@ -288,6 +296,7 @@ class Card extends React.Component {
                     onTouchMove={ev => this.onTouchMove(ev)}
                     onTouchEnd={ev => this.onTouchEnd(ev)}
                     onTouchStart={ev => this.onTouchStart(ev)}>
+                    {this.getCardOrder()}
                     <div className={cardClass}
                         onMouseOver={this.props.disableMouseOver ? null : this.onMouseOver.bind(this, this.props.card)}
                         onMouseOut={this.props.disableMouseOver ? null : this.onMouseOut}
@@ -336,6 +345,7 @@ Card.propTypes = {
         menu: React.PropTypes.array,
         name: React.PropTypes.string,
         new: React.PropTypes.bool,
+        order: React.PropTypes.number,
         power: React.PropTypes.number,
         saved: React.PropTypes.bool,
         selectable: React.PropTypes.bool,

--- a/less/cards.less
+++ b/less/cards.less
@@ -95,6 +95,24 @@
   }
 }
 
+.card-order {
+  background: rgba(0, 0, 0, 0.8);
+  border: 1px solid rgba(0, 0, 0, 0.9);
+  border-radius: 4px;
+  color: white;
+  font-size: 16px;
+  font-weight: bold;
+  height: 26px;
+  left: 50%;
+  line-height: 24px;
+  margin: 0 0 0 -12px;
+  position: absolute;
+  text-align: center;
+  top: -28px;
+  width: 24px;
+  z-index: @layer-card-menu;
+}
+
 .card-name {
   font-size: 10px;
   line-height: 14px;

--- a/server/game/gamesteps/killcharacters.js
+++ b/server/game/gamesteps/killcharacters.js
@@ -1,0 +1,103 @@
+const _ = require('underscore');
+
+const BaseStep = require('./basestep.js');
+
+class KillCharacters extends BaseStep {
+    constructor(game, cards, allowSave) {
+        super(game);
+
+        this.cards = cards;
+        this.allowSave = allowSave;
+    }
+
+    continue() {
+        let cardsInPlay = _.filter(this.cards, card => card.location === 'play area');
+        this.game.applyGameAction('killed', cardsInPlay, killable => {
+            _.each(killable, card => {
+                card.markAsInDanger();
+            });
+
+            this.game.raiseSimultaneousEvent(killable, {
+                eventName: 'onCharactersKilled',
+                params: {
+                    allowSave: this.allowSave
+                },
+                handler: event => this.handleMultipleKills(event),
+                perCardEventName: 'onCharacterKilled',
+                perCardHandler: event => this.doKill(event)
+            });
+            this.game.queueSimpleStep(() => {
+                _.each(killable, card => {
+                    card.clearDanger();
+                });
+            });
+        });
+    }
+
+    handleMultipleKills(event) {
+        this.event = event;
+
+        _.each(event.cards, card => {
+            this.automaticSave(card);
+        });
+
+        _.each(this.game.getPlayersInFirstPlayerOrder(), player => {
+            this.promptPlayerForDeadPileOrder(player);
+        });
+    }
+
+    automaticSave(card) {
+        if(card.location !== 'play area') {
+            this.event.saveCard(card);
+        } else if(!card.canBeKilled()) {
+            this.game.addMessage('{0} controlled by {1} cannot be killed',
+                                    card, card.controller);
+            this.event.saveCard(card);
+        } else if(!card.dupes.isEmpty() && this.event.allowSave) {
+            if(card.controller.removeDuplicate(card)) {
+                this.game.addMessage('{0} discards a duplicate to save {1}', card.controller, card);
+                this.event.saveCard(card);
+            }
+        }
+    }
+
+    promptPlayerForDeadPileOrder(player) {
+        let cardsOwnedByPlayer = _.filter(this.event.cards, card => card.owner === player);
+
+        if(_.size(cardsOwnedByPlayer) <= 1) {
+            return;
+        }
+
+        this.game.promptForSelect(player, {
+            ordered: true,
+            multiSelect: true,
+            numCards: _.size(cardsOwnedByPlayer),
+            activePromptTitle: 'Select order to place cards in dead pile (top first)',
+            cardCondition: card => cardsOwnedByPlayer.includes(card),
+            onSelect: (player, selectedCards) => {
+                if(cardsOwnedByPlayer.length !== selectedCards.length) {
+                    return false;
+                }
+
+                this.event.cards = _.reject(this.event.cards, card => card.owner === player).concat(selectedCards.reverse());
+
+                return true;
+            }
+        });
+    }
+
+    doKill(event) {
+        let card = event.card;
+        let player = card.controller;
+
+        if(card.location !== 'play area') {
+            event.cancel();
+            return;
+        }
+
+        player.moveCard(card, 'dead pile');
+        this.game.addMessage('{0} kills {1}', player, card);
+    }
+}
+
+module.exports = KillCharacters;

--- a/server/game/gamesteps/selectcardprompt.js
+++ b/server/game/gamesteps/selectcardprompt.js
@@ -39,6 +39,8 @@ const UiPrompt = require('./uiprompt.js');
  *                      used to provide a default waitingPromptTitle, if missing
  * gameAction         - a string representing the game action to be checked on
  *                      target cards.
+ * ordered            - an optional boolean indicating whether or not to display
+ *                      the order of the selection during the prompt.
  */
 class SelectCardPrompt extends UiPrompt {
     constructor(game, choosingPlayer, properties) {
@@ -115,6 +117,7 @@ class SelectCardPrompt extends UiPrompt {
     activePrompt() {
         return {
             selectCard: true,
+            selectOrder: this.properties.ordered,
             menuTitle: this.properties.activePromptTitle || this.defaultActivePromptTitle(),
             buttons: this.properties.additionalButtons.concat([
                 { text: 'Done', arg: 'done' }

--- a/server/game/playerpromptstate.js
+++ b/server/game/playerpromptstate.js
@@ -3,6 +3,7 @@ const _ = require('underscore');
 class PlayerPromptState {
     constructor() {
         this.selectCard = false;
+        this.selectOrder = false;
         this.menuTitle = '';
         this.promptTitle = '';
         this.buttons = [];
@@ -29,6 +30,7 @@ class PlayerPromptState {
 
     setPrompt(prompt) {
         this.selectCard = prompt.selectCard || false;
+        this.selectOrder = prompt.selectOrder || false;
         this.menuTitle = prompt.menuTitle || '';
         this.promptTitle = prompt.promptTitle;
         this.buttons = _.map(prompt.buttons || [], button => {
@@ -59,12 +61,17 @@ class PlayerPromptState {
             unselectable: this.selectCard && !selectable
         };
 
+        if(index !== -1 && this.selectOrder) {
+            return _.extend({ order: index + 1 }, result);
+        }
+
         return result;
     }
 
     getState() {
         return {
             selectCard: this.selectCard,
+            selectOrder: this.selectOrder,
             menuTitle: this.menuTitle,
             promptTitle: this.promptTitle,
             buttons: this.buttons

--- a/test/server/cards/plots/04/04080-valarmorghulis.spec.js
+++ b/test/server/cards/plots/04/04080-valarmorghulis.spec.js
@@ -3,61 +3,117 @@
 
 describe('Valar Morghulis', function() {
     integration(function() {
-        beforeEach(function() {
-            const deck1 = this.buildDeck('tyrell', [
-                'Valar Morghulis',
-                'Margaery Tyrell (AMAF)', 'Margaery Tyrell (AMAF)', 'Rickon Stark', 'Eddard Stark (Core)'
-            ]);
-            const deck2 = this.buildDeck('thenightswatch', [
-                'A Noble Cause',
-                'Samwell Tarly (Core)', 'Maester Aemon (Core)'
-            ]);
+        describe('when there are both interrupts and reactions to dying', function() {
+            beforeEach(function() {
+                const deck1 = this.buildDeck('tyrell', [
+                    'Valar Morghulis',
+                    'Margaery Tyrell (AMAF)', 'Margaery Tyrell (AMAF)', 'Rickon Stark', 'Eddard Stark (Core)'
+                ]);
+                const deck2 = this.buildDeck('thenightswatch', [
+                    'A Noble Cause',
+                    'Samwell Tarly (Core)', 'Maester Aemon (Core)'
+                ]);
 
-            this.player1.selectDeck(deck1);
-            this.player2.selectDeck(deck2);
-            this.startGame();
-            this.keepStartingHands();
+                this.player1.selectDeck(deck1);
+                this.player2.selectDeck(deck2);
+                this.startGame();
+                this.keepStartingHands();
 
-            [this.marg1, this.marg2] = this.player1.filterCardsByName('Margaery Tyrell', 'hand');
-            this.rickon = this.player1.findCardByName('Rickon Stark', 'hand');
-            this.eddard = this.player1.findCardByName('Eddard Stark', 'hand');
+                [this.marg1, this.marg2] = this.player1.filterCardsByName('Margaery Tyrell', 'hand');
+                this.rickon = this.player1.findCardByName('Rickon Stark', 'hand');
+                this.eddard = this.player1.findCardByName('Eddard Stark', 'hand');
 
-            this.samwell = this.player2.findCardByName('Samwell Tarly', 'hand');
-            this.aemon = this.player2.findCardByName('Maester Aemon', 'hand');
+                this.samwell = this.player2.findCardByName('Samwell Tarly', 'hand');
+                this.aemon = this.player2.findCardByName('Maester Aemon', 'hand');
 
-            this.player1.clickCard(this.marg1);
-            this.player1.clickCard(this.marg2);
-            this.player1.clickCard(this.rickon);
+                this.player1.clickCard(this.marg1);
+                this.player1.clickCard(this.marg2);
+                this.player1.clickCard(this.rickon);
 
-            this.player2.clickCard(this.samwell);
-            this.player2.clickCard(this.aemon);
+                this.player2.clickCard(this.samwell);
+                this.player2.clickCard(this.aemon);
 
-            this.completeSetup();
+                this.completeSetup();
 
-            this.player1Object.moveCard(this.eddard, 'draw deck');
+                this.player1Object.moveCard(this.eddard, 'draw deck');
 
-            this.player1.selectPlot('Valar Morghulis');
-            this.player2.selectPlot('A Noble Cause');
+                this.player1.selectPlot('Valar Morghulis');
+                this.player2.selectPlot('A Noble Cause');
 
-            this.selectFirstPlayer(this.player1);
+                this.selectFirstPlayer(this.player1);
+            });
+
+            it('should prompt interrupts and reactions in the proper order', function() {
+                expect(this.player1).not.toHavePromptButton('Margaery Tyrell');
+                expect(this.player2).toHavePromptButton('Maester Aemon');
+
+                // Aemon saves Sam but dies
+                this.player2.clickPrompt('Maester Aemon');
+                this.player2.clickCard('Samwell Tarly', 'play area');
+                expect(this.samwell.location).toBe('play area');
+                expect(this.aemon.location).toBe('dead pile');
+
+                // Marg's dupe saves her but Rickon dies
+                expect(this.marg1.location).toBe('play area');
+                expect(this.marg2.location).toBe('discard pile');
+                expect(this.rickon.location).toBe('dead pile');
+
+                expect(this.player1).toHavePromptButton('Margaery Tyrell');
+            });
         });
 
-        it('should prompt interrupts and reactions in the proper order', function() {
-            expect(this.player1).not.toHavePromptButton('Margaery Tyrell');
-            expect(this.player2).toHavePromptButton('Maester Aemon');
+        describe('when multiple characters die', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('tyrell', [
+                    'Valar Morghulis', 'A Noble Cause',
+                    'Arya Stark (Core)', 'Arya Stark (Core)', 'Hedge Knight', 'House Maester'
+                ]);
 
-            // Aemon saves Sam but dies
-            this.player2.clickPrompt('Maester Aemon');
-            this.player2.clickCard('Samwell Tarly', 'play area');
-            expect(this.samwell.location).toBe('play area');
-            expect(this.aemon.location).toBe('dead pile');
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
 
-            // Marg's dupe saves her but Rickon dies
-            expect(this.marg1.location).toBe('play area');
-            expect(this.marg2.location).toBe('discard pile');
-            expect(this.rickon.location).toBe('dead pile');
+                // Put out dupes for player 1's Arya so only 1 character will be
+                // killed.
+                this.player1.clickCard('Arya Stark', 'hand');
+                this.player1.clickCard('Arya Stark', 'hand');
+                this.player1.clickCard('Hedge Knight', 'hand');
 
-            expect(this.player1).toHavePromptButton('Margaery Tyrell');
+                // Put out no dupes for player 2 so multiple characters will be
+                // killed.
+                this.deadArya = this.player2.findCardByName('Arya Stark', 'hand');
+                this.deadKnight = this.player2.findCardByName('Hedge Knight', 'hand');
+                this.deadMaester = this.player2.findCardByName('House Maester', 'hand');
+                this.player2.clickCard(this.deadArya);
+                this.player2.clickCard(this.deadKnight);
+                this.player2.clickCard(this.deadMaester);
+
+                this.completeSetup();
+
+                this.player1.selectPlot('Valar Morghulis');
+                this.player2.selectPlot('A Noble Cause');
+
+                this.selectFirstPlayer(this.player1);
+            });
+
+            it('should not prompt to choose dead pile order if only one character will die', function() {
+                expect(this.player1).not.toHavePrompt('Select order to place cards in dead pile (top first)');
+            });
+
+            it('should prompt to choose dead pile order for multiple characters', function() {
+                expect(this.player2).toHavePrompt('Select order to place cards in dead pile (top first)');
+            });
+
+            it('should allow dead pile order to be chosen', function() {
+                // Top of dead pile to bottom of dead pile.
+                this.player2.clickCard(this.deadMaester);
+                this.player2.clickCard(this.deadArya);
+                this.player2.clickCard(this.deadKnight);
+                this.player2.clickPrompt('Done');
+
+                expect(this.player2Object.deadPile.pluck('name')).toEqual(['Hedge Knight', 'Arya Stark', 'House Maester']);
+            });
         });
     });
 });

--- a/test/server/gamesteps/simultaneouseventwindow.spec.js
+++ b/test/server/gamesteps/simultaneouseventwindow.spec.js
@@ -10,7 +10,9 @@ describe('SimultaneousEventWindow', function() {
     beforeEach(function() {
         this.gameSpy = jasmine.createSpyObj('game', ['emit', 'openAbilityWindow', 'queueSimpleStep']);
         this.gameSpy.queueSimpleStep.and.callFake(step => step());
-        this.cards = ['card1', 'card2'];
+        this.card1 = { uuid: '1111', name: 'card1' };
+        this.card2 = { uuid: '2222', name: 'card2' };
+        this.cards = [this.card1, this.card2];
         this.params = { foo: 'bar' };
         this.handler = jasmine.createSpy('handler');
         this.perCardHandler = jasmine.createSpy('perCardHandler');
@@ -54,8 +56,28 @@ describe('SimultaneousEventWindow', function() {
             });
 
             it('should call the handlers for each card', function() {
-                expect(this.perCardHandler).toHaveBeenCalledWith(jasmine.objectContaining({ card: 'card1' }), jasmine.any(Object));
-                expect(this.perCardHandler).toHaveBeenCalledWith(jasmine.objectContaining({ card: 'card2' }), jasmine.any(Object));
+                expect(this.perCardHandler).toHaveBeenCalledWith(jasmine.objectContaining({ card: this.card1 }), jasmine.any(Object));
+                expect(this.perCardHandler).toHaveBeenCalledWith(jasmine.objectContaining({ card: this.card2 }), jasmine.any(Object));
+            });
+        });
+
+        describe('when the handler reorders cards', function() {
+            beforeEach(function() {
+                // reorder cards during the event handler
+                this.handler.and.callFake(event => {
+                    event.cards = [this.card2, this.card1];
+                });
+
+                this.perCardOrder = [];
+                this.perCardHandler.and.callFake(event => {
+                    this.perCardOrder.push(event.card);
+                });
+
+                this.eventWindow.continue();
+            });
+
+            it('should call per-card handlers in the new order', function() {
+                expect(this.perCardOrder).toEqual([this.card2, this.card1]);
             });
         });
 
@@ -142,16 +164,16 @@ describe('SimultaneousEventWindow', function() {
 
         describe('when an individual card event is cancelled', function() {
             beforeEach(function() {
-                this.eventWindow.perCardEvents[0].cancel();
+                this.eventWindow.perCardEventMap[this.card1.uuid].cancel();
                 this.eventWindow.continue();
             });
 
             it('should not emit the interrupt/reaction events for the cancelled card', function() {
-                expect(this.gameSpy.openAbilityWindow).not.toHaveBeenCalledWith(jasmine.objectContaining({ event: jasmine.objectContaining({ name: 'percardevent', card: 'card1' }) }));
+                expect(this.gameSpy.openAbilityWindow).not.toHaveBeenCalledWith(jasmine.objectContaining({ event: jasmine.objectContaining({ name: 'percardevent', card: this.card1 }) }));
             });
 
             it('should emit all of the interrupt/reaction events for the non-cancelled cards', function() {
-                let card = 'card2';
+                let card = this.card2;
                 expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'cancelinterrupt', event: jasmine.objectContaining({ name: 'percardevent', card: card }) });
                 expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'forcedinterrupt', event: jasmine.objectContaining({ name: 'percardevent', card: card }) });
                 expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'interrupt', event: jasmine.objectContaining({ name: 'percardevent', card: card }) });


### PR DESCRIPTION
* Adds an `ordered` property to selection prompts that will display numbers above the cards selected to indicate the selection order.
* When two or more characters are killed, the player is prompted to select the order to place the characters in the dead pile (top-most card first). If only one card is killed, the player will not receive the prompt. If the player clicks 'Done' after selecting the order for some cards but not all of them, it won't continue. If the player clicks 'Done' without selecting any of the cards, it will place them in the dead pile from left to right automatically (right card being top-most).
![screen shot 2017-05-15 at 12 36 11 pm](https://cloud.githubusercontent.com/assets/145077/26075724/270b15f8-396b-11e7-8f90-dcc519510134.png)
![screen shot 2017-05-15 at 12 37 25 pm](https://cloud.githubusercontent.com/assets/145077/26075757/43245f24-396b-11e7-9d89-c168a9135872.png)
* Because killing characters was getting more complicated, it has been moved to its own game step class and off of `Game`.