### PR TITLE
Ensure legacy events placed in discard.

### DIFF
--- a/server/game/playcardaction.js
+++ b/server/game/playcardaction.js
@@ -4,10 +4,7 @@ const Costs = require('./costs.js');
 class PlayCardAction extends BaseAbility {
     constructor() {
         super({
-            cost: [
-                Costs.payReduceableGoldCost('play'),
-                Costs.playLimited()
-            ]
+            cost: Costs.playEvent()
         });
         this.title = 'Play';
     }
@@ -26,7 +23,6 @@ class PlayCardAction extends BaseAbility {
     executeHandler(context) {
         context.game.addMessage('{0} plays {1} costing {2}', context.player, context.source, context.costs.gold);
         context.source.play(context.player);
-        context.player.moveCard(context.source, 'discard pile');
     }
 
     isPlayableEventAbility() {

--- a/test/server/playcardaction.spec.js
+++ b/test/server/playcardaction.spec.js
@@ -104,9 +104,5 @@ describe('PlayCardAction', function () {
         it('should play the card', function() {
             expect(this.cardSpy.play).toHaveBeenCalledWith(this.playerSpy);
         });
-
-        it('should place the card in discard', function() {
-            expect(this.playerSpy.moveCard).toHaveBeenCalledWith(this.cardSpy, 'discard pile');
-        });
     });
 });


### PR DESCRIPTION
Previously, legacy event cards were being placed in discard as part of
their handler. However, if the effects of the event were cancelled, the
event would not be placed in discard. Now, placing in discard is
considered part of the cost as it is with events defined using the
ability API.