### PR TITLE
Add prompt title for effect cancels.

### DIFF
--- a/server/game/gamesteps/triggeredabilitywindowtitles.js
+++ b/server/game/gamesteps/triggeredabilitywindowtitles.js
@@ -1,4 +1,5 @@
 const EventToTitleFunc = {
+    onCardAbilityInitiated: event => 'the effects of ' + event.source.name,
     onCardPowerChanged: event => event.params[1].name + ' gaining power',
     onCharacterKilled: event => event.card.name + ' being killed',
     onCharactersKilled: () => 'characters being killed',


### PR DESCRIPTION
Previously, the prompts for cards like Hand's Judgment and Treachery
were not clear on which card they were interrupting. Now, the name of
the card whose effects are being applied is displayed in the prompt.