### PR TITLE
Fix simultaneous event window crash

### DIFF
--- a/server/game/gamesteps/simultaneouseventwindow.js
+++ b/server/game/gamesteps/simultaneouseventwindow.js
@@ -83,6 +83,11 @@ class SimultaneousEventWindow extends BaseStep {
         this.filterOutCancelledEvents();
         _.each(this.event.cards, card => {
             let event = this.perCardEventMap[card.uuid];
+
+            if(!event) {
+                return;
+            }
+
             this.game.openAbilityWindow({
                 abilityType: abilityType,
                 event: event

--- a/test/server/gamesteps/simultaneouseventwindow.spec.js
+++ b/test/server/gamesteps/simultaneouseventwindow.spec.js
@@ -172,6 +172,11 @@ describe('SimultaneousEventWindow', function() {
                 expect(this.gameSpy.openAbilityWindow).not.toHaveBeenCalledWith(jasmine.objectContaining({ event: jasmine.objectContaining({ name: 'percardevent', card: this.card1 }) }));
             });
 
+            it('should not open ability windows with undefined/null events', function() {
+                expect(this.gameSpy.openAbilityWindow).not.toHaveBeenCalledWith(jasmine.objectContaining({ event: undefined }));
+                expect(this.gameSpy.openAbilityWindow).not.toHaveBeenCalledWith(jasmine.objectContaining({ event: null }));
+            });
+
             it('should emit all of the interrupt/reaction events for the non-cancelled cards', function() {
                 let card = this.card2;
                 expect(this.gameSpy.openAbilityWindow).toHaveBeenCalledWith({ abilityType: 'cancelinterrupt', event: jasmine.objectContaining({ name: 'percardevent', card: card }) });


### PR DESCRIPTION
Previously, if a kill was canceled during a simultaneous kill window, it
would continue to try to fire events for that card. However, the card's
event had already been removed from the window, leading it to try and
open an ability window for an undefined / null event object.

Fixes THRONETEKI-SX
Fixes THRONETEKI-T0
Fixes THRONETEKI-SV
Fixes THRONETEKI-T2