### PR TITLE
Remove pulse effect from selectable cards.

### DIFF
--- a/less/cards.less
+++ b/less/cards.less
@@ -27,17 +27,7 @@
   }
 
   &.selectable {
-    animation: selectable-pulse 4s infinite;
     box-shadow: 0 0 10px 1px fadeout(lighten(@brand-primary, 60%), 10%);
-  }
-
-  @keyframes selectable-pulse {
-    0% {
-      box-shadow: 0 0 10px 1px fadeout(lighten(@brand-primary, 60%), 10%);
-    }
-    50% {
-      box-shadow: 0 0 10px 1px fadeout(lighten(@brand-primary, 60%), 50%);
-    }
   }
 
   &.unselectable {


### PR DESCRIPTION
With the addition of greying out unselectable cards, the pulse effect on
selectable cards is less necessary. The animation is not very
performant, so dropping it should help client side rendering
performance. The glowing shadow effect for selectable cards is still
retained to make select prompts clear in IE versions that do not support
the grey scale effect.