### PR TITLE
Fix doubling of effects from setup attachments.

### DIFF
--- a/server/game/player.js
+++ b/server/game/player.js
@@ -447,8 +447,12 @@ class Player extends Spectator {
             this.removeCardFromPile(card);
             dupeCard.addDuplicate(card);
         } else {
+            // Attachments placed in setup should not be considered to be 'played',
+            // as it will cause then to double their effects when attached later.
+            let isSetupAttachment = playingType === 'setup' && card.getType() === 'attachment';
+
             card.facedown = this.game.currentPhase === 'setup';
-            if(!dupeCard) {
+            if(!dupeCard && !isSetupAttachment) {
                 card.play(this, playingType === 'ambush');
             }
 

--- a/test/server/integration/setup.spec.js
+++ b/test/server/integration/setup.spec.js
@@ -107,14 +107,14 @@ describe('setup phase', function() {
 
         describe('when attachments are put out in the setup phase', function() {
             beforeEach(function() {
-                const deck = this.buildDeck('baratheon', ['Red God\'s Blessing', 'Dragonstone Faithful']);
+                const deck = this.buildDeck('baratheon', ['Sneak Attack', 'Valyrian Steel Dagger', 'Northern Refugee']);
                 this.player1.selectDeck(deck);
                 this.player2.selectDeck(deck);
                 this.startGame();
                 this.keepStartingHands();
 
-                this.character = this.player1.findCardByName('Dragonstone Faithful');
-                this.attachment = this.player1.findCardByName('Red God\'s Blessing');
+                this.character = this.player1.findCardByName('Northern Refugee');
+                this.attachment = this.player1.findCardByName('Valyrian Steel Dagger');
 
                 this.player1.clickCard(this.character);
                 this.player1.clickCard(this.attachment);
@@ -137,7 +137,18 @@ describe('setup phase', function() {
                 });
 
                 it('should properly calculate the effects of the attachment', function() {
-                    expect(this.character.getStrength()).toBe(2);
+                    // Get into an intrigue challenge to check the strength boost.
+                    this.player1.selectPlot('Sneak Attack');
+                    this.player2.selectPlot('Sneak Attack');
+                    this.selectFirstPlayer(this.player1);
+
+                    this.completeMarshalPhase();
+
+                    this.player1.clickPrompt('Intrigue');
+                    this.player1.clickCard(this.character);
+                    this.player1.clickPrompt('Done');
+
+                    expect(this.character.getStrength()).toBe(3);
                 });
 
                 it('should continue to the plot phase', function() {


### PR DESCRIPTION
Attachments placed during setup were having their effects doubled in at
least some cases, because the effects were registered with the engine
twice - once when placed facedown, then again when attached. Now,
effects are only registered once for attachments when they're actually
attached.

Fixes #833.