### PR TITLE
Convert Iron Throne to effect API.

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -308,10 +308,6 @@ class BaseCard {
         this.location = targetLocation;
     }
 
-    modifyDominance(player, strength) {
-        return strength;
-    }
-
     canPlay() {
         return true;
     }

--- a/server/game/cards/locations/01/theironthrone.js
+++ b/server/game/cards/locations/01/theironthrone.js
@@ -1,18 +1,14 @@
 const DrawCard = require('../../../drawcard.js');
 
 class TheIronThrone extends DrawCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.plotModifiers({
             reserve: 1
         });
-    }
-
-    modifyDominance(player, strength) {
-        if(this.controller === player && !this.isBlank()) {
-            return strength + 8;
-        }
-
-        return strength;
+        this.persistentEffect({
+            match: this,
+            effect: ability.effects.modifyDominanceStrength(8)
+        });
     }
 }
 

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -39,6 +39,7 @@ class DrawCard extends BaseCard {
 
         this.power = 0;
         this.strengthModifier = 0;
+        this.dominanceStrengthModifier = 0;
         this.contributesToDominance = true;
         this.kneeled = false;
         this.inChallenge = false;
@@ -141,6 +142,16 @@ class DrawCard extends BaseCard {
         }
 
         return Math.max(0, this.strengthModifier + (this.cardData.strength || 0));
+    }
+
+    modifyDominanceStrength(amount) {
+        this.dominanceStrengthModifier += amount;
+    }
+
+    getDominanceStrength() {
+        let baseStrength = !this.kneeled && this.getType() === 'character' && this.contributesToDominance ? this.getStrength() : 0;
+
+        return Math.max(0, baseStrength + this.dominanceStrengthModifier);
     }
 
     getIconsAdded() {

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -96,6 +96,16 @@ const Effects = {
             }
         };
     },
+    modifyDominanceStrength: function(value) {
+        return {
+            apply: function(card) {
+                card.modifyDominanceStrength(value);
+            },
+            unapply: function(card) {
+                card.modifyDominanceStrength(-value);
+            }
+        };
+    },
     modifyGold: function(value) {
         return {
             apply: function(card) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -837,17 +837,9 @@ class Player extends Spectator {
     }
 
     getDominance() {
-        var cardStrength = this.cardsInPlay.reduce((memo, card) => {
-            if(!card.kneeled && card.getType() === 'character' && card.contributesToDominance) {
-                return memo + card.getStrength();
-            }
-
-            return memo;
+        let cardStrength = this.cardsInPlay.reduce((memo, card) => {
+            return memo + card.getDominanceStrength();
         }, 0);
-
-        this.cardsInPlay.each(card => {
-            cardStrength = card.modifyDominance(this, cardStrength);
-        });
 
         return cardStrength + this.gold;
     }


### PR DESCRIPTION
Removes the legacy `modifyDominance` reducer method in favor of an
effect that modifies how much strength a card provides towards
dominance. Also moves the logic of how dominance strength is calculated
onto the DrawCard class.