### PR TITLE
fix Brothel Madame to not hang upon refused payment

### DIFF
--- a/server/game/cards/characters/02/brothelmadame.js
+++ b/server/game/cards/characters/02/brothelmadame.js
@@ -66,6 +66,12 @@ class BrothelMadame extends DrawCard {
 
         return true;
     }
+
+    doNotPay(player) {
+        this.game.addMessage('{0} declines to give {1} 1 gold for {2}', player, this.controller, this);
+
+        return true;
+    }
 }
 
 BrothelMadame.code = '02029';


### PR DESCRIPTION
The doNotPay method, called by the "No" dialog button was simply missing.
This change adds it, together with a suitable game log message.