### PR TITLE
Gaining faction affiliation loses neutrality.

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -262,7 +262,13 @@ class BaseCard {
     }
 
     isFaction(faction) {
-        return !!this.factions[faction.toLowerCase()];
+        let normalizedFaction = faction.toLowerCase();
+
+        if(normalizedFaction === 'neutral') {
+            return !!this.factions[normalizedFaction] && _.size(this.factions) === 1;
+        }
+
+        return !!this.factions[normalizedFaction];
     }
 
     isLoyal() {

--- a/test/server/card/basecard.spec.js
+++ b/test/server/card/basecard.spec.js
@@ -181,4 +181,39 @@ describe('BaseCard', function () {
             });
         });
     });
+
+    describe('isFaction()', function() {
+        beforeEach(function() {
+            this.card.factions = {};
+            this.card.addFaction('stark');
+        });
+
+        it('should return true if it has that faction', function() {
+            expect(this.card.isFaction('stark')).toBe(true);
+        });
+
+        it('should return true regardless of case', function() {
+            expect(this.card.isFaction('StArK')).toBe(true);
+        });
+
+        it('should return false for unaffiliated factions', function() {
+            expect(this.card.isFaction('baratheon')).toBe(false);
+        });
+
+        describe('when the card is neutral', function() {
+            beforeEach(function() {
+                this.card.factions = {};
+                this.card.addFaction('neutral');
+            });
+
+            it('should return true for neutral', function() {
+                expect(this.card.isFaction('neutral')).toBe(true);
+            });
+
+            it('should return false if it gains a faction affiliation (e.g. Ward)', function() {
+                this.card.addFaction('stark');
+                expect(this.card.isFaction('neutral')).toBe(false);
+            });
+        });
+    });
 });


### PR DESCRIPTION
Per the rules, cards that "are not affiliated with any faction" are
considered neutral. Thus, a neutral card that has gained an affiliation
via cards like Ward or Sworn to the Watch are no longer considered
neutral. This distinction is mildly important for cards like Tithe which
require kneeling a neutral card as a cost.