### PR TITLE
make sure non-location attachments can only be placed on characters

### DIFF
--- a/server/game/cards/attachments/01/bodyguard.js
+++ b/server/game/cards/attachments/01/bodyguard.js
@@ -17,7 +17,7 @@ class BodyGuard extends DrawCard {
     }
 
     canAttach(player, card) {
-        if(!card.hasTrait('Lady') && !card.hasTrait('Lord')) {
+        if(card.getType() !== 'character' || !card.hasTrait('Lady') && !card.hasTrait('Lord')) {
             return false;
         }
 

--- a/server/game/cards/attachments/01/drogosarakh.js
+++ b/server/game/cards/attachments/01/drogosarakh.js
@@ -17,7 +17,7 @@ class DrogosArakh extends DrawCard {
     }
 
     canAttach(player, card) {
-        if(!card.hasTrait('dothraki')) {
+        if(card.getType() !== 'character' || !card.hasTrait('dothraki')) {
             return false;
         }
 

--- a/server/game/cards/attachments/01/heartsbane.js
+++ b/server/game/cards/attachments/01/heartsbane.js
@@ -25,7 +25,7 @@ class Heartsbane extends DrawCard {
     }
 
     canAttach(player, card) {
-        if(!card.isFaction('tyrell')) {
+        if(card.getType() !== 'character' || !card.isFaction('tyrell')) {
             return false;
         }
 

--- a/server/game/cards/attachments/01/sealofthehand.js
+++ b/server/game/cards/attachments/01/sealofthehand.js
@@ -14,7 +14,7 @@ class SealOfTheHand extends DrawCard {
     }
 
     canAttach(player, card) {
-        if(!card.hasTrait('Lady') && !card.hasTrait('Lord')) {
+        if(card.getType() !== 'character' || !card.hasTrait('Lady') && !card.hasTrait('Lord')) {
             return false;
         }
 

--- a/server/game/cards/attachments/02/lady.js
+++ b/server/game/cards/attachments/02/lady.js
@@ -32,7 +32,7 @@ class Lady extends DrawCard {
     }
 
     canAttach(player, card) {
-        if(!card.isFaction('stark') || card.getType() !== 'character' || card === this.oldOwner) {
+        if(card.getType() !== 'character' || !card.isFaction('stark') || card === this.oldOwner) {
             return false;
         }
 

--- a/server/game/cards/attachments/02/mareinheat.js
+++ b/server/game/cards/attachments/02/mareinheat.js
@@ -11,7 +11,7 @@ class MareInHeat extends DrawCard {
     }
 
     canAttach(player, card) {
-        if(!card.hasTrait('Knight')) {
+        if(card.getType() !== 'character' || !card.hasTrait('Knight')) {
             return false;
         }
 

--- a/server/game/cards/attachments/03/motley.js
+++ b/server/game/cards/attachments/03/motley.js
@@ -19,7 +19,7 @@ class Motley extends DrawCard {
     }
 
     canAttach(player, card) {
-        if(card.controller === this.controller || card.getType() !== 'character') {
+        if(card.getType() !== 'character' || card.controller === this.controller) {
             return false;
         }
 

--- a/server/game/cards/attachments/03/nymeria.js
+++ b/server/game/cards/attachments/03/nymeria.js
@@ -32,7 +32,7 @@ class Nymeria extends DrawCard {
     }
 
     canAttach(player, card) {
-        if(!card.isFaction('stark') || card.getType() !== 'character' || !card.isUnique() || card === this.oldOwner) {
+        if(card.getType() !== 'character' || !card.isFaction('stark') || !card.isUnique() || card === this.oldOwner) {
             return false;
         }
 

--- a/server/game/cards/attachments/04/beggarking.js
+++ b/server/game/cards/attachments/04/beggarking.js
@@ -34,7 +34,7 @@ class BeggarKing extends DrawCard {
     }
 
     canAttach(player, card) {
-        if(!card.isFaction('targaryen')) {
+        if(card.getType() !== 'character' || !card.isFaction('targaryen')) {
             return false;
         }
 

--- a/server/game/cards/attachments/04/crownofgoldenroses.js
+++ b/server/game/cards/attachments/04/crownofgoldenroses.js
@@ -55,7 +55,7 @@ class CrownOfGoldenRoses extends DrawCard {
     }
 
     canAttach(player, card) {
-        if(!card.hasTrait('Lord')) {
+        if(card.getType() !== 'character' || !card.hasTrait('Lord')) {
             return false;
         }
 

--- a/server/game/cards/attachments/04/dragonglassdagger.js
+++ b/server/game/cards/attachments/04/dragonglassdagger.js
@@ -12,7 +12,7 @@ class DragonglassDagger extends DrawCard {
     }
 
     canAttach(player, card) {
-        if(!card.isFaction('thenightswatch') || card.getType() !== 'character') {
+        if(card.getType() !== 'character' || !card.isFaction('thenightswatch')) {
             return false;
         }
 

--- a/server/game/cards/attachments/04/kingbeyondthewall.js
+++ b/server/game/cards/attachments/04/kingbeyondthewall.js
@@ -14,7 +14,7 @@ class KingBeyondTheWall extends DrawCard {
     }
 
     canAttach(player, card) {
-        if(!card.hasTrait('Wildling') || card.getType() !== 'character') {
+        if(card.getType() !== 'character' || !card.hasTrait('Wildling')) {
             return false;
         }
 

--- a/server/game/cards/attachments/04/kingofsaltandrock.js
+++ b/server/game/cards/attachments/04/kingofsaltandrock.js
@@ -20,7 +20,7 @@ class KingOfSaltAndRock extends DrawCard {
     }
 
     canAttach(player, card) {
-        if(!card.hasTrait('Ironborn') || card.getType() !== 'character') {
+        if(card.getType() !== 'character' || !card.hasTrait('Ironborn')) {
             return false;
         }
 

--- a/server/game/cards/attachments/04/motherofdragons.js
+++ b/server/game/cards/attachments/04/motherofdragons.js
@@ -29,7 +29,7 @@ class MotherOfDragons extends DrawCard {
     }
 
     canAttach(player, card) {
-        if(!card.hasTrait('Stormborn')) {
+        if(card.getType() !== 'character' || !card.hasTrait('Stormborn')) {
             return false;
         }
 

--- a/server/game/cards/attachments/04/theboyking.js
+++ b/server/game/cards/attachments/04/theboyking.js
@@ -18,7 +18,7 @@ class TheBoyKing extends DrawCard {
     }
 
     canAttach(player, card) {
-        if(!card.hasTrait('Lord') || card.getType() !== 'character') {
+        if(card.getType() !== 'character' || !card.hasTrait('Lord')) {
             return false;
         }
 

--- a/server/game/cards/attachments/04/thewolfking.js
+++ b/server/game/cards/attachments/04/thewolfking.js
@@ -15,7 +15,7 @@ class TheWolfKing extends DrawCard {
     }
 
     canAttach(player, card) {
-        if(!card.isFaction('stark') || card.getType() !== 'character') {
+        if(card.getType() !== 'character' || !card.isFaction('stark')) {
             return false;
         }
 

--- a/server/game/cards/attachments/04/venomousblade.js
+++ b/server/game/cards/attachments/04/venomousblade.js
@@ -34,7 +34,7 @@ class VenomousBlade extends DrawCard {
     }
 
     canAttach(player, card) {
-        if(!card.isFaction('martell') || card.controller !== this.controller) {
+        if(card.getType() !== 'character' || !card.isFaction('martell') || card.controller !== this.controller) {
             return false;
         }
 

--- a/server/game/cards/attachments/05/disputedclaim.js
+++ b/server/game/cards/attachments/05/disputedclaim.js
@@ -18,7 +18,7 @@ class DisputedClaim extends DrawCard {
     }
 
     canAttach(player, card) {
-        if(!(card.hasTrait('Bastard') || card.hasTrait('Lord') || card.hasTrait('Lady'))) {
+        if(card.getType() !== 'character' || !(card.hasTrait('Bastard') || card.hasTrait('Lord') || card.hasTrait('Lady'))) {
             return false;
         }
         return super.canAttach(player, card);

--- a/server/game/cards/attachments/06/lightofthelord.js
+++ b/server/game/cards/attachments/06/lightofthelord.js
@@ -15,7 +15,7 @@ class LightOfTheLord extends DrawCard {
     }
 
     canAttach(player, card) {
-        if(!(card.isFaction('baratheon') || card.hasTrait('R\'hllor'))) {
+        if(card.getType() !== 'character' || !(card.isFaction('baratheon') || card.hasTrait('R\'hllor'))) {
             return false;
         }
 

--- a/server/game/cards/attachments/07/ghost.js
+++ b/server/game/cards/attachments/07/ghost.js
@@ -22,7 +22,7 @@ class Ghost extends DrawCard {
     }
 
     canAttach(player, card) {
-        if(!card.isFaction('thenightswatch') && !card.isFaction('stark')) {
+        if(card.getType() !== 'character' || !card.isFaction('thenightswatch') && !card.isFaction('stark')) {
             return false;
         }
 

--- a/server/game/cards/attachments/07/weirwoodbow.js
+++ b/server/game/cards/attachments/07/weirwoodbow.js
@@ -26,7 +26,7 @@ class WeirwoodBow extends DrawCard {
     }
 
     canAttach(player, card) {
-        if(!(card.isFaction('thenightswatch') || card.hasTrait('Wildling'))) {
+        if(card.getType() !== 'character' || !(card.isFaction('thenightswatch') || card.hasTrait('Wildling'))) {
             return false;
         }
 


### PR DESCRIPTION
As part of this, also uniform the canAttach() test so that checking for card
type comes first in the test.

Fixes #830