### PR TITLE
Implement 'Max X per period' ability restrictions.

### DIFF
--- a/server/game/baseability.js
+++ b/server/game/baseability.js
@@ -174,6 +174,10 @@ class BaseAbility {
     isCardAbility() {
         return true;
     }
+
+    hasMax() {
+        return false;
+    }
 }
 
 module.exports = BaseAbility;

--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -27,6 +27,9 @@ const EventRegistrar = require('./eventregistrar.js');
  *                to activate the action. Defaults to 'play area'.
  * limit        - optional AbilityLimit object that represents the max number of
  *                uses for the action as well as when it resets.
+ * max          - optional AbilityLimit object that represents the max number of
+ *                times the ability by card title can be used. Contrast with
+ *                `limit` which limits per individual card.
  * anyPlayer    - boolean indicating that the action may be executed by a player
  *                other than the card's controller. Defaults to false.
  * clickToActivate - boolean that indicates the action should be activated when
@@ -46,6 +49,7 @@ class CardAction extends BaseAbility {
         this.card = card;
         this.title = properties.title;
         this.limit = properties.limit;
+        this.max = properties.max;
         this.phase = properties.phase || 'any';
         this.anyPlayer = properties.anyPlayer || false;
         this.condition = properties.condition;
@@ -58,6 +62,10 @@ class CardAction extends BaseAbility {
 
         if(card.getType() === 'event') {
             this.cost.push(Costs.playEvent());
+        }
+
+        if(this.max) {
+            this.card.owner.registerAbilityMax(this.card.name, this.max);
         }
     }
 

--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -169,6 +169,10 @@ class CardAction extends BaseAbility {
         return this.card.getType() === 'event' && this.location === 'hand';
     }
 
+    hasMax() {
+        return !!this.max;
+    }
+
     deactivate(player) {
         var context = _.last(this.activationContexts);
 

--- a/server/game/cards/events/01/ameagercontribution.js
+++ b/server/game/cards/events/01/ameagercontribution.js
@@ -1,8 +1,9 @@
 const DrawCard = require('../../../drawcard.js');
 
 class AMeagerContribution extends DrawCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.reaction({
+            max: ability.limit.perRound(1),
             when: {
                 onIncomeCollected: event => event.player !== this.controller
             },

--- a/server/game/cards/events/01/likewarmrain.js
+++ b/server/game/cards/events/01/likewarmrain.js
@@ -6,8 +6,7 @@ class LikeWarmRain extends DrawCard {
             when: {
                 afterChallenge: (event, challenge) => this.controller === challenge.loser && challenge.challengeType === 'intrigue' && challenge.defendingPlayer === this.controller
             },
-            /// XXX This doesn't currently work for cards by title, ie events
-            limit: ability.limit.perChallenge(1),
+            max: ability.limit.perChallenge(1),
             cost: ability.costs.kneel(card => card.getType() === 'character' && card.hasTrait('Direwolf')),
             target: {
                 activePromptTitle: 'Select a character to kill',

--- a/server/game/cards/events/01/puttothesword.js
+++ b/server/game/cards/events/01/puttothesword.js
@@ -1,8 +1,9 @@
 const DrawCard = require('../../../drawcard.js');
 
 class PutToTheSword extends DrawCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.reaction({
+            max: ability.limit.perChallenge(1),
             when: {
                 afterChallenge: (event, challenge) => (
                     challenge.challengeType === 'military' &&

--- a/server/game/cards/events/01/puttothetorch.js
+++ b/server/game/cards/events/01/puttothetorch.js
@@ -1,8 +1,9 @@
 const DrawCard = require('../../../drawcard.js');
 
 class PutToTheTorch extends DrawCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.reaction({
+            max: ability.limit.perChallenge(1),
             when: {
                 afterChallenge: (event, challenge) => (
                     challenge.challengeType === 'military' &&

--- a/server/game/cards/events/01/superiorclaim.js
+++ b/server/game/cards/events/01/superiorclaim.js
@@ -1,8 +1,9 @@
 const DrawCard = require('../../../drawcard.js');
 
 class SuperiorClaim extends DrawCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.reaction({
+            max: ability.limit.perChallenge(1),
             when: {
                 afterChallenge: (event, challenge) => (
                     challenge.challengeType === 'power' &&

--- a/server/game/cards/events/01/taketheblack.js
+++ b/server/game/cards/events/01/taketheblack.js
@@ -1,9 +1,10 @@
 const DrawCard = require('../../../drawcard.js');
 
 class TakeTheBlack extends DrawCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.action({
             title: 'Take control of character',
+            max: ability.limit.perRound(1),
             phase: 'dominance',
             target: {
                 activePromptTitle: 'Select a character',

--- a/server/game/cards/events/01/winteriscoming.js
+++ b/server/game/cards/events/01/winteriscoming.js
@@ -1,11 +1,10 @@
 const DrawCard = require('../../../drawcard.js');
 
 class WinterIsComing extends DrawCard {
-
-    // TODO implement restriction "(Max 1 per challenge.)"
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.action({
             title: 'Raise claim by 1',
+            max: ability.limit.perChallenge(1),
             condition: () => this.game.currentChallenge,
             handler: () => {
                 this.untilEndOfChallenge(ability => ({

--- a/server/game/cards/events/04/thereismyclaim.js
+++ b/server/game/cards/events/04/thereismyclaim.js
@@ -1,11 +1,10 @@
 const DrawCard = require('../../../drawcard.js');
 
 class ThereIsMyClaim extends DrawCard {
-
-    // TODO implement restriction "(Max 1 per challenge.)"
     setupCardAbilities(ability) {
         this.action({
             title: 'Raise claim value by 1',
+            max: ability.limit.perChallenge(1),
             phase: 'challenge',
             condition: () => this.game.currentChallenge,
             cost: ability.costs.revealCards(4, card => card.getType() === 'character' && card.isFaction('tyrell')),

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -346,7 +346,8 @@ const Costs = {
         return Costs.all(
             Costs.payReduceableGoldCost('play'),
             Costs.expendEvent(),
-            Costs.playLimited()
+            Costs.playLimited(),
+            Costs.playMax()
         );
     },
     /**
@@ -402,6 +403,20 @@ const Costs = {
                 if(context.source.isLimited()) {
                     context.player.limitedPlayed += 1;
                 }
+            }
+        };
+    },
+    /**
+     * Cost that ensures that the player has not exceeded the maximum usage for
+     * an ability.
+     */
+    playMax: function() {
+        return {
+            canPay: function(context) {
+                return !context.player.isAbilityAtMax(context.source.name);
+            },
+            pay: function(context) {
+                context.player.incrementAbilityMax(context.source.name);
             }
         };
     },

--- a/server/game/gamesteps/triggeredabilitywindow.js
+++ b/server/game/gamesteps/triggeredabilitywindow.js
@@ -13,6 +13,10 @@ class TriggeredAbilityWindow extends BaseStep {
     }
 
     registerAbility(ability, context) {
+        if(ability.hasMax() && this.hasChoiceForCardByName(ability.card.name)) {
+            return;
+        }
+
         let player = ability.card.controller;
         let choiceTexts = ability.getChoices(context);
 
@@ -27,6 +31,10 @@ class TriggeredAbilityWindow extends BaseStep {
                 context: context
             });
         });
+    }
+
+    hasChoiceForCardByName(cardName) {
+        return _.any(this.abilityChoices, choice => choice.card.name === cardName);
     }
 
     continue() {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -40,6 +40,7 @@ class Player extends Spectator {
         this.usedPlotsModifier = 0;
         this.cannotGainChallengeBonus = false;
         this.cannotTriggerCardAbilities = false;
+        this.abilityMaxByTitle = {};
         this.promptedActionWindows = user.promptedActionWindows || {
             plot: false,
             draw: false,
@@ -383,6 +384,33 @@ class Player extends Spectator {
                 this.removeCostReducer(reducer);
             }
         });
+    }
+
+    registerAbilityMax(cardName, limit) {
+        if(this.abilityMaxByTitle[cardName]) {
+            return;
+        }
+
+        this.abilityMaxByTitle[cardName] = limit;
+        limit.registerEvents(this.game);
+    }
+
+    isAbilityAtMax(cardName) {
+        let limit = this.abilityMaxByTitle[cardName];
+
+        if(!limit) {
+            return false;
+        }
+
+        return limit.isAtMax();
+    }
+
+    incrementAbilityMax(cardName) {
+        let limit = this.abilityMaxByTitle[cardName];
+
+        if(limit) {
+            limit.increment();
+        }
     }
 
     isCharacterDead(card) {

--- a/server/game/promptedtriggeredability.js
+++ b/server/game/promptedtriggeredability.js
@@ -26,6 +26,9 @@ const TriggeredAbility = require('./triggeredability.js');
  *           are handlers when the player chooses it from the prompt.
  * limit   - optional AbilityLimit object that represents the max number of uses
  *           for the reaction as well as when it resets.
+ * max     - optional AbilityLimit object that represents the max number of
+ *           times the ability by card title can be used. Contrast with `limit`
+ *           which limits per individual card.
  * location - string indicating the location the card should be in in order
  *            to activate the reaction. Defaults to 'play area'.
  */

--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -33,12 +33,17 @@ class TriggeredAbility extends BaseAbility {
         this.game = game;
         this.card = card;
         this.limit = properties.limit;
+        this.max = properties.max;
         this.when = properties.when;
         this.eventType = eventType;
         this.location = properties.location || DefaultLocationForType[card.getType()] || 'play area';
 
         if(card.getType() === 'event' && !properties.ignoreEventCosts) {
             this.cost.push(Costs.playEvent());
+        }
+
+        if(this.max) {
+            this.card.owner.registerAbilityMax(this.card.name, this.max);
         }
     }
 

--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -114,6 +114,10 @@ class TriggeredAbility extends BaseAbility {
         return false;
     }
 
+    hasMax() {
+        return !!this.max;
+    }
+
     registerEvents() {
         if(this.events) {
             return;

--- a/test/server/cards/cancreatecards.spec.js
+++ b/test/server/cards/cancreatecards.spec.js
@@ -8,7 +8,7 @@ const cards = require('../../../server/game/cards');
 describe('All Cards', function() {
     beforeEach(function() {
         this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener', 'addPower', 'addMessage']);
-        this.playerSpy = jasmine.createSpyObj('player', ['']);
+        this.playerSpy = jasmine.createSpyObj('player', ['registerAbilityMax']);
         this.playerSpy.game = this.gameSpy;
     });
 

--- a/test/server/integration/eventmaximums.spec.js
+++ b/test/server/integration/eventmaximums.spec.js
@@ -1,0 +1,44 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+const _ = require('underscore');
+
+describe('event maximums', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck = this.buildDeck('baratheon', [
+                'A Game of Thrones',
+                'A Meager Contribution', 'A Meager Contribution'
+            ]);
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.skipSetupPhase();
+
+            this.player1.selectPlot('A Game of Thrones');
+            this.player2.selectPlot('A Game of Thrones');
+            this.selectFirstPlayer(this.player2);
+        });
+
+        it('should not allow an event with a max to be prompted past the max', function() {
+            this.player1.clickPrompt('A Meager Contribution');
+
+            expect(this.player1).not.toHavePromptButton('A Meager Contribution');
+        });
+
+        it('should only show one copy of the event in the prompt', function() {
+            let prompt = this.player1.currentPrompt();
+            let copies = _.filter(prompt.buttons, button => button.text === 'A Meager Contribution');
+            expect(_.size(copies)).toBe(1);
+        });
+
+        it('should allow other players to play the event even if it reaches a maximum with another player', function() {
+            this.player1.clickPrompt('A Meager Contribution');
+
+            // Complete marshaling
+            this.player2.clickPrompt('Done');
+
+            expect(this.player2).toHavePromptButton('A Meager Contribution');
+        });
+    });
+});


### PR DESCRIPTION
* Adds `max` property to implement maximums per card title. Uses the same objects as the `limit` property.
* Uses the new property on all event cards that have been implemented via the ability API.
* Does NOT add the restriction to event cards implemented via the legacy `canPlay` / `play` mechanism. This should be done when those cards are converted.
* As a UI nicety, if the player has multiple max-restricted cards in hand, the prompt they see will only have one button.