### PR TITLE
fix A Dragon Is No Slave so that it triggers from the discard pile

### DIFF
--- a/server/game/cards/events/06/adragonisnoslave.js
+++ b/server/game/cards/events/06/adragonisnoslave.js
@@ -25,6 +25,7 @@ class ADragonIsNoSlave extends DrawCard {
             when: {
                 afterChallenge: (event, challenge) => challenge.winner === this.controller && this.hasParticipatingDragonOrDany()
             },
+            ignoreEventCosts: true,
             cost: ability.costs.payGold(1),
             handler: () => {
                 this.game.addMessage('{0} pays 1 gold to move {1} back to their hand', this.controller, this);


### PR DESCRIPTION
... even we do not have 3 golds (i.e., event cost + reaction cost). One gold
should be enough to trigger, so we have to ignore *event* cost.