### PR TITLE
Allow abilities to trigger when they enter play.

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -286,23 +286,28 @@ class BaseCard {
     }
 
     moveTo(targetLocation) {
-        if(LocationsWithEventHandling.includes(targetLocation) && !LocationsWithEventHandling.includes(this.location)) {
+        let originalLocation = this.location;
+
+        this.location = targetLocation;
+
+        if(LocationsWithEventHandling.includes(targetLocation) && !LocationsWithEventHandling.includes(originalLocation)) {
             this.events.register(this.eventsForRegistration);
-        } else if(LocationsWithEventHandling.includes(this.location) && !LocationsWithEventHandling.includes(targetLocation)) {
+        } else if(LocationsWithEventHandling.includes(originalLocation) && !LocationsWithEventHandling.includes(targetLocation)) {
             this.events.unregisterAll();
         }
 
         _.each(this.abilities.actions, action => {
-            if(action.isEventListeningLocation(targetLocation) && !action.isEventListeningLocation(this.location)) {
+            if(action.isEventListeningLocation(targetLocation) && !action.isEventListeningLocation(originalLocation)) {
                 action.registerEvents();
-            } else if(action.isEventListeningLocation(this.location) && !action.isEventListeningLocation(targetLocation)) {
+            } else if(action.isEventListeningLocation(originalLocation) && !action.isEventListeningLocation(targetLocation)) {
                 action.unregisterEvents();
             }
         });
         _.each(this.abilities.reactions, reaction => {
-            if(reaction.isEventListeningLocation(targetLocation) && !reaction.isEventListeningLocation(this.location)) {
+            if(reaction.isEventListeningLocation(targetLocation) && !reaction.isEventListeningLocation(originalLocation)) {
                 reaction.registerEvents();
-            } else if(reaction.isEventListeningLocation(this.location) && !reaction.isEventListeningLocation(targetLocation)) {
+                this.game.registerAbility(reaction);
+            } else if(reaction.isEventListeningLocation(originalLocation) && !reaction.isEventListeningLocation(targetLocation)) {
                 reaction.unregisterEvents();
             }
         });
@@ -310,8 +315,6 @@ class BaseCard {
         if(targetLocation !== 'play area') {
             this.facedown = false;
         }
-
-        this.location = targetLocation;
     }
 
     canPlay() {

--- a/server/game/forcedtriggeredability.js
+++ b/server/game/forcedtriggeredability.js
@@ -32,10 +32,6 @@ class ForcedTriggeredAbility extends TriggeredAbility {
         return true;
     }
 
-    executeReaction(context) {
-        this.game.registerAbility(this, context);
-    }
-
     executeHandler(context) {
         if(this.handler(context) !== false && this.limit) {
             this.limit.increment();

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -600,14 +600,17 @@ class Game extends EventEmitter {
         this.queueSimpleStep(() => this.abilityWindowStack.pop());
     }
 
-    registerAbility(ability, context) {
-        var currentReaction = _.last(this.abilityWindowStack);
+    registerAbility(ability) {
+        let windowIndex = _.findLastIndex(this.abilityWindowStack, window => ability.isTriggeredByEvent(window.event));
 
-        if(!currentReaction) {
-            return false;
+        if(windowIndex === -1) {
+            return;
         }
 
-        currentReaction.registerAbility(ability, context);
+        let window = this.abilityWindowStack[windowIndex];
+        let context = ability.createContext(window.event);
+
+        window.registerAbility(ability, context);
     }
 
     raiseEvent(eventName, ...params) {

--- a/server/game/gamesteps/triggeredabilitywindow.js
+++ b/server/game/gamesteps/triggeredabilitywindow.js
@@ -88,7 +88,10 @@ class TriggeredAbilityWindow extends BaseStep {
 
         this.abilityChoices = _.reject(this.abilityChoices, ability => ability.card === choice.card);
 
-        this.players = this.filterChoicelessPlayers(this.rotatedPlayerOrder(player));
+        // Always rotate player order without filtering, in case an ability is
+        // triggered that could then make another ability eligible after it is
+        // resolved: e.g. Rains of Castamere into Wardens of the West
+        this.players = this.rotatedPlayerOrder(player);
 
         return true;
     }

--- a/server/game/promptedtriggeredability.js
+++ b/server/game/promptedtriggeredability.js
@@ -59,10 +59,6 @@ class PromptedTriggeredAbility extends TriggeredAbility {
         });
     }
 
-    executeReaction(context) {
-        this.game.registerAbility(this, context);
-    }
-
     executeHandler(context) {
         var handler = this.choices[context.choice];
 

--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -48,13 +48,25 @@ class TriggeredAbility extends BaseAbility {
     }
 
     eventHandler(event) {
-        var context = new TriggeredAbilityContext(event, this.game, this.card);
-
-        if(!this.meetsRequirements(context)) {
+        if(!this.isTriggeredByEvent(event)) {
             return;
         }
 
-        this.executeReaction(context);
+        this.game.registerAbility(this);
+    }
+
+    createContext(event) {
+        return new TriggeredAbilityContext(event, this.game, this.card);
+    }
+
+    isTriggeredByEvent(event) {
+        let listener = this.when[event.name];
+
+        if(!listener) {
+            return false;
+        }
+
+        return listener(...event.params);
     }
 
     meetsRequirements(context) {
@@ -76,7 +88,7 @@ class TriggeredAbility extends BaseAbility {
             return false;
         }
 
-        if(!this.when[context.event.name](...context.event.params)) {
+        if(!this.isTriggeredByEvent(context.event)) {
             return false;
         }
 
@@ -93,9 +105,6 @@ class TriggeredAbility extends BaseAbility {
         }
 
         return true;
-    }
-
-    executeReaction() {
     }
 
     isEventListeningLocation(location) {

--- a/test/server/card/cardforcedreaction.spec.js
+++ b/test/server/card/cardforcedreaction.spec.js
@@ -39,28 +39,6 @@ describe('CardForcedReaction', function () {
             expect(this.properties.when.onSomething).toHaveBeenCalledWith(this.event, 1, 2, 3);
         });
 
-        describe('when in the setup phase', function() {
-            beforeEach(function() {
-                this.gameSpy.currentPhase = 'setup';
-                this.executeEventHandler(1, 2, 3);
-            });
-
-            it('should not register the ability', function() {
-                expect(this.gameSpy.registerAbility).not.toHaveBeenCalled();
-            });
-        });
-
-        describe('when the card has been blanked', function() {
-            beforeEach(function() {
-                this.cardSpy.isBlank.and.returnValue(true);
-                this.executeEventHandler(1, 2, 3);
-            });
-
-            it('should not register the ability', function() {
-                expect(this.gameSpy.registerAbility).not.toHaveBeenCalled();
-            });
-        });
-
         describe('when the when condition returns false', function() {
             beforeEach(function() {
                 this.properties.when.onSomething.and.returnValue(false);
@@ -72,14 +50,70 @@ describe('CardForcedReaction', function () {
             });
         });
 
-        describe('when the card is not in the proper location', function() {
+        describe('when the when condition returns true', function() {
             beforeEach(function() {
-                this.cardSpy.location = 'foo';
+                this.properties.when.onSomething.and.returnValue(true);
                 this.executeEventHandler(1, 2, 3);
             });
 
-            it('should not register the ability', function() {
-                expect(this.gameSpy.registerAbility).not.toHaveBeenCalled();
+            it('should register the ability', function() {
+                expect(this.gameSpy.registerAbility).toHaveBeenCalledWith(this.reaction);
+            });
+        });
+    });
+
+    describe('meetsRequirements()', function() {
+        beforeEach(function() {
+            this.meetsRequirements = () => {
+                this.event = new Event('onSomething', [1, 2, 3]);
+                this.reaction = new CardForcedReaction(this.gameSpy, this.cardSpy, this.properties);
+                this.context = this.reaction.createContext(this.event);
+                return this.reaction.meetsRequirements(this.context);
+            };
+        });
+
+        it('should call the when handler with the appropriate arguments', function() {
+            this.meetsRequirements();
+            expect(this.properties.when.onSomething).toHaveBeenCalledWith(this.event, 1, 2, 3);
+        });
+
+        describe('when in the setup phase', function() {
+            beforeEach(function() {
+                this.gameSpy.currentPhase = 'setup';
+            });
+
+            it('should return false', function() {
+                expect(this.meetsRequirements()).toBe(false);
+            });
+        });
+
+        describe('when the card has been blanked', function() {
+            beforeEach(function() {
+                this.cardSpy.isBlank.and.returnValue(true);
+            });
+
+            it('should return false', function() {
+                expect(this.meetsRequirements()).toBe(false);
+            });
+        });
+
+        describe('when the when condition returns false', function() {
+            beforeEach(function() {
+                this.properties.when.onSomething.and.returnValue(false);
+            });
+
+            it('should return false', function() {
+                expect(this.meetsRequirements()).toBe(false);
+            });
+        });
+
+        describe('when the card is not in the proper location', function() {
+            beforeEach(function() {
+                this.cardSpy.location = 'foo';
+            });
+
+            it('should return false', function() {
+                expect(this.meetsRequirements()).toBe(false);
             });
         });
 
@@ -91,22 +125,20 @@ describe('CardForcedReaction', function () {
             describe('and the limit has been reached', function() {
                 beforeEach(function() {
                     this.limitSpy.isAtMax.and.returnValue(true);
-                    this.executeEventHandler(1, 2, 3);
                 });
 
-                it('should not register the ability', function() {
-                    expect(this.gameSpy.registerAbility).not.toHaveBeenCalled();
+                it('should return false', function() {
+                    expect(this.meetsRequirements()).toBe(false);
                 });
             });
 
             describe('and the limit has not been reached', function() {
                 beforeEach(function() {
                     this.limitSpy.isAtMax.and.returnValue(false);
-                    this.executeEventHandler(1, 2, 3);
                 });
 
-                it('should register the ability', function() {
-                    expect(this.gameSpy.registerAbility).toHaveBeenCalledWith(this.reaction, jasmine.any(Object));
+                it('should return true', function() {
+                    expect(this.meetsRequirements()).toBe(true);
                 });
             });
         });

--- a/test/server/card/cardreaction.spec.js
+++ b/test/server/card/cardreaction.spec.js
@@ -72,28 +72,6 @@ describe('CardReaction', function () {
             expect(this.properties.when.onSomething).toHaveBeenCalledWith(this.event, 1, 2, 3);
         });
 
-        describe('when in the setup phase', function() {
-            beforeEach(function() {
-                this.gameSpy.currentPhase = 'setup';
-                this.executeEventHandler(1, 2, 3);
-            });
-
-            it('should not register the ability', function() {
-                expect(this.gameSpy.registerAbility).not.toHaveBeenCalled();
-            });
-        });
-
-        describe('when the card has been blanked', function() {
-            beforeEach(function() {
-                this.cardSpy.isBlank.and.returnValue(true);
-                this.executeEventHandler(1, 2, 3);
-            });
-
-            it('should not register the ability', function() {
-                expect(this.gameSpy.registerAbility).not.toHaveBeenCalled();
-            });
-        });
-
         describe('when the when condition returns false', function() {
             beforeEach(function() {
                 this.properties.when.onSomething.and.returnValue(false);
@@ -105,14 +83,70 @@ describe('CardReaction', function () {
             });
         });
 
-        describe('when the card is not in the proper location', function() {
+        describe('when the when condition returns true', function() {
             beforeEach(function() {
-                this.cardSpy.location = 'foo';
+                this.properties.when.onSomething.and.returnValue(true);
                 this.executeEventHandler(1, 2, 3);
             });
 
-            it('should not register the ability', function() {
-                expect(this.gameSpy.registerAbility).not.toHaveBeenCalled();
+            it('should register the ability', function() {
+                expect(this.gameSpy.registerAbility).toHaveBeenCalledWith(this.reaction);
+            });
+        });
+    });
+
+    describe('meetsRequirements()', function() {
+        beforeEach(function() {
+            this.meetsRequirements = () => {
+                this.event = new Event('onSomething', [1, 2, 3]);
+                this.reaction = new CardReaction(this.gameSpy, this.cardSpy, this.properties);
+                this.context = this.reaction.createContext(this.event);
+                return this.reaction.meetsRequirements(this.context);
+            };
+        });
+
+        it('should call the when handler with the appropriate arguments', function() {
+            this.meetsRequirements();
+            expect(this.properties.when.onSomething).toHaveBeenCalledWith(this.event, 1, 2, 3);
+        });
+
+        describe('when in the setup phase', function() {
+            beforeEach(function() {
+                this.gameSpy.currentPhase = 'setup';
+            });
+
+            it('should return false', function() {
+                expect(this.meetsRequirements()).toBe(false);
+            });
+        });
+
+        describe('when the card has been blanked', function() {
+            beforeEach(function() {
+                this.cardSpy.isBlank.and.returnValue(true);
+            });
+
+            it('should return false', function() {
+                expect(this.meetsRequirements()).toBe(false);
+            });
+        });
+
+        describe('when the when condition returns false', function() {
+            beforeEach(function() {
+                this.properties.when.onSomething.and.returnValue(false);
+            });
+
+            it('should return false', function() {
+                expect(this.meetsRequirements()).toBe(false);
+            });
+        });
+
+        describe('when the card is not in the proper location', function() {
+            beforeEach(function() {
+                this.cardSpy.location = 'foo';
+            });
+
+            it('should return false', function() {
+                expect(this.meetsRequirements()).toBe(false);
             });
         });
 
@@ -124,22 +158,20 @@ describe('CardReaction', function () {
             describe('and the limit has been reached', function() {
                 beforeEach(function() {
                     this.limitSpy.isAtMax.and.returnValue(true);
-                    this.executeEventHandler(1, 2, 3);
                 });
 
-                it('should not register the ability', function() {
-                    expect(this.gameSpy.registerAbility).not.toHaveBeenCalled();
+                it('should return false', function() {
+                    expect(this.meetsRequirements()).toBe(false);
                 });
             });
 
             describe('and the limit has not been reached', function() {
                 beforeEach(function() {
                     this.limitSpy.isAtMax.and.returnValue(false);
-                    this.executeEventHandler(1, 2, 3);
                 });
 
-                it('should register the ability', function() {
-                    expect(this.gameSpy.registerAbility).toHaveBeenCalledWith(this.reaction, jasmine.any(Object));
+                it('should return true', function() {
+                    expect(this.meetsRequirements()).toBe(true);
                 });
             });
         });
@@ -153,22 +185,20 @@ describe('CardReaction', function () {
             describe('and the cost can be paid', function() {
                 beforeEach(function() {
                     this.cost.canPay.and.returnValue(true);
-                    this.executeEventHandler(1, 2, 3);
                 });
 
-                it('should register the ability', function() {
-                    expect(this.gameSpy.registerAbility).toHaveBeenCalledWith(this.reaction, jasmine.any(Object));
+                it('should return true', function() {
+                    expect(this.meetsRequirements()).toBe(true);
                 });
             });
 
             describe('and the cost cannot be paid', function() {
                 beforeEach(function() {
                     this.cost.canPay.and.returnValue(false);
-                    this.executeEventHandler(1, 2, 3);
                 });
 
-                it('should not register the ability', function() {
-                    expect(this.gameSpy.registerAbility).not.toHaveBeenCalled();
+                it('should return false', function() {
+                    expect(this.meetsRequirements()).toBe(false);
                 });
             });
         });

--- a/test/server/cards/agendas/05045-therainsofcastamere.spec.js
+++ b/test/server/cards/agendas/05045-therainsofcastamere.spec.js
@@ -1,4 +1,4 @@
-/* global describe, it, expect, beforeEach, jasmine */
+/* global describe, it, expect, beforeEach, jasmine, integration */
 /* eslint camelcase: 0, no-invalid-this: 0 */
 
 const _ = require('underscore');
@@ -152,8 +152,8 @@ describe('The Rains of Castamere', function() {
             });
 
             it('should register the ability', function() {
-                this.reaction.executeReaction({});
-                expect(this.gameSpy.registerAbility).toHaveBeenCalledWith(this.reaction, jasmine.any(Object));
+                this.reaction.eventHandler({ name: 'afterChallenge', params: [this.event, this.challenge] });
+                expect(this.gameSpy.registerAbility).toHaveBeenCalledWith(this.reaction);
             });
         });
     });
@@ -273,6 +273,53 @@ describe('The Rains of Castamere', function() {
                     expect(this.player.kneelCard).toHaveBeenCalledWith(this.player.faction);
                 });
             });
+        });
+    });
+
+    integration(function() {
+        beforeEach(function() {
+            const deck = this.buildDeck('lannister', [
+                '"The Rains of Castamere"',
+                'Trading with the Pentoshi', 'Wardens of the West',
+                'Cersei Lannister (LoCR)'
+            ]);
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.keepStartingHands();
+            this.player1.clickCard('Cersei Lannister', 'hand');
+            this.completeSetup();
+            this.player1.selectPlot('Trading with the Pentoshi');
+            this.player2.selectPlot('Trading with the Pentoshi');
+            this.selectFirstPlayer(this.player1);
+            this.selectPlotOrder(this.player1);
+            this.completeMarshalPhase();
+
+            this.player1.clickPrompt('Intrigue');
+            this.player1.clickCard('Cersei Lannister', 'play area');
+            this.player1.clickPrompt('Done');
+
+            this.skipActionWindow();
+
+            this.player2.clickPrompt('Done');
+
+            this.skipActionWindow();
+
+            this.wardens = this.player1.findCardByName('Wardens of the West');
+
+            this.player1.clickPrompt('"The Rains of Castamere"');
+        });
+
+        it('should allow a scheme to be played', function() {
+            this.player1.clickPrompt('Wardens of the West');
+
+            expect(this.player1Object.activePlot).toBe(this.wardens);
+        });
+
+        it('should allow reactions in the current reaction window to trigger', function() {
+            this.player1.clickPrompt('Wardens of the West');
+
+            expect(this.player1).toHavePromptButton('Wardens of the West');
         });
     });
 });

--- a/test/server/integration/nestedabilitysequences.spec.js
+++ b/test/server/integration/nestedabilitysequences.spec.js
@@ -3,124 +3,173 @@
 
 describe('nested ability sequences', function() {
     integration(function() {
-        beforeEach(function() {
-            const deck = this.buildDeck('stark', [
-                'Trading with the Pentoshi',
-                'Robb Stark (Core)', 'Arya Stark (WotN)', 'Catelyn Stark (WotN)', 'Winterfell Steward', 'Winterfell Steward'
-            ]);
-            this.player1.selectDeck(deck);
-            this.player2.selectDeck(deck);
-            this.startGame();
-            this.keepStartingHands();
-
-            this.robb = this.player1.findCardByName('Robb Stark (Core)', 'hand');
-            this.arya = this.player1.findCardByName('Arya Stark (WotN)', 'hand');
-            this.cat = this.player1.findCardByName('Catelyn Stark (WotN)', 'hand');
-            [this.steward1, this.steward2] = this.player1.filterCardsByName('Winterfell Steward', 'hand');
-
-            this.enemyRobb = this.player2.findCardByName('Robb Stark (Core)', 'hand');
-
-            this.player1.clickCard(this.robb);
-            this.player1.clickCard(this.steward1);
-            this.player1.clickCard(this.steward2);
-            this.player2.clickCard(this.enemyRobb);
-
-            this.completeSetup();
-
-            this.player1.selectPlot('Trading with the Pentoshi');
-            this.player2.selectPlot('Trading with the Pentoshi');
-            this.selectFirstPlayer(this.player1);
-
-            // Resolve plot order
-            this.selectPlotOrder(this.player1);
-
-            this.player1.clickCard(this.steward1);
-            this.player1.clickCard(this.steward2);
-            this.player1.clickCard(this.arya);
-            this.player1.clickCard(this.cat);
-            this.completeMarshalPhase();
-
-            this.player1.clickPrompt('Done');
-
-            // Initiate a military challenge vs player 1
-            this.player2.clickPrompt('Military');
-            this.player2.clickCard(this.enemyRobb);
-            this.player2.clickPrompt('Done');
-            this.skipActionWindow();
-
-            this.player1.clickCard(this.robb);
-            this.player1.clickPrompt('Done');
-            this.skipActionWindow();
-
-            this.skipActionWindow();
-
-            this.player2.clickPrompt('Apply Claim');
-
-            // kill someone
-            this.player1.clickCard(this.steward2);
-        });
-
-        it('should prompt with all available reactions', function() {
-            expect(this.player1).toHavePromptButton('Robb Stark');
-            expect(this.player1).toHavePromptButton('Arya Stark');
-            expect(this.player1).toHavePromptButton('Catelyn Stark');
-        });
-
-        describe('when an ability triggers a new ability window', function() {
+        describe('abilities already in play', function() {
             beforeEach(function() {
-                // Arya Stark sacrifices herself, prompt to trigger
-                this.player1.clickPrompt('Arya Stark');
-            });
+                const deck = this.buildDeck('stark', [
+                    'Trading with the Pentoshi',
+                    'Robb Stark (Core)', 'Arya Stark (WotN)', 'Catelyn Stark (WotN)', 'Winterfell Steward', 'Winterfell Steward'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
 
-            it('should prompt again with eligible cards', function() {
-                expect(this.player1).toHavePromptButton('Robb Stark');
-                expect(this.player1).toHavePromptButton('Catelyn Stark');
-                expect(this.player1).not.toHavePromptButton('Arya Stark');
-            });
+                this.robb = this.player1.findCardByName('Robb Stark (Core)', 'hand');
+                this.arya = this.player1.findCardByName('Arya Stark (WotN)', 'hand');
+                this.cat = this.player1.findCardByName('Catelyn Stark (WotN)', 'hand');
+                [this.steward1, this.steward2] = this.player1.filterCardsByName('Winterfell Steward', 'hand');
 
-            it('should resolve the current trigger before continuing', function() {
-                this.player1.clickPrompt('Catelyn Stark');
+                this.enemyRobb = this.player2.findCardByName('Robb Stark (Core)', 'hand');
 
-                expect(this.cat.power).toBe(1);
-                expect(this.player1).toHavePromptButton('Robb Stark');
-                expect(this.player1).not.toHavePromptButton('Catelyn Stark');
-                expect(this.player1).not.toHavePromptButton('Arya Stark');
-            });
+                this.player1.clickCard(this.robb);
+                this.player1.clickCard(this.steward1);
+                this.player1.clickCard(this.steward2);
+                this.player2.clickCard(this.enemyRobb);
 
-            it('should continue with the previous reaction window once the current trigger is resolved', function() {
-                this.player1.clickPrompt('Catelyn Stark');
-                this.player1.clickPrompt('Pass');
+                this.completeSetup();
 
-                expect(this.player1).toHavePrompt('Select a character');
+                this.player1.selectPlot('Trading with the Pentoshi');
+                this.player2.selectPlot('Trading with the Pentoshi');
+                this.selectFirstPlayer(this.player1);
+
+                // Resolve plot order
+                this.selectPlotOrder(this.player1);
+
+                this.player1.clickCard(this.steward1);
+                this.player1.clickCard(this.steward2);
+                this.player1.clickCard(this.arya);
+                this.player1.clickCard(this.cat);
+                this.completeMarshalPhase();
+
                 this.player1.clickPrompt('Done');
 
-                expect(this.player1).toHavePromptButton('Robb Stark');
-                expect(this.player1).toHavePromptButton('Catelyn Stark');
-                expect(this.player1).not.toHavePromptButton('Arya Stark');
+                // Initiate a military challenge vs player 1
+                this.player2.clickPrompt('Military');
+                this.player2.clickCard(this.enemyRobb);
+                this.player2.clickPrompt('Done');
+                this.skipActionWindow();
+
+                this.player1.clickCard(this.robb);
+                this.player1.clickPrompt('Done');
+                this.skipActionWindow();
+
+                this.skipActionWindow();
+
+                this.player2.clickPrompt('Apply Claim');
+
+                // kill someone
+                this.player1.clickCard(this.steward2);
             });
 
-            it('should not allow abilities to trigger past their limit upon rewinding', function() {
-                // Gain power for Catelyn from Arya sacrifice (1)
-                this.player1.clickPrompt('Catelyn Stark');
-                this.player1.clickPrompt('Pass');
-
-                // Kill the other steward using Arya
-                expect(this.player1).toHavePrompt('Select a character');
-                this.player1.clickCard(this.steward1);
-
-                // Gain power for Catelyn from Steward #2 kill (2)
-                this.player1.clickPrompt('Catelyn Stark');
-                this.player1.clickPrompt('Pass');
-
-                // Even though Catelyn original was able to trigger from the
-                // killing of Steward #1, she has reached her ability limit and
-                // is no longer eligible.
-                expect(this.cat.power).toBe(2);
-                expect(this.player1).not.toHavePromptButton('Catelyn Stark');
-
-                // Robb Stark is still eligible though.
+            it('should prompt with all available reactions', function() {
                 expect(this.player1).toHavePromptButton('Robb Stark');
-                expect(this.player1).not.toHavePromptButton('Arya Stark');
+                expect(this.player1).toHavePromptButton('Arya Stark');
+                expect(this.player1).toHavePromptButton('Catelyn Stark');
+            });
+
+            describe('when an ability triggers a new ability window', function() {
+                beforeEach(function() {
+                    // Arya Stark sacrifices herself, prompt to trigger
+                    this.player1.clickPrompt('Arya Stark');
+                });
+
+                it('should prompt again with eligible cards', function() {
+                    expect(this.player1).toHavePromptButton('Robb Stark');
+                    expect(this.player1).toHavePromptButton('Catelyn Stark');
+                    expect(this.player1).not.toHavePromptButton('Arya Stark');
+                });
+
+                it('should resolve the current trigger before continuing', function() {
+                    this.player1.clickPrompt('Catelyn Stark');
+
+                    expect(this.cat.power).toBe(1);
+                    expect(this.player1).toHavePromptButton('Robb Stark');
+                    expect(this.player1).not.toHavePromptButton('Catelyn Stark');
+                    expect(this.player1).not.toHavePromptButton('Arya Stark');
+                });
+
+                it('should continue with the previous reaction window once the current trigger is resolved', function() {
+                    this.player1.clickPrompt('Catelyn Stark');
+                    this.player1.clickPrompt('Pass');
+
+                    expect(this.player1).toHavePrompt('Select a character');
+                    this.player1.clickPrompt('Done');
+
+                    expect(this.player1).toHavePromptButton('Robb Stark');
+                    expect(this.player1).toHavePromptButton('Catelyn Stark');
+                    expect(this.player1).not.toHavePromptButton('Arya Stark');
+                });
+
+                it('should not allow abilities to trigger past their limit upon rewinding', function() {
+                    // Gain power for Catelyn from Arya sacrifice (1)
+                    this.player1.clickPrompt('Catelyn Stark');
+                    this.player1.clickPrompt('Pass');
+
+                    // Kill the other steward using Arya
+                    expect(this.player1).toHavePrompt('Select a character');
+                    this.player1.clickCard(this.steward1);
+
+                    // Gain power for Catelyn from Steward #2 kill (2)
+                    this.player1.clickPrompt('Catelyn Stark');
+                    this.player1.clickPrompt('Pass');
+
+                    // Even though Catelyn original was able to trigger from the
+                    // killing of Steward #1, she has reached her ability limit and
+                    // is no longer eligible.
+                    expect(this.cat.power).toBe(2);
+                    expect(this.player1).not.toHavePromptButton('Catelyn Stark');
+
+                    // Robb Stark is still eligible though.
+                    expect(this.player1).toHavePromptButton('Robb Stark');
+                    expect(this.player1).not.toHavePromptButton('Arya Stark');
+                });
+            });
+        });
+
+        describe('when an eligible event is drawn mid-sequence', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('stark', [
+                    'A Song of Summer',
+                    'The Blackfish', 'Put to the Torch', 'Heart Tree Grove'
+                ]);
+
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.eventCard = this.player1.findCardByName('Put to the Torch', 'hand');
+                this.player1.clickCard('The Blackfish', 'hand');
+                this.player2.clickCard('Heart Tree Grove', 'hand');
+
+                this.completeSetup();
+
+                this.player1.selectPlot('A Song of Summer');
+                this.player2.selectPlot('A Song of Summer');
+                this.selectFirstPlayer(this.player1);
+
+                // Move the event to draw so that it can be drawn via The Blackfish.
+                this.player1Object.moveCard(this.eventCard, 'draw deck');
+
+                this.completeMarshalPhase();
+
+                this.player1.clickPrompt('Military');
+                this.player1.clickCard('The Blackfish', 'play area');
+                this.player1.clickPrompt('Done');
+
+                this.skipActionWindow();
+
+                this.player2.clickPrompt('Done');
+
+                this.skipActionWindow();
+
+                // Activate Blackfish to draw a card.
+                this.player1.clickPrompt('The Blackfish');
+            });
+
+            it('should prompt for the drawn card when eligible', function() {
+                expect(this.eventCard.location).toBe('hand');
+                expect(this.player1).toHavePromptButton('Put to the Torch');
             });
         });
     });


### PR DESCRIPTION
Previously, if an ability triggering brought a card into play or into
hand that should be playable, the new card wouldn't trigger because the
appropriate event listeners weren't bound when the original event
occurred. Now, when a card is moved to a location it would listen to
events, it registers its abilities with the Game object, which will add
the abilities to any prompts that are already open. This allows
interactions such as triggering Rains of Castamere to play Wardens of
the West, or allowing an event card drawn mid-reaction to be playable if
that ability window is still open.

Fixes #245.