### PR TITLE
Kneeling Winterfell is an effect, not a cost.

### DIFF
--- a/server/game/cards/locations/03/winterfell.js
+++ b/server/game/cards/locations/03/winterfell.js
@@ -9,10 +9,10 @@ class Winterfell extends DrawCard {
 
         this.reaction({
             when: {
-                onChallenge: () => true
+                onChallenge: () => !this.kneeled
             },
-            costs: ability.costs.kneelSelf(),
             handler: () => {
+                this.controller.kneelCard(this);
                 this.untilEndOfChallenge(ability => ({
                     targetType: 'player',
                     targetController: 'any',


### PR DESCRIPTION
Previously, Winterfell was not kneeling because the `cost` property was
typoed as `costs` (plural). However, in the case of Winterfell, kneeling
is not a cost for the ability; it is a pre-then effect. Thus, if
Winterfell is canceled through cards like Treachery, it will not kneel.
The implementation now reflects this.

Fixes #950.