### PR TITLE
Properly handle unique attachments on opponents.

### DIFF
--- a/server/game/player.js
+++ b/server/game/player.js
@@ -155,9 +155,12 @@ class Player extends Spectator {
             return undefined;
         }
 
-        return this.findCard(this.cardsInPlay, playCard => {
-            return playCard !== card && (playCard.code === card.code || playCard.name === card.name);
-        });
+        return this.allCards.find(playCard => (
+            playCard.location === 'play area' &&
+            playCard !== card &&
+            (playCard.code === card.code || playCard.name === card.name) &&
+            playCard.owner === this
+        ));
     }
 
     getNumberOfChallengesWon(challengeType) {

--- a/test/server/integration/marshalphase.spec.js
+++ b/test/server/integration/marshalphase.spec.js
@@ -156,5 +156,64 @@ describe('marshal phase', function() {
                 });
             });
         });
+
+        describe('when unique attachments are marshalled on opponent cards', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('targaryen', [
+                    'Trading with the Pentoshi',
+                    'Crown of Gold', 'Crown of Gold', 'Khal Drogo'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.player1Character = this.player1.findCardByName('Khal Drogo', 'hand');
+                [this.player1Crown, this.player1CrownDupe] = this.player1.filterCardsByName('Crown of Gold', 'hand');
+                this.player2Character = this.player2.findCardByName('Khal Drogo', 'hand');
+                this.player2Crown = this.player2.findCardByName('Crown of Gold', 'hand');
+
+                this.player1.clickCard(this.player1Character);
+                this.player2.clickCard(this.player2Character);
+
+                this.completeSetup();
+
+                this.player1.selectPlot('Trading with the Pentoshi');
+                this.player2.selectPlot('Trading with the Pentoshi');
+                this.selectFirstPlayer(this.player1);
+                this.selectPlotOrder(this.player1);
+
+                // Player 1 marshals a Crown on player 2's character
+                this.player1.clickCard(this.player1Crown);
+                this.player1.clickCard(this.player2Character);
+
+                expect(this.player2Character.getStrength()).toBe(1);
+            });
+
+            it('should marshal a dupe automatically', function() {
+                this.player1.clickCard(this.player1CrownDupe);
+
+                expect(this.player1).not.toHavePrompt('Select target for attachment');
+                expect(this.player1Crown.dupes.pluck('uuid')).toContain(this.player1CrownDupe.uuid);
+            });
+
+            describe('when the opponent tries to marshal the same attachment', function() {
+                beforeEach(function() {
+                    this.player1.clickPrompt('Done');
+
+                    this.player2.clickCard(this.player2Crown);
+                });
+
+                it('should not marshal it as a duplicate for player 1\'s attachment', function() {
+                    expect(this.player1Crown.dupes.pluck('uuid')).not.toContain(this.player2Crown.uuid);
+                });
+
+                it('should allow it to be marshalled as normal', function() {
+                    this.player2.clickCard(this.player1Character);
+
+                    expect(this.player1Character.getStrength()).toBe(1);
+                });
+            });
+        });
     });
 });

--- a/test/server/player/getduplicateinplay.spec.js
+++ b/test/server/player/getduplicateinplay.spec.js
@@ -12,8 +12,9 @@ describe('Player', function() {
             this.player.initialise();
 
             this.dupeCard = new DrawCard(this.player, { code: '1', name: 'Test' });
+            this.dupeCard.location = 'play area';
 
-            this.player.cardsInPlay.push(this.dupeCard);
+            this.player.allCards.push(this.dupeCard);
 
             this.cardSpy = jasmine.createSpyObj('card', ['isUnique']);
 
@@ -23,6 +24,30 @@ describe('Player', function() {
         describe('when the card is not unique', function() {
             beforeEach(function() {
                 this.cardSpy.isUnique.and.returnValue(false);
+
+                this.dupe = this.player.getDuplicateInPlay(this.cardSpy);
+            });
+
+            it('should return undefined', function() {
+                expect(this.isDupe).toBeUndefined;
+            });
+        });
+
+        describe('when the other copy is not in play', function() {
+            beforeEach(function() {
+                this.dupeCard.location = 'hand';
+
+                this.dupe = this.player.getDuplicateInPlay(this.cardSpy);
+            });
+
+            it('should return undefined', function() {
+                expect(this.isDupe).toBeUndefined;
+            });
+        });
+
+        describe('when the other copy is not owned by the player', function() {
+            beforeEach(function() {
+                this.dupeCard.owner = {};
 
                 this.dupe = this.player.getDuplicateInPlay(this.cardSpy);
             });
@@ -61,6 +86,8 @@ describe('Player', function() {
         describe('when there is a matching attached card in play', function() {
             beforeEach(function() {
                 this.attachedCard = new DrawCard(this.player, { code: '3', name: 'Attached', type_code: 'attachment' });
+                this.attachedCard.location = 'play area';
+                this.player.allCards.push(this.attachedCard);
                 this.dupeCard.attachments.push(this.attachedCard);
 
                 this.cardSpy.code = '3';


### PR DESCRIPTION
Previously, if the opponent placed a unique attachment on one of your
cards and you attempted to play the same attachment, it would improperly
be placed as a duplicate on top of the opponent's copy. Additionally,
the opponent could place multiple copies of that attachment instead of
it automatically duplicating the original.

Fixes #967.