### PR TITLE
Remove permission prompts from reveal hand cards.

### DIFF
--- a/server/game/cards/characters/06/melisandre.js
+++ b/server/game/cards/characters/06/melisandre.js
@@ -8,38 +8,19 @@ class Melisandre extends DrawCard {
             },
             handler: () => {
                 let otherPlayer = this.game.getOtherPlayer(this.controller);
+                let buttons = otherPlayer.hand.map(card => {
+                    return { method: 'cardSelected', card: card };
+                });
 
-                this.game.promptWithMenu(otherPlayer, this, {
+                this.game.promptWithMenu(this.controller, this, {
                     activePrompt: {
-                        menuTitle: 'Resolve ' + this.name + ' and reveal hand to opponent?',
-                        buttons: [
-                            { text: 'Yes', method: 'revealHand' },
-                            { text: 'No', method: 'cancel' }
-                        ]
+                        menuTitle: 'Select a card to discard',
+                        buttons: buttons
                     },
                     source: this
                 });
             }
         });
-    }
-
-    revealHand() {
-        let otherPlayer = this.game.getOtherPlayer(this.controller);
-        let buttons = otherPlayer.hand.map(card => {
-            return { method: 'cardSelected', card: card };
-        });
-
-        buttons.push({ text: 'Cancel', method: 'cancel' });
-
-        this.game.promptWithMenu(this.controller, this, {
-            activePrompt: {
-                menuTitle: 'Select a card to discard',
-                buttons: buttons
-            },
-            source: this
-        });
-
-        return true;
     }
 
     cardSelected(player, cardId) {
@@ -58,15 +39,9 @@ class Melisandre extends DrawCard {
                 otherPlayer.moveCard(card, 'dead pile');
             }
 
-            this.game.addMessage('{0} uses {1} to discard {2} from {3}\'s hand{4}', 
+            this.game.addMessage('{0} uses {1} to discard {2} from {3}\'s hand{4}',
                                   player, this, card, otherPlayer, charMessage);
         });
-
-        return true;
-    }
-
-    cancel(player) {
-        this.game.addMessage('{0} cancels the resolution of {1}', player, this);
 
         return true;
     }

--- a/server/game/cards/events/01/seeninflames.js
+++ b/server/game/cards/events/01/seeninflames.js
@@ -15,13 +15,14 @@ class SeenInFlames extends DrawCard {
                     return;
                 }
 
-                this.game.promptWithMenu(otherPlayer, this, {
+                let buttons = otherPlayer.hand.map(card => {
+                    return { method: 'cardSelected', card: card };
+                });
+
+                this.game.promptWithMenu(this.controller, this, {
                     activePrompt: {
-                        menuTitle: 'Resolve ' + this.name + ' and reveal hand to opponent?',
-                        buttons: [
-                            { text: 'Yes', method: 'revealHand' },
-                            { text: 'No', method: 'cancel' }
-                        ]
+                        menuTitle: 'Select a card to discard',
+                        buttons: buttons
                     },
                     source: this
                 });
@@ -32,25 +33,6 @@ class SeenInFlames extends DrawCard {
     opponentHasCards() {
         let otherPlayer = this.game.getOtherPlayer(this.controller);
         return otherPlayer && !otherPlayer.hand.isEmpty();
-    }
-
-    revealHand() {
-        var otherPlayer = this.game.getOtherPlayer(this.controller);
-        var buttons = otherPlayer.hand.map(card => {
-            return { method: 'cardSelected', card: card };
-        });
-
-        buttons.push({ text: 'Cancel', method: 'cancel' });
-
-        this.game.promptWithMenu(this.controller, this, {
-            activePrompt: {
-                menuTitle: 'Select a card to discard',
-                buttons: buttons
-            },
-            source: this
-        });
-
-        return true;
     }
 
     cardSelected(player, cardId) {
@@ -67,12 +49,6 @@ class SeenInFlames extends DrawCard {
         otherPlayer.discardCard(card);
 
         this.game.addMessage('{0} uses {1} to discard {2} from {3}\'s hand', player, this, card, otherPlayer);
-
-        return true;
-    }
-
-    cancel(player) {
-        this.game.addMessage('{0} cancels the resolution of {1}', player, this);
 
         return true;
     }

--- a/server/game/cards/events/03/hisvipereyes.js
+++ b/server/game/cards/events/03/hisvipereyes.js
@@ -1,58 +1,32 @@
 const DrawCard = require('../../../drawcard.js');
 
 class HisViperEyes extends DrawCard {
-    canPlay(player, card) {
-        if(player !== this.controller || this !== card) {
-            return false;
-        }
-
-        if(!this.game.currentChallenge || this.game.currentChallenge.winner === this.controller ||
-                (this.game.currentChallenge.challengeType !== 'military' && this.game.currentChallenge.challengeType !== 'power')) {
-            return false;
-        }
-
-        return true;
-    }
-
-    play(player) {
-        if(this.controller !== player) {
-            return;
-        }
-
-        var otherPlayer = this.game.getOtherPlayer(player);
-        if(!otherPlayer) {
-            return;
-        }
-
-        this.game.promptWithMenu(otherPlayer, this, {
-            activePrompt: {
-                menuTitle: 'Resolve ' + this.name + ' and reveal hand to opponent?',
-                buttons: [
-                    { text: 'Yes', method: 'revealHand' },
-                    { text: 'No', method: 'cancel' }
-                ]
+    setupCardAbilities() {
+        this.reaction({
+            when: {
+                afterChallenge: (event, challenge) => (
+                    challenge.defendingPlayer === this.controller &&
+                    challenge.loser === this.controller &&
+                    ['military', 'power'].includes(challenge.challengeType) &&
+                    challenge.winner.hand.size() >= 1
+                )
             },
-            source: this
+            handler: () => {
+                let otherPlayer = this.game.currentChallenge.winner;
+
+                let buttons = otherPlayer.hand.map(card => {
+                    return { method: 'cardSelected', card: card };
+                });
+
+                this.game.promptWithMenu(this.controller, this, {
+                    activePrompt: {
+                        menuTitle: 'Select a card to discard',
+                        buttons: buttons
+                    },
+                    source: this
+                });
+            }
         });
-    }
-
-    revealHand() {
-        var otherPlayer = this.game.getOtherPlayer(this.controller);
-        var buttons = otherPlayer.hand.map(card => {
-            return { method: 'cardSelected', card: card };
-        });
-
-        buttons.push({ text: 'Cancel', method: 'cancel' });
-
-        this.game.promptWithMenu(this.controller, this, {
-            activePrompt: {
-                menuTitle: 'Select a card to discard',
-                buttons: buttons
-            },
-            source: this
-        });
-
-        return true;
     }
 
     cardSelected(player, cardId) {
@@ -69,12 +43,6 @@ class HisViperEyes extends DrawCard {
         otherPlayer.discardCard(card);
 
         this.game.addMessage('{0} uses {1} to discard {2} from {3}\'s hand', player, this, card, otherPlayer);
-
-        return true;
-    }
-
-    cancel(player) {
-        this.game.addMessage('{0} cancels the resolution of {1}', player, this);
 
         return true;
     }

--- a/test/server/integration/playingevents.spec.js
+++ b/test/server/integration/playingevents.spec.js
@@ -40,7 +40,6 @@ describe('playing events', function() {
                 this.player2.clickPrompt('Pass');
 
                 // Discard Hand's Judgment from the opponent's hand
-                this.player2.clickPrompt('Yes');
                 this.player1.clickPrompt('The Hand\'s Judgment');
             });
 


### PR DESCRIPTION
Now that cancel abilities are implemented, it is no longer necessary to
ask the opponent whether to reveal their hand or not - the cancel will
prompt before the reveal happens.