### PR TITLE
Only attackers can win unopposed.

### DIFF
--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -207,7 +207,7 @@ class Challenge {
     }
 
     isUnopposed() {
-        return this.loserStrength <= 0 && this.winnerStrength > 0;
+        return this.loserStrength <= 0 && this.winnerStrength > 0 && this.winner === this.attackingPlayer;
     }
 
     getClaim() {


### PR DESCRIPTION
Great Kraken and other abilities were triggering inappropriately when a
challenge was won with the attacker at 0 strength. Only challenges
ending with 0 defending strength count as unopposed, so the attacker
must be the winner.

Fixes #906.