### PR TITLE
Apply effects after the controller is set.

### DIFF
--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -55,8 +55,16 @@ class EffectEngine {
                 // the new controller from scratch.
                 effect.cancel();
                 effect.addTargets(this.getTargets());
+            } else if(effect.duration === 'persistent' && effect.hasTarget(card) && !effect.isValidTarget(card)) {
+                // Evict the card from any effects applied on it that are no
+                // longer valid under the new controller.
+                effect.removeTarget(card);
             }
         });
+
+        // Reapply all relevant persistent effects given the card's new
+        // controller.
+        this.addTargetForPersistentEffects(card, 'play area');
     }
 
     addTargetForPersistentEffects(card, targetLocation) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -480,13 +480,13 @@ class Player extends Spectator {
             let isSetupAttachment = playingType === 'setup' && card.getType() === 'attachment';
 
             card.facedown = this.game.currentPhase === 'setup';
-            if(!dupeCard && !isSetupAttachment) {
-                card.play(this, playingType === 'ambush');
-            }
-
             card.new = true;
             this.moveCard(card, 'play area', { isDupe: !!dupeCard });
             card.controller = this;
+
+            if(!dupeCard && !isSetupAttachment) {
+                card.play(this, playingType === 'ambush');
+            }
 
             if(this.game.currentPhase !== 'setup' && card.isBestow()) {
                 this.game.queueStep(new BestowPrompt(this.game, this, card));

--- a/test/server/integration/takecontrol.spec.js
+++ b/test/server/integration/takecontrol.spec.js
@@ -208,7 +208,7 @@ describe('take control', function() {
             beforeEach(function() {
                 const deck1 = this.buildDeck('greyjoy', [
                     'Trading with the Pentoshi',
-                    'Euron Crow\'s Eye (Core)', 'Maester Aemon (Core)', 'Sea Bitch'
+                    'Euron Crow\'s Eye (Core)', 'Maester Aemon (Core)', 'Sea Bitch', 'Ward'
                 ]);
                 const deck2 = this.buildDeck('thenightswatch', [
                     'Trading with the Pentoshi',
@@ -231,13 +231,13 @@ describe('take control', function() {
 
                 this.player1.selectPlot('Trading with the Pentoshi');
                 this.player2.selectPlot('Trading with the Pentoshi');
-
-                this.selectFirstPlayer(this.player1);
-                this.selectPlotOrder(this.player1);
             });
 
             describe('when it comes into play under control', function() {
                 beforeEach(function() {
+                    this.selectFirstPlayer(this.player1);
+                    this.selectPlotOrder(this.player1);
+
                     // Move The Wall back into draw deck for Euron's pillage.
                     this.wall.controller.moveCard(this.wall, 'draw deck');
 
@@ -280,6 +280,9 @@ describe('take control', function() {
 
             describe('when it transfers control', function() {
                 beforeEach(function() {
+                    this.selectFirstPlayer(this.player1);
+                    this.selectPlotOrder(this.player1);
+
                     this.seaBitch = this.player1.findCardByName('Sea Bitch', 'hand');
 
                     // Marshal cards
@@ -302,6 +305,27 @@ describe('take control', function() {
 
                 it('should apply the effect to the new controller', function() {
                     expect(this.aemon.getStrength()).toBe(3);
+                });
+
+                it('should unapply the effect from the old controller', function() {
+                    expect(this.steward.getStrength()).toBe(1);
+                });
+            });
+
+            describe('when control of effect-modified character is transfered', function() {
+                beforeEach(function() {
+                    this.selectFirstPlayer(this.player2);
+                    this.selectPlotOrder(this.player2);
+
+                    // Marshal cards
+                    this.player2.clickCard(this.wall);
+                    this.player2.clickPrompt('Done');
+                    this.player1.clickCard('Ward', 'hand');
+                    this.player1.clickCard(this.steward);
+
+                    expect(this.player1Object.cardsInPlay.pluck('uuid')).toContain(this.steward.uuid);
+                    expect(this.steward.controller.name).toBe(this.player1Object.name);
+                    expect(this.steward.location).toBe('play area');
                 });
 
                 it('should unapply the effect from the old controller', function() {

--- a/test/server/integration/takecontrol.spec.js
+++ b/test/server/integration/takecontrol.spec.js
@@ -203,5 +203,204 @@ describe('take control', function() {
                 expect(this.kingsroad.controller.name).toBe(this.player2Object.name);
             });
         });
+
+        describe('take control + persistent effects', function() {
+            beforeEach(function() {
+                const deck1 = this.buildDeck('greyjoy', [
+                    'Trading with the Pentoshi',
+                    'Euron Crow\'s Eye (Core)', 'Maester Aemon (Core)', 'Sea Bitch'
+                ]);
+                const deck2 = this.buildDeck('thenightswatch', [
+                    'Trading with the Pentoshi',
+                    'Steward at the Wall', 'The Wall'
+                ]);
+                this.player1.selectDeck(deck1);
+                this.player2.selectDeck(deck2);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.euron = this.player1.findCardByName('Euron Crow\'s Eye', 'hand');
+                this.aemon = this.player1.findCardByName('Maester Aemon', 'hand');
+                this.steward = this.player2.findCardByName('Steward at the Wall', 'hand');
+                this.wall = this.player2.findCardByName('The Wall', 'hand');
+
+                this.player1.clickCard(this.euron);
+                this.player2.clickCard(this.steward);
+
+                this.completeSetup();
+
+                this.player1.selectPlot('Trading with the Pentoshi');
+                this.player2.selectPlot('Trading with the Pentoshi');
+
+                this.selectFirstPlayer(this.player1);
+                this.selectPlotOrder(this.player1);
+            });
+
+            describe('when it comes into play under control', function() {
+                beforeEach(function() {
+                    // Move The Wall back into draw deck for Euron's pillage.
+                    this.wall.controller.moveCard(this.wall, 'draw deck');
+
+                    // Marshal cards
+                    this.player1.clickCard(this.aemon);
+                    this.player1.clickPrompt('Done');
+                    this.player2.clickPrompt('Done');
+
+                    // Challenges
+                    this.player1.clickPrompt('Power');
+                    this.player1.clickCard(this.euron);
+                    this.player1.clickPrompt('Done');
+
+                    this.skipActionWindow();
+
+                    this.player2.clickPrompt('Done');
+
+                    this.skipActionWindow();
+                    this.skipActionWindow();
+
+                    this.player1.clickPrompt('Apply Claim');
+
+                    // Use Euron to take control of the opponent Wall.
+                    this.player1.clickPrompt('Euron Crow\'s Eye');
+                    this.player1.clickCard(this.wall);
+
+                    expect(this.player1Object.cardsInPlay.pluck('uuid')).toContain(this.wall.uuid);
+                    expect(this.wall.controller.name).toBe(this.player1Object.name);
+                    expect(this.wall.location).toBe('play area');
+                });
+
+                it('should apply the effect to the new controller', function() {
+                    expect(this.aemon.getStrength()).toBe(3);
+                });
+
+                it('should not apply the effect to the old controller', function() {
+                    expect(this.steward.getStrength()).toBe(1);
+                });
+            });
+
+            describe('when it transfers control', function() {
+                beforeEach(function() {
+                    this.seaBitch = this.player1.findCardByName('Sea Bitch', 'hand');
+
+                    // Marshal cards
+                    this.player1.clickCard(this.aemon);
+                    this.player1.clickCard(this.seaBitch);
+                    this.player1.clickPrompt('Done');
+                    this.player2.clickCard(this.wall);
+                    this.player2.clickPrompt('Done');
+
+                    expect(this.steward.getStrength()).toBe(2);
+
+                    // Use Sea Bitch to take control of the opponent Wall.
+                    this.player1.clickMenu(this.seaBitch, 'Sacrifice this card');
+                    this.player1.clickCard(this.wall);
+
+                    expect(this.player1Object.cardsInPlay.pluck('uuid')).toContain(this.wall.uuid);
+                    expect(this.wall.controller.name).toBe(this.player1Object.name);
+                    expect(this.wall.location).toBe('play area');
+                });
+
+                it('should apply the effect to the new controller', function() {
+                    expect(this.aemon.getStrength()).toBe(3);
+                });
+
+                it('should unapply the effect from the old controller', function() {
+                    expect(this.steward.getStrength()).toBe(1);
+                });
+            });
+        });
+
+        describe('take control + abilities', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('greyjoy', [
+                    'Trading with the Pentoshi',
+                    'Euron Crow\'s Eye (Core)', 'Iron Mines', 'Hedge Knight'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.euron = this.player1.findCardByName('Euron Crow\'s Eye', 'hand');
+                this.mines = this.player2.findCardByName('Iron Mines', 'hand');
+
+                this.completeSetup();
+
+                this.player1.selectPlot('Trading with the Pentoshi');
+                this.player2.selectPlot('Trading with the Pentoshi');
+
+                this.selectFirstPlayer(this.player1);
+                this.selectPlotOrder(this.player1);
+
+                this.player2Object.moveCard(this.mines, 'draw deck');
+
+                this.player1.clickCard('Euron Crow\'s Eye', 'hand');
+                this.player1.clickCard('Hedge Knight', 'hand');
+                this.player1.clickPrompt('Done');
+                this.player2.clickCard('Hedge Knight', 'hand');
+                this.player2.clickPrompt('Done');
+
+                this.player1.clickPrompt('Power');
+                this.player1.clickCard(this.euron);
+                this.player1.clickPrompt('Done');
+
+                this.skipActionWindow();
+
+                this.player2.clickPrompt('Done');
+
+                this.skipActionWindow();
+                this.skipActionWindow();
+
+                this.player1.clickPrompt('Apply Claim');
+
+                // Use Euron to take control of the opponent Iron Mines.
+                this.player1.clickPrompt('Euron Crow\'s Eye');
+                this.player1.clickCard(this.mines);
+            });
+
+            it('should trigger for the current player', function() {
+                this.player1.clickPrompt('Done');
+
+                this.player2.clickPrompt('Military');
+                this.player2.clickCard('Hedge Knight', 'play area');
+                this.player2.clickPrompt('Done');
+
+                this.skipActionWindow();
+
+                this.player1.clickPrompt('Done');
+
+                this.skipActionWindow();
+                this.skipActionWindow();
+
+                this.player2.clickPrompt('Apply Claim');
+
+                this.player1.clickCard('Hedge Knight', 'play area');
+
+                this.player1.clickPrompt('Iron Mines');
+                this.player1.clickCard('Hedge Knight', 'play area');
+
+                expect(this.player1.findCardByName('Hedge Knight', 'play area')).toBeDefined();
+            });
+
+            it('should not trigger for the opponent', function() {
+                this.player1.clickPrompt('Military');
+                this.player1.clickCard('Hedge Knight', 'play area');
+                this.player1.clickPrompt('Done');
+
+                this.skipActionWindow();
+
+                this.player2.clickPrompt('Done');
+
+                this.skipActionWindow();
+                this.skipActionWindow();
+
+                this.player1.clickPrompt('Apply Claim');
+
+                this.player2.clickCard('Hedge Knight', 'play area');
+
+                expect(this.player1).not.toHavePromptButton('Iron Mines');
+                expect(this.player2).not.toHavePromptButton('Iron Mines');
+            });
+        });
     });
 });


### PR DESCRIPTION
Previously, if a card was put into play under another player's control
(e.g. through Euron's ability), effects were being applied before the
control change occurred. Thus, the effects would be applied to the
opponent and not the player taking control.

Fixes #711 
Fixes #845 
Fixes #906 
Fixes #924 