### PR TITLE
make all (non-location) attachments check target card is a character

### DIFF
--- a/server/game/cards/attachments/01/dawn.js
+++ b/server/game/cards/attachments/01/dawn.js
@@ -11,6 +11,14 @@ class Dawn extends DrawCard {
             effect: ability.effects.addKeyword('Intimidate')
         });
     }
+
+    canAttach(player, card) {
+        if(card.getType() !== 'character') {
+            return false;
+        }
+
+        return super.canAttach(player, card);
+    }
 }
 
 Dawn.code = '01115';

--- a/server/game/cards/attachments/01/littlebird.js
+++ b/server/game/cards/attachments/01/littlebird.js
@@ -6,6 +6,14 @@ class LittleBird extends DrawCard {
             effect: ability.effects.addIcon('intrigue')
         });
     }
+
+    canAttach(player, card) {
+        if(card.getType() !== 'character') {
+            return false;
+        }
+
+        return super.canAttach(player, card);
+    }
 }
 
 LittleBird.code = '01034';

--- a/server/game/cards/attachments/01/longclaw.js
+++ b/server/game/cards/attachments/01/longclaw.js
@@ -9,6 +9,14 @@ class Longclaw extends DrawCard {
             ]
         });
     }
+
+    canAttach(player, card) {
+        if(card.getType() !== 'character') {
+            return false;
+        }
+
+        return super.canAttach(player, card);
+    }
 }
 
 Longclaw.code = '01135';

--- a/server/game/cards/attachments/01/milkofthepoppy.js
+++ b/server/game/cards/attachments/01/milkofthepoppy.js
@@ -6,6 +6,14 @@ class MilkOfThePoppy extends DrawCard {
             effect: ability.effects.blank
         });
     }
+
+    canAttach(player, card) {
+        if(card.getType() !== 'character') {
+            return false;
+        }
+
+        return super.canAttach(player, card);
+    }
 }
 
 MilkOfThePoppy.code = '01035';

--- a/server/game/cards/attachments/01/noblelineage.js
+++ b/server/game/cards/attachments/01/noblelineage.js
@@ -6,6 +6,14 @@ class NobleLineage extends DrawCard {
             effect: ability.effects.addIcon('power')
         });
     }
+
+    canAttach(player, card) {
+        if(card.getType() !== 'character') {
+            return false;
+        }
+
+        return super.canAttach(player, card);
+    }
 }
 
 NobleLineage.code = '01036';

--- a/server/game/cards/attachments/01/syriostraining.js
+++ b/server/game/cards/attachments/01/syriostraining.js
@@ -6,6 +6,14 @@ class SyriosTraining extends DrawCard {
             effect: ability.effects.addIcon('military')
         });
     }
+
+    canAttach(player, card) {
+        if(card.getType() !== 'character') {
+            return false;
+        }
+
+        return super.canAttach(player, card);
+    }
 }
 
 SyriosTraining.code = '01037';

--- a/server/game/cards/attachments/01/widowswail.js
+++ b/server/game/cards/attachments/01/widowswail.js
@@ -10,6 +10,14 @@ class WidowsWail extends DrawCard {
             effect: ability.effects.addIcon('military')
         });
     }
+
+    canAttach(player, card) {
+        if(card.getType() !== 'character') {
+            return false;
+        }
+
+        return super.canAttach(player, card);
+    }
 }
 
 WidowsWail.code = '01096';

--- a/server/game/cards/attachments/02/attainted.js
+++ b/server/game/cards/attachments/02/attainted.js
@@ -6,6 +6,14 @@ class Attainted extends DrawCard {
             effect: ability.effects.removeIcon('intrigue')
         });
     }
+
+    canAttach(player, card) {
+        if(card.getType() !== 'character') {
+            return false;
+        }
+
+        return super.canAttach(player, card);
+    }
 }
 
 Attainted.code = '02055';

--- a/server/game/cards/attachments/02/condemned.js
+++ b/server/game/cards/attachments/02/condemned.js
@@ -6,6 +6,14 @@ class Condemned extends DrawCard {
             effect: ability.effects.removeIcon('power')
         });
     }
+
+    canAttach(player, card) {
+        if(card.getType() !== 'character') {
+            return false;
+        }
+
+        return super.canAttach(player, card);
+    }
 }
 
 Condemned.code = '02077';

--- a/server/game/cards/attachments/02/drownedgodsblessing.js
+++ b/server/game/cards/attachments/02/drownedgodsblessing.js
@@ -10,6 +10,14 @@ class DrownedGodsBlessing extends DrawCard {
             initiative: 1
         });
     }
+
+    canAttach(player, card) {
+        if(card.getType() !== 'character') {
+            return false;
+        }
+
+        return super.canAttach(player, card);
+    }
 }
 
 DrownedGodsBlessing.code = '02112';

--- a/server/game/cards/attachments/02/imprisoned.js
+++ b/server/game/cards/attachments/02/imprisoned.js
@@ -6,6 +6,14 @@ class Imprisoned extends DrawCard {
             effect: ability.effects.removeIcon('military')
         });
     }
+
+    canAttach(player, card) {
+        if(card.getType() !== 'character') {
+            return false;
+        }
+
+        return super.canAttach(player, card);
+    }
 }
 
 Imprisoned.code = '02116';

--- a/server/game/cards/attachments/02/kingrobertswarhammer.js
+++ b/server/game/cards/attachments/02/kingrobertswarhammer.js
@@ -41,6 +41,14 @@ class KingRobertsWarhammer extends DrawCard {
     cancelSelection(player) {
         this.game.addMessage('{0} cancels the resolution of {1}', player, this);
     }
+
+    canAttach(player, card) {
+        if(card.getType() !== 'character') {
+            return false;
+        }
+
+        return super.canAttach(player, card);
+    }
 }
 
 KingRobertsWarhammer.code = '02008';

--- a/server/game/cards/attachments/02/knighted.js
+++ b/server/game/cards/attachments/02/knighted.js
@@ -9,6 +9,14 @@ class Knighted extends DrawCard {
             ]
         });
     }
+
+    canAttach(player, card) {
+        if(card.getType() !== 'character') {
+            return false;
+        }
+
+        return super.canAttach(player, card);
+    }
 }
 
 Knighted.code = '02058';

--- a/server/game/cards/attachments/03/greendreams.js
+++ b/server/game/cards/attachments/03/greendreams.js
@@ -35,6 +35,14 @@ class GreenDreams extends DrawCard {
 
         return true;
     }
+
+    canAttach(player, card) {
+        if(card.getType() !== 'character') {
+            return false;
+        }
+
+        return super.canAttach(player, card);
+    }
 }
 
 GreenDreams.code = '03043';

--- a/server/game/cards/attachments/04/craven.js
+++ b/server/game/cards/attachments/04/craven.js
@@ -6,6 +6,14 @@ class Craven extends DrawCard {
             effect: ability.effects.cannotBeDeclaredAsAttacker()
         });
     }
+
+    canAttach(player, card) {
+        if(card.getType() !== 'character') {
+            return false;
+        }
+
+        return super.canAttach(player, card);
+    }
 }
 
 Craven.code = '04026';

--- a/server/game/cards/attachments/04/redgodsblessing.js
+++ b/server/game/cards/attachments/04/redgodsblessing.js
@@ -13,6 +13,14 @@ class RedGodsBlessing extends DrawCard {
     getNumberOfCardsWithRhllor() {
         return this.controller.getNumberOfCardsInPlay(c => c.hasTrait('R\'hllor') && c.getType() === 'character');
     }
+
+    canAttach(player, card) {
+        if(card.getType() !== 'character') {
+            return false;
+        }
+
+        return super.canAttach(player, card);
+    }
 }
 
 RedGodsBlessing.code = '04068';

--- a/server/game/cards/attachments/05/shieldoflannisport.js
+++ b/server/game/cards/attachments/05/shieldoflannisport.js
@@ -21,6 +21,14 @@ class ShieldOfLannisport extends DrawCard {
             card.getCost() >= 4
         ));
     }
+
+    canAttach(player, card) {
+        if(card.getType() !== 'character') {
+            return false;
+        }
+
+        return super.canAttach(player, card);
+    }
 }
 
 ShieldOfLannisport.code = '05020';

--- a/server/game/cards/attachments/06/marriagepact.js
+++ b/server/game/cards/attachments/06/marriagepact.js
@@ -23,6 +23,14 @@ class MarriagePact extends DrawCard {
             }
         });
     }
+
+    canAttach(player, card) {
+        if(card.getType() !== 'character') {
+            return false;
+        }
+
+        return super.canAttach(player, card);
+    }
 }
 
 MarriagePact.code = '06022';

--- a/server/game/cards/attachments/07/sworntothewatch.js
+++ b/server/game/cards/attachments/07/sworntothewatch.js
@@ -18,6 +18,14 @@ class SwornToTheWatch extends DrawCard {
             effect: ability.effects.addTrait('Builder')
         });
     }
+
+    canAttach(player, card) {
+        if(card.getType() !== 'character') {
+            return false;
+        }
+
+        return super.canAttach(player, card);
+    }
 }
 
 SwornToTheWatch.code = '07022';


### PR DESCRIPTION
This change should fix all other (current) instances of bugs like #970.