### PR TITLE
Convert Core Stannis to an effect.

### DIFF
--- a/server/game/cards/characters/01/stannisbaratheon.js
+++ b/server/game/cards/characters/01/stannisbaratheon.js
@@ -1,71 +1,12 @@
-const _ = require('underscore');
-
 const DrawCard = require('../../../drawcard.js');
 
 class StannisBaratheon extends DrawCard {
-    setupCardAbilities() {
-        // TODO: This is a hack, as Stannis' ability is a persistent effect, not
-        //       an interrupt.
-        this.forcedInterrupt({
-            when: {
-                onStandAllCards: () => true
-            },
-            handler: context => {
-                context.skipHandler();
-                this.selections = [];
-                this.remainingPlayers = this.game.getPlayersInFirstPlayerOrder();
-                this.proceedToNextStep();
-            }
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            targetType: 'player',
+            targetController: 'any',
+            effect: ability.effects.cannotStandMoreThan(2, card => card.getType() === 'character')
         });
-    }
-
-    onSelect(player, cards) {
-        this.selections.push({ player: player, cards: cards });
-        this.proceedToNextStep();
-        return true;
-    }
-
-    cancelSelection(player) {
-        this.selections.push({ player: player, cards: [] });
-        this.proceedToNextStep();
-    }
-
-    doStand() {
-        _.each(this.selections, selection => {
-            var player = selection.player;
-            var toStand = selection.cards;
-
-            _.each(toStand, card => {
-                card.controller.standCard(card);
-            });
-
-            if(_.isEmpty(toStand)) {
-                this.game.addMessage('{0} does not stand any characters with {1}', player, this);
-            } else {
-                this.game.addMessage('{0} uses {1} to stand {2}', player, this, toStand);
-            }
-
-            // Stand all non character cards
-            player.standCards(true);
-        });
-
-        this.selections = [];
-    }
-
-    proceedToNextStep() {
-        if(this.remainingPlayers.length > 0) {
-            var currentPlayer = this.remainingPlayers.shift();
-            this.game.promptForSelect(currentPlayer, {
-                numCards: 2,
-                activePromptTitle: 'Select up to 2 characters to stand',
-                source: this,
-                cardCondition: card => card.controller === currentPlayer && card.getType() === 'character',
-                onSelect: (player, cards) => this.onSelect(player, cards),
-                onCancel: (player) => this.cancelSelection(player)
-            });
-        } else {
-            this.doStand();
-        }
     }
 }
 

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -602,6 +602,17 @@ const Effects = {
             }
         };
     },
+    cannotStandMoreThan: function(max, match) {
+        let restriction = { max: max, match: match };
+        return {
+            apply: function(player) {
+                player.standPhaseRestrictions.push(restriction);
+            },
+            unapply: function(player) {
+                player.standPhaseRestrictions = _.reject(player.standPhaseRestrictions, r => r === restriction);
+            }
+        };
+    },
     reduceCost: function(properties) {
         return {
             apply: function(player, context) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -41,6 +41,7 @@ class Player extends Spectator {
         this.cannotGainChallengeBonus = false;
         this.cannotTriggerCardAbilities = false;
         this.abilityMaxByTitle = {};
+        this.standPhaseRestrictions = [];
         this.promptedActionWindows = user.promptedActionWindows || {
             plot: false,
             draw: false,
@@ -877,22 +878,6 @@ class Player extends Spectator {
         }, 0);
 
         return cardStrength + this.gold;
-    }
-
-    standCards(notCharacters = false) {
-        this.cardsInPlay.each(card => {
-            card.attachments.each(attachment => {
-                this.standCard(attachment);
-            });
-
-            if((notCharacters && card.getType() === 'character') || !card.standsDuringStanding) {
-                return;
-            }
-
-            this.standCard(card);
-        });
-
-        this.faction.kneeled = false;
     }
 
     taxation() {

--- a/test/server/cards/characters/01/01052-stannisbaratheon.spec.js
+++ b/test/server/cards/characters/01/01052-stannisbaratheon.spec.js
@@ -13,7 +13,6 @@ describe('Stannis Baratheon', function() {
             this.startGame();
             this.keepStartingHands();
 
-            // this.stannis = this.player1.findCardByName('Stannis Baratheon', 'hand');
             this.character1 = this.player1.findCardByName('Robert Baratheon', 'hand');
             this.character2 = this.player1.findCardByName('Dragonstone Faithful', 'hand');
             this.character3 = this.player1.findCardByName('Maester Cressen', 'hand');

--- a/test/server/cards/characters/01/01052-stannisbaratheon.spec.js
+++ b/test/server/cards/characters/01/01052-stannisbaratheon.spec.js
@@ -1,0 +1,105 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('Stannis Baratheon', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck = this.buildDeck('baratheon', [
+                'Trading with the Pentoshi',
+                'Stannis Baratheon (Core)', 'Robert Baratheon', 'Dragonstone Faithful', 'Maester Cressen', 'The Roseroad', 'Bodyguard'
+            ]);
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.keepStartingHands();
+
+            // this.stannis = this.player1.findCardByName('Stannis Baratheon', 'hand');
+            this.character1 = this.player1.findCardByName('Robert Baratheon', 'hand');
+            this.character2 = this.player1.findCardByName('Dragonstone Faithful', 'hand');
+            this.character3 = this.player1.findCardByName('Maester Cressen', 'hand');
+            this.attachment = this.player1.findCardByName('Bodyguard', 'hand');
+            this.location = this.player1.findCardByName('The Roseroad', 'hand');
+
+            this.player1.clickCard(this.character1);
+            this.player1.clickCard(this.attachment);
+            this.player1.clickCard(this.location);
+            this.player2.clickCard('Stannis Baratheon', 'hand');
+            this.completeSetup();
+
+            // Attach Bodyguard.
+            this.player1.clickCard(this.attachment);
+            this.player1.clickCard(this.character1);
+
+            this.player1.selectPlot('Trading with the Pentoshi');
+            this.player2.selectPlot('Trading with the Pentoshi');
+            this.selectFirstPlayer(this.player1);
+            this.selectPlotOrder(this.player1);
+
+            this.player1.clickCard(this.character2);
+            this.player1.clickCard(this.character3);
+
+            // Manually kneel everything
+            this.player1.clickCard(this.character1);
+            this.player1.clickCard(this.character2);
+            this.player1.clickCard(this.location);
+            this.player1.clickCard(this.attachment);
+        });
+
+        describe('when there are 2 or fewer characters are kneeling', function() {
+            beforeEach(function() {
+                this.player1.clickPrompt('Done');
+                this.player2.clickPrompt('Done');
+
+                this.completeChallengesPhase();
+            });
+
+            it('should automatically stand all characters', function() {
+                expect(this.character1.kneeled).toBe(false);
+                expect(this.character2.kneeled).toBe(false);
+                expect(this.location.kneeled).toBe(false);
+                expect(this.attachment.kneeled).toBe(false);
+            });
+        });
+
+        describe('when there are more than 2 characters kneeling', function() {
+            beforeEach(function() {
+                this.player1.clickCard(this.character3);
+
+                this.player1.clickPrompt('Done');
+                this.player2.clickPrompt('Done');
+
+                this.completeChallengesPhase();
+            });
+
+            it('should prompt to stand characters', function() {
+                expect(this.player1).toHavePrompt('Select 2 cards to stand');
+            });
+
+            it('should require 2 cards be selected', function() {
+                this.player1.clickCard(this.character1);
+                this.player1.clickPrompt('Done');
+
+                expect(this.player1).toHavePrompt('Select 2 cards to stand');
+            });
+
+            describe('when cards are selected', function() {
+                beforeEach(function() {
+                    this.player1.clickCard(this.character1);
+                    this.player1.clickCard(this.character3);
+                    this.player1.clickPrompt('Done');
+                });
+
+                it('should stand only selected characters', function() {
+                    expect(this.character1.kneeled).toBe(false);
+                    expect(this.character3.kneeled).toBe(false);
+                    expect(this.character2.kneeled).toBe(true);
+                });
+
+                it('should automatically stand non-characters', function() {
+                    expect(this.location.kneeled).toBe(false);
+                    expect(this.attachment.kneeled).toBe(false);
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Moves the logic for the stand phase off of player and into the
StandingPhase class. Core Stannis is now implemented by adding a
'standing phase restriction' to each player that filters out character
cards from automatically standing.

Additionally, the player is now required to select 2 cards to stand if
they have more than 2 cards. Previously it was implemented as 'up to 2
cards' but standing during the standing phase is mandatory.

Finally, if the player has less than the stand maximum, all cards will
be stood automatically with no player selection.