### PR TITLE
Implement Recruiter for the Watch

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -238,6 +238,15 @@ class BaseCard {
         this.game.addEffect(this, _.extend({ duration: 'untilEndOfRound' }, properties));
     }
 
+    /**
+     * Applies a lasting effect which lasts until an event contained in the
+     * `until` property for the effect has occurred.
+     */
+    lastingEffect(propertyFactory) {
+        let properties = propertyFactory(AbilityDsl);
+        this.game.addEffect(this, _.extend({ duration: 'custom' }, properties));
+    }
+
     doAction(player, arg) {
         var action = this.abilities.actions[arg];
 

--- a/server/game/cards/characters/06/recruiterforthewatch.js
+++ b/server/game/cards/characters/06/recruiterforthewatch.js
@@ -6,7 +6,26 @@ class RecruiterForTheWatch extends DrawCard {
             match: this,
             effect: ability.effects.optionalStandDuringStanding()
         });
-        // TODO: Marshaling action to take control.
+        this.action({
+            title: 'Take control of character',
+            phase: 'marshal',
+            cost: ability.costs.kneelSelf(),
+            target: {
+                activePromptTitle: 'Select character with printed cost 2 or less',
+                cardCondition: card => card.getType() === 'character' && card.controller !== this.controller && card.getCost(true) <= 2
+            },
+            handler: context => {
+                this.game.addMessage('{0} kneels {1} to take control of {2}', this.controller, this, context.target);
+                this.lastingEffect(ability => ({
+                    until: {
+                        onCardStood: (event, player, card) => card === this,
+                        onCardLeftPlay: event => event.card === this
+                    },
+                    match: context.target,
+                    effect: ability.effects.takeControl(this.controller)
+                }));
+            }
+        });
     }
 }
 

--- a/server/game/cards/characters/06/recruiterforthewatch.js
+++ b/server/game/cards/characters/06/recruiterforthewatch.js
@@ -1,0 +1,15 @@
+const DrawCard = require('../../../drawcard.js');
+
+class RecruiterForTheWatch extends DrawCard {
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            match: this,
+            effect: ability.effects.optionalStandDuringStanding()
+        });
+        // TODO: Marshaling action to take control.
+    }
+}
+
+RecruiterForTheWatch.code = '06045';
+
+module.exports = RecruiterForTheWatch;

--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -14,6 +14,12 @@ const PlayAreaLocations = ['play area', 'active plot'];
  *                    effect applied. Alternatively, a card can be passed as the
  *                    match property to match that single card.
  * duration         - string representing how long the effect lasts.
+ * until            - optional object to specify events that will cancel the
+ *                    effect when duration is 'custom'. The keys of the object
+ *                    represent event names that will be listened to and the
+ *                    corresponding values should be handler functions for those
+ *                    events that return true when the effect should be
+ *                    cancelled.
  * condition        - function that returns a boolean determining whether the
  *                    effect can be applied. Use with cards that have a
  *                    condition that must be met before applying a persistent
@@ -42,6 +48,7 @@ class Effect {
         this.source = source;
         this.match = properties.match || (() => true);
         this.duration = properties.duration;
+        this.until = properties.until || {};
         this.condition = properties.condition || (() => true);
         this.targetController = properties.targetController || 'current';
         this.targetType = properties.targetType || 'card';

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -422,6 +422,16 @@ const Effects = {
             }
         };
     },
+    optionalStandDuringStanding: function() {
+        return {
+            apply: function(card) {
+                card.optionalStandDuringStanding = true;
+            },
+            unapply: function(card) {
+                card.optionalStandDuringStanding = false;
+            }
+        };
+    },
     immuneTo: function(cardCondition) {
         let restriction = new ImmunityRestriction(cardCondition);
         return {

--- a/server/game/gamesteps/standingphase.js
+++ b/server/game/gamesteps/standingphase.js
@@ -29,14 +29,15 @@ class StandingPhase extends Phase {
             restrictedSubset.push({ max: restriction.max, cards: restrictedCards });
         });
         // Automatically stand non-restricted cards
-        let cardsToStand = kneelingCards;
+        let cardsToStand = { automatic: kneelingCards, selected: [] };
 
         _.each(restrictedSubset, restriction => {
             this.selectRestrictedCards(cardsToStand, player, restriction);
         });
         this.game.queueSimpleStep(() => {
+            let finalCards = _.flatten(_.values(cardsToStand));
             player.faction.kneeled = false;
-            _.each(cardsToStand, card => {
+            _.each(finalCards, card => {
                 player.standCard(card);
             });
         });
@@ -44,7 +45,7 @@ class StandingPhase extends Phase {
 
     selectRestrictedCards(cardsToStand, player, restriction) {
         if(restriction.cards.length <= restriction.max) {
-            _.each(restriction.cards, card => cardsToStand.push(card));
+            cardsToStand.automatic = cardsToStand.automatic.concat(restriction.cards);
             return;
         }
 
@@ -61,7 +62,7 @@ class StandingPhase extends Phase {
                     return false;
                 }
 
-                _.each(cards, card => cardsToStand.push(card));
+                cardsToStand.selected = cardsToStand.selected.concat(cards);
                 return true;
             }
         });

--- a/server/game/gamesteps/standingphase.js
+++ b/server/game/gamesteps/standingphase.js
@@ -35,6 +35,9 @@ class StandingPhase extends Phase {
             this.selectRestrictedCards(cardsToStand, player, restriction);
         });
         this.game.queueSimpleStep(() => {
+            this.selectOptionalCards(cardsToStand, player);
+        });
+        this.game.queueSimpleStep(() => {
             let finalCards = _.flatten(_.values(cardsToStand));
             player.faction.kneeled = false;
             _.each(finalCards, card => {
@@ -62,6 +65,27 @@ class StandingPhase extends Phase {
                     return false;
                 }
 
+                cardsToStand.selected = cardsToStand.selected.concat(cards);
+                return true;
+            }
+        });
+    }
+
+    selectOptionalCards(cardsToStand, player) {
+        let optionalStandCards = _.filter(cardsToStand.automatic, card => card.optionalStandDuringStanding);
+
+        if(optionalStandCards.length === 0) {
+            return;
+        }
+
+        cardsToStand.automatic = _.filter(cardsToStand.automatic, card => !card.optionalStandDuringStanding);
+
+        this.game.promptForSelect(player, {
+            numCards: 0,
+            multiSelect: true,
+            activePromptTitle: 'Select optional cards to stand',
+            cardCondition: card => optionalStandCards.includes(card),
+            onSelect: (player, cards) => {
                 cardsToStand.selected = cardsToStand.selected.concat(cards);
                 return true;
             }

--- a/test/server/cards/agendas/01027-fealty.spec.js
+++ b/test/server/cards/agendas/01027-fealty.spec.js
@@ -7,7 +7,7 @@ describe('Fealty', function() {
             const deck = this.buildDeck('greyjoy', [
                 'Fealty',
                 'Sneak Attack',
-                'Balon Greyjoy (Core)', 'Theon Greyjoy'
+                'Balon Greyjoy (Core)', 'Theon Greyjoy (Core)'
             ]);
             this.player1.selectDeck(deck);
             this.player2.selectDeck(deck);

--- a/test/server/cards/characters/01/01052-stannisbaratheon.spec.js
+++ b/test/server/cards/characters/01/01052-stannisbaratheon.spec.js
@@ -6,7 +6,7 @@ describe('Stannis Baratheon', function() {
         beforeEach(function() {
             const deck = this.buildDeck('baratheon', [
                 'Trading with the Pentoshi',
-                'Stannis Baratheon (Core)', 'Robert Baratheon', 'Dragonstone Faithful', 'Maester Cressen', 'The Roseroad', 'Bodyguard'
+                'Stannis Baratheon (Core)', 'Robert Baratheon', 'Dragonstone Faithful', 'Maester Cressen', 'The Roseroad', 'Bodyguard', 'Recruiter for the Watch'
             ]);
             this.player1.selectDeck(deck);
             this.player2.selectDeck(deck);
@@ -39,13 +39,14 @@ describe('Stannis Baratheon', function() {
 
             // Manually kneel everything
             this.player1.clickCard(this.character1);
-            this.player1.clickCard(this.character2);
             this.player1.clickCard(this.location);
             this.player1.clickCard(this.attachment);
         });
 
         describe('when there are 2 or fewer characters are kneeling', function() {
             beforeEach(function() {
+                this.player1.clickCard(this.character2);
+
                 this.player1.clickPrompt('Done');
                 this.player2.clickPrompt('Done');
 
@@ -62,6 +63,7 @@ describe('Stannis Baratheon', function() {
 
         describe('when there are more than 2 characters kneeling', function() {
             beforeEach(function() {
+                this.player1.clickCard(this.character2);
                 this.player1.clickCard(this.character3);
 
                 this.player1.clickPrompt('Done');
@@ -97,6 +99,66 @@ describe('Stannis Baratheon', function() {
                 it('should automatically stand non-characters', function() {
                     expect(this.location.kneeled).toBe(false);
                     expect(this.attachment.kneeled).toBe(false);
+                });
+            });
+        });
+
+        describe('when Recruiter for the Watch is out', function() {
+            beforeEach(function() {
+                this.recruiter = this.player1.findCardByName('Recruiter for the Watch', 'hand');
+
+                this.player1.clickCard(this.recruiter);
+
+                // Kneel Recruiter
+                this.player1.clickCard(this.recruiter);
+            });
+
+            describe('and there are 2 or fewer kneeling cards', function() {
+                beforeEach(function() {
+                    this.player1.clickPrompt('Done');
+                    this.player2.clickPrompt('Done');
+
+                    this.completeChallengesPhase();
+                });
+
+                it('should prompt to stand the Recruiter', function() {
+                    expect(this.player1).toHavePrompt('Select optional cards to stand');
+                });
+            });
+
+            describe('and there are more than 2 kneeling cards', function() {
+                beforeEach(function() {
+                    this.player1.clickCard(this.character2);
+
+                    this.player1.clickPrompt('Done');
+                    this.player2.clickPrompt('Done');
+
+                    this.completeChallengesPhase();
+                });
+
+                it('should prompt to stand 2 characters', function() {
+                    expect(this.player1).toHavePrompt('Select 2 cards to stand');
+                });
+
+                it('should not prompt for Recruiter when it is selected', function() {
+                    this.player1.clickCard(this.character1);
+                    this.player1.clickCard(this.recruiter);
+                    this.player1.clickPrompt('Done');
+
+                    expect(this.player1).not.toHavePrompt('Select optional cards to stand');
+                    expect(this.character1.kneeled).toBe(false);
+                    expect(this.recruiter.kneeled).toBe(false);
+                });
+
+                it('should not prompt for Recruiter when it is not selected', function() {
+                    this.player1.clickCard(this.character1);
+                    this.player1.clickCard(this.character2);
+                    this.player1.clickPrompt('Done');
+
+                    expect(this.player1).not.toHavePrompt('Select optional cards to stand');
+                    expect(this.character1.kneeled).toBe(false);
+                    expect(this.character2.kneeled).toBe(false);
+                    expect(this.recruiter.kneeled).toBe(true);
                 });
             });
         });

--- a/test/server/cards/characters/06/06045-recruiterforthewatch.spec.js
+++ b/test/server/cards/characters/06/06045-recruiterforthewatch.spec.js
@@ -1,0 +1,76 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('Recruiter for the Watch', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck = this.buildDeck('thenightswatch', [
+                'Sneak Attack',
+                'Recruiter for the Watch', 'Dragonstone Faithful', 'Nightmares'
+            ]);
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.recruiter = this.player1.findCardByName('Recruiter for the Watch', 'hand');
+            this.character = this.player2.findCardByName('Dragonstone Faithful', 'hand');
+            this.nightmares = this.player2.findCardByName('Nightmares', 'hand');
+
+            this.player1.clickCard(this.recruiter);
+            this.player2.clickCard(this.character);
+            this.completeSetup();
+
+            this.player1.selectPlot('Sneak Attack');
+            this.player2.selectPlot('Sneak Attack');
+            this.selectFirstPlayer(this.player1);
+
+            this.player1.clickMenu(this.recruiter, 'Take control of character');
+            this.player1.clickCard(this.character);
+        });
+
+        it('should kneel the Recruiter', function() {
+            expect(this.recruiter.kneeled).toBe(true);
+        });
+
+        it('should take control of the selected character', function() {
+            expect(this.character.controller.name).toBe(this.player1Object.name);
+        });
+
+        describe('when the Recruiter stands', function() {
+            beforeEach(function() {
+                this.completeMarshalPhase();
+                this.completeChallengesPhase();
+
+                expect(this.player1).toHavePrompt('Select optional cards to stand');
+                this.player1.clickCard(this.recruiter);
+                this.player1.clickPrompt('Done');
+            });
+
+            it('should revert control of the selected character', function() {
+                expect(this.character.controller.name).toBe(this.player2Object.name);
+            });
+        });
+
+        describe('when the Recruiter leaves play', function() {
+            beforeEach(function() {
+                this.player1.dragCard(this.recruiter, 'discard pile');
+            });
+
+            it('should revert control of the selected character', function() {
+                expect(this.character.controller.name).toBe(this.player2Object.name);
+            });
+        });
+
+        describe('when the Recruiter is blanked', function() {
+            beforeEach(function() {
+                this.player2.clickCard(this.nightmares);
+                this.player2.clickCard(this.recruiter);
+            });
+
+            it('should not modify control of the character', function() {
+                expect(this.character.controller.name).toBe(this.player1Object.name);
+            });
+        });
+    });
+});


### PR DESCRIPTION
* Adds an 'optional stand' effect that allows the player to choose whether or not to stand affected cards during the standing phase.
* Ensures that if a card is explicitly selected in the standing phase (e.g. through Core Stannis) that the player will not be prompted to stand the character.
* Adds the ability to do lasting effects with custom durations using the `lastingEffect` method. An `until` property is specified with event listeners, similar to the way `when` works for reactions / interrupts.
* Putting it all together, implements Recruiter for the Watch.