### PR TITLE
Fix Funeral Pyre

### DIFF
--- a/server/game/cards/events/02/funeralpyre.js
+++ b/server/game/cards/events/02/funeralpyre.js
@@ -4,10 +4,7 @@ class FuneralPyre extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onCharacterKilled: event => (
-                    event.card.controller === this.controller &&
-                    (event.card.hasTrait('Lord') || event.card.hasTrait('Lady'))
-                )
+                onCharacterKilled: event => event.card.hasTrait('Lord') || event.card.hasTrait('Lady')
             },
             cost: ability.costs.kneelFactionCard(),
             handler: () => {


### PR DESCRIPTION
Funeral Pyre should trigger when any Lord/Lady is killed, not just controlled by yourself