### PR TITLE
Implement Catapult on the Wall.

### DIFF
--- a/server/game/cards/attachments/07/catapultonthewall.js
+++ b/server/game/cards/attachments/07/catapultonthewall.js
@@ -1,0 +1,40 @@
+const DrawCard = require('../../../drawcard.js');
+
+class CatapultOnTheWall extends DrawCard {
+    setupCardAbilities(ability) {
+        this.action({
+            title: 'Kneel Catapult and attached character',
+            condition: () => this.game.currentChallenge,
+
+            // This is not a nice interaction for users, but `ability.costs` would need to be updated with a different method to allow something like attachment.parent.kneel() (I think)
+            cost: [
+                ability.costs.kneelSelf(),
+                ability.costs.kneel(card => card === this.parent)
+            ],
+            target: {
+                activePromptTitle: 'Select character to kill',
+                cardCondition: card => this.game.currentChallenge.isAttacking(card)
+            },
+            handler: context => {
+                context.target.owner.killCharacter(context.target);
+                this.game.addMessage('{0} kneels {1} and {2} to kill {3}', context.player, this, this.parent, context.target);
+                this.parent.untilEndOfRound(ability => ({
+                    match: this.parent,
+                    effect: ability.effects.doesNotStandDuringStanding()
+                }));
+            }
+        });
+    }
+
+    canAttach(player, card) {
+        if(card.getType() !== 'character') {
+            return false;
+        }
+
+        return super.canAttach(player, card);
+    }
+}
+
+CatapultOnTheWall.code = '07020';
+
+module.exports = CatapultOnTheWall;

--- a/server/game/cards/attachments/07/catapultonthewall.js
+++ b/server/game/cards/attachments/07/catapultonthewall.js
@@ -13,7 +13,7 @@ class CatapultOnTheWall extends DrawCard {
             ],
             target: {
                 activePromptTitle: 'Select character to kill',
-                cardCondition: card => this.game.currentChallenge.isAttacking(card)
+                cardCondition: card => this.game.currentChallenge.isAttacking(card) && card.getStrength() <= 4
             },
             handler: context => {
                 context.target.owner.killCharacter(context.target);

--- a/server/game/cards/attachments/07/catapultonthewall.js
+++ b/server/game/cards/attachments/07/catapultonthewall.js
@@ -9,7 +9,7 @@ class CatapultOnTheWall extends DrawCard {
             // This is not a nice interaction for users, but `ability.costs` would need to be updated with a different method to allow something like attachment.parent.kneel() (I think)
             cost: [
                 ability.costs.kneelSelf(),
-                ability.costs.kneel(card => card === this.parent)
+                ability.costs.kneelParent()
             ],
             target: {
                 activePromptTitle: 'Select character to kill',

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -34,6 +34,19 @@ const Costs = {
         };
     },
     /**
+     * Cost that will kneel the parent card the current card is attached to.
+     */
+    kneelParent: function() {
+        return {
+            canPay: function(context) {
+                return !!context.source.parent && !context.source.parent.kneeled;
+            },
+            pay: function(context) {
+                context.source.parent.controller.kneelCard(context.source.parent);
+            }
+        };
+    },
+    /**
      * Cost that will kneel the player's faction card.
      */
     kneelFactionCard: function() {


### PR DESCRIPTION
As noted (at least as far as I could figure out), there's not really a clean way to include kneeling the attached character as part of the cost of using the attachment action.  `ability.costs` needs another / updated kneel method to allow for this.  Certainly something I could do / we might consider, as I'm sure more costs like this are coming, but as I'm probably the least familiar with the code and gameflow, I figured I would just do the quick and dirty implementation.

