### PR TITLE
Implement Wheels Within Wheels

### DIFF
--- a/server/game/cards/plots/06/wheelswithinwheels.js
+++ b/server/game/cards/plots/06/wheelswithinwheels.js
@@ -1,0 +1,85 @@
+const _ = require('underscore');
+
+const PlotCard = require('../../../plotcard.js');
+
+class WheelsWithinWheels extends PlotCard {
+    setupCardAbilities() {
+        this.whenRevealed({
+            handler: () => {
+                this.game.promptForDeckSearch(this.controller, {
+                    numCards: 10,
+                    numToSelect: 10,
+                    activePromptTitle: 'Select any number of cards to reveal',
+                    cardType: 'event',
+                    onSelect: (player, card) => this.cardsToReveal(player, card),
+                    onCancel: player => this.doneSelecting(player),
+                    source: this
+                });
+            }
+        });
+    }
+
+    cardsToReveal(player, card) {
+        this.cards = this.cards || [];
+        this.cards.push(card);
+        player.moveCard(card, 'discard pile');
+        
+        return true;
+    }
+
+    doneSelecting(player) {
+        if(_.isEmpty(this.cards)) {
+            this.game.addMessage('{0} does not use {1} to reveal any cards', 
+                                  player, this);
+        
+            return true;
+        }
+
+        if(this.cards.length === 1) {
+            this.game.addMessage('{0} uses {1} to reveal and add {2} to their hand', 
+                                player, this, this.cards[0]);
+
+            player.moveCard(this.cards[0], 'hand');
+
+            return true;
+        }
+
+        this.game.addMessage('{0} uses {1} to reveal {2}', player, this, this.cards);
+
+        var buttons = _.map(this.cards, (card, i) => {
+            return { card: card, method: 'resolve', arg: i };
+        });
+
+        this.game.promptWithMenu(this.controller, this, {
+            activePrompt: {
+                menuTitle: 'Select a card to add to your hand',
+                buttons: buttons
+            },
+            source: this
+        });
+
+        return true;
+    }
+
+    resolve(player, index) {
+        let cardToHand = this.cards[index];
+        player.moveCard(cardToHand, 'hand');
+        this.cards.splice(index, 1);
+
+        if(this.cards.length === 1) {
+            this.game.addMessage('{0} uses {1} to add {2} to their hand, {3} is placed in their discard pile', 
+                                  player, this, cardToHand, this.cards);
+
+            return true;
+        }
+
+        this.game.addMessage('{0} uses {1} to add {2} to their hand, {3} are placed in their discard pile', 
+                              player, this, cardToHand, this.cards);
+
+        return true;
+    }
+}
+
+WheelsWithinWheels.code = '06100';
+
+module.exports = WheelsWithinWheels;


### PR DESCRIPTION
Took a stab at this weird card, couple of notes:

* Cards are dumped in the discard pile before being "officially" revealed through a chat message. This is not ideal, though to get the ever-decreasing prompt we want for effects like these I needed to move them somewhere, and discard pile makes the most sense here to me.

* The prompt does not show duplicates. That is preferable for a card like Summons, a bit less so for this one. If you hit a duplicate, you won't know it at first, though you find out after selecting them (since the card will just keep showing in the prompt until all duplicates have been moved to the discard pile). Not a huge deal though.

* I'm quite sure that if you would manage to hit 10 events, it won't resolve correctly since you won't get the chance to choose Done. Increasing numToSelect to 11 does not solve this, as that triggers a whole new search of 10 more cards. This is an extremely unlikely occurrence, and it should work correctly for all other use cases.

* It is quite verbose, but I like the extra checks to minimize clicks and get the messages just right.