### PR TITLE
Implement `choose` cost.

### DIFF
--- a/server/game/cards/events/03/thepacksurvives.js
+++ b/server/game/cards/events/03/thepacksurvives.js
@@ -4,31 +4,23 @@ class ThePackSurvives extends DrawCard {
     setupCardAbilities(ability) {
         this.interrupt({
             canCancel: true,
-            title: () => 'Sacrifice Direwolf',
             when: {
                 onCardAbilityInitiated: event => event.source.getType() === 'event' && event.player !== this.controller
             },
-            cost: ability.costs.sacrifice(card => card.hasTrait('Direwolf')),
+            cost: ability.costs.choose({
+                'Sacrifice Direwolf': ability.costs.sacrifice(card => card.hasTrait('Direwolf')),
+                'Kneel 2 Starks': ability.costs.kneelMultiple(2, card => card.isFaction('stark') && card.getType() === 'character')
+            }),
             handler: context => {
                 context.event.cancel();
-                
-                this.game.addMessage('{0} plays {1} and sacrifices {2} to cancel {3}', 
-                                      this.controller, this, context.sacrificeCostCard, context.event.source);
-            }
-        });
 
-        this.interrupt({
-            canCancel: true,
-            title: () => 'Kneel characters',
-            when: {
-                onCardAbilityInitiated: event => event.source.getType() === 'event' && event.player !== this.controller
-            },
-            cost: ability.costs.kneelMultiple(2, card => card.isFaction('stark') && card.getType() === 'character'),
-            handler: context => {
-                context.event.cancel();
-                
-                this.game.addMessage('{0} plays {1} and kneels {2} to cancel {3}', 
-                                      this.controller, this, context.kneelingCostCards, context.event.source);
+                if(context.sacrificeCostCard) {
+                    this.game.addMessage('{0} plays {1} and sacrifices {2} to cancel {3}',
+                                          this.controller, this, context.sacrificeCostCard, context.event.source);
+                } else {
+                    this.game.addMessage('{0} plays {1} and kneels {2} to cancel {3}',
+                                          this.controller, this, context.kneelingCostCards, context.event.source);
+                }
             }
         });
     }

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -1,4 +1,5 @@
 const _ = require('underscore');
+const ChooseCost = require('./costs/choosecost.js');
 
 const Costs = {
     /**
@@ -13,6 +14,15 @@ const Costs = {
                 _.each(costs, cost => cost.pay(context));
             }
         };
+    },
+    /**
+     * Cost that allows the player to choose between multiple costs. The
+     * `choices` object should have string keys representing the button text
+     * that will be used to prompt the player, with the values being the cost
+     * associated with that choice.
+     */
+    choose: function(choices) {
+        return new ChooseCost(choices);
     },
     /**
      * Cost that will kneel the card that initiated the ability.
@@ -74,11 +84,7 @@ const Costs = {
             canPay: function(context) {
                 return context.player.anyCardsInPlay(card => fullCondition(card, context));
             },
-            resolve: function(context) {
-                var result = {
-                    resolved: false
-                };
-
+            resolve: function(context, result = { resolved: false }) {
                 context.game.promptForSelect(context.player, {
                     cardCondition: card => fullCondition(card, context),
                     activePromptTitle: 'Select card to kneel',
@@ -118,11 +124,7 @@ const Costs = {
             canPay: function(context) {
                 return context.player.getNumberOfCardsInPlay(card => fullCondition(card, context)) >= number;
             },
-            resolve: function(context) {
-                var result = {
-                    resolved: false
-                };
-
+            resolve: function(context, result = { resolved: false }) {
                 context.game.promptForSelect(context.player, {
                     cardCondition: card => fullCondition(card, context),
                     activePromptTitle: 'Select ' + number + ' cards to kneel',
@@ -182,11 +184,7 @@ const Costs = {
             canPay: function(context) {
                 return context.player.anyCardsInPlay(card => fullCondition(card, context));
             },
-            resolve: function(context) {
-                var result = {
-                    resolved: false
-                };
-
+            resolve: function(context, result = { resolved: false }) {
                 context.game.promptForSelect(context.player, {
                     cardCondition: card => fullCondition(card, context),
                     activePromptTitle: 'Select card to sacrifice',
@@ -238,11 +236,7 @@ const Costs = {
             canPay: function(context) {
                 return context.player.anyCardsInPlay(card => fullCondition(card, context));
             },
-            resolve: function(context) {
-                var result = {
-                    resolved: false
-                };
-
+            resolve: function(context, result = { resolved: false }) {
                 context.game.promptForSelect(context.player, {
                     cardCondition: card => fullCondition(card, context),
                     activePromptTitle: 'Select card to return to hand',
@@ -295,11 +289,7 @@ const Costs = {
                 let potentialCards = context.player.findCards(context.player.hand, card => fullCondition(card, context));
                 return _.size(potentialCards) >= number;
             },
-            resolve: function(context) {
-                var result = {
-                    resolved: false
-                };
-
+            resolve: function(context, result = { resolved: false }) {
                 context.game.promptForSelect(context.player, {
                     cardCondition: card => fullCondition(card, context),
                     activePromptTitle: 'Select ' + number + ' cards to reveal',
@@ -371,11 +361,7 @@ const Costs = {
             canPay: function(context) {
                 return context.player.allCards.any(card => fullCondition(card, context));
             },
-            resolve: function(context) {
-                var result = {
-                    resolved: false
-                };
-
+            resolve: function(context, result = { resolved: false }) {
                 context.game.promptForSelect(context.player, {
                     cardCondition: card => fullCondition(card, context),
                     activePromptTitle: 'Select card to discard',
@@ -467,11 +453,7 @@ const Costs = {
             canPay: function(context) {
                 return context.player.anyCardsInPlay(card => fullCondition(card, context));
             },
-            resolve: function(context) {
-                var result = {
-                    resolved: false
-                };
-
+            resolve: function(context, result = { resolved: false }) {
                 context.game.promptForSelect(context.player, {
                     cardCondition: card => fullCondition(card, context),
                     activePromptTitle: 'Select card to discard ' + amount + ' power from',

--- a/server/game/costs/choosecost.js
+++ b/server/game/costs/choosecost.js
@@ -1,0 +1,64 @@
+const _ = require('underscore');
+
+class ChooseCost {
+    constructor(choices) {
+        this.choices = choices;
+    }
+
+    canPay(context) {
+        return _.any(this.choices, cost => cost.canPay(context));
+    }
+
+    resolve(context, result = { resolved: false }) {
+        let payableCosts = _.pick(this.choices, cost => cost.canPay(context));
+        let payableCostsSize = _.size(payableCosts);
+
+        if(payableCostsSize === 0) {
+            result.value = false;
+            result.resolved = true;
+            return result;
+        }
+
+        if(payableCostsSize === 1) {
+            this.chosenCost = _.values(payableCosts)[0];
+            return this.resolveCost(this.chosenCost, context, result);
+        }
+
+        this.context = context;
+        this.result = result;
+
+        context.game.promptWithMenu(context.player, this, {
+            activePrompt: {
+                menuTitle: 'Choose cost to pay',
+                buttons: _.map(payableCosts, (cost, text) => {
+                    return { text: text, arg: text, method: 'chooseCost' };
+                })
+            },
+            source: context.source
+        });
+
+        return result;
+    }
+
+    chooseCost(player, choice) {
+        this.chosenCost = this.choices[choice];
+        this.resolveCost(this.chosenCost, this.context, this.result);
+        return true;
+    }
+
+    resolveCost(cost, context, result) {
+        if(cost.resolve) {
+            return cost.resolve(context, result);
+        }
+
+        result.resolved = true;
+        result.value = cost.canPay(context);
+        return result;
+    }
+
+    pay(context) {
+        this.chosenCost.pay(context);
+    }
+}
+
+module.exports = ChooseCost;


### PR DESCRIPTION
Implements a choose cost that allows the player to choose which cost
they want to pay on a card. Useful for cards like The Pack Survives and
I Shall Win No Glory which give players an 'or' choice. If only one cost
is able to be paid, it will pick that cost automatically. If multiple
costs are payable, the player will be prompted to choose which they wish
to pay.