### PR TITLE
Fix /cancel-prompt during challenge.

### DIFF
--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -231,6 +231,10 @@ class ChallengeFlow extends BaseStep {
         this.challenge.finish();
     }
 
+    isComplete() {
+        return this.pipeline.length === 0;
+    }
+
     onCardClicked(player, card) {
         return this.pipeline.handleCardClicked(player, card);
     }


### PR DESCRIPTION
Previously, using /cancel-prompt during a challenge would not just
cancel the current prompt as intended but cancel the entire challenge.
This lead to situations where cleanup of reaction / interrupt windows
was inappropriately canceled, causing crashes when a card with that
event handler came into hand or into play.

Example: a "when you win/lose a challenge" ability would be prompted.
The player uses /cancel-prompt instead of clicking on 'Pass.' The player
later draws an event card that triggers when winning/losing a challenge.
The game potentially crashes if that card expects there to be an active
challenge.

Now, /cancel-prompt will appropriately only cancel the current prompt,
not the entire challenge.

Fixes THRONETEKI-VN
Fixes THRONETEKI-V7
Fixes THRONETEKI-V6