### PR TITLE
add effect cannotBeDiscarded and use it to immunize The God's Eye

### DIFF
--- a/server/game/cards/locations/04/thegodseye.js
+++ b/server/game/cards/locations/04/thegodseye.js
@@ -1,8 +1,12 @@
 const DrawCard = require('../../../drawcard.js');
 
 class TheGodsEye extends DrawCard {
-    setupCardAbilities() {
-        // TODO: Cannot be discarded.
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            match: this,
+            effect: ability.effects.cannotBeDiscarded()
+        });
+
         this.plotModifiers({
             reserve: 1,
             gold: 1

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -480,6 +480,7 @@ const Effects = {
     cannotMarshal: cannotEffect('marshal'),
     cannotPlay: cannotEffect('play'),
     cannotBeBypassedByStealth: cannotEffect('bypassByStealth'),
+    cannotBeDiscarded: cannotEffect('discard'),
     cannotBeKneeled: cannotEffect('kneel'),
     cannotBeKilled: cannotEffect('kill'),
     cannotGainChallengeBonus: function() {


### PR DESCRIPTION
Note that this assumes that all possibilities of discarding The God's Eye from
play are via the engine effect. As far as I understand this should be the case
right now, but @ystros might want to double-check that.