### PR TITLE
Implement Summer (WotW)

### DIFF
--- a/server/game/cards/attachments/07/summer.js
+++ b/server/game/cards/attachments/07/summer.js
@@ -1,0 +1,58 @@
+const DrawCard = require('../../../drawcard.js');
+
+class Summer extends DrawCard {
+
+    setupCardAbilities(ability) {
+        this.action({
+            title: 'Have parent participate',
+            condition: () => this.game.currentChallenge && this.game.currentChallenge.challengeType === 'military',
+            cost: ability.costs.kneelParent(),
+            limit: ability.limit.perChallenge(1),
+            handler: () => {
+                if(this.game.currentChallenge.attackingPlayer === this.controller) {
+                    this.game.currentChallenge.addAttacker(this.parent, false);
+                } else {
+                    this.game.currentChallenge.addDefender(this.parent, false);
+                }
+                
+                this.game.addMessage('{0} uses {1} and kneels {2} to have {2} participate on their side',
+                                      this.controller, this, this.parent);
+            }
+        }),
+
+        this.action({
+            title: 'Attach to a different character',
+            cost: ability.costs.payGold(1),
+            limit: ability.limit.perPhase(1),
+            target: {
+                activePromptTitle: 'Select a character',
+                cardCondition: card => (
+                    card.location === 'play area' &&
+                    card !== this.parent &&
+                    this.canAttach(this.controller, card))
+            },
+            handler: context => {
+                this.controller.removeCardFromPile(this);
+                this.parent = context.target;
+                this.moveTo('play area');
+                context.target.attachments.push(this);
+                this.attach();
+
+                this.game.addMessage('{0} uses {1} and pays 1 gold to attach {1} to {2}',
+                                      this.controller, this, this.parent);
+            }
+        });
+    }
+
+    canAttach(player, card) {
+        if(card.getType() !== 'character' || !card.isFaction('stark') || !card.isUnique()) {
+            return false;
+        }
+
+        return super.canAttach(player, card);
+    }
+}
+
+Summer.code = '07034';
+
+module.exports = Summer;

--- a/server/game/cards/attachments/07/summer.js
+++ b/server/game/cards/attachments/07/summer.js
@@ -32,11 +32,7 @@ class Summer extends DrawCard {
                     this.canAttach(this.controller, card))
             },
             handler: context => {
-                this.controller.removeCardFromPile(this);
-                this.parent = context.target;
-                this.moveTo('play area');
-                context.target.attachments.push(this);
-                this.attach();
+                this.controller.attach(this.controller, this, context.target.uuid);
 
                 this.game.addMessage('{0} uses {1} and pays 1 gold to attach {1} to {2}',
                                       this.controller, this, this.parent);

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -620,21 +620,23 @@ class Player extends Spectator {
     }
 
     attach(player, attachment, cardId, playingType) {
-        var card = this.findCardInPlayByUuid(cardId);
+        let card = this.findCardInPlayByUuid(cardId);
 
         if(!card || !attachment) {
             return;
         }
 
-        attachment.owner.removeCardFromPile(attachment);
-
-        attachment.parent = card;
         let originalLocation = attachment.location;
-        attachment.moveTo('play area');
-        this.game.raiseMergedEvent('onCardEntersPlay', { card: attachment, playingType: playingType, originalLocation: originalLocation });
-        card.attachments.push(attachment);
 
+        attachment.owner.removeCardFromPile(attachment);
+        attachment.parent = card;
+        attachment.moveTo('play area');
+        card.attachments.push(attachment);
         attachment.attach(player, card);
+
+        if(originalLocation !== 'play area') {
+            this.game.raiseMergedEvent('onCardEntersPlay', { card: attachment, playingType: playingType, originalLocation: originalLocation });
+        }
     }
 
     showDrawDeck() {


### PR DESCRIPTION
The 'attach to a different character' handler is a little bit awkward, but I didn't want to just invoke player.attach() since that raises onCardEntersPlay, or player.putIntoPlay(), which would prompt for a parent where the old parent would be made a legal choice (and invokes player.attach() itself anyway).