### PR TITLE
improve and uniform game messages for all tutoring cards

### DIFF
--- a/server/game/cards/characters/02/serhobberredwyne.js
+++ b/server/game/cards/characters/02/serhobberredwyne.js
@@ -20,11 +20,13 @@ class SerHobberRedwyne extends DrawCard {
 
     cardSelected(player, card) {
         player.moveCard(card, 'hand');
-        this.game.addMessage('{0} uses {1} to reveal {2} and add it to their hand', player, this, card);
+        this.game.addMessage('{0} uses {1} to search their deck and add {2} to their hand',
+                             player, this, card);
     }
 
     doneSelecting(player) {
-        this.game.addMessage('{0} does not use {1} to add a card to their hand', player, this);
+        this.game.addMessage('{0} uses {1} to search their deck, but does not add any card to their hand',
+                             player, this);
     }
 }
 

--- a/server/game/cards/characters/04/pyatpree.js
+++ b/server/game/cards/characters/04/pyatpree.js
@@ -21,11 +21,13 @@ class PyatPree extends DrawCard {
 
     cardSelected(player, card) {
         player.moveCard(card, 'hand');
-        this.game.addMessage('{0} uses {1} to reveal {2} and add it to their hand', player, this, card);
+        this.game.addMessage('{0} uses {1} to search their deck and add {2} to their hand',
+                             player, this, card);
     }
 
     doneSelecting(player) {
-        this.game.addMessage('{0} does not use {1} to add a card to their hand', player, this);
+        this.game.addMessage('{0} uses {1} to search their deck, but does not add any card to their hand',
+                             player, this);
     }
 }
 

--- a/server/game/cards/characters/05/alerietyrell.js
+++ b/server/game/cards/characters/05/alerietyrell.js
@@ -21,11 +21,13 @@ class AlerieTyrell extends DrawCard {
 
     cardSelected(player, card) {
         player.moveCard(card, 'hand');
-        this.game.addMessage('{0} uses {1} to search the top 10 cards of their deck and reveal {2} and add it to their hand', player, this, card);
+        this.game.addMessage('{0} uses {1} to search their deck and add {2} to their hand',
+                             player, this, card);
     }
 
     doneSelecting(player) {
-        this.game.addMessage('{0} does not use {1} to add a card to their hand', player, this);
+        this.game.addMessage('{0} uses {1} to search their deck, but does not add any card to their hand',
+                             player, this);
     }
 }
 

--- a/server/game/cards/characters/06/margaerytyrell.js
+++ b/server/game/cards/characters/06/margaerytyrell.js
@@ -23,11 +23,13 @@ class MargaeryTyrell extends DrawCard {
 
     cardSelected(player, card) {
         player.putIntoPlay(card);
-        this.game.addMessage('{0} uses {1} to search their deck and put {2} into play', player, this, card);
+        this.game.addMessage('{0} uses {1} to search their deck and put {2} into play',
+                             player, this, card);
     }
 
     doneSelecting(player) {
-        this.game.addMessage('{0} does not use {1} to put a card into play', player, this);
+        this.game.addMessage('{0} uses {1} to search their deck, but does not put any card into play',
+                             player, this);
     }
 }
 

--- a/server/game/cards/characters/07/castleblackmason.js
+++ b/server/game/cards/characters/07/castleblackmason.js
@@ -7,26 +7,27 @@ class CastleBlackMason extends DrawCard {
             cost: ability.costs.kneelMultiple(2, card => card.getType() === 'character' && card.hasTrait('Builder')),
             limit: ability.limit.perRound(2),
             handler: context => {
-                this.game.addMessage('{0} uses {1} to kneel {2} to search the top 10 cards of their deck for a location or attachment', this.controller, this, context.kneelingCostCards);
                 this.game.promptForDeckSearch(this.controller, {
                     numCards: 10,
                     activePromptTitle: 'Select a card to add to your hand',
                     cardType: ['attachment', 'location'],
-                    onSelect: (player, card) => this.cardSelected(player, card),
-                    onCancel: player => this.doneSelecting(player),
+                    onSelect: (player, card) => this.cardSelected(player, card, context.kneelingCostCards),
+                    onCancel: player => this.doneSelecting(player, context.kneelingCostCards),
                     source: this
                 });
             }
         });
     }
 
-    cardSelected(player, card) {
+    cardSelected(player, card, kneeledCards) {
         player.moveCard(card, 'hand');
-        this.game.addMessage('{0} uses {1} to reveal {2} and add it to their hand', player, this, card);
+        this.game.addMessage('{0} uses {1} to kneel {2}, search their deck, and add {3} to their hand',
+                             player, this, kneeledCards, card);
     }
 
-    doneSelecting(player) {
-        this.game.addMessage('{0} does not use {1} to add a card to their hand', player, this);
+    doneSelecting(player, kneeledCards) {
+        this.game.addMessage('{0} uses {1} to kneel {2} and search their deck, but does not add any card to their hand',
+                             player, this, kneeledCards);
     }
 }
 

--- a/server/game/cards/events/01/olennascunning.js
+++ b/server/game/cards/events/01/olennascunning.js
@@ -42,11 +42,13 @@ class OlennasCunning extends DrawCard {
 
     cardSelected(player, card) {
         player.moveCard(card, 'hand');
-        this.game.addMessage('{0} uses {1} to reveal {2} and add it to their hand', player, this, card);
+        this.game.addMessage('{0} uses {1} to search their deck and add {2} to their hand',
+                             player, this, card);
     }
 
     doneSelecting(player) {
-        this.game.addMessage('{0} does not use {1} to add a card to their hand', player, this);
+        this.game.addMessage('{0} uses {1} to search their deck but does not add any card to their hand',
+                             player, this);
     }
 }
 

--- a/server/game/cards/events/02/supportofthepeople.js
+++ b/server/game/cards/events/02/supportofthepeople.js
@@ -24,11 +24,13 @@ class SupportOfThePeople extends DrawCard {
 
     cardSelected(player, card) {
         player.putIntoPlay(card);
-        this.game.addMessage('{0} uses {1} to search their deck and put {2} into play', player, this, card);
+        this.game.addMessage('{0} uses {1} to search their deck and put {2} into play',
+                             player, this, card);
     }
 
     doneSelecting(player) {
-        this.game.addMessage('{0} does not use {1} to search for a card', player, this);
+        this.game.addMessage('{0} uses {1} to search their deck but does not put any card into play',
+                             player, this);
     }
 }
 

--- a/server/game/cards/events/02/thewatchhasneed.js
+++ b/server/game/cards/events/02/thewatchhasneed.js
@@ -31,7 +31,7 @@ class TheWatchHasNeed extends DrawCard {
             activePromptTitle: 'Select a card to add to hand',
             cardCondition: card => card.getType() === 'character' && card.hasTrait(trait),
             onSelect: (player, card) => this.cardSelected(player, trait, card),
-            onCancel: player => this.doneSelecting(player),
+            onCancel: player => this.doneSelecting(player, trait),
             source: this
         });
 
@@ -52,9 +52,9 @@ class TheWatchHasNeed extends DrawCard {
         return true;
     }
 
-    doneSelecting(player) {
-        this.game.addMessage('{0} does not use {1} to add a card to their hand',
-                             player, this);
+    doneSelecting(player, trait) {
+        this.game.addMessage('{0} uses {1} to search their deck for a {2}, but does not add any card to their hand',
+                             player, this, trait);
 
         return true;
     }

--- a/server/game/cards/events/02/wolfdreams.js
+++ b/server/game/cards/events/02/wolfdreams.js
@@ -19,11 +19,13 @@ class WolfDreams extends DrawCard {
 
     cardSelected(player, card) {
         player.moveCard(card, 'hand');
-        this.game.addMessage('{0} uses {1} to search their deck and add {2} to their hand', player, this, card);
+        this.game.addMessage('{0} uses {1} to search their deck and add {2} to their hand',
+                             player, this, card);
     }
 
     doneSelecting(player) {
-        this.game.addMessage('{0} does not use {1} to add a card to their hand', player, this);
+        this.game.addMessage('{0} uses {1} to search their deck, but does not add any card to their hand',
+                             player, this);
     }
 }
 

--- a/server/game/cards/events/04/bloodofmyblood.js
+++ b/server/game/cards/events/04/bloodofmyblood.js
@@ -25,11 +25,13 @@ class BloodOfMyBlood extends DrawCard {
             effect: ability.effects.returnToHandIfStillInPlay(true)
         }));
 
-        this.game.addMessage('{0} uses {1} to reveal {2} and put it into play', player, this, card);
+        this.game.addMessage('{0} uses {1} to search their deck and put {2} into play',
+                             player, this, card);
     }
 
     doneSelecting(player) {
-        this.game.addMessage('{0} does not use {1} to put a card in play', player, this);
+        this.game.addMessage('{0} uses {1} to search their deck, but does not put any card into play',
+                             player, this);
     }
 }
 

--- a/server/game/cards/locations/02/shadowblacklane.js
+++ b/server/game/cards/locations/02/shadowblacklane.js
@@ -22,11 +22,13 @@ class ShadowblackLane extends DrawCard {
 
     cardSelected(player, card) {
         player.moveCard(card, 'hand');
-        this.game.addMessage('{0} uses {1} to reveal {2} and add it to their hand', player, this, card);
+        this.game.addMessage('{0} uses {1} to search their deck and add {2} to their hand',
+                             player, this, card);
     }
 
     doneSelecting(player) {
-        this.game.addMessage('{0} does not use {1} to add a card to their hand', player, this);
+        this.game.addMessage('{0} uses {1} to search their deck but does not add any card to their hand',
+                             player, this);
     }
 }
 

--- a/server/game/cards/locations/02/streetofsilk.js
+++ b/server/game/cards/locations/02/streetofsilk.js
@@ -34,11 +34,13 @@ class StreetOfSilk extends DrawCard {
 
     cardSelected(player, card) {
         player.moveCard(card, 'hand');
-        this.game.addMessage('{0} uses {1} to reveal {2} and add it to their hand', player, this, card);
+        this.game.addMessage('{0} uses {1} to search their deck and add {2} to their hand',
+                             player, this, card);
     }
 
     doneSelecting(player) {
-        this.game.addMessage('{0} does not use {1} to add a card to their hand', player, this);
+        this.game.addMessage('{0} uses {1} to search their deck, but does not add any card to their hand',
+                             player, this);
     }
 }
 

--- a/server/game/cards/locations/02/streetofsteel.js
+++ b/server/game/cards/locations/02/streetofsteel.js
@@ -22,11 +22,13 @@ class StreetOfSteel extends DrawCard {
 
     cardSelected(player, card) {
         player.moveCard(card, 'hand');
-        this.game.addMessage('{0} uses {1} to reveal {2} and add it to their hand', player, this, card);
+        this.game.addMessage('{0} uses {1} to search their deck and add {2} to their hand',
+                             player, this, card);
     }
 
     doneSelecting(player) {
-        this.game.addMessage('{0} does not use {1} to add a card to their hand', player, this);
+        this.game.addMessage('{0} uses {1} to search their deck but does not add any card to their hand',
+                             player, this);
     }
 }
 

--- a/server/game/cards/plots/01/buildingorders.js
+++ b/server/game/cards/plots/01/buildingorders.js
@@ -18,11 +18,13 @@ class BuildingOrders extends PlotCard {
 
     cardSelected(player, card) {
         player.moveCard(card, 'hand');
-        this.game.addMessage('{0} uses {1} to reveal {2} and add it to their hand', player, this, card);
+        this.game.addMessage('{0} uses {1} to search their deck and add {2} to their hand',
+                             player, this, card);
     }
 
     doneSelecting(player) {
-        this.game.addMessage('{0} does not use {1} to add a card to their hand', player, this);
+        this.game.addMessage('{0} uses {1} to search their deck, but does not add any card to their hand',
+                             player, this);
     }
 }
 

--- a/server/game/cards/plots/01/summons.js
+++ b/server/game/cards/plots/01/summons.js
@@ -18,11 +18,13 @@ class Summons extends PlotCard {
 
     cardSelected(player, card) {
         player.moveCard(card, 'hand');
-        this.game.addMessage('{0} uses {1} to reveal {2} and add it to their hand', player, this, card);
+        this.game.addMessage('{0} uses {1} to search their deck and add {2} to their hand',
+                             player, this, card);
     }
 
     doneSelecting(player) {
-        this.game.addMessage('{0} does not use {1} to add a card to their hand', player, this);
+        this.game.addMessage('{0} uses {1} to search their deck, but does not add any card to their hand',
+                             player, this);
     }
 }
 

--- a/server/game/cards/plots/02/heretoserve.js
+++ b/server/game/cards/plots/02/heretoserve.js
@@ -16,12 +16,14 @@ class HereToServe extends PlotCard {
     }
 
     cardSelected(player, card) {
-        this.game.addMessage('{0} uses {1} to put {2} into play', player, this, card);
+        this.game.addMessage('{0} uses {1} to search their deck and put {2} into play',
+                             player, this, card);
         player.putIntoPlay(card);
     }
 
     doneSelecting(player) {
-        this.game.addMessage('{0} does not use {1} to find a card', player, this);
+        this.game.addMessage('{0} uses {1} to search their deck, but does not put any card into play',
+                             player, this);
     }
 }
 

--- a/server/game/cards/plots/03/atimeforwolves.js
+++ b/server/game/cards/plots/03/atimeforwolves.js
@@ -19,7 +19,8 @@ class ATimeForWolves extends PlotCard {
         player.moveCard(card, 'hand');
 
         if(card.getCost() > 3) {
-            this.game.addMessage('{0} uses {1} to reveal {2} and add it to their hand', player, this, card);
+            this.game.addMessage('{0} uses {1} to search their deck and add {2} to their hand',
+                                 player, this, card);
             return;
         }
 
@@ -45,7 +46,8 @@ class ATimeForWolves extends PlotCard {
             return false;
         }
 
-        this.game.addMessage('{0} uses {1} to reveal {2} and add it to their hand', player, this, this.revealedCard);
+        this.game.addMessage('{0} uses {1} to search their deck and add {2} to their hand',
+                             player, this, this.revealedCard);
         this.revealedCard = null;
 
         return true;
@@ -56,7 +58,8 @@ class ATimeForWolves extends PlotCard {
             return false;
         }
 
-        this.game.addMessage('{0} uses {1} to reveal {2} and put it in play', player, this, this.revealedCard);
+        this.game.addMessage('{0} uses {1} to search their deck and put {2} into play',
+                             player, this, this.revealedCard);
         player.putIntoPlay(this.revealedCard);
         this.revealedCard = null;
 
@@ -64,7 +67,8 @@ class ATimeForWolves extends PlotCard {
     }
 
     doneSelecting(player) {
-        this.game.addMessage('{0} does not use {1} to find a card', player, this);
+        this.game.addMessage('{0} uses {1} to search their deck, but does not retrieve any card',
+                             player, this);
     }
 }
 

--- a/server/game/cards/plots/06/wheelswithinwheels.js
+++ b/server/game/cards/plots/06/wheelswithinwheels.js
@@ -29,22 +29,20 @@ class WheelsWithinWheels extends PlotCard {
 
     doneSelecting(player) {
         if(_.isEmpty(this.cards)) {
-            this.game.addMessage('{0} does not use {1} to reveal any cards', 
+            this.game.addMessage('{0} uses {1} to search their deck, but does not retrieve any cards', 
                                   player, this);
         
             return true;
         }
 
         if(this.cards.length === 1) {
-            this.game.addMessage('{0} uses {1} to reveal and add {2} to their hand', 
+            this.game.addMessage('{0} uses {1} to search their deck and add {2} to their hand', 
                                 player, this, this.cards[0]);
 
             player.moveCard(this.cards[0], 'hand');
 
             return true;
         }
-
-        this.game.addMessage('{0} uses {1} to reveal {2}', player, this, this.cards);
 
         let buttons = _.map(this.cards, (card, i) => {
             return { card: card, method: 'resolve', arg: i };
@@ -70,8 +68,8 @@ class WheelsWithinWheels extends PlotCard {
             player.moveCard(card, 'discard pile');
         });
 
-        this.game.addMessage('{0} uses {1} to add {2} to their hand, {3} {4} placed in their discard pile', 
-                              player, this, cardToHand, this.cards, this.cards.length > 1 ? 'are' : 'is');
+        this.game.addMessage('{0} uses {1} to add {2} to their hand and place {3} in their discard pile', 
+                              player, this, cardToHand, this.cards);
 
         return true;
     }


### PR DESCRIPTION
Before this change, when no card was found (or chosen) by the user, tutoring
completed with messages "FOO does not use BAR to ...", which is misleading
given the player did use the card, but did not find (or choose) any card. With
this change this is replaced by message like "FOO uses BAR, but does not ...".

Also, this change uniform tutoring so that there is a single message about
tutoring outcome, rather than more than once for some weird cards.

Finally, this change also drops the explicit use of the verb "reveal", which
was redundant given that tutoring success messages always name cards,
"revealing" them to the opponent already.