### PR TITLE
Fix forced claim messaging

### DIFF
--- a/server/game/gamesteps/challenge/fulfillmilitaryclaim.js
+++ b/server/game/gamesteps/challenge/fulfillmilitaryclaim.js
@@ -15,7 +15,7 @@ class FulfillMilitaryClaim extends BaseStep {
         
         let claimToSelect = this.claim;
         
-        if(this.forcedClaim.length < this.claim) {
+        if(this.forcedClaim.length >= 1 && this.forcedClaim.length < this.claim) {
             claimToSelect = this.claim - this.forcedClaim.length;
             this.game.addMessage('{0} {1} automatically chosen for claim',
                                   this.forcedClaim, this.forcedClaim.length > 1 ? 'are' : 'is');


### PR DESCRIPTION
Previously, when no characters where forced to be chosen for claim, a "is automatically chosen for claim"-message would be displayed. Checking if there's any cards in forcedClaim before displaying the message fixes that.