### PR TITLE
Implement Burning on the Sand

### DIFF
--- a/server/game/cards/events/04/burningonthesand.js
+++ b/server/game/cards/events/04/burningonthesand.js
@@ -1,0 +1,26 @@
+const DrawCard = require('../../../drawcard.js');
+
+class BurningOnTheSand extends DrawCard {
+    setupCardAbilities() {
+        this.reaction({
+            when: {
+                afterChallenge: (event, challenge) => challenge.loser === this.controller && challenge.isUnopposed()
+            },
+            handler: () => {
+                this.untilEndOfChallenge(ability => ({
+                    match: card => card === card.controller.activePlot,
+                    targetController: 'opponent',
+                    effect: ability.effects.setClaim(0)
+                }));
+
+                let opponent = this.game.getOtherPlayer(this.controller);
+                this.game.addMessage('{0} plays {1} to set the claim value on {2}\'s revealed plot card to 0 until the end of the challenge', 
+                                      this.controller, this, opponent);
+            }
+        });
+    }
+}
+
+BurningOnTheSand.code = '04076';
+
+module.exports = BurningOnTheSand;

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -181,6 +181,16 @@ const Effects = {
             }
         };
     },
+    setClaim: function(value) {
+        return {
+            apply: function(card) {
+                card.claimSet = value;
+            },
+            unapply: function(card) {
+                card.claimSet = undefined;
+            }
+        };
+    },
     preventPlotModifier: function(modifier) {
         return {
             apply: function(card) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -403,12 +403,12 @@ class Game extends EventEmitter {
     }
 
     changeStat(playerName, stat, value) {
-        var player = this.getPlayerByName(playerName);
+        let player = this.getPlayerByName(playerName);
         if(!player) {
             return;
         }
 
-        var target = player;
+        let target = player;
 
         if(stat === 'power') {
             target = player.faction;
@@ -418,6 +418,19 @@ class Game extends EventEmitter {
             }
 
             target = player.activePlot.cardData;
+        }
+
+        if(stat === 'claim' && _.isNumber(player.activePlot.claimSet)) {
+            player.activePlot.claimSet += value;
+
+            this.raiseEvent('onStatChanged', player, stat, value);
+
+            if(player.activePlot.claimSet < 0) {
+                player.activePlot.claimSet = 0;
+            } else {
+                this.addMessage('{0} changes the set claim value to be {1} ({2})', player, player.activePlot.claimSet, (value > 0 ? '+' : '') + value);
+            }
+            return;
         }
 
         target[stat] += value;

--- a/server/game/plotcard.js
+++ b/server/game/plotcard.js
@@ -11,6 +11,7 @@ class PlotCard extends BaseCard {
         this.goldModifier = 0;
         this.initiativeModifier = 0;
         this.claimModifier = 0;
+        this.claimSet = undefined;
     }
 
     whenRevealed(properties) {
@@ -47,8 +48,8 @@ class PlotCard extends BaseCard {
         return baseValue + this.reserveModifier;
     }
 
-    getClaim() {
-        return this.cardData.claim + this.claimModifier;
+    getClaim() {        
+        return _.isNumber(this.claimSet) ? this.claimSet : this.cardData.claim + this.claimModifier;
     }
 
     canChallenge() {


### PR DESCRIPTION
* Fixes #1062 
* This has some wonky interactions with the claim modification buttons in the client, as illustrated by the pasted game chat below. Nothing game-breaking though.

```
user1 is initiating a  challenge
user1 has initiated a  challenge with strength 2
DukeTax does not defend the challenge
user1 uses Winter Is Coming to raise the claim value on their revealed plot card by 1 until the end of the challenge
user1 won a  challenge 2 vs 0
DukeTax plays Burning on the Sand to set the claim value on user1's revealed plot card to 0 until the end of the challenge
//Here I press the + Claim button three times. Claim remains 0 on the indicator, though chat messages don't correspond
user1 sets claim to 2 (+1)
user1 sets claim to 3 (+1)
user1 sets claim to 4 (+1)
user1 has gained 1 power from an unopposed challenge
The claim value for  is 0
//After the challenge the claim indicator rose to 4
```