### PR TITLE
Prevent premature kills from burn effects.

### DIFF
--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -209,6 +209,10 @@ class Effect {
             this.effect.apply(target, this.context);
         };
     }
+
+    get order() {
+        return this.effect.order || 0;
+    }
 }
 
 module.exports = Effect;

--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -18,6 +18,7 @@ class EffectEngine {
         }
 
         this.effects.push(effect);
+        this.effects = _.sortBy(this.effects, effect => effect.order);
         effect.addTargets(this.getTargets());
         this.registerRecalculateEvents(effect.recalculateWhen);
         if(effect.duration === 'custom') {

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -40,7 +40,8 @@ const Effects = {
             unapply: function(card, context) {
                 _.each(effects, effect => effect.unapply(card, context));
             },
-            isStateDependent: (stateDependentEffects.length !== 0)
+            isStateDependent: (stateDependentEffects.length !== 0),
+            order: _.max(_.pluck(effects, 'order'))
         };
     },
     cannotBeDeclaredAsAttacker: cannotEffect('declareAsAttacker'),

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -336,7 +336,8 @@ const Effects = {
         unapply: function() {
             // nothing happens when this effect expires.
         },
-        isStateDependent: true
+        isStateDependent: true,
+        order: 1000
     },
     blank: {
         apply: function(card) {

--- a/test/server/integration/burneffects.spec.js
+++ b/test/server/integration/burneffects.spec.js
@@ -1,0 +1,84 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('burn effects', function() {
+    integration(function() {
+        describe('when external effects are applied to a card that will be burned', function() {
+            beforeEach(function() {
+                const deck1 = this.buildDeck('baratheon', [
+                    'Blood of the Dragon',
+                    'Drogon'
+                ]);
+                const deck2 = this.buildDeck('thenightswatch', [
+                    'Trading with the Pentoshi',
+                    'The Wall', 'Messenger Raven'
+                ]);
+                this.player1.selectDeck(deck1);
+                this.player2.selectDeck(deck2);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.wall = this.player2.findCardByName('The Wall', 'hand');
+                this.raven = this.player2.findCardByName('Messenger Raven', 'hand');
+
+                this.completeSetup();
+
+                this.player1.selectPlot('Blood of the Dragon');
+                this.player2.selectPlot('Trading with the Pentoshi');
+                this.selectFirstPlayer(this.player2);
+
+                this.player2.clickCard(this.wall);
+                this.player2.clickCard(this.raven);
+            });
+
+            it('should not kill the character', function() {
+                expect(this.raven.location).toBe('play area');
+            });
+
+            it('should calculate the character\'s strength correctly', function() {
+                // 1 base + 1 from Wall - 1 from Blood of the Dragon = 1
+                expect(this.raven.getStrength()).toBe(1);
+            });
+        });
+
+        describe('when effects are self-applied to a card that will be burned', function() {
+            beforeEach(function() {
+                const deck1 = this.buildDeck('baratheon', [
+                    'Blood of the Dragon',
+                    'Drogon'
+                ]);
+                const deck2 = this.buildDeck('thenightswatch', [
+                    'Trading with the Pentoshi',
+                    'Hedge Knight', 'Silent Sisters'
+                ]);
+                this.player1.selectDeck(deck1);
+                this.player2.selectDeck(deck2);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.knight = this.player2.findCardByName('Hedge Knight', 'hand');
+                this.sisters = this.player2.findCardByName('Silent Sisters', 'hand');
+
+                this.completeSetup();
+
+                this.player1.selectPlot('Blood of the Dragon');
+                this.player2.selectPlot('Trading with the Pentoshi');
+                this.selectFirstPlayer(this.player2);
+
+                // Move character to dead pile to give Silent Sisters +1 STR.
+                this.player2.dragCard(this.knight, 'dead pile');
+
+                this.player2.clickCard(this.sisters);
+            });
+
+            it('should not kill the character', function() {
+                expect(this.sisters.location).toBe('play area');
+            });
+
+            it('should calculate the character\'s strength correctly', function() {
+                // 1 base + 1 from dead pile - 1 from Blood of the Dragon = 1
+                expect(this.sisters.getStrength()).toBe(1);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Previously, the order burn effects were applied was determined by the
order of players joining the game plus the order that the burn effect
came into play. This lead to bugs where a card both buffed by one card
and burned by another was killed because the burn effect happened first.
Now, the `killByStrength` effect is explicitly ordered to be applied
after other effects so that cards aren't killed inappropriately.

Fixes #868.
Fixes #966.
Fixes #543.