### PR TITLE
Fix Old Wyk

### DIFF
--- a/server/game/cards/characters/04/dolorousedd.js
+++ b/server/game/cards/characters/04/dolorousedd.js
@@ -17,7 +17,7 @@ class DolorousEdd extends DrawCard {
                 // Manually kneel Edd, since he enters play that way - should not fire a kneeling event.
                 this.kneeled = true;
                 this.game.currentChallenge.addDefender(this);
-                this.game.once('afterChallenge:interrupt', (event, challenge) => this.promptOnWin(challenge));
+                this.game.once('afterChallenge', (event, challenge) => this.promptOnWin(challenge));
             }
         });
     }

--- a/server/game/cards/characters/04/spearmaiden.js
+++ b/server/game/cards/characters/04/spearmaiden.js
@@ -16,7 +16,7 @@ class Spearmaiden extends DrawCard {
             handler: context => {
                 this.game.addMessage('{0} chooses {1} as the target for {2}', this.controller, context.target, this);
 
-                this.game.once('afterChallenge:interrupt', (event, challenge) => this.resolveIfWinBy5(challenge, context));
+                this.game.once('afterChallenge', (event, challenge) => this.resolveIfWinBy5(challenge, context));
             }
         });
     }

--- a/server/game/cards/locations/05/oldwyk.js
+++ b/server/game/cards/locations/05/oldwyk.js
@@ -21,7 +21,7 @@ class OldWyk extends DrawCard {
                 this.game.addMessage('{0} kneels {1} to put {2} into play from their dead pile as an attacker', 
                                       this.controller, this, card);
 
-                this.game.once('afterChallenge:interrupt', (event, challenge) => this.resolveAfterChallenge(challenge, card));
+                this.game.once('afterChallenge', (event, challenge) => this.resolveAfterChallenge(challenge, card));
             }
         });
     }

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -787,33 +787,6 @@ const Effects = {
                 player.mustChooseAsClaim = _.reject(player.mustChooseAsClaim, c => c === card);
             }
         };
-    },
-    /**
-     * Effects specifically for Old Wyk.
-     */
-    returnToHandOrDeckBottom: function() {
-        return {
-            apply: function(card, context) {
-                context.returnToHandOrDeckBottom = context.returnToHandOrDeckBottom || [];
-                context.returnToHandOrDeckBottom.push(card);
-            },
-            unapply: function(card, context) {
-                if(!context.returnToHandOrDeckBottom.includes(card)) {
-                    return;
-                }
-
-                context.returnToHandOrDeckBottom = _.reject(context.returnToHandOrDeckBottom, c => c === card);
-
-                var challenge = context.game.currentChallenge;
-                if(challenge && challenge.winner === context.source.controller && challenge.strengthDifference >= 5) {
-                    card.controller.moveCard(card, 'hand');
-                    context.game.addMessage('{0} returns {1} to their hand', context.source.controller, card);
-                } else {
-                    card.controller.moveCard(card, 'draw deck', { bottom: true });
-                    context.game.addMessage('{0} returns {1} to the bottom of their deck', context.source.controller, card);
-                }
-            }
-        };
     }
 };
 


### PR DESCRIPTION
* Previously, Old Wyk made use of a lasting effect until the end of the challenge to resolve its effect. This was incorrect as its ability should resolve after the winner is determined, but before any reactions, similar to Dolorous Edd or Spearmaiden.
* Checking if there's any Drowned God characters in the dead pile before prompting to trigger the reaction prevents triggering it without any change in game state.