### PR TITLE
Trigger reaction events for Annals of Castle Black.

### DIFF
--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -109,7 +109,11 @@ class TriggeredAbility extends BaseAbility {
     }
 
     isEventListeningLocation(location) {
-        return this.location === location;
+        // Reactions / interrupts need to listen for events in all open
+        // information locations plus while in hand. The location property of
+        // the ability will prevent it from firing in inappropriate locations
+        // when requirements are checked for the ability.
+        return ['active plot', 'agenda', 'discard pile', 'dead pile', 'faction', 'hand', 'play area'].includes(location);
     }
 
     isAction() {

--- a/test/server/cards/plots/06/06040-theannalsofcastleblack.spec.js
+++ b/test/server/cards/plots/06/06040-theannalsofcastleblack.spec.js
@@ -4,13 +4,17 @@
 describe('The Annals of Castle Black', function() {
     integration(function() {
         beforeEach(function() {
-            const deck = this.buildDeck('greyjoy', [
-                'The Annals of Castle Black', 'A Noble Cause',
-                'Wildling Horde', 'Lannisport Merchant', 'Hear Me Roar!'
+            const deck1 = this.buildDeck('greyjoy', [
+                'The Annals of Castle Black',
+                'Wildling Horde', 'Lannisport Merchant', 'Hear Me Roar!', 'Ahead of the Tide'
+            ]);
+            const deck2 = this.buildDeck('greyjoy', [
+                'A Noble Cause',
+                'Lannisport Merchant', 'Hear Me Roar!'
             ]);
 
-            this.player1.selectDeck(deck);
-            this.player2.selectDeck(deck);
+            this.player1.selectDeck(deck1);
+            this.player2.selectDeck(deck2);
             this.startGame();
             this.keepStartingHands();
 
@@ -19,8 +23,12 @@ describe('The Annals of Castle Black', function() {
             this.completeSetup();
 
             this.eventCard = this.player1.findCardByName('Hear Me Roar!', 'hand');
+            this.interruptEventCard = this.player1.findCardByName('Ahead of the Tide', 'hand');
             this.character = this.player1.findCardByName('Lannisport Merchant', 'hand');
             this.opponentEventCard = this.player2.findCardByName('Hear Me Roar!', 'hand');
+
+            // Move Ahead of the Tide to draw deck so it won't trigger
+            this.player1Object.moveCard(this.interruptEventCard, 'draw deck');
         });
 
         describe('when playing an event from hand', function() {
@@ -61,6 +69,25 @@ describe('The Annals of Castle Black', function() {
 
             it('should remove the event from the game', function() {
                 expect(this.eventCard.location).toBe('out of game');
+            });
+        });
+
+        describe('when an interrupt / reaction event is in discard', function() {
+            beforeEach(function() {
+                this.player1Object.moveCard(this.interruptEventCard, 'discard pile');
+
+                this.player1.selectPlot('The Annals of Castle Black');
+                this.player2.selectPlot('A Noble Cause');
+            });
+
+            it('should allow the event to trigger', function() {
+                expect(this.player1).toHavePromptButton('Ahead of the Tide');
+            });
+
+            it('should remove the event from the game if played', function() {
+                this.player1.clickPrompt('Ahead of the Tide');
+
+                expect(this.interruptEventCard.location).toBe('out of game');
             });
         });
 


### PR DESCRIPTION
Previously, Annals of Castle Black would not allow event interrupts /
reactions to trigger from discard. This is because event listeners were
only ever bound if the card was in the expected location - in the case
of event cards, in hand.

Now, interrupts / reactions listen to events in all open information
locations plus while in hand. Since the `location` property restricts
whether the ability actually fires, abilities should not activate while
in inappropriate locations even if it listens to events.

Fixes #1048.