### PR TITLE
Properly remove / apply effects during reattach.

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -316,10 +316,12 @@ class BaseCard {
         this.tokens = {};
     }
 
-    moveTo(targetLocation) {
+    moveTo(targetLocation, parent) {
         let originalLocation = this.location;
+        let originalParent = this.parent;
 
         this.location = targetLocation;
+        this.parent = parent;
 
         if(LocationsWithEventHandling.includes(targetLocation) && !LocationsWithEventHandling.includes(originalLocation)) {
             this.events.register(this.eventsForRegistration);
@@ -347,8 +349,8 @@ class BaseCard {
             this.facedown = false;
         }
 
-        if(originalLocation !== targetLocation) {
-            this.game.raiseMergedEvent('onCardMoved', { card: this, originalLocation: originalLocation, newLocation: targetLocation });
+        if(originalLocation !== targetLocation || originalParent !== parent) {
+            this.game.raiseMergedEvent('onCardMoved', { card: this, originalLocation: originalLocation, newLocation: targetLocation, parentChanged: originalParent !== parent });
         }
     }
 

--- a/server/game/cards/events/03/aryasgift.js
+++ b/server/game/cards/events/03/aryasgift.js
@@ -28,7 +28,6 @@ class AryasGift extends DrawCard {
     moveAttachment(player, newOwner, attachment, oldOwner) {
         player.attach(player, attachment, newOwner.uuid);
         this.game.addMessage('{0} moves {1} from {2} to {3}', player, attachment, oldOwner, newOwner);
-        this.game.addMessage(this.dupes.length);
 
         return true;
     }

--- a/server/game/cards/events/03/aryasgift.js
+++ b/server/game/cards/events/03/aryasgift.js
@@ -10,11 +10,8 @@ class AryasGift extends DrawCard {
                     card.parent.isFaction('stark') && card.parent.controller === this.controller
             },
             handler: context => {
-                let player = context.player;
                 let attachment = context.target;
                 let oldOwner = attachment.parent;
-
-                player.moveCard(attachment, 'play area');
 
                 this.game.promptForSelect(this.controller, {
                     cardCondition: card => card.getType() === 'character' && card.controller === this.controller &&

--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -42,7 +42,7 @@ class EffectEngine {
         let originalArea = event.originalLocation === 'hand' ? 'hand' : 'play area';
         let newArea = event.newLocation === 'hand' ? 'hand' : 'play area';
         this.removeTargetFromPersistentEffects(event.card, originalArea);
-        this.unapplyAndRemove(effect => effect.duration === 'persistent' && effect.source === event.card && effect.location === event.originalLocation);
+        this.unapplyAndRemove(effect => effect.duration === 'persistent' && effect.source === event.card && (effect.location === event.originalLocation || event.parentChanged));
         this.addTargetForPersistentEffects(event.card, newArea);
     }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -629,11 +629,12 @@ class Player extends Spectator {
         let originalLocation = attachment.location;
 
         attachment.owner.removeCardFromPile(attachment);
-        attachment.parent = card;
-        attachment.moveTo('play area');
+        attachment.moveTo('play area', card);
         card.attachments.push(attachment);
 
-        attachment.applyPersistentEffects();
+        this.game.queueSimpleStep(() => {
+            attachment.applyPersistentEffects();
+        });
 
         if(originalLocation !== 'play area') {
             this.game.raiseMergedEvent('onCardEntersPlay', { card: attachment, playingType: playingType, originalLocation: originalLocation });

--- a/test/server/cards/events/03/03024-aryasgift.spec.js
+++ b/test/server/cards/events/03/03024-aryasgift.spec.js
@@ -1,0 +1,58 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('Arya\'s Gift', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck = this.buildDeck('stark', [
+                'A Noble Cause',
+                'Winterfell Steward', 'Bran Stark', 'Milk of the Poppy', 'Arya\'s Gift'
+            ]);
+
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.character1 = this.player1.findCardByName('Bran Stark', 'hand');
+            this.character2 = this.player1.findCardByName('Winterfell Steward', 'hand');
+
+            this.milk = this.player2.findCardByName('Milk of the Poppy', 'hand');
+
+            this.player1.clickCard(this.character1);
+            this.player1.clickCard(this.character2);
+
+            this.completeSetup();
+
+            this.player1.selectPlot('A Noble Cause');
+            this.player2.selectPlot('A Noble Cause');
+            this.selectFirstPlayer(this.player2);
+
+            // Attach Milk to the first character.
+            this.player2.clickCard(this.milk);
+            this.player2.clickCard(this.character1);
+
+            this.completeMarshalPhase();
+        });
+
+        describe('when played', function() {
+            beforeEach(function() {
+                this.player1.clickCard('Arya\'s Gift', 'hand');
+                this.player1.clickCard(this.milk);
+                this.player1.clickCard(this.character2);
+            });
+
+            it('should move the attachment to the new parent', function() {
+                expect(this.milk.parent).toBe(this.character2);
+            });
+
+            it('should apply effects to the new parent', function() {
+                expect(this.character2.isBlank()).toBe(true);
+            });
+
+            it('should unapply effects from the old parent', function() {
+                expect(this.character1.isBlank()).toBe(false);
+            });
+        });
+    });
+});

--- a/test/server/player/removeattachment.spec.js
+++ b/test/server/player/removeattachment.spec.js
@@ -6,7 +6,8 @@ const DrawCard = require('../../../server/game/drawcard.js');
 
 describe('Player', function() {
     beforeEach(function() {
-        this.gameSpy = jasmine.createSpyObj('game', ['addMessage', 'raiseEvent', 'raiseMergedEvent', 'getOtherPlayer', 'playerDecked']);
+        this.gameSpy = jasmine.createSpyObj('game', ['addMessage', 'queueSimpleStep', 'raiseEvent', 'raiseMergedEvent', 'getOtherPlayer', 'playerDecked']);
+        this.gameSpy.queueSimpleStep.and.callFake(step => step());
         this.player = new Player('1', 'Player 1', true, this.gameSpy);
         this.player.deck = {};
         this.player.initialise();


### PR DESCRIPTION
Previously, when an attachment was re-attached from one card to another,
it would leave its effect on the original parent in addition to applying
it to the new parent. Now, effects are removed immediately when the
parent changes, and effects are applied to the new parent asynchronously
after the move has completed.

Fixes #1097 