### PR TITLE
Fix ordering of leaves play events / effects.

### DIFF
--- a/server/game/player.js
+++ b/server/game/player.js
@@ -945,20 +945,20 @@ class Player extends Spectator {
                 return;
             }
 
-            card.attachments.each(attachment => {
-                this.removeAttachment(attachment, false);
-            });
-
-            while(card.dupes.size() > 0 && targetLocation !== 'play area') {
-                this.removeDuplicate(card, true);
-            }
-
             var params = {
                 player: this,
                 card: card
             };
 
             this.game.raiseMergedEvent('onCardLeftPlay', params, event => {
+                card.attachments.each(attachment => {
+                    this.removeAttachment(attachment, false);
+                });
+
+                while(card.dupes.size() > 0 && targetLocation !== 'play area') {
+                    this.removeDuplicate(card, true);
+                }
+
                 event.card.leavesPlay();
 
                 if(event.card.parent && event.card.parent.attachments) {

--- a/test/server/cards/attachments/06022-marriagepact.spec.js
+++ b/test/server/cards/attachments/06022-marriagepact.spec.js
@@ -1,0 +1,79 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('Marriage Pact', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck = this.buildDeck('greyjoy', [
+                'A Noble Cause',
+                'Hedge Knight', 'Marriage Pact'
+            ]);
+
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.character = this.player1.findCardByName('Hedge Knight', 'hand');
+            this.pact = this.player1.findCardByName('Marriage Pact', 'hand');
+            this.opponentCharacter = this.player2.findCardByName('Hedge Knight', 'hand');
+
+
+            this.player1.clickCard(this.character);
+            this.player2.clickCard(this.opponentCharacter);
+            this.completeSetup();
+
+            this.player1.selectPlot('A Noble Cause');
+            this.player2.selectPlot('A Noble Cause');
+            this.selectFirstPlayer(this.player1);
+
+            // Attach Marriage Pact
+            this.player1.clickCard(this.pact);
+            this.player1.clickCard(this.opponentCharacter);
+
+            this.completeMarshalPhase();
+        });
+
+        describe('when the opponent is defender', function() {
+            beforeEach(function() {
+                this.player1.clickPrompt('Done');
+
+                this.player2.clickPrompt('Military');
+            });
+
+            it('should not allow the attached character to attack in a challenge', function() {
+                let selectState = this.player2Object.getCardSelectionState(this.opponentCharacter);
+                expect(selectState.selectable).toBe(false);
+            });
+        });
+
+        describe('when the opponent is defender', function() {
+            beforeEach(function() {
+                this.player1.clickPrompt('Military');
+                this.player1.clickCard(this.character);
+                this.player1.clickPrompt('Done');
+
+                this.skipActionWindow();
+            });
+
+            it('should not allow the attached character to defend in a challenge', function() {
+                let selectState = this.player2Object.getCardSelectionState(this.opponentCharacter);
+                expect(selectState.selectable).toBe(false);
+            });
+        });
+
+        describe('when the attached character is killed', function() {
+            beforeEach(function() {
+                this.unopposedChallenge(this.player1, 'Military', this.character);
+                this.player1.clickPrompt('Apply Claim');
+                this.player2.clickCard(this.opponentCharacter);
+            });
+
+            it('should prompt the player to sacrifice a character', function() {
+                expect(this.player1).toHavePrompt('Select a character');
+                this.player1.clickCard(this.character);
+                expect(this.character.location).toBe('discard pile');
+            });
+        });
+    });
+});


### PR DESCRIPTION
Previously, when a card would leave play it would remove attachments and
dupes from the card prior to interrupts firing. This caused a bug where
Marriage Pact's forced interrupt would not fire because it was detached
from the parent before the parent started to leave play.

Now, all interrupts fire for the card leaving play, then attachments and
dupes on the card leave play, then reactions to the card leaving play
fire.

Fixes #1052 