### PR TITLE
Explicitly recalculate effects at phase start.

### DIFF
--- a/server/game/game.js
+++ b/server/game/game.js
@@ -804,6 +804,10 @@ class Game extends EventEmitter {
         this.addMessage('{0} has reconnected', player);
     }
 
+    reapplyStateDependentEffects() {
+        this.effectEngine.reapplyStateDependentEffects();
+    }
+
     continue() {
         this.effectEngine.reapplyStateDependentEffects();
         this.pipeline.continue();

--- a/server/game/gamesteps/phase.js
+++ b/server/game/gamesteps/phase.js
@@ -45,6 +45,7 @@ class Phase extends BaseStep {
         _.each(this.game.getPlayers(), player => {
             player.phase = this.name;
         });
+        this.game.reapplyStateDependentEffects();
         this.game.raiseEvent('onPhaseStarted', this.name);
     }
 


### PR DESCRIPTION
Previously, effects were only recalculated when user input was required.
This could lead to bugs with effect recalculation during long periods
that may not have any user input - e.g. from the end of the challenges
phase to the beginning of the taxation phase if both players had those
windows off. The biggest example being lasting effects that only applied
during the standing phase (Stannis TIMC, etc). Now effects are
explicitly recalculated at the beginning of each phase.