### PR TITLE
Convert 'cannot stand during standing' to true cannot effect

### DIFF
--- a/server/game/cards/attachments/07/catapultonthewall.js
+++ b/server/game/cards/attachments/07/catapultonthewall.js
@@ -5,8 +5,6 @@ class CatapultOnTheWall extends DrawCard {
         this.action({
             title: 'Kneel Catapult and attached character',
             condition: () => this.game.currentChallenge,
-
-            // This is not a nice interaction for users, but `ability.costs` would need to be updated with a different method to allow something like attachment.parent.kneel() (I think)
             cost: [
                 ability.costs.kneelSelf(),
                 ability.costs.kneelParent()
@@ -16,11 +14,12 @@ class CatapultOnTheWall extends DrawCard {
                 cardCondition: card => this.game.currentChallenge.isAttacking(card) && card.getStrength() <= 4
             },
             handler: context => {
-                context.target.owner.killCharacter(context.target);
+                this.game.killCharacter(context.target);
                 this.game.addMessage('{0} kneels {1} and {2} to kill {3}', context.player, this, this.parent, context.target);
-                this.parent.untilEndOfRound(ability => ({
+                this.untilEndOfRound(ability => ({
+                    condition: () => this.game.currentPhase === 'standing',
                     match: this.parent,
-                    effect: ability.effects.doesNotStandDuringStanding()
+                    effect: ability.effects.cannotBeStood()
                 }));
             }
         });

--- a/server/game/cards/characters/04/stannisbaratheon.js
+++ b/server/game/cards/characters/04/stannisbaratheon.js
@@ -16,30 +16,22 @@ class StannisBaratheon extends DrawCard {
             when: {
                 onDominanceDetermined: (event, winner) => this.controller === winner
             },
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    cardCondition: card => (
-                        card.location === 'play area' && 
-                        card.getType() === 'character' && 
-                        !card.isLoyal()),
-                    activePromptTitle: 'Select a character',
-                    source: this,
-                    onSelect: (player, card) => this.onCardSelected(player, card)
-                });
+            target: {
+                activePromptTitle: 'Select a character',
+                cardCondition: card => card.location === 'play area' && card.getType() === 'character' &&
+                                       !card.isLoyal()
+            },
+            handler: context => {
+                this.untilEndOfRound(ability => ({
+                    condition: () => this.game.currentPhase === 'standing',
+                    match: context.target,
+                    effect: ability.effects.cannotBeStood()
+                }));
+
+                this.game.addMessage('{0} uses {1} to make {2} unable to stand during the standing phase this round', 
+                                      this.controller, this, context.target);
             }
         });
-    }
-
-    onCardSelected(player, card) {
-        this.game.addMessage('{0} uses {1} to make {2} unable to stand during the standing phase this round', 
-                              player, this, card);
-
-        this.untilEndOfRound(ability => ({
-            match: card,
-            effect: ability.effects.doesNotStandDuringStanding()
-        }));
-
-        return true;
     }
 }
 

--- a/server/game/cards/events/06/savingthekingdom.js
+++ b/server/game/cards/events/06/savingthekingdom.js
@@ -13,11 +13,12 @@ class SavingTheKingdom extends DrawCard {
                 context.target.controller.kneelCard(context.target);
 
                 this.untilEndOfRound(ability => ({
+                    condition: () => this.game.currentPhase === 'standing',
                     match: context.target,
-                    effect: ability.effects.doesNotStandDuringStanding()
+                    effect: ability.effects.cannotBeStood()
                 }));
 
-                this.game.addMessage('{0} plays {1} to make {2} unable to stand during the standing phase this round', 
+                this.game.addMessage('{0} plays {1} to kneel and make {2} unable to stand during the standing phase this round', 
                                       this.controller, this, context.target);
             }
         });

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -45,7 +45,6 @@ class DrawCard extends BaseCard {
         this.inDanger = false;
         this.wasAmbush = false;
         this.saved = false;
-        this.standsDuringStanding = true;
         this.challengeOptions = {
             doesNotContributeStrength: false,
             doesNotKneelAs: {

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -457,16 +457,6 @@ const Effects = {
             }
         };
     },
-    doesNotStandDuringStanding: function() {
-        return {
-            apply: function(card) {
-                card.standsDuringStanding = false;
-            },
-            unapply: function(card) {
-                card.standsDuringStanding = true;
-            }
-        };
-    },
     optionalStandDuringStanding: function() {
         return {
             apply: function(card) {

--- a/server/game/gamesteps/standingphase.js
+++ b/server/game/gamesteps/standingphase.js
@@ -21,7 +21,7 @@ class StandingPhase extends Phase {
     }
 
     standCardsForPlayer(player) {
-        let kneelingCards = this.game.allCards.filter(card => card.location === 'play area' && card.kneeled && card.controller === player && card.standsDuringStanding && card.allowGameAction('stand'));
+        let kneelingCards = this.game.allCards.filter(card => card.location === 'play area' && card.kneeled && card.controller === player && card.allowGameAction('stand'));
         let restrictedSubset = [];
         _.each(player.standPhaseRestrictions, restriction => {
             let restrictedCards = _.filter(kneelingCards, card => restriction.match(card));


### PR DESCRIPTION
Previously, effects that made cards unable to stand during the standing phase were implemented by setting and checking a flag during the mandatory standing in the standing phase. This worked fine for the majority of use cases, but it still wrongly allowed cards to be stood during the standing phase by for example a card like Magister Illyrio. This PR fixes that by porting these implementations to true cannot effects.

Needs #1109 