### PR TITLE
Handle characters with null strength.

### DIFF
--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -149,11 +149,12 @@ class DrawCard extends BaseCard {
     }
 
     getStrength(printed = false) {
+        let baseStrength = (this.cardData.strength || 0);
+
         if(this.controller.phase === 'setup' || printed) {
-            return this.cardData.strength || undefined;
+            return baseStrength;
         }
 
-        let baseStrength = (this.cardData.strength || 0);
         let modifiedStrength = this.strengthModifier + baseStrength;
         let multipliedStrength = Math.round(this.strengthMultiplier * modifiedStrength);
         return Math.max(0, multipliedStrength);
@@ -368,7 +369,7 @@ class DrawCard extends BaseCard {
             attachments: this.attachments.map(attachment => {
                 return attachment.getSummary(activePlayer, hideWhenFaceup);
             }),
-            baseStrength: _.isNull(this.cardData.strength) ? 0 : this.cardData.strength,
+            baseStrength: this.getStrength(true),
             dupes: this.dupes.map(dupe => {
                 if(dupe.dupes.size() !== 0) {
                     throw new Error('A dupe should not have dupes! ' + dupe.name);
@@ -383,7 +384,7 @@ class DrawCard extends BaseCard {
             kneeled: this.kneeled,
             power: this.power,
             saved: this.saved,
-            strength: !_.isNull(this.cardData.strength) ? this.getStrength() : 0,
+            strength: this.getStrength(),
             stealth: this.stealth
         });
     }


### PR DESCRIPTION
Per this change to the JSON data format, cards that have X strength like
Dacey Mormont and Beric Dondarrian are represented with a NULL strength.
https://github.com/Alsciende/thronesdb-json-data/pull/160/commits/b5982faf8126c4f030af26dc71d28150f235983b

Such cards were not displaying their strength at all because the
serializer was always sending strength 0 even if the strength was
boosted through effects. Now, the printed strength and current strength
are fully calculated regardless of whether the JSON field is null. This
should ensure strength is always displayed properly. It should not
affect location and attachment cards, as their strength was already
being sent as 0 and `DrawCard.getStrength` now always returns 0 if
strength is not defined.

Fixes #1131.