### PR TITLE
Handle layout for additional piles client side.

### DIFF
--- a/client/GameBoard.jsx
+++ b/client/GameBoard.jsx
@@ -269,24 +269,23 @@ export class InnerGameBoard extends React.Component {
         return cardsByLocation;
     }
 
-    getAdditionalPlotPiles(player, isMe) {
-        if(!player) {
+    getSchemePile(player, isMe) {
+        let schemePile = player && player.additionalPiles['scheme plots'];
+
+        if(!schemePile) {
             return;
         }
 
-        var piles = _.reject(player.additionalPiles, pile => pile.cards.length === 0 || pile.area !== 'plots');
-        var index = 0;
-        return _.map(piles, pile => {
-            return (
-                <AdditionalCardPile key={'additional-pile-' + index++}
-                    className='plot'
-                    isMe={isMe}
-                    onMouseOut={this.onMouseOut}
-                    onMouseOver={this.onMouseOver}
-                    pile={pile}
-                    spectating={this.state.spectating} />
-            );
-        });
+        return (
+            <AdditionalCardPile
+                className='plot'
+                isMe={isMe}
+                onMouseOut={this.onMouseOut}
+                onMouseOver={this.onMouseOver}
+                pile={schemePile}
+                spectating={this.state.spectating}
+                title='Schemes' />
+        );
     }
 
     onCommand(command, arg, method) {
@@ -393,7 +392,7 @@ export class InnerGameBoard extends React.Component {
                         <div className='middle'>
                              <div className='plots-pane'>
                                 <div className='plot-group'>
-                                    {this.getAdditionalPlotPiles(otherPlayer, false)}
+                                    {this.getSchemePile(otherPlayer, false)}
                                     <CardCollection className={otherPlayer && otherPlayer.plotSelected ? 'plot plot-selected' : 'plot'}
                                                     title='Plots' source='plot deck' cards={otherPlayer ? otherPlayer.plotDeck : []}
                                                     topCard={{ facedown: true, kneeled: true }} orientation='horizontal'
@@ -410,7 +409,7 @@ export class InnerGameBoard extends React.Component {
                                     <CardCollection className={thisPlayer.plotSelected ? 'plot plot-selected' : 'plot'}
                                                     title='Plots' source='plot deck' cards={thisPlayer.plotDeck} topCard={{ facedown: true, kneeled: true }} orientation='horizontal'
                                                     onMouseOver={this.onMouseOver} onMouseOut={this.onMouseOut} onCardClick={this.onCardClick} onDragDrop={this.onDragDrop} />
-                                    {this.getAdditionalPlotPiles(thisPlayer, !this.state.spectating)}
+                                    {this.getSchemePile(thisPlayer, !this.state.spectating)}
                                 </div>
                             </div>
                             <div className='middle-right'>

--- a/client/GameComponents/AdditionalCardPile.jsx
+++ b/client/GameComponents/AdditionalCardPile.jsx
@@ -15,7 +15,7 @@ class AdditionalCardPile extends React.Component {
         return (
             <CardCollection
                 className={this.props.className}
-                title={this.props.pile.title}
+                title={this.props.title}
                 source='additional'
                 cards={this.props.pile.cards}
                 topCard={topCard}
@@ -35,7 +35,8 @@ AdditionalCardPile.propTypes = {
     onMouseOut: React.PropTypes.func,
     onMouseOver: React.PropTypes.func,
     pile: React.PropTypes.object,
-    spectating: React.PropTypes.bool
+    spectating: React.PropTypes.bool,
+    title: React.PropTypes.string
 };
 
 export default AdditionalCardPile;

--- a/client/GameComponents/PlayerRow.jsx
+++ b/client/GameComponents/PlayerRow.jsx
@@ -148,20 +148,23 @@ class PlayerRow extends React.Component {
         }
     }
 
-    getAdditionalPiles() {
-        var piles = _.reject(this.props.additionalPiles, pile => pile.cards.length === 0 || pile.area !== 'player row');
-        var index = 0;
-        return _.map(piles, pile => {
-            return (
-                <AdditionalCardPile key={'additional-pile-' + index++}
-                    className='additional-cards'
-                    isMe={this.props.isMe}
-                    onMouseOut={this.props.onMouseOut}
-                    onMouseOver={this.props.onMouseOver}
-                    pile={pile}
-                    spectating={this.props.spectating} />
-            );
-        });
+    getOutOfGamePile() {
+        let pile = this.props.additionalPiles['out of game'];
+
+        if(!pile || pile.cards.length === 0) {
+            return;
+        }
+
+        return (
+            <AdditionalCardPile
+                className='additional-cards'
+                isMe={this.props.isMe}
+                onMouseOut={this.props.onMouseOut}
+                onMouseOver={this.props.onMouseOver}
+                pile={pile}
+                spectating={this.props.spectating}
+                title='Out of Game' />
+        );
     }
 
     render() {
@@ -173,8 +176,6 @@ class PlayerRow extends React.Component {
         }
 
         var hand = this.getHand(needsSquish);
-
-        var additionalPiles = this.getAdditionalPiles();
 
         var drawDeckMenu = [
             { text: 'Show', handler: this.onShowDeckClick, showPopup: true },
@@ -206,7 +207,7 @@ class PlayerRow extends React.Component {
                 <CardCollection className='dead' title='Dead' source='dead pile' cards={this.props.deadPile}
                                 onMouseOver={this.props.onMouseOver} onMouseOut={this.props.onMouseOut} onCardClick={this.props.onCardClick}
                                 popupLocation={this.props.isMe || this.props.spectating ? 'top' : 'bottom'} onDragDrop={this.props.onDragDrop} orientation='kneeled' />
-                  {additionalPiles}
+                  {this.getOutOfGamePile()}
                 </div>
             </div>
         );

--- a/server/game/cards/agendas/therainsofcastamere.js
+++ b/server/game/cards/agendas/therainsofcastamere.js
@@ -41,7 +41,7 @@ class TheRainsOfCastamere extends AgendaCard {
     }
 
     onDecksPrepared() {
-        this.owner.createAdditionalPile('scheme plots', { title: 'Schemes', area: 'plots', isPrivate: true });
+        this.owner.createAdditionalPile('scheme plots', { isPrivate: true });
         var schemePartition = this.owner.plotDeck.partition(card => card.hasTrait('Scheme'));
         this.schemes = schemePartition[0];
         this.owner.plotDeck = _(schemePartition[1]);

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -54,7 +54,7 @@ class Player extends Spectator {
             standing: false
         };
 
-        this.createAdditionalPile('out of game', { title: 'Out of Game', area: 'player row' });
+        this.createAdditionalPile('out of game');
 
         this.promptState = new PlayerPromptState();
     }
@@ -691,7 +691,7 @@ class Player extends Spectator {
         }
     }
 
-    createAdditionalPile(name, properties) {
+    createAdditionalPile(name, properties = {}) {
         this.additionalPiles[name] = _.extend({ cards: _([]) }, properties);
     }
 
@@ -1135,8 +1135,6 @@ class Player extends Spectator {
         let state = {
             activePlot: this.activePlot ? this.activePlot.getSummary(activePlayer) : undefined,
             additionalPiles: _.mapObject(this.additionalPiles, pile => ({
-                title: pile.title,
-                area: pile.area,
                 isPrivate: pile.isPrivate,
                 cards: this.getSummaryForCardList(pile.cards, activePlayer, pile.isPrivate)
             })),

--- a/test/client/GameBoard.spec.jsx
+++ b/test/client/GameBoard.spec.jsx
@@ -1,4 +1,4 @@
-/* global describe, it, expect, beforeEach, jasmine */
+/* global describe, it, expect, beforeEach, jasmine, xdescribe */
 /* eslint camelcase: 0, no-invalid-this: 0 */
 
 import GameBoard, { InnerGameBoard } from '../../client/GameBoard.jsx';
@@ -36,8 +36,8 @@ describe('the <GameBoard /> component', function() {
 
         component = ReactDOM.render(<InnerGameBoard />, node);
 
-        state.games.currentGame.players['1'] = { id: 1, name: '1' };
-        state.games.currentGame.players['2'] = { id: 2, name: '2' };
+        state.games.currentGame.players['1'] = { id: 1, name: '1', additionalPiles: {} };
+        state.games.currentGame.players['2'] = { id: 2, name: '2', additionalPiles: {} };
         state.socket.socket = jasmine.createSpyObj('socket', ['emit']);
         state.auth.username = '1';
         state.socket.username = '1';

--- a/test/server/cards/agendas/05045-therainsofcastamere.spec.js
+++ b/test/server/cards/agendas/05045-therainsofcastamere.spec.js
@@ -45,7 +45,7 @@ describe('The Rains of Castamere', function() {
         });
 
         it('should create the schemes plot pile', function() {
-            expect(this.player.createAdditionalPile).toHaveBeenCalledWith('scheme plots', { title: jasmine.any(String), area: 'plots', isPrivate: true });
+            expect(this.player.createAdditionalPile).toHaveBeenCalledWith('scheme plots', { isPrivate: true });
         });
 
         it('should remove the schemes from the players plot deck', function() {


### PR DESCRIPTION
Removes the presentational concerns of 'area' and 'title' for Scheme and
Out of Game piles from the backend and moves them to the client side.