### PR TITLE
Do not let abilities trigger in the wrong window.

### DIFF
--- a/server/game/game.js
+++ b/server/game/game.js
@@ -623,7 +623,7 @@ class Game extends EventEmitter {
     }
 
     registerAbility(ability) {
-        let windowIndex = _.findLastIndex(this.abilityWindowStack, window => ability.isTriggeredByEvent(window.event));
+        let windowIndex = _.findLastIndex(this.abilityWindowStack, window => ability.eventType === window.abilityType && ability.isTriggeredByEvent(window.event));
 
         if(windowIndex === -1) {
             return;

--- a/test/server/cards/agendas/05045-therainsofcastamere.spec.js
+++ b/test/server/cards/agendas/05045-therainsofcastamere.spec.js
@@ -280,7 +280,7 @@ describe('The Rains of Castamere', function() {
         beforeEach(function() {
             const deck = this.buildDeck('lannister', [
                 '"The Rains of Castamere"',
-                'Trading with the Pentoshi', 'Wardens of the West',
+                'Trading with the Pentoshi', 'Wardens of the West', 'The Red Wedding',
                 'Cersei Lannister (LoCR)'
             ]);
             this.player1.selectDeck(deck);
@@ -320,6 +320,12 @@ describe('The Rains of Castamere', function() {
             this.player1.clickPrompt('Wardens of the West');
 
             expect(this.player1).toHavePromptButton('Wardens of the West');
+        });
+
+        it('should not allow interrupts in the current window to trigger since the current window is for reactions only', function() {
+            this.player1.clickPrompt('The Red Wedding');
+
+            expect(this.player1).not.toHavePromptButton('The Red Wedding');
         });
     });
 });


### PR DESCRIPTION
Previously, if a card with an interrupt ability entered play during the
window for reactions (e.g. reveal The Red Wedding with Rains of
Castamere), the player would be inappropriately prompted. Now, the
ability type for abilities are checked against the ability type for any
open windows.

Fixes #1118 