### PR TITLE
Implement Craster's resurrect ability.

### DIFF
--- a/server/game/cardeventlog.js
+++ b/server/game/cardeventlog.js
@@ -1,0 +1,32 @@
+const _ = require('underscore');
+
+const EventRegistrar = require('./eventregistrar.js');
+
+class CardEventLog {
+    constructor(game) {
+        this.game = game;
+        this.events = new EventRegistrar(game, this);
+
+        this.log = [];
+
+        this.events.register(['onCharacterKilled']);
+    }
+
+    any(predicate) {
+        return _.any(this.log, predicate);
+    }
+
+    filterCards(predicate) {
+        return _.pluck(_.filter(this.log, predicate), 'card');
+    }
+
+    register(type, card) {
+        this.log.push({ type: type, card: card, round: this.game.round, phase: this.game.currentPhase });
+    }
+
+    onCharacterKilled(event) {
+        this.register('kill', event.card);
+    }
+}
+
+module.exports = CardEventLog;

--- a/server/game/cards/characters/04/craster.js
+++ b/server/game/cards/characters/04/craster.js
@@ -1,3 +1,5 @@
+const _ = require('underscore');
+
 const DrawCard = require('../../../drawcard.js');
 
 class Craster extends DrawCard {
@@ -6,7 +8,27 @@ class Craster extends DrawCard {
             match: this,
             effect: ability.effects.immuneTo(card => card.hasTrait('Omen'))
         });
-        // TODO: Sacrifice to put characters killed this phase back into play.
+        this.action({
+            title: 'Sacrifice to resurrect',
+            cost: ability.costs.sacrificeSelf(),
+            condition: () => this.game.anyCardsInLog(log => this.killedInCurrentPhase(log)),
+            handler: () => {
+                let characters = this.game.filterCardsInLog(log => this.killedInCurrentPhase(log));
+                _.each(characters, character => {
+                    character.owner.putIntoPlay(character);
+                });
+                this.game.addMessage('{0} sacrifices {1} to put into play each character killed this phase', this.controller, this);
+            }
+        });
+    }
+
+    killedInCurrentPhase(log) {
+        return (
+            log.type === 'kill' &&
+            log.round === this.game.round &&
+            log.phase === this.game.currentPhase &&
+            log.card.location === 'dead pile'
+        );
     }
 }
 

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -56,6 +56,7 @@ class Game extends EventEmitter {
             isApplying: false,
             type: undefined
         };
+        this.round = 0;
 
         _.each(details.players, player => {
             this.playersAndSpectators[player.user.username] = new Player(player.id, player.user, this.owner === player.user.username, this);
@@ -572,6 +573,7 @@ class Game extends EventEmitter {
     }
 
     beginRound() {
+        this.round += 1;
         this.raiseEvent('onBeginRound');
         this.queueStep(new PlotPhase(this));
         this.queueStep(new DrawPhase(this));

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -27,6 +27,7 @@ const SimultaneousEventWindow = require('./gamesteps/simultaneouseventwindow.js'
 const AbilityResolver = require('./gamesteps/abilityresolver.js');
 const ForcedTriggeredAbilityWindow = require('./gamesteps/forcedtriggeredabilitywindow.js');
 const TriggeredAbilityWindow = require('./gamesteps/triggeredabilitywindow.js');
+const CardEventLog = require('./cardeventlog.js');
 const KillCharacters = require('./gamesteps/killcharacters.js');
 
 class Game extends EventEmitter {
@@ -57,6 +58,7 @@ class Game extends EventEmitter {
             type: undefined
         };
         this.round = 0;
+        this.cardEventLog = new CardEventLog(this);
 
         _.each(details.players, player => {
             this.playersAndSpectators[player.user.username] = new Player(player.id, player.user, this.owner === player.user.username, this);
@@ -691,6 +693,14 @@ class Game extends EventEmitter {
 
             this.raiseEvent('onCardTakenControl', card);
         });
+    }
+
+    anyCardsInLog(predicate) {
+        return this.cardEventLog.any(predicate);
+    }
+
+    filterCardsInLog(predicate) {
+        return this.cardEventLog.filterCards(predicate);
     }
 
     applyGameAction(actionType, cards, func) {

--- a/test/server/cards/characters/04/04085-craster.spec.js
+++ b/test/server/cards/characters/04/04085-craster.spec.js
@@ -1,0 +1,108 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('Craster', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck1 = this.buildDeck('thenightswatch', [
+                'A Noble Cause', 'Called Into Service',
+                'Craster', 'Steward at the Wall', 'Old Forest Hunter'
+            ]);
+            const deck2 = this.buildDeck('thenightswatch', [
+                'Valar Morghulis',
+                'Benjen Stark', 'Steward at the Wall', 'Old Forest Hunter'
+            ]);
+
+            this.player1.togglePromptedActionWindow('plot', true);
+            this.player1.selectDeck(deck1);
+            this.player2.selectDeck(deck2);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.craster = this.player1.findCardByName('Craster', 'hand');
+            this.character = this.player1.findCardByName('Steward at the Wall', 'hand');
+
+            this.opponentCharacter = this.player2.findCardByName('Steward at the Wall', 'hand');
+
+        });
+
+        describe('while Craster is out when characters are killed', function() {
+            beforeEach(function() {
+                this.benjen = this.player2.findCardByName('Benjen Stark', 'hand');
+
+                this.player1.clickCard(this.craster);
+                this.player1.clickCard(this.character);
+                this.player2.clickCard(this.benjen);
+                this.player2.clickCard(this.opponentCharacter);
+                this.completeSetup();
+                this.player1.selectPlot('A Noble Cause');
+                this.player2.selectPlot('Valar Morghulis');
+                this.selectFirstPlayer(this.player1);
+
+                this.player2.clickPrompt('Benjen Stark');
+                expect(this.benjen.location).toBe('draw deck');
+            });
+
+            describe('when sacrificing Craster in the same phase', function() {
+                beforeEach(function() {
+                    this.player1.clickMenu(this.craster, 'Sacrifice to resurrect');
+                });
+
+                it('should put your dead pile cards into play', function() {
+                    expect(this.character.location).toBe('play area');
+                });
+
+                it('should put opponent dead pile cards into play', function() {
+                    expect(this.opponentCharacter.location).toBe('play area');
+                });
+
+                it('should not put killed characters not in dead pile into play', function() {
+                    expect(this.benjen.location).not.toBe('play area');
+                });
+            });
+
+            describe('when sacrificing Craster in the following phase', function() {
+                beforeEach(function() {
+                    // Clear plot phase by passing on the action window.
+                    this.player1.clickPrompt('Done');
+
+                    this.player1.clickMenu(this.craster, 'Sacrifice to resurrect');
+                });
+
+                it('should not resurrect any cards', function() {
+                    expect(this.character.location).toBe('dead pile');
+                    expect(this.opponentCharacter.location).toBe('dead pile');
+                    expect(this.benjen.location).not.toBe('play area');
+                });
+            });
+        });
+
+        describe('when Craster comes out after characters are killed', function() {
+            beforeEach(function() {
+                this.player1.clickCard(this.character);
+                this.player2.clickCard(this.opponentCharacter);
+                this.completeSetup();
+
+                // Move Craster to the top of draw deck to put him into play with Called Into Service.
+                this.player1Object.moveCard(this.craster, 'draw deck');
+
+                this.player1.selectPlot('Called Into Service');
+                this.player2.selectPlot('Valar Morghulis');
+                this.selectFirstPlayer(this.player1);
+                // Resolve Valar before Called Into Service.
+                this.selectPlotOrder(this.player2);
+
+                expect(this.craster.location).toBe('play area');
+                this.player1.clickMenu(this.craster, 'Sacrifice to resurrect');
+            });
+
+            it('should put your dead pile cards into play', function() {
+                expect(this.character.location).toBe('play area');
+            });
+
+            it('should put opponent dead pile cards into play', function() {
+                expect(this.opponentCharacter.location).toBe('play area');
+            });
+        });
+    });
+});


### PR DESCRIPTION
* Keeps track of the current round of the game.
* Keeps track of when characters are killed in a card event log (can be extended in the future should we need to track discards, return to hand, etc for effects similar to Craster).
* Implements Craster's ability.

I would have preferred to track character's killed directly on Craster, but he can't listen to events when he's not in play. Thus, if characters are killed during the same phase prior to him entering play (see test w/ Valar vs Called Into Service), it wouldn't register those characters as having been killed when tracking on the card directly.