### PR TITLE
allow saves for all (savable) "return to hand" effects

### DIFF
--- a/server/game/cards/characters/05/redkeepspy.js
+++ b/server/game/cards/characters/05/redkeepspy.js
@@ -20,7 +20,7 @@ class RedKeepSpy extends DrawCard {
                         card.getType() === 'character' &&
                         card.getCost() <= 3),
                     onSelect: (player, card) => {
-                        card.controller.moveCard(card, 'hand');
+                        card.owner.returnCardToHand(card);
                         this.game.addMessage('{0} uses {1} to return {2} to {3}\'s hand', player, this, card, card.controller);
 
                         return true;

--- a/server/game/cards/characters/06/orphanofthegreenblood.js
+++ b/server/game/cards/characters/06/orphanofthegreenblood.js
@@ -14,7 +14,7 @@ class OrphanOfTheGreenblood extends DrawCard {
                     card.getType() === 'character')
             },
             handler: context => {
-                context.target.controller.moveCard(context.target, 'hand');
+                context.target.owner.returnCardToHand(context.target);
                 this.game.addMessage('{0} discards 1 gold from {1} to return {2} to their hand', 
                                       this.controller, this, context.target);
             }

--- a/server/game/cards/events/01/thethingsidoforlove.js
+++ b/server/game/cards/events/01/thethingsidoforlove.js
@@ -12,7 +12,7 @@ class TheThingsIDoForLove extends DrawCard {
                 cardCondition: card => card.location === 'play area' && card.controller !== this.controller && card.getType() === 'character' && card.getCost() <= this.controller.gold
             },
             handler: context => {
-                context.target.controller.moveCard(context.target, 'hand');
+                context.target.controller.returnCardsToHand(context.target);
                 context.player.gold -= context.target.getCost();
 
                 this.game.addMessage('{0} uses {1} to return {2} to {3}\'s hand', context.player, this, context.target, context.target.owner);

--- a/server/game/cards/events/05/daringrescue.js
+++ b/server/game/cards/events/05/daringrescue.js
@@ -14,7 +14,7 @@ class DaringRescue extends DrawCard {
                     card.getType() === 'character')
             },
             handler: context => {
-                this.controller.moveCard(context.target, 'hand');
+                context.target.owner.returnCardToHand(context.target);
                 this.game.addMessage('{0} plays {1} to return {2} to its owner\'s hand', 
                                       this.controller, this, context.target);
                 this.game.promptForSelect(this.controller, {


### PR DESCRIPTION
This propagates the fix done in 7c37a0d8e62ea05ca4cda5cc7669959c164ed0ae for
Scaling the Wall to other cards that should behave similarly with respect to
save by duplicates.