### PR TITLE
Only prompt Eastwatch Carpenter when there is gold to gain

### DIFF
--- a/server/game/cards/characters/06/eastwatchcarpenter.js
+++ b/server/game/cards/characters/06/eastwatchcarpenter.js
@@ -4,23 +4,22 @@ class EastwatchCarpenter extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onIncomeCollected: event => event.player === this.controller
+                onIncomeCollected: event => event.player === this.controller && this.getGoldBonus() >= 1
             },
             handler: () => {
-                var gold = Math.floor(this.numberOfNWLocations() / 2);
+                let gold = this.getGoldBonus();
                 this.game.addGold(this.controller, gold);
-
                 this.game.addMessage('{0} uses {1} to gain {2} gold', this.controller, this, gold);
             }
         });
     }
 
-    numberOfNWLocations() {
-        var cards = this.controller.filterCardsInPlay(card => {
+    getGoldBonus() {
+        let numCards = this.controller.getNumberOfCardsInPlay(card => {
             return card.isFaction('thenightswatch') && card.getType() === 'location';
         });
 
-        return cards.length;
+        return Math.floor(numCards / 2);
     }
 }
 


### PR DESCRIPTION
Previously, Eastwatch Carpenter would prompt even when triggering it would result in no extra gold. This PR fixes that, and also checks for the number of locations in a more desired way.