### PR TITLE
Implement pre-challenge windows.

### DIFF
--- a/client/GameComponents/ActionWindowsMenu.jsx
+++ b/client/GameComponents/ActionWindowsMenu.jsx
@@ -8,7 +8,7 @@ class ActionWindowsMenu extends React.Component {
         this.windows = [
             { name: 'plot', label: 'Plots revealed' },
             { name: 'draw', label: 'Draw phase' },
-            { name: 'challengeBegin', label: 'Challenge phase begins' },
+            { name: 'challengeBegin', label: 'Before challenge' },
             { name: 'attackersDeclared', label: 'Attackers declared' },
             { name: 'defendersDeclared', label: 'Defenders declared' },
             { name: 'winnerDetermined', label: 'Winner determined' },

--- a/client/Profile.jsx
+++ b/client/Profile.jsx
@@ -41,7 +41,7 @@ class InnerProfile extends React.Component {
         this.windows = [
             { name: 'plot', label: 'Plots revealed' },
             { name: 'draw', label: 'Draw phase' },
-            { name: 'challengeBegin', label: 'Challenge phase begins' },
+            { name: 'challengeBegin', label: 'Before challenge' },
             { name: 'attackersDeclared', label: 'Attackers declared' },
             { name: 'defendersDeclared', label: 'Defenders declared' },
             { name: 'winnerDetermined', label: 'Winner determined' },

--- a/server/game/gamesteps/challengephase.js
+++ b/server/game/gamesteps/challengephase.js
@@ -10,7 +10,7 @@ class ChallengePhase extends Phase {
         super(game, 'challenge');
         this.initialise([
             new SimpleStep(this.game, () => this.beginPhase()),
-            new ActionWindow(this.game, 'Before challenges', 'challengeBegin'),
+            new ActionWindow(this.game, 'Before challenge', 'challengeBegin'),
             new SimpleStep(this.game, () => this.promptForChallenge())
         ]);
     }
@@ -64,6 +64,7 @@ class ChallengePhase extends Phase {
         this.game.currentChallenge = challenge;
         this.game.queueStep(new ChallengeFlow(this.game, challenge));
         this.game.queueStep(new SimpleStep(this.game, () => this.cleanupChallenge()));
+        this.game.queueStep(new ActionWindow(this.game, 'Before challenge', 'challengeBegin'));
     }
 
     cleanupChallenge() {


### PR DESCRIPTION
Previously, there was a "Challenge phase begins" window that
corresponded to the action window in the challenge phase before the
first challenge. This option has been renamed to "Before challenge" to
better match up with the rules and will now prompt before / after each
challenge in accordance with the RRG.

Fixes #1149.