### PR TITLE
Remove attachments from previous parent on reattach.

### DIFF
--- a/server/game/cards/attachments/02/lady.js
+++ b/server/game/cards/attachments/02/lady.js
@@ -41,7 +41,7 @@ class Lady extends DrawCard {
 
     moveAttachment(player, newOwner) {
         var targetPlayer = this.game.getPlayerByName(newOwner.controller.name);
-        targetPlayer.attach(player, this, newOwner.uuid);
+        targetPlayer.attach(player, this, newOwner);
         player.gold -= 1;
         if(newOwner.name === 'Sansa Stark' && newOwner.kneeled) {
             player.standCard(newOwner);

--- a/server/game/cards/attachments/03/nymeria.js
+++ b/server/game/cards/attachments/03/nymeria.js
@@ -41,7 +41,7 @@ class Nymeria extends DrawCard {
 
     moveAttachment(player, newOwner) {
         var targetPlayer = this.game.getPlayerByName(newOwner.controller.name);
-        targetPlayer.attach(player, this, newOwner.uuid);
+        targetPlayer.attach(player, this, newOwner);
         player.gold -= 1;
         this.game.addMessage('{0} pays 1 gold to attach {1} from {2} to {3}', player, this, this.oldOwner, newOwner);
         this.oldOwner = null;

--- a/server/game/cards/attachments/07/summer.js
+++ b/server/game/cards/attachments/07/summer.js
@@ -32,7 +32,7 @@ class Summer extends DrawCard {
                     this.canAttach(this.controller, card))
             },
             handler: context => {
-                this.controller.attach(this.controller, this, context.target.uuid);
+                this.controller.attach(this.controller, this, context.target);
 
                 this.game.addMessage('{0} uses {1} and pays 1 gold to attach {1} to {2}',
                                       this.controller, this, this.parent);

--- a/server/game/cards/events/01/risenfromthesea.js
+++ b/server/game/cards/events/01/risenfromthesea.js
@@ -14,8 +14,8 @@ class RisenFromTheSea extends DrawCard {
             },
             handler: context => {
                 context.event.saveCard(context.target);
-                this.controller.attach(this.controller, this, context.target.uuid, 'play');
-                
+                this.controller.attach(this.controller, this, context.target, 'play');
+
                 this.game.addMessage('{0} plays {1} to save {2}', this.controller, this, context.target);
             }
         });

--- a/server/game/cards/events/02/bloodmagicritual.js
+++ b/server/game/cards/events/02/bloodmagicritual.js
@@ -14,8 +14,8 @@ class BloodMagicRitual extends DrawCard {
             },
             handler: context => {
                 context.event.saveCard(context.target);
-                context.target.controller.attach(this.controller, this, context.target.uuid, 'play');
-                
+                context.target.controller.attach(this.controller, this, context.target, 'play');
+
                 this.game.addMessage('{0} plays {1} to save {2}', this.controller, this, context.target);
             }
         });

--- a/server/game/cards/events/03/aryasgift.js
+++ b/server/game/cards/events/03/aryasgift.js
@@ -26,7 +26,7 @@ class AryasGift extends DrawCard {
     }
 
     moveAttachment(player, newOwner, attachment, oldOwner) {
-        player.attach(player, attachment, newOwner.uuid);
+        player.attach(player, attachment, newOwner);
         this.game.addMessage('{0} moves {1} from {2} to {3}', player, attachment, oldOwner, newOwner);
 
         return true;

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -299,6 +299,15 @@ class DrawCard extends BaseCard {
         return card.allowAttachment(this);
     }
 
+    removeAttachment(attachment) {
+        if(!attachment || !this.attachments.includes(attachment)) {
+            return;
+        }
+
+        this.attachments = _(this.attachments.reject(a => a === attachment));
+        attachment.parent = undefined;
+    }
+
     getPlayActions() {
         return StandardPlayActions
             .concat(this.abilities.playActions)

--- a/server/game/gamesteps/attachmentprompt.js
+++ b/server/game/gamesteps/attachmentprompt.js
@@ -14,7 +14,7 @@ class AttachmentPrompt extends UiPrompt {
             cardCondition: card => this.attachmentCard.owner.canAttach(this.attachmentCard.uuid, card),
             onSelect: (player, card) => {
                 let targetPlayer = card.controller;
-                targetPlayer.attach(player, this.attachmentCard, card.uuid, this.playingType);
+                targetPlayer.attach(player, this.attachmentCard, card, this.playingType);
                 return true;
             }
         });

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -629,8 +629,12 @@ class Player extends Spectator {
         }
 
         let originalLocation = attachment.location;
+        let originalParent = attachment.parent;
 
         attachment.owner.removeCardFromPile(attachment);
+        if(originalParent) {
+            originalParent.removeAttachment(attachment);
+        }
         attachment.moveTo('play area', card);
         card.attachments.push(attachment);
 
@@ -964,9 +968,8 @@ class Player extends Spectator {
 
                 event.card.leavesPlay();
 
-                if(event.card.parent && event.card.parent.attachments) {
-                    event.card.parent.attachments = this.removeCardByUuid(event.card.parent.attachments, event.card.uuid);
-                    event.card.parent = undefined;
+                if(event.card.parent) {
+                    event.card.parent.removeAttachment(event.card);
                 }
 
                 card.moveTo(targetLocation);

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -623,9 +623,7 @@ class Player extends Spectator {
         return attachment.canAttach(this, card);
     }
 
-    attach(player, attachment, cardId, playingType) {
-        let card = this.findCardInPlayByUuid(cardId);
-
+    attach(player, attachment, card, playingType) {
         if(!card || !attachment) {
             return;
         }

--- a/test/server/cards/events/03/03024-aryasgift.spec.js
+++ b/test/server/cards/events/03/03024-aryasgift.spec.js
@@ -46,6 +46,10 @@ describe('Arya\'s Gift', function() {
                 expect(this.milk.parent).toBe(this.character2);
             });
 
+            it('should remove the attachment from the old parent', function() {
+                expect(this.character1.attachments.includes(this.milk)).toBe(false);
+            });
+
             it('should apply effects to the new parent', function() {
                 expect(this.character2.isBlank()).toBe(true);
             });

--- a/test/server/player/removeattachment.spec.js
+++ b/test/server/player/removeattachment.spec.js
@@ -17,7 +17,7 @@ describe('Player', function() {
         this.attachment = new DrawCard(this.attachmentOwner, {});
         this.card = new DrawCard(this.player, {});
         this.player.cardsInPlay.push(this.card);
-        this.player.attach(this.player, this.attachment, this.card.uuid);
+        this.player.attach(this.player, this.attachment, this.card);
 
         this.gameSpy.raiseMergedEvent.and.callFake((name, params, handler) => {
             if(handler) {


### PR DESCRIPTION
Also stops passing around UUIDs when attaching cards, instead passing the object directly.

Fixes #1138.