### PR TITLE
Use proper discard for Wardens of the West.

### DIFF
--- a/server/game/cards/plots/02/wardensofthewest.js
+++ b/server/game/cards/plots/02/wardensofthewest.js
@@ -1,15 +1,14 @@
-const _ = require('underscore');
-
 const PlotCard = require('../../../plotcard.js');
 
 class WardensOfTheWest extends PlotCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.reaction({
             when: {
                 afterChallenge: (event, challenge) => {
                     return challenge.winner === this.controller && challenge.challengeType === 'intrigue' && this.controller.gold >= 2;
                 }
             },
+            cost: ability.costs.payGold(2),
             handler: () => {
                 this.game.promptForSelect(this.game.currentChallenge.loser, {
                     numCards: 2,
@@ -26,11 +25,7 @@ class WardensOfTheWest extends PlotCard {
     }
 
     onSelect(player, cards) {
-        this.game.addGold(this.controller, -2);
-
-        _.each(cards, card => {
-            card.controller.moveCard(card, 'discard pile');
-        });
+        player.discardCards(cards, false);
 
         this.game.addMessage('{0} chooses {1} to discard from their hand', player, cards);
 


### PR DESCRIPTION
Previously, Wardens of the West was manually moving cards into discard,
which should only be done when an ability says "place" the cards in
discard. It now uses the proper `discardCards` method to ensure LoCR
Cersei can gain power off the ability.