### PR TITLE
Save cards for ability activator for Iron Mines.

### DIFF
--- a/server/game/cards/locations/02/ironmines.js
+++ b/server/game/cards/locations/02/ironmines.js
@@ -10,11 +10,11 @@ class IronMines extends DrawCard {
             cost: ability.costs.sacrificeSelf(),
             target: {
                 activePromptTitle: 'Select character to save',
-                cardCondition: (card, context) => context.event.cards.includes(card) && card.controller === this.controller
+                cardCondition: (card, context) => context.event.cards.includes(card) && card.controller === context.player
             },
             handler: context => {
                 context.event.saveCard(context.target);
-                this.game.addMessage('{0} sacrifices {1} to save {2}', this.controller, this, context.target);
+                this.game.addMessage('{0} sacrifices {1} to save {2}', context.player, this, context.target);
             }
         });
     }

--- a/test/server/integration/takecontrol.spec.js
+++ b/test/server/integration/takecontrol.spec.js
@@ -383,6 +383,8 @@ describe('take control', function() {
             });
 
             it('should trigger for the current player', function() {
+                let knight = this.player1.findCardByName('Hedge Knight', 'play area');
+
                 this.player1.clickPrompt('Done');
 
                 this.player2.clickPrompt('Military');
@@ -398,12 +400,14 @@ describe('take control', function() {
 
                 this.player2.clickPrompt('Apply Claim');
 
-                this.player1.clickCard('Hedge Knight', 'play area');
+                this.player1.clickCard(knight);
 
                 this.player1.clickPrompt('Iron Mines');
-                this.player1.clickCard('Hedge Knight', 'play area');
+                expect(this.player1).toHavePrompt('Select character to save');
+                this.player1.clickCard(knight);
 
-                expect(this.player1.findCardByName('Hedge Knight', 'play area')).toBeDefined();
+                expect(this.player1).not.toHavePrompt('Select character to save');
+                expect(knight.location).toBe('play area');
             });
 
             it('should not trigger for the opponent', function() {


### PR DESCRIPTION
Because Iron Mines sacrifices itself as a cost to activate, it is placed
in its owner's discard pile before the target for the save is prompted.
This means that the controller has reverted to the original owner by the
time targeting happens. This caused a bug where a taken-control-of Iron
Mines would trigger if any of your characters were killed, but then
would only allow you to use it to save your opponent's characters.

Now, Iron Mines explicitly compares the target's controller with the
player that activated the ability.