### PR TITLE
Properly remove Annals of Castle Black effect.

### DIFF
--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -674,12 +674,13 @@ const Effects = {
         return {
             apply: function(player, context) {
                 let playableLocation = new PlayableLocation('play', player, location);
-                context.canPlayFromOwn = playableLocation;
+                context.canPlayFromOwn = context.canPlayFromOwn || {};
+                context.canPlayFromOwn[player.name] = playableLocation;
                 player.playableLocations.push(playableLocation);
             },
             unapply: function(player, context) {
-                player.playableLocations = _.reject(player.playableLocations, l => l === context.canPlayFromOwn);
-                delete context.canPlayFromOwn;
+                player.playableLocations = _.reject(player.playableLocations, l => l === context.canPlayFromOwn[player.name]);
+                delete context.canPlayFromOwn[player.name];
             }
         };
     },

--- a/test/server/cards/plots/06/06040-theannalsofcastleblack.spec.js
+++ b/test/server/cards/plots/06/06040-theannalsofcastleblack.spec.js
@@ -5,11 +5,11 @@ describe('The Annals of Castle Black', function() {
     integration(function() {
         beforeEach(function() {
             const deck1 = this.buildDeck('greyjoy', [
-                'The Annals of Castle Black',
+                'The Annals of Castle Black', 'A Noble Cause',
                 'Wildling Horde', 'Lannisport Merchant', 'Hear Me Roar!', 'Ahead of the Tide'
             ]);
             const deck2 = this.buildDeck('greyjoy', [
-                'A Noble Cause',
+                'A Noble Cause', 'A Noble Cause',
                 'Lannisport Merchant', 'Hear Me Roar!'
             ]);
 
@@ -88,6 +88,19 @@ describe('The Annals of Castle Black', function() {
                 this.player1.clickPrompt('Ahead of the Tide');
 
                 expect(this.interruptEventCard.location).toBe('out of game');
+            });
+
+            it('should remove the effect next round', function() {
+                this.player1.clickPrompt('Pass');
+                this.selectFirstPlayer(this.player1);
+                this.completeMarshalPhase();
+                this.completeChallengesPhase();
+                this.completeTaxationPhase();
+
+                this.player1.selectPlot('A Noble Cause');
+                this.player2.selectPlot('A Noble Cause');
+
+                expect(this.player1).not.toHavePromptButton('Ahead of the Tide');
             });
         });
 


### PR DESCRIPTION
Because each player gets applied with the effect from Annals of Castle
Black, the playable location must be associated with a specific player.
Previously it was using the same variable for all players, which caused
the effect to not be removed from the first player during two player
games.