### PR TITLE
Combine windows during challenge initiation

### DIFF
--- a/server/game/cards/characters/07/maryaseaworth.js
+++ b/server/game/cards/characters/07/maryaseaworth.js
@@ -3,6 +3,7 @@ const DrawCard = require('../../../drawcard.js');
 class MaryaSeaworth extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
+            title: context => 'Kneel ' + context.event.target.name,
             when: {
                 onBypassedByStealth: () => true
             },

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -15,6 +15,7 @@ class Challenge {
         this.defenders = [];
         this.defenderStrength = 0;
         this.defenderStrengthModifier = 0;
+        this.stealthData = [],
         this.events = new EventRegistrar(game, this);
         this.registerEvents(['onCardLeftPlay']);
     }
@@ -104,6 +105,34 @@ class Challenge {
 
             return count;
         }, 0);
+    }
+
+    getAllStealthSources() {
+        return _.flatten(_.pluck(this.stealthData, 'source'));
+    }
+
+    getAllStealthTargets() {
+        return _.flatten(_.pluck(this.stealthData, 'targets'));
+    }
+
+    isStealthSource(card) {
+        return this.getAllStealthSources().includes(card);
+    }
+
+    isStealthTarget(card) {
+        return this.getAllStealthTargets().includes(card);
+    }
+
+    getStealthTargetFor(card) {
+        let stealthPair = _.where(this.stealthData, { source: card });
+
+        if(!stealthPair) {
+            return false;
+        }
+
+        let targets = _.flatten(_.pluck(stealthPair, 'targets'));
+
+        return targets.length > 1 ? targets : _.first(targets);
     }
 
     calculateStrength() {

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -107,32 +107,8 @@ class Challenge {
         }, 0);
     }
 
-    getAllStealthSources() {
-        return _.flatten(_.pluck(this.stealthData, 'source'));
-    }
-
-    getAllStealthTargets() {
-        return _.flatten(_.pluck(this.stealthData, 'targets'));
-    }
-
-    isStealthSource(card) {
-        return this.getAllStealthSources().includes(card);
-    }
-
-    isStealthTarget(card) {
-        return this.getAllStealthTargets().includes(card);
-    }
-
-    getStealthTargetFor(card) {
-        let stealthPair = _.where(this.stealthData, { source: card });
-
-        if(!stealthPair) {
-            return false;
-        }
-
-        let targets = _.flatten(_.pluck(stealthPair, 'targets'));
-
-        return targets.length > 1 ? targets : _.first(targets);
+    addStealthChoice(source, target) {
+        this.stealthData.push({ source: source, target: target });
     }
 
     calculateStrength() {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -617,22 +617,20 @@ class Game extends EventEmitter {
         let windowClass = ['forcedreaction', 'forcedinterrupt', 'whenrevealed'].includes(properties.abilityType) ? ForcedTriggeredAbilityWindow : TriggeredAbilityWindow;
         let window = new windowClass(this, { abilityType: properties.abilityType, event: properties.event });
         this.abilityWindowStack.push(window);
-        this.emit(properties.event.name + ':' + properties.abilityType, ...properties.event.params);
+        window.emitEvents();
         this.queueStep(window);
         this.queueSimpleStep(() => this.abilityWindowStack.pop());
     }
 
     registerAbility(ability) {
-        let windowIndex = _.findLastIndex(this.abilityWindowStack, window => ability.eventType === window.abilityType && ability.isTriggeredByEvent(window.event));
+        let windowIndex = _.findLastIndex(this.abilityWindowStack, window => window.canTriggerAbility(ability));
 
         if(windowIndex === -1) {
             return;
         }
 
         let window = this.abilityWindowStack[windowIndex];
-        let context = ability.createContext(window.event);
-
-        window.registerAbility(ability, context);
+        window.registerAbility(ability);
     }
 
     raiseEvent(eventName, ...params) {

--- a/server/game/gamesteps/atomiceventwindow.js
+++ b/server/game/gamesteps/atomiceventwindow.js
@@ -1,0 +1,84 @@
+const _ = require('underscore');
+
+const BaseStep = require('./basestep.js');
+const GamePipeline = require('../gamepipeline.js');
+const SimpleStep = require('./simplestep.js');
+const Event = require('../event.js');
+
+class AtomicEventWindow extends BaseStep {
+    constructor(game, eventProperties, handler) {
+        super(game);
+
+        this.events = _.map(eventProperties, event => new Event(event.name, event.params, true));
+        this.handler = handler || (() => true);
+
+        this.pipeline = new GamePipeline();
+        this.pipeline.initialise([
+            new SimpleStep(game, () => this.openWindow('cancelinterrupt')),
+            new SimpleStep(game, () => this.openWindow('forcedinterrupt')),
+            new SimpleStep(game, () => this.openWindow('interrupt')),
+            new SimpleStep(game, () => this.executeHandler()),
+            new SimpleStep(game, () => this.openWindow('forcedreaction')),
+            new SimpleStep(game, () => this.openWindow('reaction'))
+        ]);
+    }
+
+    queueStep(step) {
+        this.pipeline.queueStep(step);
+    }
+
+    isComplete() {
+        return this.pipeline.length === 0;
+    }
+
+    onCardClicked(player, card) {
+        return this.pipeline.handleCardClicked(player, card);
+    }
+
+    onMenuCommand(player, arg, method) {
+        return this.pipeline.handleMenuCommand(player, arg, method);
+    }
+
+    cancelStep() {
+        this.pipeline.cancelStep();
+    }
+
+    continue() {
+        return this.pipeline.continue();
+    }
+
+    openWindow(abilityType) {
+        this.filterOutCancelledEvents();
+
+        if(_.isEmpty(this.events)) {
+            return;
+        }
+
+        this.game.openAbilityWindow({
+            abilityType: abilityType,
+            event: this.events
+        });
+    }
+
+    filterOutCancelledEvents() {
+        this.events = _.reject(this.events, event => event.cancelled);
+    }
+
+    executeHandler() {
+        this.filterOutCancelledEvents();
+
+        if(_.isEmpty(this.events)) {
+            return;
+        }
+
+        if(_.all(this.events, event => !event.shouldSkipHandler)) {
+            this.handler();
+        }
+
+        _.each(this.events, event => {
+            this.game.emit(event.name, ...event.params);
+        });
+    }
+}
+
+module.exports = AtomicEventWindow;

--- a/server/game/gamesteps/baseabilitywindow.js
+++ b/server/game/gamesteps/baseabilitywindow.js
@@ -1,0 +1,31 @@
+const _ = require('underscore');
+
+const BaseStep = require('./basestep.js');
+
+class BaseAbilityWindow extends BaseStep {
+    constructor(game, properties) {
+        super(game);
+        this.abilityChoices = [];
+        this.events = _.flatten([properties.event]);
+        this.abilityType = properties.abilityType;
+    }
+
+    canTriggerAbility(ability) {
+        return ability.eventType === this.abilityType && _.any(this.events, event => ability.isTriggeredByEvent(event));
+    }
+
+    emitEvents() {
+        _.each(this.events, event => {
+            this.game.emit(event.name + ':' + this.abilityType, ...event.params);
+        });
+    }
+
+    registerAbilityForEachEvent(ability) {
+        let matchingEvents = _.filter(this.events, event => ability.isTriggeredByEvent(event));
+        _.each(matchingEvents, event => {
+            this.registerAbility(ability, event);
+        });
+    }
+}
+
+module.exports = BaseAbilityWindow;

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -77,6 +77,7 @@ class ChallengeFlow extends BaseStep {
     announceAttackerStrength() {
         // Explicitly recalculate strength in case an effect has modified character strength.
         this.challenge.calculateStrength();
+
         this.game.addMessage('{0} has initiated a {1} challenge with strength {2}', this.challenge.attackingPlayer, this.challenge.challengeType, this.challenge.attackerStrength);
     }
 
@@ -96,15 +97,15 @@ class ChallengeFlow extends BaseStep {
 
         if(!_.isEmpty(this.forcedDefenders)) {
             if(this.forcedDefenders.length === defenderLimit) {
-                this.game.addMessage('{0} {1} automatically declared as {2}', 
+                this.game.addMessage('{0} {1} automatically declared as {2}',
                                       this.forcedDefenders, this.forcedDefenders.length > 1 ? 'are' : 'is', this.forcedDefenders.length > 1 ? 'defenders' : 'defender');
-                
+
                 this.chooseDefenders([]);
                 return;
             }
 
             if(this.forcedDefenders.length < defenderLimit || defenderLimit === 0) {
-                this.game.addMessage('{0} {1} automatically declared as {2}', 
+                this.game.addMessage('{0} {1} automatically declared as {2}',
                                       this.forcedDefenders, this.forcedDefenders.length > 1 ? 'are' : 'is', this.forcedDefenders.length > 1 ? 'defenders' : 'defender');
 
                 if(defenderLimit !== 0) {
@@ -130,7 +131,7 @@ class ChallengeFlow extends BaseStep {
     }
 
     allowAsDefender(card) {
-        return this.challenge.defendingPlayer === card.controller && 
+        return this.challenge.defendingPlayer === card.controller &&
                card.canDeclareAsDefender(this.challenge.challengeType) &&
                this.mustBeDeclaredAsDefender(card);
     }

--- a/server/game/gamesteps/challenge/choosestealthtargets.js
+++ b/server/game/gamesteps/challenge/choosestealthtargets.js
@@ -47,6 +47,7 @@ class ChooseStealthTargets extends BaseStep {
             }
 
             this.game.raiseMergedEvent('onBypassedByStealth', { challenge: this.challenge, source: character, target: target });
+            this.challenge.stealthData.push({ source: character, target: target });
         });
 
         this.game.addMessage('{0} has chosen {1} as the stealth target for {2}', this.challenge.attackingPlayer, targets, character);

--- a/server/game/gamesteps/challenge/choosestealthtargets.js
+++ b/server/game/gamesteps/challenge/choosestealthtargets.js
@@ -46,7 +46,6 @@ class ChooseStealthTargets extends BaseStep {
                 return false;
             }
 
-            this.game.raiseMergedEvent('onBypassedByStealth', { challenge: this.challenge, source: character, target: target });
             this.challenge.stealthData.push({ source: character, target: target });
         });
 

--- a/server/game/gamesteps/challenge/choosestealthtargets.js
+++ b/server/game/gamesteps/challenge/choosestealthtargets.js
@@ -46,7 +46,7 @@ class ChooseStealthTargets extends BaseStep {
                 return false;
             }
 
-            this.challenge.stealthData.push({ source: character, target: target });
+            this.challenge.addStealthChoice(character, target);
         });
 
         this.game.addMessage('{0} has chosen {1} as the stealth target for {2}', this.challenge.attackingPlayer, targets, character);

--- a/server/game/gamesteps/forcedtriggeredabilitywindow.js
+++ b/server/game/gamesteps/forcedtriggeredabilitywindow.js
@@ -1,33 +1,10 @@
 const _ = require('underscore');
 const uuid = require('uuid');
 
-const BaseStep = require('./basestep.js');
+const BaseAbilityWindow = require('./baseabilityWindow.js');
 const TriggeredAbilityWindowTitles = require('./triggeredabilitywindowtitles.js');
 
-class ForcedTriggeredAbilityWindow extends BaseStep {
-    constructor(game, properties) {
-        super(game);
-        this.abilityChoices = [];
-        this.events = _.flatten([properties.event]);
-        this.abilityType = properties.abilityType;
-    }
-
-    canTriggerAbility(ability) {
-        return ability.eventType === this.abilityType && _.any(this.events, event => ability.isTriggeredByEvent(event));
-    }
-
-    emitEvents() {
-        _.each(this.events, event => {
-            this.game.emit(event.name + ':' + this.abilityType, ...event.params);
-        });
-    }
-
-    registerAbilityForEachEvent(ability) {
-        _.each(this.events, event => {
-            this.registerAbility(ability, event);
-        });
-    }
-
+class ForcedTriggeredAbilityWindow extends BaseAbilityWindow {
     registerAbility(ability, event) {
         let context = ability.createContext(event);
         let player = ability.card.controller;

--- a/server/game/gamesteps/forcedtriggeredabilitywindow.js
+++ b/server/game/gamesteps/forcedtriggeredabilitywindow.js
@@ -1,7 +1,7 @@
 const _ = require('underscore');
 const uuid = require('uuid');
 
-const BaseAbilityWindow = require('./baseabilityWindow.js');
+const BaseAbilityWindow = require('./baseabilitywindow.js');
 const TriggeredAbilityWindowTitles = require('./triggeredabilitywindowtitles.js');
 
 class ForcedTriggeredAbilityWindow extends BaseAbilityWindow {

--- a/server/game/gamesteps/forcedtriggeredabilitywindow.js
+++ b/server/game/gamesteps/forcedtriggeredabilitywindow.js
@@ -12,7 +12,16 @@ class ForcedTriggeredAbilityWindow extends BaseStep {
         this.abilityType = properties.abilityType;
     }
 
-    registerAbility(ability, context) {
+    canTriggerAbility(ability) {
+        return ability.eventType === this.abilityType && ability.isTriggeredByEvent(this.event);
+    }
+
+    emitEvents() {
+        this.game.emit(this.event.name + ':' + this.abilityType, ...this.event.params);
+    }
+
+    registerAbility(ability) {
+        let context = ability.createContext(this.event);
         let player = ability.card.controller;
         this.abilityChoices.push({
             id: uuid.v1(),

--- a/server/game/gamesteps/triggeredabilitywindow.js
+++ b/server/game/gamesteps/triggeredabilitywindow.js
@@ -1,33 +1,10 @@
 const _ = require('underscore');
 const uuid = require('uuid');
 
-const BaseStep = require('./basestep.js');
+const BaseAbilityWindow = require('./baseabilityWindow.js');
 const TriggeredAbilityWindowTitles = require('./triggeredabilitywindowtitles.js');
 
-class TriggeredAbilityWindow extends BaseStep {
-    constructor(game, properties) {
-        super(game);
-        this.abilityChoices = [];
-        this.events = _.flatten([properties.event]);
-        this.abilityType = properties.abilityType;
-    }
-
-    canTriggerAbility(ability) {
-        return ability.eventType === this.abilityType && _.any(this.events, event => ability.isTriggeredByEvent(event));
-    }
-
-    emitEvents() {
-        _.each(this.events, event => {
-            this.game.emit(event.name + ':' + this.abilityType, ...event.params);
-        });
-    }
-
-    registerAbilityForEachEvent(ability) {
-        _.each(this.events, event => {
-            this.registerAbility(ability, event);
-        });
-    }
-
+class TriggeredAbilityWindow extends BaseAbilityWindow {
     registerAbility(ability, event) {
         if(ability.hasMax() && this.hasChoiceForCardByName(ability.card.name)) {
             return;

--- a/server/game/gamesteps/triggeredabilitywindow.js
+++ b/server/game/gamesteps/triggeredabilitywindow.js
@@ -12,11 +12,20 @@ class TriggeredAbilityWindow extends BaseStep {
         this.abilityType = properties.abilityType;
     }
 
-    registerAbility(ability, context) {
+    canTriggerAbility(ability) {
+        return ability.eventType === this.abilityType && ability.isTriggeredByEvent(this.event);
+    }
+
+    emitEvents() {
+        this.game.emit(this.event.name + ':' + this.abilityType, ...this.event.params);
+    }
+
+    registerAbility(ability) {
         if(ability.hasMax() && this.hasChoiceForCardByName(ability.card.name)) {
             return;
         }
 
+        let context = ability.createContext(this.event);
         let player = context.player;
         let choiceTexts = ability.getChoices(context);
 

--- a/server/game/gamesteps/triggeredabilitywindow.js
+++ b/server/game/gamesteps/triggeredabilitywindow.js
@@ -1,7 +1,7 @@
 const _ = require('underscore');
 const uuid = require('uuid');
 
-const BaseAbilityWindow = require('./baseabilityWindow.js');
+const BaseAbilityWindow = require('./baseabilitywindow.js');
 const TriggeredAbilityWindowTitles = require('./triggeredabilitywindowtitles.js');
 
 class TriggeredAbilityWindow extends BaseAbilityWindow {

--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -53,7 +53,7 @@ class TriggeredAbility extends BaseAbility {
             return;
         }
 
-        this.game.registerAbility(this);
+        this.game.registerAbility(this, event);
     }
 
     createContext(event) {

--- a/test/server/card/cardforcedreaction.spec.js
+++ b/test/server/card/cardforcedreaction.spec.js
@@ -57,7 +57,7 @@ describe('CardForcedReaction', function () {
             });
 
             it('should register the ability', function() {
-                expect(this.gameSpy.registerAbility).toHaveBeenCalledWith(this.reaction);
+                expect(this.gameSpy.registerAbility).toHaveBeenCalledWith(this.reaction, this.event);
             });
         });
     });

--- a/test/server/card/cardreaction.spec.js
+++ b/test/server/card/cardreaction.spec.js
@@ -109,7 +109,7 @@ describe('CardReaction', function () {
             });
 
             it('should register the ability', function() {
-                expect(this.gameSpy.registerAbility).toHaveBeenCalledWith(this.reaction);
+                expect(this.gameSpy.registerAbility).toHaveBeenCalledWith(this.reaction, this.event);
             });
         });
     });

--- a/test/server/cards/agendas/05045-therainsofcastamere.spec.js
+++ b/test/server/cards/agendas/05045-therainsofcastamere.spec.js
@@ -152,8 +152,9 @@ describe('The Rains of Castamere', function() {
             });
 
             it('should register the ability', function() {
-                this.reaction.eventHandler({ name: 'afterChallenge', params: [this.event, this.challenge] });
-                expect(this.gameSpy.registerAbility).toHaveBeenCalledWith(this.reaction);
+                let event = { name: 'afterChallenge', params: [this.event, this.challenge] };
+                this.reaction.eventHandler(event);
+                expect(this.gameSpy.registerAbility).toHaveBeenCalledWith(this.reaction, event);
             });
         });
     });

--- a/test/server/gamesteps/forcedtriggeredabilitywindow.spec.js
+++ b/test/server/gamesteps/forcedtriggeredabilitywindow.spec.js
@@ -55,11 +55,14 @@ describe('ForcedTriggeredAbilityWindow', function() {
 
     describe('registerAbility()', function() {
         beforeEach(function() {
-            this.abilityCard = { card: 1, name: 'The Card', controller: this.player1Spy };
-            this.abilitySpy = { card: this.abilityCard };
             this.context = { context: 1 };
+            this.abilityCard = { card: 1, name: 'The Card', controller: this.player1Spy };
+            this.abilitySpy = jasmine.createSpyObj('ability', ['createContext']);
+            this.abilitySpy.createContext.and.returnValue(this.context);
+            this.abilitySpy.card = this.abilityCard;
 
-            this.window.registerAbility(this.abilitySpy, this.context);
+
+            this.window.registerAbility(this.abilitySpy);
         });
 
         it('should add the ability to the list of choices', function() {

--- a/test/server/gamesteps/triggeredabilitywindow.spec.js
+++ b/test/server/gamesteps/triggeredabilitywindow.spec.js
@@ -55,11 +55,12 @@ describe('TriggeredAbilityWindow', function() {
 
     describe('registerAbility()', function() {
         beforeEach(function() {
+            this.context = { context: 1, player: this.player1Spy };
             this.abilityCard = { card: 1, name: 'The Card' };
-            this.abilitySpy = jasmine.createSpyObj('ability', ['getChoices', 'hasMax']);
+            this.abilitySpy = jasmine.createSpyObj('ability', ['createContext', 'getChoices', 'hasMax']);
+            this.abilitySpy.createContext.and.returnValue(this.context);
             this.abilitySpy.getChoices.and.returnValue([{ text: 'Choice 1', choice: 'choice1' }, { text: 'Choice 2', choice: 'choice2' }]);
             this.abilitySpy.card = this.abilityCard;
-            this.context = { context: 1, player: this.player1Spy };
         });
 
         describe('when a normal ability is registered', function() {

--- a/test/server/integration/challengesphase.spec.js
+++ b/test/server/integration/challengesphase.spec.js
@@ -85,5 +85,70 @@ describe('challenges phase', function() {
                 expect(this.player1).toHavePromptButton('Power');
             });
         });
+
+        describe('when initiating a challenge', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('lannister', [
+                    'Trading with the Pentoshi',
+                    'Tyrion Lannister (Core)', 'Dornish Paramour', 'Marya Seaworth', 'Jojen Reed', 'Hedge Knight', 'Lannisport Merchant'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.knight = this.player2.findCardByName('Hedge Knight', 'hand');
+                this.merchant = this.player2.findCardByName('Lannisport Merchant', 'hand');
+
+                this.player1.clickCard('Tyrion Lannister', 'hand');
+                this.player1.clickCard('Dornish Paramour', 'hand');
+                this.player2.clickCard(this.knight);
+                this.player2.clickCard(this.merchant);
+                this.completeSetup();
+
+                this.player1.selectPlot('Trading with the Pentoshi');
+                this.player2.selectPlot('Trading with the Pentoshi');
+                this.selectFirstPlayer(this.player1);
+                this.selectPlotOrder(this.player1);
+
+                this.player1.clickCard('Marya Seaworth', 'hand');
+                this.player1.clickCard('Jojen Reed', 'hand');
+                this.completeMarshalPhase();
+
+                this.initiateChallenge = () => {
+                    this.player1.clickPrompt('Intrigue');
+                    this.player1.clickCard('Tyrion Lannister', 'play area');
+                    this.player1.clickCard('Jojen Reed', 'play area');
+                    this.player1.clickCard('Dornish Paramour', 'play area');
+                    this.player1.clickPrompt('Done');
+
+                    // Select 2 stealth targets
+                    this.player1.clickCard(this.knight);
+                    this.player1.clickCard(this.merchant);
+                };
+            });
+
+            it('should prompt for challenge initiated, attackers declared, and stealth simultaneously', function() {
+                this.initiateChallenge();
+
+                expect(this.player1).toHavePromptButton('Tyrion Lannister');
+                expect(this.player1).toHavePromptButton('Dornish Paramour');
+                expect(this.player1).toHavePromptButton('Marya Seaworth - Kneel Hedge Knight');
+                expect(this.player1).toHavePromptButton('Marya Seaworth - Kneel Lannisport Merchant');
+                expect(this.player1.currentPrompt().buttons.length).toBe(5);
+            });
+
+            it('should reactions in the same window to generate gold needed to pay costs', function() {
+                this.player1Object.gold = 0;
+                this.initiateChallenge();
+                expect(this.player1).not.toHavePromptButton('Marya Seaworth - Kneel Hedge Knight');
+                expect(this.player1).not.toHavePromptButton('Marya Seaworth - Kneel Lannisport Merchant');
+
+                this.player1.clickPrompt('Tyrion Lannister');
+
+                expect(this.player1).toHavePromptButton('Marya Seaworth - Kneel Hedge Knight');
+                expect(this.player1).toHavePromptButton('Marya Seaworth - Kneel Lannisport Merchant');
+            });
+        });
     });
 });


### PR DESCRIPTION
Combines the interrupt / reaction windows for challenge initiation, attackers declared and bypasses by stealth into a single window per the timing note under RRG 4.2. This is done by introducing an 'atomic' event type, which takes multiple events and raises them within the same window.

Fixes #1047.