### PR TITLE
make sure that canPartecipateInChallenge() succeeds only on characters

### DIFF
--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -356,7 +356,8 @@ class DrawCard extends BaseCard {
     }
 
     canParticipateInChallenge() {
-        return this.allowGameAction('participateInChallenge');
+        return this.getType() === 'character'
+            && this.allowGameAction('participateInChallenge');
     }
 
     canBeBypassedByStealth() {


### PR DESCRIPTION
Before this change locations could --- in corner cases where challenge icones
are ignored, e.g., when Ours Is The Fury is triggered --- be allowed to be
selected as cards that can participate in challenge.