### PR TITLE
Implement Devout Freerider

### DIFF
--- a/server/game/cards/characters/01/oldforesthunter.js
+++ b/server/game/cards/characters/01/oldforesthunter.js
@@ -4,29 +4,15 @@ class OldForestHunter extends DrawCard {
     setupCardAbilities(ability) {
         this.action({
             title: 'Discard a card to gain 1 gold',
-            method: 'discard',
-            limit: ability.limit.perPhase(1)
+            condition: () => !this.controller.cannotGainGold,
+            cost: ability.costs.discardFromHand(),
+            limit: ability.limit.perPhase(1),
+            handler: context => {
+                this.game.addGold(this.controller, 1);
+                this.game.addMessage('{0} uses {1} and discards {2} from their hand to gain 1 gold', 
+                                      this.controller, this, context.discardCostCard);
+            }
         });
-    }
-
-    discard(player) {
-        this.game.promptForSelect(player, {
-            activePromptTitle: 'Select a card to discard',
-            source: this,
-            cardCondition: card => card.location === 'hand',
-            onSelect: (p, card) => this.onCardSelected(p, card)
-        });
-
-        return true;
-    }
-
-    onCardSelected(player, card) {
-        this.controller.discardCard(card);
-        this.game.addGold(this.controller, 1);
-
-        this.game.addMessage('{0} uses {1} to discard {2} and gain 1 gold', player, this, card);
-
-        return true;
     }
 }
 

--- a/server/game/cards/characters/01/tyrionlannister.js
+++ b/server/game/cards/characters/01/tyrionlannister.js
@@ -4,12 +4,12 @@ class TyrionLannister extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onChallengeInitiated: event => event.challenge.challengeType === 'intrigue'
+                onChallengeInitiated: event => event.challenge.challengeType === 'intrigue' && !this.controller.cannotGainGold
             },
             limit: ability.limit.perRound(2),
             handler: () => {
                 this.game.addGold(this.controller, 2);
-                this.game.addMessage('{0} uses {1} to gain 2 gold as an intrigue challenge has been declared', this.controller, this);
+                this.game.addMessage('{0} uses {1} to gain 2 gold', this.controller, this);
             }
         });
     }

--- a/server/game/cards/characters/05/devoutfreerider.js
+++ b/server/game/cards/characters/05/devoutfreerider.js
@@ -1,0 +1,16 @@
+const DrawCard = require('../../../drawcard.js');
+
+class DevoutFreerider extends DrawCard {
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            condition: () => this.game.currentPhase === 'challenge',
+            targetType: 'player',
+            targetController: 'any',
+            effect: ability.effects.cannotGainGold()
+        });
+    }
+}
+
+DevoutFreerider.code = '05040';
+
+module.exports = DevoutFreerider;

--- a/server/game/cards/events/02/indoransname.js
+++ b/server/game/cards/events/02/indoransname.js
@@ -4,12 +4,12 @@ class InDoransName extends DrawCard {
     setupCardAbilities(ability) {
         this.action({
             title: 'Kneel faction card to gain gold',
-            condition: () => this.controller.getNumberOfUsedPlots() >= 1,
+            condition: () => this.controller.getNumberOfUsedPlots() >= 1 && !this.controller.cannotGainGold,
             cost: ability.costs.kneelFactionCard(),
             handler: context => {
                 let gold = this.controller.getNumberOfUsedPlots();
                 this.game.addGold(this.controller, gold);
-                this.game.addMessage('{0} uses {1} to kneel their faction card to gain {2} gold', context.player, this, gold);
+                this.game.addMessage('{0} plays {1} and kneels their faction card to gain {2} gold', context.player, this, gold);
             }
         });
     }

--- a/server/game/cards/events/06/plunder.js
+++ b/server/game/cards/events/06/plunder.js
@@ -4,7 +4,7 @@ class Plunder extends DrawCard {
     setupCardAbilities(ability) {
         this.action({
             title: 'Gain gold',
-            condition: () => this.getGold() >= 1,
+            condition: () => this.getGold() >= 1 && !this.controller.cannotGainGold,
             cost: ability.costs.kneelFactionCard(),
             handler: () => {
                 let gold = this.getGold();

--- a/server/game/cards/plots/05/lionsoftherock.js
+++ b/server/game/cards/plots/05/lionsoftherock.js
@@ -4,7 +4,7 @@ class LionsOfTheRock extends PlotCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onPhaseStarted: (event, phase) => phase === 'challenge'
+                onPhaseStarted: (event, phase) => phase === 'challenge' && !this.controller.cannotGainGold
             },
             handler: () => {
                 this.game.addGold(this.controller, 3);

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -523,6 +523,16 @@ const Effects = {
     cannotBeStood: cannotEffect('stand'),
     cannotBeKilled: cannotEffect('kill'),
     cannotGainPower: cannotEffect('gainPower'),
+    cannotGainGold: function() {
+        return {
+            apply: function(player) {
+                player.cannotGainGold = true;
+            },
+            unapply: function(player) {
+                player.cannotGainGold = false;
+            }
+        };
+    },
     cannotGainChallengeBonus: function() {
         return {
             apply: function(player) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -345,6 +345,11 @@ class Game extends EventEmitter {
     }
 
     addGold(player, gold) {
+        if(gold > 0 && player.cannotGainGold) {
+            this.addMessage('{0} cannot gain gold', player);
+            return;
+        }
+
         player.gold += gold;
 
         if(player.gold < 0) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -38,6 +38,7 @@ class Player extends Spectator {
         this.costReducers = [];
         this.playableLocations = _.map(['marshal', 'play', 'ambush'], playingType => new PlayableLocation(playingType, this, 'hand'));
         this.usedPlotsModifier = 0;
+        this.cannotGainGold = false;
         this.cannotGainChallengeBonus = false;
         this.cannotTriggerCardAbilities = false;
         this.abilityMaxByTitle = {};


### PR DESCRIPTION
Not entirely sure if this is the desired way, but..... it works I guess. I don't really like the additional checks on other cards to prevent trigger prompts, but it's only a handful (and even then it's 95% Tyrion Lannister (Core)).

Other slight issue: there are a bunch of cards that transfer gold implemented by invoking game.addGold() twice, instead of just game.transferGold(), which could be prevented from resolving correctly by Devout Freerider. It's on the list for when I go through the entire cardpool.