### PR TITLE
Pass the deck name when saving it

### DIFF
--- a/client/ReduxActions/deck.js
+++ b/client/ReduxActions/deck.js
@@ -59,7 +59,7 @@ export function deleteDeck(deck) {
 export function saveDeck(deck) {
     let str = JSON.stringify({
         deckName: deck.name,
-        faction: { value: deck.faction.value },
+        faction: { name: deck.faction.name, value: deck.faction.value },
         agenda: deck.agenda ? { code: deck.agenda.code } : null,
         plotCards: formatCards(deck.plotCards),
         drawCards: formatCards(deck.drawCards),

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -830,7 +830,7 @@ class Game extends EventEmitter {
         var players = _.map(this.getPlayers(), player => {
             return {
                 name: player.name,
-                faction: player.faction.name,
+                faction: player.faction.name || player.faction.value,
                 agenda: player.agenda ? player.agenda.name : undefined,
                 power: player.getTotalPower()
             };

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -934,7 +934,7 @@ class Player extends Spectator {
         this.deck.selected = true;
 
         this.faction.cardData = deck.faction;
-        this.faction.cardDat.name = deck.faction.name;
+        this.faction.cardData.name = deck.faction.name;
         this.faction.cardData.code = deck.faction.value;
         this.faction.cardData.type_code = 'faction';
         this.faction.cardData.strength = 0;

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -934,6 +934,7 @@ class Player extends Spectator {
         this.deck.selected = true;
 
         this.faction.cardData = deck.faction;
+        this.faction.cardDat.name = deck.faction.name;
         this.faction.cardData.code = deck.faction.value;
         this.faction.cardData.type_code = 'faction';
         this.faction.cardData.strength = 0;


### PR DESCRIPTION
Pass the deck name when saving it as stats use it.  Patch existing decks which don't have a faction name with value - will require fixing in stats too later