### PR TITLE
Fix prompts for cards with maximum limits.

### DIFF
--- a/server/game/gamesteps/triggeredabilitywindow.js
+++ b/server/game/gamesteps/triggeredabilitywindow.js
@@ -6,10 +6,6 @@ const TriggeredAbilityWindowTitles = require('./triggeredabilitywindowtitles.js'
 
 class TriggeredAbilityWindow extends BaseAbilityWindow {
     registerAbility(ability, event) {
-        if(ability.hasMax() && this.hasChoiceForCardByName(ability.card.name)) {
-            return;
-        }
-
         let context = ability.createContext(event);
         let player = context.player;
         let choiceTexts = ability.getChoices(context);
@@ -25,10 +21,6 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
                 context: context
             });
         });
-    }
-
-    hasChoiceForCardByName(cardName) {
-        return _.any(this.abilityChoices, choice => choice.card.name === cardName);
     }
 
     continue() {
@@ -52,7 +44,7 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
     }
 
     promptPlayer(player) {
-        let choicesForPlayer = _.filter(this.abilityChoices, abilityChoice => this.eligibleChoiceForPlayer(abilityChoice, player));
+        let choicesForPlayer = this.getChoicesForPlayer(player);
         let buttons = _.map(choicesForPlayer, abilityChoice => {
             let title = abilityChoice.card.name;
             if(abilityChoice.text !== 'default') {
@@ -68,6 +60,13 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
             },
             waitingPromptTitle: 'Waiting for opponents'
         });
+    }
+
+    getChoicesForPlayer(player) {
+        let choices = _.filter(this.abilityChoices, abilityChoice => this.eligibleChoiceForPlayer(abilityChoice, player));
+        // Cards that have a maximum should only display a single choice by
+        // title even if multiple copies are available to be triggered.
+        return _.uniq(choices, choice => choice.ability.hasMax() ? choice.card.name : choice);
     }
 
     chooseAbility(player, id) {

--- a/test/server/integration/eventmaximums.spec.js
+++ b/test/server/integration/eventmaximums.spec.js
@@ -7,7 +7,7 @@ describe('event maximums', function() {
     integration(function() {
         beforeEach(function() {
             const deck = this.buildDeck('baratheon', [
-                'A Game of Thrones',
+                'A Game of Thrones', 'A Game of Thrones',
                 'A Meager Contribution', 'A Meager Contribution'
             ]);
             this.player1.selectDeck(deck);
@@ -39,6 +39,27 @@ describe('event maximums', function() {
             this.player2.clickPrompt('Done');
 
             expect(this.player2).toHavePromptButton('A Meager Contribution');
+        });
+
+        describe('when the maximum period has passed', function() {
+            beforeEach(function() {
+                // Play the card Round 1
+                this.player1.clickPrompt('A Meager Contribution');
+                this.player2.clickPrompt('Done');
+                this.player2.clickPrompt('Pass');
+                this.player1.clickPrompt('Done');
+
+                this.completeChallengesPhase();
+                this.completeTaxationPhase();
+
+                this.player1.selectPlot('A Game of Thrones');
+                this.player2.selectPlot('A Game of Thrones');
+                this.selectFirstPlayer(this.player2);
+            });
+
+            it('should allow the card to be prompted again', function() {
+                expect(this.player1).toHavePromptButton('A Meager Contribution');
+            });
         });
     });
 });


### PR DESCRIPTION
Previously, if a copy of a card with a maximum limit was in the discard
pile, the player would not be prompted to trigger that card if they had
another copy in hand. This was because the copy in discard would
register with the prompt first, preventing any other copies from being
registered. Then, when the prompt activated it saw that the registered
copy was in discard and therefore couldn't be triggered.

Instead of preventing multiple copies from being registered, it is now
filtered when the prompt is generated and presented to the player.

Fixes #1172.