### PR TITLE
Fix uniqueness checks for take control.

### DIFF
--- a/server/game/game.js
+++ b/server/game/game.js
@@ -694,6 +694,10 @@ class Game extends EventEmitter {
             return;
         }
 
+        if(!newController.canPutIntoPlay(card)) {
+            return;
+        }
+
         this.applyGameAction('takeControl', card, card => {
             oldController.removeCardFromPile(card);
             oldController.allCards = _(oldController.allCards.reject(c => c === card));

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -451,15 +451,36 @@ class Player extends Spectator {
 
     canPutIntoPlay(card) {
         let owner = card.owner;
-        return (
-            (!this.isCharacterDead(card) || this.canResurrect(card)) && !this.cannotMarshalOrPutIntoPlayByTitle.includes(card.name) &&
-            (
-                owner === this ||
-                !this.getDuplicateInPlay(card) &&
-                !owner.getDuplicateInPlay(card) &&
-                (!owner.isCharacterDead(card) || owner.canResurrect(card))
-            )
-        );
+
+        if(!card.isUnique()) {
+            return true;
+        }
+
+        if(this.cannotMarshalOrPutIntoPlayByTitle.includes(card.name)) {
+            return false;
+        }
+
+        if(this.isCharacterDead(card) && !this.canResurrect(card)) {
+            return false;
+        }
+
+        if(owner === this) {
+            let controlsAnOpponentsCopy = this.anyCardsInPlay(c => c.name === card.name && c.owner !== this);
+            let opponentControlsOurCopy = _.any(this.game.getPlayers(), player => {
+                return player !== this && player.anyCardsInPlay(c => c.name === card.name && c.owner === this && c !== card);
+            });
+
+            return !controlsAnOpponentsCopy && !opponentControlsOurCopy;
+        }
+
+        if(owner.isCharacterDead(card) && !owner.canResurrect(card)) {
+            return false;
+        }
+
+        let controlsACopy = this.anyCardsInPlay(c => c.name === card.name);
+        let opponentControlsACopy = owner.anyCardsInPlay(c => c.name === card.name && c !== card);
+
+        return !controlsACopy && !opponentControlsACopy;
     }
 
     canResurrect(card) {

--- a/test/helpers/integrationhelper.js
+++ b/test/helpers/integrationhelper.js
@@ -52,6 +52,24 @@ var customMatchers = {
                 return result;
             }
         };
+    },
+    toBeControlledBy: function(util, customEqualityMatchers) {
+        return {
+            compare: function(actual, expected) {
+                let result = {};
+                let controller = actual.controller;
+
+                result.pass = util.equals(controller.name, expected.name, customEqualityMatchers);
+
+                if(result.pass) {
+                    result.message = `Expected ${actual.name} not to be controlled by ${expected.name} but it is.`;
+                } else {
+                    result.message = `Expected ${actual.name} to be controlled by ${expected.name} but is controlled by ${controller.name}`;
+                }
+
+                return result;
+            }
+        };
     }
 };
 

--- a/test/server/integration/takecontrol.spec.js
+++ b/test/server/integration/takecontrol.spec.js
@@ -473,5 +473,163 @@ describe('take control', function() {
                 expect(this.ranger.location).toBe('play area');
             });
         });
+
+        describe('take control + uniqueness', function() {
+            beforeEach(function() {
+                const deck1 = this.buildDeck('greyjoy', [
+                    'Trading with the Pentoshi',
+                    'Ward', 'Night Gathers...', 'Will'
+                ]);
+                const deck2 = this.buildDeck('thenightswatch', [
+                    'A Noble Cause',
+                    'Will', 'Will'
+                ]);
+
+                this.player1.selectDeck(deck1);
+                this.player2.selectDeck(deck2);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.ourCharacter = this.player1.findCardByName('Will', 'hand');
+                [this.theirCharacter, this.theirDupe] = this.player2.filterCardsByName('Will', 'hand');
+            });
+
+            describe('when the player has a character out', function() {
+                beforeEach(function() {
+                    this.player1.clickCard(this.ourCharacter);
+                    this.completeSetup();
+
+                    this.player1.selectPlot('Trading with the Pentoshi');
+                    this.player2.selectPlot('A Noble Cause');
+                    this.selectFirstPlayer(this.player1);
+
+                    expect(this.ourCharacter.location).toBe('play area');
+                });
+
+                it('should not be able to put an opponents copy into play', function() {
+                    this.player2.dragCard(this.theirCharacter, 'discard pile');
+                    this.player1.clickCard('Night Gathers...');
+                    this.player1.clickCard(this.theirCharacter);
+
+                    expect(this.theirCharacter.location).toBe('discard pile');
+                    expect(this.theirCharacter).toBeControlledBy(this.player2);
+                });
+
+                it('should not be able to take control of an opponents copy already in play', function() {
+                    this.player2.dragCard(this.theirCharacter, 'play area');
+                    this.player1.clickCard('Ward');
+                    this.player1.clickCard(this.theirCharacter);
+
+                    expect(this.theirCharacter).toBeControlledBy(this.player2);
+                });
+            });
+
+            describe('when the player has a character in their own dead pile', function() {
+                beforeEach(function() {
+                    this.player1.dragCard(this.ourCharacter, 'dead pile');
+                    this.completeSetup();
+
+                    this.player1.selectPlot('Trading with the Pentoshi');
+                    this.player2.selectPlot('A Noble Cause');
+                    this.selectFirstPlayer(this.player1);
+                });
+
+                it('should not be able to put an opponents copy into play', function() {
+                    this.player2.dragCard(this.theirCharacter, 'discard pile');
+                    this.player1.clickCard('Night Gathers...');
+                    this.player1.clickCard(this.theirCharacter);
+
+                    expect(this.theirCharacter.location).toBe('discard pile');
+                    expect(this.theirCharacter).toBeControlledBy(this.player2);
+                });
+
+                it('should not be able to take control of an opponents copy already in play', function() {
+                    this.player2.dragCard(this.theirCharacter, 'play area');
+                    this.player1.clickCard('Ward');
+                    this.player1.clickCard(this.theirCharacter);
+
+                    expect(this.theirCharacter).toBeControlledBy(this.player2);
+                });
+            });
+
+            describe('when the player controls an opponents character', function() {
+                beforeEach(function() {
+                    this.player2.clickCard(this.theirCharacter);
+                    this.completeSetup();
+
+                    this.player1.selectPlot('Trading with the Pentoshi');
+                    this.player2.selectPlot('A Noble Cause');
+                    this.selectFirstPlayer(this.player1);
+
+                    this.player1.clickCard('Ward');
+                    this.player1.clickCard(this.theirCharacter);
+
+                    expect(this.theirCharacter.location).toBe('play area');
+                    expect(this.theirCharacter).toBeControlledBy(this.player1);
+                });
+
+                it('should not allow the player to put out their own copy', function() {
+                    this.player1.clickCard(this.ourCharacter);
+
+                    expect(this.ourCharacter.location).toBe('hand');
+                });
+
+                it('should not allow the opponent to put out another copy', function() {
+                    this.player1.clickPrompt('Done');
+                    this.player2.clickCard(this.theirDupe);
+
+                    expect(this.theirDupe.location).toBe('hand');
+                });
+            });
+
+            describe('when the opponent has the character out', function() {
+                beforeEach(function() {
+                    this.player2.clickCard(this.theirCharacter);
+                    this.completeSetup();
+
+                    this.player1.selectPlot('Trading with the Pentoshi');
+                    this.player2.selectPlot('A Noble Cause');
+                    this.selectFirstPlayer(this.player1);
+                });
+
+                it('should not allow the player to put into play another copy owned by the opponent', function() {
+                    this.player2.dragCard(this.theirDupe, 'discard pile');
+                    this.player1.clickCard('Night Gathers...');
+                    this.player1.clickCard(this.theirDupe);
+
+                    expect(this.theirDupe.location).toBe('discard pile');
+                    expect(this.theirDupe).toBeControlledBy(this.player2);
+                });
+
+                it('should not allow the player to take control of it if another copy is in the opponents dead pile', function() {
+                    this.player2.dragCard(this.theirDupe, 'dead pile');
+                    this.player1.clickCard('Ward');
+                    this.player1.clickCard(this.theirCharacter);
+
+                    expect(this.theirCharacter.location).toBe('play area');
+                    expect(this.theirCharacter).toBeControlledBy(this.player2);
+                });
+            });
+
+            describe('when the opponent has the character in their dead pile', function() {
+                beforeEach(function() {
+                    this.player2.dragCard(this.theirCharacter, 'dead pile');
+                    this.completeSetup();
+
+                    this.player1.selectPlot('Trading with the Pentoshi');
+                    this.player2.selectPlot('A Noble Cause');
+                    this.selectFirstPlayer(this.player1);
+                });
+
+                it('should not allow the player to put into play another copy owned by the opponent', function() {
+                    this.player2.dragCard(this.theirDupe, 'discard pile');
+                    this.player1.clickCard('Night Gathers...');
+                    this.player1.clickCard(this.theirDupe);
+
+                    expect(this.theirDupe.location).toBe('discard pile');
+                    expect(this.theirDupe).toBeControlledBy(this.player2);
+                });
+            });
+        });
     });
 });

--- a/test/server/player/putintoplay.spec.js
+++ b/test/server/player/putintoplay.spec.js
@@ -15,112 +15,12 @@ describe('Player', function() {
         spyOn(this.player, 'isCharacterDead');
         spyOn(this.player, 'canResurrect');
 
-        this.cardSpy = jasmine.createSpyObj('card', ['getType', 'getCost', 'isBestow', 'applyPersistentEffects', 'moveTo']);
+        this.cardSpy = jasmine.createSpyObj('card', ['getType', 'getCost', 'isBestow', 'isUnique', 'applyPersistentEffects', 'moveTo']);
         this.cardSpy.controller = this.player;
         this.cardSpy.owner = this.player;
         this.dupeCardSpy = jasmine.createSpyObj('dupecard', ['addDuplicate']);
         this.player.hand.push(this.cardSpy);
         this.cardSpy.location = 'hand';
-    });
-
-    describe('canPutIntoPlay()', function() {
-        beforeEach(function() {
-            this.ownerSpy = jasmine.createSpyObj('ownerPlayer', ['canResurrect', 'getDuplicateInPlay', 'isCharacterDead']);
-        });
-
-        describe('when the player is the owner of the card', function() {
-            beforeEach(function() {
-                this.cardSpy.owner = this.player;
-            });
-
-            describe('and the character is already in play', function() {
-                beforeEach(function() {
-                    this.player.getDuplicateInPlay.and.returnValue({ foo: 'bar' });
-                });
-
-                it('should return true', function() {
-                    expect(this.player.canPutIntoPlay(this.cardSpy)).toBe(true);
-                });
-            });
-
-            describe('and the character is dead', function() {
-                beforeEach(function() {
-                    this.player.isCharacterDead.and.returnValue(true);
-                });
-
-                describe('and the character can be resurrected', function() {
-                    beforeEach(function() {
-                        this.player.canResurrect.and.returnValue(true);
-                    });
-
-                    it('should return true', function() {
-                        expect(this.player.canPutIntoPlay(this.cardSpy)).toBe(true);
-                    });
-                });
-
-                describe('and the character cannot be resurrected', function() {
-                    beforeEach(function() {
-                        this.player.canResurrect.and.returnValue(false);
-                    });
-
-                    it('should return false', function() {
-                        expect(this.player.canPutIntoPlay(this.cardSpy)).toBe(false);
-                    });
-                });
-            });
-        });
-
-        describe('when the player is not the owner of the card', function() {
-            beforeEach(function() {
-                this.cardSpy.owner = this.ownerSpy;
-            });
-
-            describe('and the character is already in play', function() {
-                beforeEach(function() {
-                    this.player.getDuplicateInPlay.and.returnValue({ foo: 'bar' });
-                });
-
-                it('should return false', function() {
-                    expect(this.player.canPutIntoPlay(this.cardSpy)).toBe(false);
-                });
-            });
-
-            describe('and the character is in play for the owner', function() {
-                beforeEach(function() {
-                    this.ownerSpy.getDuplicateInPlay.and.returnValue({ foo: 'bar' });
-                });
-
-                it('should return false', function() {
-                    expect(this.player.canPutIntoPlay(this.cardSpy)).toBe(false);
-                });
-            });
-
-            describe('and the character is dead for the owner', function() {
-                beforeEach(function() {
-                    this.ownerSpy.isCharacterDead.and.returnValue(true);
-                });
-
-                describe('and the character can be resurrected', function() {
-                    beforeEach(function() {
-                        this.ownerSpy.canResurrect.and.returnValue(true);
-                    });
-
-                    it('should return true', function() {
-                        expect(this.player.canPutIntoPlay(this.cardSpy)).toBe(true);
-                    });
-                });
-
-                describe('and the character cannot be resurrected', function() {
-                    beforeEach(function() {
-                        this.ownerSpy.canResurrect.and.returnValue(false);
-                    });
-
-                    it('should return false', function() {
-                        expect(this.player.canPutIntoPlay(this.cardSpy)).toBe(false);
-                    });
-                });
-            });
-        });
     });
 
     describe('putIntoPlay', function() {


### PR DESCRIPTION
The checks applied to putting unique cards into play were not being
checked on take control. Thus, players were able to take control of
cards in their dead pile. Additionally, checks were not being made that
an opponent had taken control of your card, allowing players to put out
a new copy of a unique card already stolen by the opponent.

Fixes #1170.