### PR TITLE
Remove plots before revealing new ones

### DIFF
--- a/server/game/cards/agendas/therainsofcastamere.js
+++ b/server/game/cards/agendas/therainsofcastamere.js
@@ -7,7 +7,7 @@ class TheRainsOfCastamere extends AgendaCard {
     constructor(owner, cardData) {
         super(owner, cardData);
 
-        this.registerEvents(['onDecksPrepared', { 'onPlotFlip:forcedinterrupt': 'onPlotFlip' }]);
+        this.registerEvents(['onDecksPrepared', 'onPlotDiscarded']);
     }
 
     setupCardAbilities(ability) {
@@ -50,18 +50,10 @@ class TheRainsOfCastamere extends AgendaCard {
         });
     }
 
-    onPlotFlip() {
-        this.removeExistingSchemeFromGame();
-    }
-
-    removeExistingSchemeFromGame() {
-        var previousPlot = this.owner.activePlot;
-
-        if(!previousPlot || !previousPlot.hasTrait('Scheme')) {
-            return;
+    onPlotDiscarded(event) {
+        if(event.card.hasTrait('Scheme')) {
+            this.owner.moveCard(event.card, 'out of game');
         }
-
-        this.owner.removeActivePlot('out of game');
     }
 
     menuButtons() {
@@ -82,11 +74,10 @@ class TheRainsOfCastamere extends AgendaCard {
 
         this.game.addMessage('{0} uses {1} to reveal {2}', player, this, scheme);
 
-        this.removeExistingSchemeFromGame();
-
         this.schemes = _.reject(this.schemes, card => card === scheme);
 
         player.selectedPlot = scheme;
+        player.removeActivePlot();
         player.flipPlotFaceup();
         this.game.queueStep(new RevealPlots(this.game, [scheme]));
 

--- a/server/game/gamesteps/plotphase.js
+++ b/server/game/gamesteps/plotphase.js
@@ -11,6 +11,7 @@ class PlotPhase extends Phase {
         this.initialise([
             new SimpleStep(game, () => this.startPlotPhase()),
             new SelectPlotPrompt(game),
+            new SimpleStep(game, () => this.removeActivePlots()),
             new SimpleStep(game, () => this.flipPlotsFaceup()),
             () => new RevealPlots(game, _.map(this.game.getPlayers(), player => player.activePlot)),
             new ActionWindow(this.game, 'After plots revealed', 'plot'),
@@ -21,6 +22,12 @@ class PlotPhase extends Phase {
     startPlotPhase() {
         _.each(this.game.getPlayers(), player => {
             player.startPlotPhase();
+        });
+    }
+
+    removeActivePlots() {
+        _.each(this.game.getPlayers(), player => {
+            player.removeActivePlot();
         });
     }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -556,8 +556,7 @@ class Player extends Spectator {
 
     flipPlotFaceup() {
         if(this.activePlot) {
-            var previousPlot = this.removeActivePlot('revealed plots');
-            this.game.raiseEvent('onPlotDiscarded', this, previousPlot);
+            this.removeActivePlot('revealed plots');
         }
 
         this.selectedPlot.flipFaceup();
@@ -581,8 +580,9 @@ class Player extends Spectator {
 
     removeActivePlot(targetLocation) {
         if(this.activePlot) {
-            var plot = this.activePlot;
+            let plot = this.activePlot;
             this.moveCard(this.activePlot, targetLocation);
+            this.game.raiseMergedEvent('onPlotDiscarded', { player: this, card: plot });
             this.activePlot = undefined;
             return plot;
         }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -555,10 +555,6 @@ class Player extends Spectator {
     }
 
     flipPlotFaceup() {
-        if(this.activePlot) {
-            this.removeActivePlot('revealed plots');
-        }
-
         this.selectedPlot.flipFaceup();
         this.moveCard(this.selectedPlot, 'active plot');
         this.selectedPlot.applyPersistentEffects();
@@ -578,10 +574,10 @@ class Player extends Spectator {
         }
     }
 
-    removeActivePlot(targetLocation) {
+    removeActivePlot() {
         if(this.activePlot) {
             let plot = this.activePlot;
-            this.moveCard(this.activePlot, targetLocation);
+            this.moveCard(this.activePlot, 'revealed plots');
             this.game.raiseMergedEvent('onPlotDiscarded', { player: this, card: plot });
             this.activePlot = undefined;
             return plot;

--- a/test/helpers/playerinteractionwrapper.js
+++ b/test/helpers/playerinteractionwrapper.js
@@ -75,7 +75,7 @@ class PlayerInteractionWrapper {
 
     selectPlot(plot) {
         if(_.isString(plot)) {
-            plot = this.findCardByName(plot);
+            plot = this.findCardByName(plot, 'plot deck');
         }
 
         this.player.selectedPlot = plot;

--- a/test/server/cards/agendas/05045-therainsofcastamere.spec.js
+++ b/test/server/cards/agendas/05045-therainsofcastamere.spec.js
@@ -57,44 +57,31 @@ describe('The Rains of Castamere', function() {
         });
     });
 
-    describe('onPlotFlip()', function() {
-        describe('when there is no active plot', function() {
+    describe('onPlotDiscarded()', function() {
+        beforeEach(function() {
+            this.plotSpy = jasmine.createSpyObj('plot', ['hasTrait']);
+            this.event = { player: this.player, card: this.plotSpy };
+        });
+
+        describe('when the plot is a scheme', function() {
             beforeEach(function() {
-                this.player.activePlot = undefined;
+                this.plotSpy.hasTrait.and.callFake(trait => trait === 'Scheme');
+                this.agenda.onPlotDiscarded(this.event);
             });
 
-            it('should not crash', function() {
-                expect(() => {
-                    this.agenda.onPlotFlip();
-                }).not.toThrow();
+            it('should move the card out of the game', function() {
+                expect(this.player.moveCard).toHaveBeenCalledWith(this.plotSpy, 'out of game');
             });
         });
 
-        describe('when the active plot is not a scheme', function() {
+        describe('when the plot is not a scheme', function() {
             beforeEach(function() {
-                this.player.activePlot = this.plot1;
-
-                this.agenda.onPlotFlip();
+                this.plotSpy.hasTrait.and.returnValue(false);
+                this.agenda.onPlotDiscarded(this.event);
             });
 
-            it('should not remove the plot directly', function() {
-                expect(this.player.activePlot).toBe(this.plot1);
-            });
-
-            it('should not make the plot leave play directly', function() {
-                expect(this.player.removeActivePlot).not.toHaveBeenCalled();
-            });
-        });
-
-        describe('when the active plot is a scheme', function() {
-            beforeEach(function() {
-                this.player.activePlot = this.scheme1;
-
-                this.agenda.onPlotFlip();
-            });
-
-            it('should remove the active plot from the game', function() {
-                expect(this.player.removeActivePlot).toHaveBeenCalledWith('out of game');
+            it('should not move the card', function() {
+                expect(this.player.moveCard).not.toHaveBeenCalled();
             });
         });
     });

--- a/test/server/cards/plots/07/07047-retaliation.spec.js
+++ b/test/server/cards/plots/07/07047-retaliation.spec.js
@@ -5,7 +5,7 @@ describe('Retaliation', function() {
     integration(function() {
         beforeEach(function() {
             const deck = this.buildDeck('greyjoy', [
-                'Retaliation', 'Sneak Attack', 'A Noble Cause'
+                'Retaliation', 'Retaliation', 'Sneak Attack', 'A Noble Cause', 'A Noble Cause'
             ]);
 
             this.player1.selectDeck(deck);
@@ -36,6 +36,26 @@ describe('Retaliation', function() {
             it('should allow the opponent to select the player to be first player', function() {
                 expect(this.player2).toHavePromptButton('player1');
                 expect(this.player2).toHavePromptButton('player2');
+            });
+        });
+
+        describe('when revealed two rounds in a row', function() {
+            beforeEach(function() {
+                this.player1.selectPlot('Retaliation');
+                this.player2.selectPlot('A Noble Cause');
+                this.selectFirstPlayer(this.player2);
+
+                this.completeMarshalPhase();
+                this.completeChallengesPhase();
+                this.completeTaxationPhase();
+
+                this.player1.selectPlot('Retaliation');
+                this.player2.selectPlot('A Noble Cause');
+            });
+
+            it('should not allow the player to select themselves to be first player', function() {
+                expect(this.player1).not.toHavePromptButton('player1');
+                expect(this.player1).toHavePromptButton('player2');
             });
         });
     });

--- a/test/server/integration/takecontrol.spec.js
+++ b/test/server/integration/takecontrol.spec.js
@@ -133,7 +133,7 @@ describe('take control', function() {
         describe('when a permanent take control occurs', function() {
             beforeEach(function() {
                 const deck = this.buildDeck('greyjoy', [
-                    'Sneak Attack',
+                    'Sneak Attack', 'Sneak Attack',
                     'Euron Crow\'s Eye (Core)', 'The Kingsroad', 'Theon Greyjoy (Core)'
                 ]);
                 this.player1.selectDeck(deck);

--- a/test/server/player/flipplotfaceup.spec.js
+++ b/test/server/player/flipplotfaceup.spec.js
@@ -51,29 +51,33 @@ describe('Player', function() {
                 expect(this.player.plotDeck).not.toContain(this.selectedPlotSpy);
             });
         });
+    });
 
-        describe('when there is an active plot', function() {
-            beforeEach(function() {
-                this.activePlotSpy = jasmine.createSpyObj('plot', ['leavesPlay', 'moveTo']);
-                this.activePlotSpy.location = 'active plot';
-                this.activePlotSpy.controller = this.player;
-                this.player.activePlot = this.activePlotSpy;
+    describe('removeActivePlot()', function() {
+        beforeEach(function() {
+            this.activePlotSpy = jasmine.createSpyObj('plot', ['leavesPlay', 'moveTo']);
+            this.activePlotSpy.location = 'active plot';
+            this.activePlotSpy.controller = this.player;
+            this.player.activePlot = this.activePlotSpy;
 
-                this.player.flipPlotFaceup();
-            });
+            this.player.removeActivePlot();
+        });
 
-            it('should move the plot to the revealed plots pile', function() {
-                expect(this.activePlotSpy.moveTo).toHaveBeenCalledWith('revealed plots');
-                expect(this.player.plotDiscard).toContain(this.activePlotSpy);
-            });
+        it('should move the plot to the revealed plots pile', function() {
+            expect(this.activePlotSpy.moveTo).toHaveBeenCalledWith('revealed plots');
+            expect(this.player.plotDiscard).toContain(this.activePlotSpy);
+        });
 
-            it('should have the plot leave play', function() {
-                expect(this.activePlotSpy.leavesPlay).toHaveBeenCalled();
-            });
+        it('should have the plot leave play', function() {
+            expect(this.activePlotSpy.leavesPlay).toHaveBeenCalled();
+        });
 
-            it('should raise the onCardLeftPlay event', function() {
-                expect(this.gameSpy.raiseMergedEvent).toHaveBeenCalledWith('onCardLeftPlay', { player: this.player, card: this.activePlotSpy });
-            });
+        it('should raise the onCardLeftPlay event', function() {
+            expect(this.gameSpy.raiseMergedEvent).toHaveBeenCalledWith('onCardLeftPlay', { player: this.player, card: this.activePlotSpy });
+        });
+
+        it('should raise the onPlotDiscarded event', function() {
+            expect(this.gameSpy.raiseMergedEvent).toHaveBeenCalledWith('onPlotDiscarded', { player: this.player, card: this.activePlotSpy });
         });
     });
 


### PR DESCRIPTION
Because plots were being removed and revealed in the same game step, the unapply of effects from the active plot could occur after the effects of the new plot. Thus in cases where the same plot was revealed twice, it could end up unapplying the effect of the new plot as well (e.g. Retaliation not working when revealed twice).

Fixes #1165 