### PR TITLE
Remove choices from Jon Snow (Watchers on the Wall)

### DIFF
--- a/server/game/cards/characters/07/jonsnow.js
+++ b/server/game/cards/characters/07/jonsnow.js
@@ -9,25 +9,23 @@ class JonSnow extends DrawCard {
                 afterChallenge: (event, challenge) => challenge.winner === this.controller && challenge.isParticipating(this)
             },
             limit: ability.limit.perPhase(1),
-            choices: {
-                'Stand Wildlings': () => {
-                    let attackingWildlings = this.controller.filterCardsInPlay(card => this.game.currentChallenge.isAttacking(card) && card.hasTrait('Wildling') && card.getType() === 'character');
-
-                    _.each(attackingWildlings, card => {
-                        card.controller.standCard(card);
-                    });
-
-                    this.game.addMessage('{0} uses {1} to stand each attacking Wildling character', this.controller, this);
-                },
-                'Stand Nights Watch': () => {
-                    let defendingWatch = this.controller.filterCardsInPlay(card => this.game.currentChallenge.isDefending(card) && card.isFaction('thenightswatch') && card.getType() === 'character');
-
-                    _.each(defendingWatch, card => {
-                        card.controller.standCard(card);
-                    });
-
-                    this.game.addMessage('{0} uses {1} to stand each defending {2} character', this.controller, this, 'thenightswatch');
+            handler: () => {
+                let affectedCharacters = [];
+                if(this.game.currentChallenge.attackingPlayer === this.controller) {
+                    affectedCharacters = this.controller.filterCardsInPlay(card => this.game.currentChallenge.isAttacking(card) &&
+                                                                                   card.hasTrait('Wildling') &&
+                                                                                   card.getType() === 'character');
+                } else {
+                    affectedCharacters = this.controller.filterCardsInPlay(card => this.game.currentChallenge.isDefending(card) &&
+                                                                                   card.isFaction('thenightswatch') &&
+                                                                                   card.getType() === 'character');
                 }
+
+                _.each(affectedCharacters, card => {
+                    card.controller.standCard(card);
+                });
+
+                this.game.addMessage('{0} uses {1} to stand {2}', this.controller, this, affectedCharacters);
             }
         });
     }


### PR DESCRIPTION
The previous implementation of Jon Snow was a little bit confusing. This one removes the choice and prevents accidental misclicks, at the cost of not being able to stand your opponent's characters, with which I'm completely fine.