### PR TITLE
Enforce attachment restrictions when attaching cards

### DIFF
--- a/server/game/cards/attachments/02/lady.js
+++ b/server/game/cards/attachments/02/lady.js
@@ -22,7 +22,7 @@ class Lady extends DrawCard {
         player.moveCard(this, 'play area');
 
         this.game.promptForSelect(this.controller, {
-            cardCondition: card => this.canAttach(player, card) && card.location === 'play area',
+            cardCondition: card => player.canAttach(this, card) && card.location === 'play area',
             activePromptTitle: 'Select a different character for attachment',
             waitingPromptTitle: 'Waiting for opponent to move attachment',
             onSelect: (player, card) => this.moveAttachment(player, card)

--- a/server/game/cards/attachments/03/nymeria.js
+++ b/server/game/cards/attachments/03/nymeria.js
@@ -22,7 +22,7 @@ class Nymeria extends DrawCard {
         player.moveCard(this, 'play area');
 
         this.game.promptForSelect(this.controller, {
-            cardCondition: card => this.canAttach(player, card) && card.location === 'play area',
+            cardCondition: card => player.canAttach(this, card) && card.location === 'play area',
             activePromptTitle: 'Select a different character for attachment',
             waitingPromptTitle: 'Waiting for opponent to move attachment',
             onSelect: (player, card) => this.moveAttachment(player, card)

--- a/server/game/cards/attachments/07/summer.js
+++ b/server/game/cards/attachments/07/summer.js
@@ -29,7 +29,7 @@ class Summer extends DrawCard {
                 cardCondition: card => (
                     card.location === 'play area' &&
                     card !== this.parent &&
-                    this.canAttach(this.controller, card))
+                    this.controller.canAttach(this, card))
             },
             handler: context => {
                 this.controller.attach(this.controller, this, context.target);

--- a/server/game/cards/events/01/risenfromthesea.js
+++ b/server/game/cards/events/01/risenfromthesea.js
@@ -33,6 +33,10 @@ class RisenFromTheSea extends DrawCard {
             ]
         });
     }
+
+    canAttach(player, card) {
+        return card.getType() === 'character';
+    }
 }
 
 RisenFromTheSea.code = '01081';

--- a/server/game/cards/events/02/bloodmagicritual.js
+++ b/server/game/cards/events/02/bloodmagicritual.js
@@ -33,6 +33,10 @@ class BloodMagicRitual extends DrawCard {
             ]
         });
     }
+
+    canAttach(player, card) {
+        return card.getType() === 'character';
+    }
 }
 
 BloodMagicRitual.code = '02094';

--- a/server/game/cards/events/03/aryasgift.js
+++ b/server/game/cards/events/03/aryasgift.js
@@ -15,7 +15,7 @@ class AryasGift extends DrawCard {
 
                 this.game.promptForSelect(this.controller, {
                     cardCondition: card => card.getType() === 'character' && card.controller === this.controller &&
-                        card !== oldOwner && attachment.canAttach(this.controller, card) && card.location === 'play area',
+                        card !== oldOwner && this.controller.canAttach(attachment, card) && card.location === 'play area',
                     activePromptTitle: 'Select another character for attachment',
                     waitingPromptTitle: 'Waiting for opponent to move attachment',
                     onSelect: (player, card) => this.moveAttachment(player, card, attachment, oldOwner)

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -291,6 +291,10 @@ class DrawCard extends BaseCard {
         });
     }
 
+    /**
+     * Checks 'no attachment' restrictions for this card when attempting to
+     * attach the passed attachment card.
+     */
     allowAttachment(attachment) {
         return (
             this.isBlank() ||
@@ -299,12 +303,12 @@ class DrawCard extends BaseCard {
         );
     }
 
+    /**
+     * Checks whether the passed card meets the attachment restrictions (e.g.
+     * Opponent cards only, specific factions, etc) for this card.
+     */
     canAttach(player, card) {
-        if(this.getType() !== 'attachment') {
-            return false;
-        }
-
-        return card.allowAttachment(this);
+        return card && this.getType() === 'attachment';
     }
 
     removeAttachment(attachment) {

--- a/server/game/gamesteps/attachmentprompt.js
+++ b/server/game/gamesteps/attachmentprompt.js
@@ -11,7 +11,7 @@ class AttachmentPrompt extends UiPrompt {
     continue() {
         this.game.promptForSelect(this.player, {
             activePromptTitle: 'Select target for attachment',
-            cardCondition: card => this.attachmentCard.owner.canAttach(this.attachmentCard.uuid, card),
+            cardCondition: card => this.attachmentCard.owner.canAttach(this.attachmentCard, card),
             onSelect: (player, card) => {
                 let targetPlayer = card.controller;
                 targetPlayer.attach(player, this.attachmentCard, card, this.playingType);

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -607,10 +607,8 @@ class Player extends Spectator {
         });
     }
 
-    canAttach(attachmentId, card) {
-        var attachment = this.findCardByUuidInAnyList(attachmentId);
-
-        if(!attachment) {
+    canAttach(attachment, card) {
+        if(!attachment || !card) {
             return false;
         }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -612,15 +612,12 @@ class Player extends Spectator {
             return false;
         }
 
-        if(card.location !== 'play area') {
-            return false;
-        }
-
-        if(card === attachment) {
-            return false;
-        }
-
-        return attachment.canAttach(this, card);
+        return (
+            card.location === 'play area' &&
+            card !== attachment &&
+            card.allowAttachment(attachment) &&
+            attachment.canAttach(this, card)
+        );
     }
 
     attach(player, attachment, card, playingType) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -625,6 +625,10 @@ class Player extends Spectator {
             return;
         }
 
+        if(!this.canAttach(attachment, card)) {
+            return;
+        }
+
         let originalLocation = attachment.location;
         let originalParent = attachment.parent;
 

--- a/test/server/card/drawcard.canAttach.spec.js
+++ b/test/server/card/drawcard.canAttach.spec.js
@@ -3,12 +3,23 @@
 
 const DrawCard = require('../../../server/game/drawcard.js');
 
-describe('the DrawCard', function() {
-    describe('the canAttach() function', function() {
-        beforeEach(function() {
-            this.owner = {
-                game: jasmine.createSpyObj('game', ['raiseEvent'])
-            };
+describe('DrawCard', function() {
+    beforeEach(function() {
+        this.owner = {
+            game: jasmine.createSpyObj('game', ['raiseEvent'])
+        };
+    });
+
+    describe('canAttach()', function() {
+        describe('when the card is an attachment', function() {
+            beforeEach(function() {
+                this.targetCard = new DrawCard(this.owner, { text: '' });
+                this.attachment = new DrawCard(this.owner, { type_code: 'attachment' });
+            });
+
+            it('should return true', function() {
+                expect(this.attachment.canAttach(this.player, this.targetCard)).toBe(true);
+            });
         });
 
         describe('when the card is not an attachment', function() {
@@ -21,7 +32,9 @@ describe('the DrawCard', function() {
                 expect(this.attachment.canAttach(this.player, this.targetCard)).toBe(false);
             });
         });
+    });
 
+    describe('allowAttachment()', function() {
         describe('when the target card does not allow attachments', function() {
             beforeEach(function() {
                 this.targetCard = new DrawCard(this.owner, { text: 'No attachments.' });
@@ -29,7 +42,7 @@ describe('the DrawCard', function() {
             });
 
             it('should return false', function() {
-                expect(this.attachment.canAttach(this.player, this.targetCard)).toBe(false);
+                expect(this.targetCard.allowAttachment(this.attachment)).toBe(false);
             });
 
             describe('but the target card is blank', function() {
@@ -38,7 +51,7 @@ describe('the DrawCard', function() {
                 });
 
                 it('should return true', function() {
-                    expect(this.attachment.canAttach(this.player, this.targetCard)).toBe(true);
+                    expect(this.targetCard.allowAttachment(this.attachment)).toBe(true);
                 });
             });
         });
@@ -59,7 +72,7 @@ describe('the DrawCard', function() {
                     });
 
                     it('should return true', function() {
-                        expect(this.attachment.canAttach(this.player, this.targetCard)).toBe(true);
+                        expect(this.targetCard.allowAttachment(this.attachment)).toBe(true);
                     });
                 });
             });
@@ -70,7 +83,7 @@ describe('the DrawCard', function() {
                 });
 
                 it('should return true', function() {
-                    expect(this.attachment.canAttach(this.player, this.targetCard)).toBe(true);
+                    expect(this.targetCard.allowAttachment(this.attachment)).toBe(true);
                 });
             });
 
@@ -80,7 +93,7 @@ describe('the DrawCard', function() {
                 });
 
                 it('should return false', function() {
-                    expect(this.attachment.canAttach(this.player, this.targetCard)).toBe(false);
+                    expect(this.targetCard.allowAttachment(this.attachment)).toBe(false);
                 });
 
                 describe('but the target card is blank', function() {
@@ -89,7 +102,7 @@ describe('the DrawCard', function() {
                     });
 
                     it('should return true', function() {
-                        expect(this.attachment.canAttach(this.player, this.targetCard)).toBe(true);
+                        expect(this.targetCard.allowAttachment(this.attachment)).toBe(true);
                     });
                 });
             });
@@ -102,7 +115,7 @@ describe('the DrawCard', function() {
             });
 
             it('should return true', function() {
-                expect(this.attachment.canAttach(this.player, this.targetCard)).toBe(true);
+                expect(this.targetCard.allowAttachment(this.attachment)).toBe(true);
             });
         });
     });

--- a/test/server/cards/events/01/01081-risenfromthesea.spec.js
+++ b/test/server/cards/events/01/01081-risenfromthesea.spec.js
@@ -1,0 +1,80 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('Risen from the Sea', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck = this.buildDeck('greyjoy', [
+                'A Noble Cause',
+                'Theon Greyjoy (Core)', 'Drowned Men', 'Risen from the Sea'
+            ]);
+
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.keepStartingHands();
+
+
+            this.character = this.player1.findCardByName('Theon Greyjoy', 'hand');
+            this.noAttachmentCharacter = this.player1.findCardByName('Drowned Men', 'hand');
+            this.event = this.player1.findCardByName('Risen from the Sea', 'hand');
+
+            this.player1.clickCard(this.character);
+            this.player1.clickCard(this.noAttachmentCharacter);
+            this.player2.clickCard('Drowned Men', 'hand');
+            this.completeSetup();
+
+            this.player1.selectPlot('A Noble Cause');
+            this.player2.selectPlot('A Noble Cause');
+            this.selectFirstPlayer(this.player2);
+
+            this.completeMarshalPhase();
+
+            this.unopposedChallenge(this.player2, 'military', 'Drowned Men');
+            this.player2.clickPrompt('Apply Claim');
+        });
+
+        describe('when a character is killed', function() {
+            beforeEach(function() {
+                this.player1.clickCard(this.character);
+                this.player1.clickPrompt('Risen from the Sea');
+                this.player1.clickCard(this.character);
+            });
+
+            it('should save the character', function() {
+                expect(this.character.location).toBe('play area');
+            });
+
+            it('should attach the event to the character', function() {
+                expect(this.character.attachments).toContain(this.event);
+            });
+
+            it('should provide +1 STR', function() {
+                // 3 base STR + 1 STR.
+                expect(this.character.getStrength()).toBe(4);
+            });
+        });
+
+        describe('when a no-attachments character is killed', function() {
+            beforeEach(function() {
+                this.player1.clickCard(this.noAttachmentCharacter);
+                this.player1.clickPrompt('Risen from the Sea');
+                this.player1.clickCard(this.noAttachmentCharacter);
+            });
+
+            it('should save the character', function() {
+                expect(this.noAttachmentCharacter.location).toBe('play area');
+            });
+
+            it('should not attach the event to the character', function() {
+                expect(this.noAttachmentCharacter.attachments.size()).toBe(0);
+                expect(this.event.location).toBe('discard pile');
+            });
+
+            it('should not provide +1 STR', function() {
+                // 3 base STR
+                expect(this.noAttachmentCharacter.getStrength()).toBe(3);
+            });
+        });
+    });
+});

--- a/test/server/player/canattach.spec.js
+++ b/test/server/player/canattach.spec.js
@@ -1,0 +1,56 @@
+/*global describe, it, beforeEach, expect, jasmine*/
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+const Player = require('../../../server/game/player.js');
+
+describe('Player', function() {
+    beforeEach(function() {
+        this.gameSpy = jasmine.createSpyObj('game', ['getOtherPlayer', 'playerDecked', 'raiseMergedEvent']);
+        this.player = new Player('1', 'Player 1', true, this.gameSpy);
+        this.player.initialise();
+
+        this.cardSpy = jasmine.createSpyObj('card', ['allowAttachment']);
+        this.cardSpy.allowAttachment.and.returnValue(true);
+        this.cardSpy.location = 'play area';
+        this.attachmentSpy = jasmine.createSpyObj('attachment', ['canAttach']);
+        this.attachmentSpy.canAttach.and.returnValue(true);
+    });
+
+    describe('canAttach()', function() {
+        describe('when everything is correct', function() {
+            it('should return true', function() {
+                expect(this.player.canAttach(this.attachmentSpy, this.cardSpy)).toBe(true);
+            });
+        });
+
+        describe('when the card is not in play area', function() {
+            beforeEach(function() {
+                this.cardSpy.location = 'hand';
+            });
+
+            it('should return false', function() {
+                expect(this.player.canAttach(this.attachmentSpy, this.cardSpy)).toBe(false);
+            });
+        });
+
+        describe('when the card does not allow the attachment', function() {
+            beforeEach(function() {
+                this.cardSpy.allowAttachment.and.returnValue(false);
+            });
+
+            it('should return false', function() {
+                expect(this.player.canAttach(this.attachmentSpy, this.cardSpy)).toBe(false);
+            });
+        });
+
+        describe('when the attachment cannot be attached to the card', function() {
+            beforeEach(function() {
+                this.attachmentSpy.canAttach.and.returnValue(false);
+            });
+
+            it('should return false', function() {
+                expect(this.player.canAttach(this.attachmentSpy, this.cardSpy)).toBe(false);
+            });
+        });
+    });
+});

--- a/test/server/player/removeattachment.spec.js
+++ b/test/server/player/removeattachment.spec.js
@@ -15,7 +15,9 @@ describe('Player', function() {
         this.attachmentOwner = new Player('2', 'Player 2', false, this.gameSpy);
         this.attachmentOwner.initialise();
         this.attachment = new DrawCard(this.attachmentOwner, {});
+        spyOn(this.attachment, 'canAttach').and.returnValue(true);
         this.card = new DrawCard(this.player, {});
+        this.card.location = 'play area';
         this.player.cardsInPlay.push(this.card);
         this.player.attach(this.player, this.attachment, this.card);
 


### PR DESCRIPTION
* Introduces better separation between `canAttach` and `allowAttachment` in `DrawCard` to make inheritance less error prone.
* Checks both methods when calling `Player.attach`, which fixes the problem of Risen from the Sea and Blood Magic Ritual inappropriately attaching to 'No attachments' cards.

Fixes #953.