### PR TITLE
Allow player to choose pillage order

### DIFF
--- a/server/game/gamesteps/keywordwindow.js
+++ b/server/game/gamesteps/keywordwindow.js
@@ -27,27 +27,26 @@ class KeywordWindow extends BaseStep {
     }
 
     applyKeyword(keyword) {
-        let appliedIntimidate = false;
         let ability = GameKeywords[keyword];
-        _.each(this.winnerCardsWithContext, participant => {
-            let {card, context} = participant;
+        let participantsWithKeyword = this.getParticipantsForKeyword(keyword, ability);
 
-            // It is necessary to check whether intimidate has been applied
-            // here instead of in the ability class because the individual
-            // keywords are resolved asynchronously but are queued up
-            // synchronously here. So two intimidates could be queued when
-            // only one is allowed.
-            if(keyword === 'intimidate' && appliedIntimidate) {
-                return;
-            }
-
-            if(card.hasKeyword(keyword) && ability.meetsRequirements(context)) {
-                appliedIntimidate = appliedIntimidate || (keyword === 'intimidate');
-                this.game.resolveAbility(ability, context);
-            }
+        _.each(participantsWithKeyword, participant => {
+            this.game.resolveAbility(ability, participant.context);
         });
 
         this.game.checkWinCondition(this.challenge.winner);
+    }
+
+    getParticipantsForKeyword(keyword, ability) {
+        let participants = _.filter(this.winnerCardsWithContext, participant => {
+            return participant.card.hasKeyword(keyword) && ability.meetsRequirements(participant.context);
+        });
+
+        if(keyword === 'intimidate' && !_.isEmpty(participants)) {
+            return [participants[0]];
+        }
+
+        return participants;
     }
 }
 

--- a/server/game/gamesteps/keywordwindow.js
+++ b/server/game/gamesteps/keywordwindow.js
@@ -9,36 +9,45 @@ class KeywordWindow extends BaseStep {
     constructor(game, challenge) {
         super(game);
         this.challenge = challenge;
-        this.winnerCards = challenge.getWinnerCards();
+        this.winnerCardsWithContext = _.map(challenge.getWinnerCards(), card => {
+            return { card: card, context: { game: this.game, challenge: this.challenge, source: card } };
+        });
     }
 
     continue() {
-        let appliedIntimidate = false;
+        if(!this.challenge.winner) {
+            return;
+        }
 
-        _.each(this.winnerCards, card => {
-            let context = { game: this.game, challenge: this.challenge, source: card };
-
-            _.each(challengeKeywords, keyword => {
-                // It is necessary to check whether intimidate has been applied
-                // here instead of in the ability class because the individual
-                // keywords are resolved asynchronously but are queued up
-                // synchronously here. So two intimidates could be queued when
-                // only one is allowed.
-                if(keyword === 'intimidate' && appliedIntimidate) {
-                    return;
-                }
-
-                let ability = GameKeywords[keyword];
-                if(card.hasKeyword(keyword) && ability.meetsRequirements(context)) {
-                    appliedIntimidate = appliedIntimidate || (keyword === 'intimidate');
-                    this.game.resolveAbility(ability, context);
-                }
-            });
-
-            this.game.checkWinCondition(this.challenge.winner);
+        _.each(challengeKeywords, keyword => {
+            this.applyKeyword(keyword);
         });
 
         return true;
+    }
+
+    applyKeyword(keyword) {
+        let appliedIntimidate = false;
+        let ability = GameKeywords[keyword];
+        _.each(this.winnerCardsWithContext, participant => {
+            let {card, context} = participant;
+
+            // It is necessary to check whether intimidate has been applied
+            // here instead of in the ability class because the individual
+            // keywords are resolved asynchronously but are queued up
+            // synchronously here. So two intimidates could be queued when
+            // only one is allowed.
+            if(keyword === 'intimidate' && appliedIntimidate) {
+                return;
+            }
+
+            if(card.hasKeyword(keyword) && ability.meetsRequirements(context)) {
+                appliedIntimidate = appliedIntimidate || (keyword === 'intimidate');
+                this.game.resolveAbility(ability, context);
+            }
+        });
+
+        this.game.checkWinCondition(this.challenge.winner);
     }
 }
 

--- a/server/game/gamesteps/keywordwindow.js
+++ b/server/game/gamesteps/keywordwindow.js
@@ -1,0 +1,45 @@
+const _ = require('underscore');
+
+const BaseStep = require('./basestep.js');
+const GameKeywords = require('../gamekeywords.js');
+
+const challengeKeywords = ['insight', 'intimidate', 'pillage', 'renown'];
+
+class KeywordWindow extends BaseStep {
+    constructor(game, challenge) {
+        super(game);
+        this.challenge = challenge;
+        this.winnerCards = challenge.getWinnerCards();
+    }
+
+    continue() {
+        let appliedIntimidate = false;
+
+        _.each(this.winnerCards, card => {
+            let context = { game: this.game, challenge: this.challenge, source: card };
+
+            _.each(challengeKeywords, keyword => {
+                // It is necessary to check whether intimidate has been applied
+                // here instead of in the ability class because the individual
+                // keywords are resolved asynchronously but are queued up
+                // synchronously here. So two intimidates could be queued when
+                // only one is allowed.
+                if(keyword === 'intimidate' && appliedIntimidate) {
+                    return;
+                }
+
+                let ability = GameKeywords[keyword];
+                if(card.hasKeyword(keyword) && ability.meetsRequirements(context)) {
+                    appliedIntimidate = appliedIntimidate || (keyword === 'intimidate');
+                    this.game.resolveAbility(ability, context);
+                }
+            });
+
+            this.game.checkWinCondition(this.challenge.winner);
+        });
+
+        return true;
+    }
+}
+
+module.exports = KeywordWindow;

--- a/test/server/integration/pillage.spec.js
+++ b/test/server/integration/pillage.spec.js
@@ -44,6 +44,11 @@ describe('pillage', function() {
                 this.skipActionWindow();
 
                 this.player1.clickPrompt('Apply Claim');
+
+                // Choose order for pillage
+                this.player1.clickCard(this.wildlingHorde1);
+                this.player1.clickCard(this.wildlingHorde2);
+                this.player1.clickPrompt('Done');
             });
 
             it('should discard two cards', function() {


### PR DESCRIPTION
* Processes keywords in sequence instead of processing all keywords for a given card before moving to the next card.
* If there is a single card with keyword Pillage, pillage will automatically occur as before.
* If there are multiple cards with keyword Pillage, the player will be prompted to select the order to process pillage. If they click 'Done' without selecting the order, then pillage will occur in the default order (the order the characters were declared as attackers). Otherwise, pillage will be processed in the order they select.

Fixes #909.