### PR TITLE
Prompt the defending player to apply claim

### DIFF
--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -221,20 +221,20 @@ class ChallengeFlow extends BaseStep {
         }
 
         this.challenge.claim = this.challenge.getClaim();
-        this.game.promptWithMenu(this.challenge.winner, this, {
+        this.game.promptWithMenu(this.challenge.loser, this, {
             activePrompt: {
-                menuTitle: 'Perform before claim actions',
+                menuTitle: 'Claim will be applied',
                 buttons: [
-                    { text: 'Apply Claim', method: 'applyClaim' },
-                    { text: 'Continue', method: 'cancelClaim' }
+                    { text: 'Continue', method: 'applyClaim' },
+                    { text: 'Cancel', method: 'cancelClaim' }
                 ]
             },
-            waitingPromptTitle: 'Waiting for opponent to apply claim'
+            waitingPromptTitle: 'Waiting for opponents'
         });
     }
 
     applyClaim(player) {
-        if(player !== this.challenge.winner) {
+        if(player !== this.challenge.loser) {
             return false;
         }
 
@@ -246,7 +246,7 @@ class ChallengeFlow extends BaseStep {
     }
 
     cancelClaim(player) {
-        this.game.addMessage('{0} continues without applying claim', player, this);
+        this.game.addMessage('{0} cancels applying claim', player, this);
 
         return true;
     }


### PR DESCRIPTION
As discussed in chat, this PR prompts the defending player to apply claim, instead of the attacker. By having the waiting prompt be identical to that of triggered abilities, the attacker will not be able to tell whether the defender gets prompted to play Vengeance for Elia immediately after applying claim, thereby preventing leaking of crucial game state.