### PR TITLE
Show Alliance banner cards under agenda card

### DIFF
--- a/client/GameBoard.jsx
+++ b/client/GameBoard.jsx
@@ -271,6 +271,32 @@ export class InnerGameBoard extends React.Component {
         return cardsByLocation;
     }
 
+    getAgenda(player, popupLocation) {
+        if(!player || !player.agenda || player.agenda.code === '') {
+            return <div className='agenda card-pile vertical panel' />;
+        }
+
+        let cards = [];
+
+        // Alliance
+        if(player.agenda.code === '06018') {
+            cards = player.bannerCards;
+        }
+
+        return (
+            <CardCollection className='agenda'
+                cards={ cards }
+                disablePopup={ cards.length === 0 }
+                onCardClick={ this.onCardClick }
+                onMenuItemClick={ this.onMenuItemClick }
+                onMouseOut={ this.onMouseOut }
+                onMouseOver={ this.onMouseOver }
+                popupLocation={ popupLocation }
+                source='agenda'
+                topCard={ player.agenda } />
+        );
+    }
+
     getSchemePile(player, isMe) {
         let schemePile = player && player.additionalPiles['scheme plots'];
 
@@ -382,11 +408,7 @@ export class InnerGameBoard extends React.Component {
                             <div className='deck-info'>
                                 <div className='deck-type'>
                                     <CardCollection className='faction' source='faction' cards={[]} topCard={otherPlayer ? otherPlayer.faction : undefined} onMouseOver={this.onMouseOver} onMouseOut={this.onMouseOut} disablePopup />
-                                    {otherPlayer && otherPlayer.agenda && otherPlayer.agenda.code !== '' ?
-                                        <CardCollection className='agenda' source='agenda' cards={[]} topCard={otherPlayer ? otherPlayer.agenda : undefined} onMouseOver={this.onMouseOver} onMouseOut={this.onMouseOut}
-                                              onCardClick={this.onCardClick} disablePopup onMenuItemClick={this.onMenuItemClick} />
-                                        : <div className='agenda card-pile vertical panel' />
-                                    }
+                                    { this.getAgenda(otherPlayer, 'bottom') }
                                 </div>
                                 { otherPlayer ? <div className={'first-player-indicator ' + (!thisPlayer.firstPlayer ? '' : 'hidden')}>First player</div> : ''}
                             </div>
@@ -437,11 +459,7 @@ export class InnerGameBoard extends React.Component {
                                 <div className={'first-player-indicator ' + (thisPlayer.firstPlayer ? '' : 'hidden')}>First player</div>
                                 <div className='deck-type'>
                                     <CardCollection className='faction' source='faction' cards={[]} topCard={thisPlayer.faction} onMouseOver={this.onMouseOver} onMouseOut={this.onMouseOut} disablePopup onCardClick={this.onFactionCardClick} />
-                                    {thisPlayer.agenda && thisPlayer.agenda.code !== '' ?
-                                        <CardCollection className='agenda' source='agenda' cards={[]} topCard={thisPlayer.agenda} onMouseOver={this.onMouseOver} onMouseOut={this.onMouseOut}
-                                              onCardClick={this.onCardClick} disablePopup onMenuItemClick={this.onMenuItemClick} />
-                                        : <div className='agenda card-pile vertical panel' />
-                                    }
+                                    { this.getAgenda(thisPlayer, 'top') }
                                 </div>
                             </div>
                         </div>

--- a/less/gameboard.less
+++ b/less/gameboard.less
@@ -336,6 +336,32 @@ span.down-arrow {
   position: absolute;
 }
 
+.agenda .popup {
+  position: absolute;
+  left: -100px;
+  top: 85px;
+  bottom: initial;
+  width: 500px;
+  min-height: 92px;
+
+  .arrow-indicator {
+    transform: rotate(135deg);
+    top: -11px;
+    left: 110px;
+  }
+
+  &.our-side {
+    top: initial;
+    bottom: 85px;
+
+    .arrow-indicator {
+      transform: rotate(-45deg);
+      top: inherit;
+      bottom: -11px;
+    }
+  }
+}
+
 .discard .popup {
   position: absolute;
   left: -100px;

--- a/server/game/deck.js
+++ b/server/game/deck.js
@@ -54,6 +54,8 @@ class Deck {
             result.agenda = undefined;
         }
 
+        result.bannerCards = _.map(this.data.bannerCards, card => this.createCard(AgendaCard, player, card));
+
         return result;
     }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -327,6 +327,7 @@ class Player extends Spectator {
         this.agenda = preparedDeck.agenda;
         this.faction = preparedDeck.faction;
         this.drawDeck = _(preparedDeck.drawCards);
+        this.bannerCards = _(preparedDeck.bannerCards);
         this.allCards = _(preparedDeck.allCards);
     }
 
@@ -1148,7 +1149,7 @@ class Player extends Spectator {
                 cards: this.getSummaryForCardList(pile.cards, activePlayer, pile.isPrivate)
             })),
             agenda: this.agenda ? this.agenda.getSummary(activePlayer) : undefined,
-            promptedActionWindows: this.promptedActionWindows,
+            bannerCards: this.getSummaryForCardList(this.bannerCards, activePlayer),
             cardsInPlay: this.getSummaryForCardList(this.cardsInPlay, activePlayer),
             claim: this.getClaim(),
             deadPile: this.getSummaryForCardList(this.deadPile, activePlayer),
@@ -1167,6 +1168,7 @@ class Player extends Spectator {
             plotDeck: this.getSummaryForCardList(this.plotDeck, activePlayer, true),
             plotDiscard: this.getSummaryForCardList(this.plotDiscard, activePlayer),
             plotSelected: !!this.selectedPlot,
+            promptedActionWindows: this.promptedActionWindows,
             reserve: this.getTotalReserve(),
             totalPower: this.getTotalPower(),
             user: _.omit(this.user, ['password', 'email'])


### PR DESCRIPTION
Adds a popup when clicking the Alliance agenda that will display the
banner cards selected for the deck.

![screen shot 2017-07-19 at 11 48 29 am](https://user-images.githubusercontent.com/145077/28384380-66f03a18-6c79-11e7-8145-bd445632cf64.png)