### PR TITLE
Only event cards should listen in many locations

### DIFF
--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -109,11 +109,15 @@ class TriggeredAbility extends BaseAbility {
     }
 
     isEventListeningLocation(location) {
-        // Reactions / interrupts need to listen for events in all open
-        // information locations plus while in hand. The location property of
-        // the ability will prevent it from firing in inappropriate locations
-        // when requirements are checked for the ability.
-        return ['active plot', 'agenda', 'discard pile', 'dead pile', 'faction', 'hand', 'play area'].includes(location);
+        // Reactions / interrupts for playable event cards need to listen for
+        // game events in all open information locations plus while in hand.
+        // The location property of the ability will prevent it from firing in
+        // inappropriate locations when requirements are checked for the ability.
+        if(this.isPlayableEventAbility()) {
+            return ['discard pile', 'hand'].includes(location);
+        }
+
+        return this.location === location;
     }
 
     isAction() {


### PR DESCRIPTION
Listening to events for all open information areas for all cards caused
problems with attachments such as Paid Off whose listeners expected to
be attached to another card. Thus, only reaction / interrupts for event
cards should listen in multiple locations. Right now that's hand and
discard as they are the only playable locations for events.

Fixes THRONETEKI-Z3
Fixes THRONETEKI-Z5
Fixes THRONETEKI-Z7