### PR TITLE
Fix targeting crash for Tower of the Hand

### DIFF
--- a/server/game/cards/locations/03/towerofthehand.js
+++ b/server/game/cards/locations/03/towerofthehand.js
@@ -13,7 +13,7 @@ class TowerOfTheHand extends DrawCard {
             target: {
                 activePromptTitle: 'Select a character',
                 cardCondition: (card, context) => card.location === 'play area' && card.getType() === 'character' && card.controller !== this.controller &&
-                                                  card.getPrintedCost() < context.costs.returnedToHandCard.getPrintedCost()
+                                                  (!context.costs.returnedToHandCard || card.getPrintedCost() < context.costs.returnedToHandCard.getPrintedCost())
             },
             handler: context => {
                 let returnedCostCard = context.costs.returnedToHandCard;

--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -9,6 +9,7 @@ class TriggeredAbilityContext {
         this.game = game;
         this.source = source;
         this.player = player;
+        this.costs = {};
     }
 
     cancel() {


### PR DESCRIPTION
The 'returnedToHand' cost card currently cannot be resolved before
target eligibility is checked, causing a crash when trying to get the
printed cost for that card.

Fixes THRONETEKI-114
Fixes THRONETEKI-115