### PR TITLE
Better crash recovery

### DIFF
--- a/server/game/game.js
+++ b/server/game/game.js
@@ -73,6 +73,10 @@ class Game extends EventEmitter {
         this.pushAbilityContext('framework', null, 'framework');
     }
 
+    reportError(e) {
+        this.router.handleError(this, e);
+    }
+
     addMessage() {
         this.gameChat.addMessage(...arguments);
     }

--- a/server/game/gamesteps/abilityresolver.js
+++ b/server/game/gamesteps/abilityresolver.js
@@ -48,7 +48,18 @@ class AbilityResolver extends BaseStep {
     }
 
     continue() {
-        return this.pipeline.continue();
+        try {
+            return this.pipeline.continue();
+        } catch(e) {
+            this.game.reportError(e);
+
+            let currentAbilityContext = this.game.currentAbilityContext;
+            if(currentAbilityContext && currentAbilityContext.source === 'card' && currentAbilityContext.card === this.context.source) {
+                this.game.popAbilityContext();
+            }
+
+            return true;
+        }
     }
 
     markActionAsTaken() {

--- a/server/game/gamesteps/triggeredabilitywindow.js
+++ b/server/game/gamesteps/triggeredabilitywindow.js
@@ -63,7 +63,15 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
     }
 
     getChoicesForPlayer(player) {
-        let choices = _.filter(this.abilityChoices, abilityChoice => this.eligibleChoiceForPlayer(abilityChoice, player));
+        let choices = _.filter(this.abilityChoices, abilityChoice => {
+            try {
+                return this.eligibleChoiceForPlayer(abilityChoice, player);
+            } catch(e) {
+                this.abilityChoices = _.reject(this.abilityChoices, a => a === abilityChoice);
+                this.game.reportError(e);
+                return false;
+            }
+        });
         // Cards that have a maximum should only display a single choice by
         // title even if multiple copies are available to be triggered.
         return _.uniq(choices, choice => choice.ability.hasMax() ? choice.card.name : choice);


### PR DESCRIPTION
* When the resolution of ability throws an exception anywhere (paying costs, targeting, in the handler, in prompts nested under the handler, etc), the error will be reported and the ability will be cancelled.
* When a prompt checks an ability for eligibility and the eligibility check throws an exception, the prompt will report the error and remove that ability from the prompt.

There may be cleanup paths I'm missing, particularly around ability resolution, but having the game in a slightly weird state but playable is preferable to total crash, which can happen currently.