### PR TITLE
Implement Queen's Men

### DIFF
--- a/server/game/cards/characters/08/queensmen.js
+++ b/server/game/cards/characters/08/queensmen.js
@@ -59,7 +59,7 @@ class QueensMen extends DrawCard {
         toKneel.controller.kneelCard(toKneel);
         toDiscard.owner.discardCard(toDiscard);
         this.game.addMessage('{0} then kneels {1} to discard {2} from {3}\'s hand',
-                              this.controller, toKneel, toDiscard, toDiscard.owner);
+            this.controller, toKneel, toDiscard, toDiscard.owner);
 
         return true;
     }

--- a/server/game/cards/characters/08/queensmen.js
+++ b/server/game/cards/characters/08/queensmen.js
@@ -1,0 +1,70 @@
+const DrawCard = require('../../../drawcard.js');
+
+class QueensMen extends DrawCard {
+    setupCardAbilities() {
+        this.reaction({
+            when: {
+                onCardEntersPlay: event => event.card === this && event.playingType === 'marshal'
+            },
+            handler: () => {
+                let opponent = this.game.getOtherPlayer(this.controller);
+
+                if(!opponent) {
+                    return;
+                }
+
+                let buttons = opponent.hand.map(card => {
+                    return { card: card, method: 'cardSelected' };
+                });
+
+                buttons.push({ text: 'Done', method: 'doneSelected' });
+
+                this.game.promptWithMenu(this.controller, this, {
+                    activePrompt: {
+                        menuTitle: 'Choose whether to discard a non-character card, or click done',
+                        buttons: buttons
+                    },
+                    source: this
+                });
+            }
+        });
+    }
+
+    cardSelected(player, cardId) {
+        let opponent = this.game.getOtherPlayer(this.controller);
+        let toDiscard = opponent.findCardByUuid(opponent.hand, cardId);
+        this.game.addMessage('{0} uses {1} to look at {2}\'s hand', this.controller, this, opponent);
+
+        if(toDiscard && toDiscard.getType() !== 'character' && this.controller.anyCardsInPlay(card => !card.isFaction('baratheon') && card.getType() === 'character' && !card.kneeled)) {
+            this.game.promptForSelect(this.controller, {
+                activePromptTitle: 'Select a character to kneel',
+                source: this,
+                gameAction: 'kneel',
+                cardCondition: card => card.location === 'play area' && card.controller === this.controller &&
+                                       !card.isFaction('baratheon') && card.getType() === 'character',
+                onSelect: (player, toKneel) => this.kneelToDiscard(player, toKneel, toDiscard)
+            });
+        }
+
+        return true;
+    }
+
+    doneSelected() {
+        let opponent = this.game.getOtherPlayer(this.controller);
+        this.game.addMessage('{0} uses {1} to look at {2}\'s hand', this.controller, this, opponent);
+        return true;
+    }
+
+    kneelToDiscard(p, toKneel, toDiscard) {
+        toKneel.controller.kneelCard(toKneel);
+        toDiscard.owner.discardCard(toDiscard);
+        this.game.addMessage('{0} then kneels {1} to discard {2} from {3}\'s hand',
+                              this.controller, toKneel, toDiscard, toDiscard.owner);
+
+        return true;
+    }
+}
+
+QueensMen.code = '08008';
+
+module.exports = QueensMen;


### PR DESCRIPTION
@ystros: As we talked about in chat, showing the hand through a prompt instead of a chat message would help with an eventual melee implementation. Not sure if I like how this turned out though. Clicking a character card has the same effect as clicking Done, which seems weird but I don't know a way around this. And if you decide to trigger then then-effect, the cost-effect flow is reversed from the usual. On the other hand, this way does take relatively few clicks.

Another possibility: reveal the hand via chat message. Then, if you have a standing non-Bara character, prompt whether to kneel one, and if so, only prompt non-character cards from the opponents hand to be discarded. Showing the hand through a chat message can't be used in melee obviously, unless we would implement player specific chat messages (and the ability to whisper in melee would be cool aside from this). Aside from that, this is much how we would do other cards, with costs paid before deciding on effects, but takes either 0,1 or 3 clicks to resolve after triggering. The current implementation takes 1 or 2 clicks to resolve after triggering.

Finally, is there a way to pass a card object through a menuPrompt instead of a cardId as I do now?