### PR TITLE
Remove "winner determined" action window

### DIFF
--- a/client/GameComponents/ActionWindowsMenu.jsx
+++ b/client/GameComponents/ActionWindowsMenu.jsx
@@ -11,7 +11,6 @@ class ActionWindowsMenu extends React.Component {
             { name: 'challengeBegin', label: 'Before challenge' },
             { name: 'attackersDeclared', label: 'Attackers declared' },
             { name: 'defendersDeclared', label: 'Defenders declared' },
-            { name: 'winnerDetermined', label: 'Winner determined' },
             { name: 'dominance', label: 'Dominance phase' },
             { name: 'standing', label: 'Standing phase' }
         ];

--- a/client/Profile.jsx
+++ b/client/Profile.jsx
@@ -23,7 +23,6 @@ class InnerProfile extends React.Component {
             challengeBegin: false,
             attackersDeclared: true,
             defendersDeclared: true,
-            winnerDetermined: false,
             dominance: false,
             standing: false
         };
@@ -44,7 +43,6 @@ class InnerProfile extends React.Component {
             { name: 'challengeBegin', label: 'Before challenge' },
             { name: 'attackersDeclared', label: 'Attackers declared' },
             { name: 'defendersDeclared', label: 'Defenders declared' },
-            { name: 'winnerDetermined', label: 'Winner determined' },
             { name: 'dominance', label: 'Dominance phase' },
             { name: 'standing', label: 'Standing phase' }
         ];

--- a/server/api/account.js
+++ b/server/api/account.js
@@ -17,7 +17,6 @@ const defaultWindows = {
     challengeBegin: false,
     attackersDeclared: true,
     defendersDeclared: true,
-    winnerDetermined: false,
     dominance: false,
     standing: false
 };

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -191,11 +191,6 @@ class ChallengeFlow extends BaseStep {
         }
 
         this.game.raiseEvent('afterChallenge', this.challenge);
-
-        // Only open a winner action window if a winner / loser was determined.
-        if(this.challenge.winner) {
-            this.game.queueStep(new ActionWindow(this.game, 'After winner determined', 'winnerDetermined'));
-        }
     }
 
     unopposedPower() {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -51,7 +51,6 @@ class Player extends Spectator {
             challengeBegin: false,
             attackersDeclared: true,
             defendersDeclared: true,
-            winnerDetermined: true,
             dominance: false,
             standing: false
         };

--- a/server/server.js
+++ b/server/server.js
@@ -29,7 +29,6 @@ const defaultWindows = {
     challengeBegin: false,
     attackersDeclared: true,
     defendersDeclared: true,
-    winnerDetermined: false,
     dominance: false,
     standing: false
 };

--- a/test/helpers/gameflowwrapper.js
+++ b/test/helpers/gameflowwrapper.js
@@ -102,7 +102,7 @@ class GameFlowWrapper {
         promptedPlayer.clickPrompt(buttonText);
     }
 
-    unopposedChallenge(player, type, participant, reactionExpected) {
+    unopposedChallenge(player, type, participant) {
         var opponent = this.allPlayers.find(p => p !== player);
 
         player.clickPrompt(type);
@@ -114,10 +114,6 @@ class GameFlowWrapper {
         opponent.clickPrompt('Done');
 
         this.skipActionWindow();
-
-        if(!reactionExpected) {
-            this.skipActionWindow();
-        }
     }
 }
 

--- a/test/server/cards/agendas/02060-thelordofthecrossing.spec.js
+++ b/test/server/cards/agendas/02060-thelordofthecrossing.spec.js
@@ -64,7 +64,6 @@ describe('The Lord of the Crossing', function() {
                 this.skipActionWindow();
                 this.player2.clickPrompt('Done');
                 this.skipActionWindow();
-                this.skipActionWindow();
                 this.player1.clickPrompt('Apply Claim');
                 this.player2.clickPrompt('Done');
 
@@ -99,7 +98,6 @@ describe('The Lord of the Crossing', function() {
                 this.skipActionWindow();
                 this.player2.clickPrompt('Done');
                 this.skipActionWindow();
-                this.skipActionWindow();
                 this.player1.clickPrompt('Apply Claim');
                 this.player2.clickPrompt('Done');
 
@@ -108,7 +106,6 @@ describe('The Lord of the Crossing', function() {
                 this.player1.clickPrompt('Done');
                 this.skipActionWindow();
                 this.player2.clickPrompt('Done');
-                this.skipActionWindow();
                 this.skipActionWindow();
                 this.player1.clickPrompt('Apply Claim');
 
@@ -138,7 +135,6 @@ describe('The Lord of the Crossing', function() {
                 beforeEach(function() {
                     this.skipActionWindow();
                     this.player2.clickPrompt('Done');
-                    this.skipActionWindow();
                     this.skipActionWindow();
                 });
 

--- a/test/server/cards/characters/01/01183-randylltarly.spec.js
+++ b/test/server/cards/characters/01/01183-randylltarly.spec.js
@@ -102,9 +102,6 @@ describe('Randyll Tarly', function() {
                 // Skip post defense action window
                 this.skipActionWindow();
 
-                // Skip post winner window
-                this.skipActionWindow();
-
                 this.player1.clickPrompt('Apply Claim');
             });
 

--- a/test/server/cards/characters/05/05006-tywinlannister.spec.js
+++ b/test/server/cards/characters/05/05006-tywinlannister.spec.js
@@ -99,7 +99,6 @@ describe('Tywin Lannister (LoCR)', function() {
                 this.player2.clickPrompt('Done');
 
                 this.skipActionWindow();
-                this.skipActionWindow();
 
                 this.player1.clickPrompt('Apply Claim');
             });

--- a/test/server/cards/locations/04/04066-thehauntedforest.spec.js
+++ b/test/server/cards/locations/04/04066-thehauntedforest.spec.js
@@ -64,8 +64,6 @@ describe('The Haunted Forest', function() {
                 this.skipActionWindow();
 
                 this.player2.clickPrompt('player1 - The Haunted Forest');
-
-                this.skipActionWindow();
             });
 
             it('should kneel the Haunted Forest', function() {

--- a/test/server/cards/plots/01/01008-calmoverwesteros.spec.js
+++ b/test/server/cards/plots/01/01008-calmoverwesteros.spec.js
@@ -37,7 +37,6 @@ describe('Calm Over Westeros', function() {
                 this.player1.clickPrompt('Done');
 
                 this.skipActionWindow();
-                this.skipActionWindow();
 
                 this.player2.clickPrompt('Apply Claim');
             });
@@ -57,7 +56,6 @@ describe('Calm Over Westeros', function() {
 
                 this.player1.clickPrompt('Done');
 
-                this.skipActionWindow();
                 this.skipActionWindow();
 
                 this.player2.clickPrompt('Apply Claim');

--- a/test/server/cards/plots/02/02080-wraithsintheirmidst.spec.js
+++ b/test/server/cards/plots/02/02080-wraithsintheirmidst.spec.js
@@ -63,7 +63,7 @@ describe('WraithsInTheirMidst', function() {
 
                 this.completeMarshalPhase();
 
-                this.unopposedChallenge(this.player2, 'intrigue', 'Tywin Lannister', true);
+                this.unopposedChallenge(this.player2, 'intrigue', 'Tywin Lannister');
 
                 this.player2.clickPrompt('"The Rains of Castamere"');
                 this.player2.clickPrompt('Filthy Accusations');

--- a/test/server/cards/plots/04/04020-varyssriddle.spec.js
+++ b/test/server/cards/plots/04/04020-varyssriddle.spec.js
@@ -98,7 +98,6 @@ describe('Varys\'s Riddle', function() {
                     this.player1.clickPrompt('Done');
 
                     this.skipActionWindow();
-                    this.skipActionWindow();
 
                     this.player2.clickPrompt('Apply Claim');
                 });

--- a/test/server/cards/plots/06/06040-theannalsofcastleblack.spec.js
+++ b/test/server/cards/plots/06/06040-theannalsofcastleblack.spec.js
@@ -138,8 +138,6 @@ describe('The Annals of Castle Black', function() {
 
                 this.skipActionWindow();
 
-                this.skipActionWindow();
-
                 this.player1.clickPrompt('Apply Claim');
             });
 

--- a/test/server/cards/plots/06/06080-theredwedding.spec.js
+++ b/test/server/cards/plots/06/06080-theredwedding.spec.js
@@ -28,7 +28,7 @@ describe('The Red Wedding', function() {
         });
 
         it('should kill an opponent Lord/Lady when winning challenge', function() {
-            this.unopposedChallenge(this.player1, 'Power', this.character, true);
+            this.unopposedChallenge(this.player1, 'Power', this.character);
             this.player1.clickPrompt('The Red Wedding');
             this.player1.clickCard(this.opponentCharacter);
 
@@ -38,7 +38,7 @@ describe('The Red Wedding', function() {
         it('should allow the opponent to kill a character when they win a challenge', function() {
             this.player1.clickPrompt('Done');
 
-            this.unopposedChallenge(this.player2, 'Power', this.opponentCharacter, true);
+            this.unopposedChallenge(this.player2, 'Power', this.opponentCharacter);
             this.player2.clickPrompt('The Red Wedding');
             this.player2.clickCard(this.character);
 

--- a/test/server/integration/effects.spec.js
+++ b/test/server/integration/effects.spec.js
@@ -48,7 +48,6 @@ describe('effects', function() {
                 this.player2.clickPrompt('Done');
 
                 this.skipActionWindow();
-                this.skipActionWindow();
                 this.player1.clickPrompt('Apply Claim');
             });
 
@@ -111,8 +110,6 @@ describe('effects', function() {
                 this.player2.clickCard(this.character);
 
                 expect(this.character.tokens['poison']).toBeTruthy();
-
-                this.skipActionWindow();
 
                 this.player2.clickPrompt('Apply Claim');
 

--- a/test/server/integration/intimidate.spec.js
+++ b/test/server/integration/intimidate.spec.js
@@ -53,8 +53,6 @@ describe('intimidate', function() {
 
                 this.skipActionWindow();
 
-                this.skipActionWindow();
-
                 this.player1.clickPrompt('Apply Claim');
             });
 
@@ -88,8 +86,6 @@ describe('intimidate', function() {
 
                 this.skipActionWindow();
 
-                this.skipActionWindow();
-
                 this.player1.clickPrompt('Apply Claim');
 
                 // Skip military claim for simplicity.
@@ -118,8 +114,6 @@ describe('intimidate', function() {
 
                 this.player1.clickCard('Robert Baratheon', 'play area');
                 this.player1.clickPrompt('Done');
-
-                this.skipActionWindow();
 
                 this.skipActionWindow();
             });

--- a/test/server/integration/nestedabilitysequences.spec.js
+++ b/test/server/integration/nestedabilitysequences.spec.js
@@ -53,8 +53,6 @@ describe('nested ability sequences', function() {
                 this.player1.clickPrompt('Done');
                 this.skipActionWindow();
 
-                this.skipActionWindow();
-
                 this.player2.clickPrompt('Apply Claim');
 
                 // kill someone

--- a/test/server/integration/pillage.spec.js
+++ b/test/server/integration/pillage.spec.js
@@ -41,7 +41,6 @@ describe('pillage', function() {
                 this.skipActionWindow();
                 this.player2.clickPrompt('Done');
                 this.skipActionWindow();
-                this.skipActionWindow();
 
                 this.player1.clickPrompt('Apply Claim');
             });

--- a/test/server/integration/takecontrol.spec.js
+++ b/test/server/integration/takecontrol.spec.js
@@ -167,7 +167,6 @@ describe('take control', function() {
                 this.player2.clickPrompt('Done');
 
                 this.skipActionWindow();
-                this.skipActionWindow();
 
                 this.player1.clickPrompt('Apply Claim');
 
@@ -255,7 +254,6 @@ describe('take control', function() {
 
                     this.player2.clickPrompt('Done');
 
-                    this.skipActionWindow();
                     this.skipActionWindow();
 
                     this.player1.clickPrompt('Apply Claim');
@@ -373,7 +371,6 @@ describe('take control', function() {
                 this.player2.clickPrompt('Done');
 
                 this.skipActionWindow();
-                this.skipActionWindow();
 
                 this.player1.clickPrompt('Apply Claim');
 
@@ -395,7 +392,6 @@ describe('take control', function() {
 
                 this.player1.clickPrompt('Done');
 
-                this.skipActionWindow();
                 this.skipActionWindow();
 
                 this.player2.clickPrompt('Apply Claim');
@@ -419,7 +415,6 @@ describe('take control', function() {
 
                 this.player2.clickPrompt('Done');
 
-                this.skipActionWindow();
                 this.skipActionWindow();
 
                 this.player1.clickPrompt('Apply Claim');


### PR DESCRIPTION
The "winner determined" action window was put into place to allow a
pause to play in-hand event cards. Now that nearly all events in hand
prompt the player directly, the window is no longer needed.
Additionally, the presence of the window leads newer players to believe
they can ambush cards or play Action events in this pause, which is not
allowed by the rules.