### PR TITLE
Clarify amount of power moved when claim exceeds power

### DIFF
--- a/server/game/gamesteps/challenge/applyclaim.js
+++ b/server/game/gamesteps/challenge/applyclaim.js
@@ -29,12 +29,13 @@ class ApplyClaim extends BaseStep {
                     this.challenge.claim > 1 ? 's' : '');
                 this.challenge.loser.discardAtRandom(this.challenge.claim);
                 break;
-            case 'power':
+            case 'power': {
                 let appliedPower = Math.min(this.challenge.loser.faction.power, this.challenge.claim);
                 this.game.addMessage('{0} {1} claim is applied.  {2} removes {3} power and {4} gains {3} power', this.challenge.claim, this.challenge.challengeType, this.challenge.loser, appliedPower,
                     this.challenge.winner);
                 this.game.transferPower(this.challenge.winner, this.challenge.loser, this.challenge.claim);
                 break;
+            }
         }
 
         this.game.queueSimpleStep(() => {

--- a/server/game/gamesteps/challenge/applyclaim.js
+++ b/server/game/gamesteps/challenge/applyclaim.js
@@ -30,10 +30,9 @@ class ApplyClaim extends BaseStep {
                 this.challenge.loser.discardAtRandom(this.challenge.claim);
                 break;
             case 'power':
-                if(this.challenge.loser.faction.power > 0) {
-                    this.game.addMessage('{0} claim is applied.  {1} removes {2} power and {3} gains {2} power', this.challenge.challengeType, this.challenge.loser, this.challenge.claim,
-                        this.challenge.winner);
-                }
+                let appliedPower = Math.min(this.challenge.loser.faction.power, this.challenge.claim);
+                this.game.addMessage('{0} {1} claim is applied.  {2} removes {3} power and {4} gains {3} power', this.challenge.claim, this.challenge.challengeType, this.challenge.loser, appliedPower,
+                    this.challenge.winner);
                 this.game.transferPower(this.challenge.winner, this.challenge.loser, this.challenge.claim);
                 break;
         }


### PR DESCRIPTION
Previously, when winning a power challenge while having higher claim than the amount of power on the defending player's house card, chatmessages would indicate the full claim amount was moved to the attacking player's house card. Even though the transferPower method already guards against this, players who were unaware of the exact power totals before claim was applied could still wonder whether or not too much power was gained by the attacker. This PR should fix that by differentiating in the chatmessage between the claim value and the amount of power moved.