### PR TITLE
Calculate Crossing STR based on challenge number

### DIFF
--- a/server/game/cards/agendas/thelordofthecrossing.js
+++ b/server/game/cards/agendas/thelordofthecrossing.js
@@ -17,7 +17,7 @@ class TheLordOfTheCrossing extends AgendaCard {
     }
 
     challengeBonus() {
-        var numChallenges = this.controller.getNumberOfChallengesInitiated();
+        let numChallenges = this.game.currentChallenge.number;
         if(numChallenges === 1) {
             return -1;
         }
@@ -34,7 +34,7 @@ class TheLordOfTheCrossing extends AgendaCard {
             return;
         }
 
-        var currentChallenge = this.controller.getNumberOfChallengesInitiated();
+        let currentChallenge = this.game.currentChallenge.number;
         if(challenge.winner === this.controller && currentChallenge === 3) {
             this.game.addMessage('{0} gains 1 power from {1}', challenge.winner, this);
             this.game.addPower(challenge.winner, 1);

--- a/server/game/cards/characters/06/blackwalder.js
+++ b/server/game/cards/characters/06/blackwalder.js
@@ -4,9 +4,9 @@ class BlackWalder extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             condition: () => (
-                this.game.currentChallenge && 
-                this.game.currentChallenge.attackingPlayer === this.controller && 
-                this.controller.getNumberOfChallengesInitiated() === 3),
+                this.game.currentChallenge &&
+                this.game.currentChallenge.attackingPlayer === this.controller &&
+                this.game.currentChallenge.number === 3),
             match: this,
             recalculateWhen: ['onAttackersDeclared'],
             effect: [

--- a/server/game/cards/events/06/freyhospitality.js
+++ b/server/game/cards/events/06/freyhospitality.js
@@ -5,7 +5,7 @@ class FreyHospitality extends DrawCard {
         this.reaction({
             when: {
                 afterChallenge: (event, challenge) => challenge.winner === this.controller &&
-                                                      this.controller.getNumberOfChallengesInitiated() === 3 &&
+                                                      challenge.number === 3 &&
                                                       this.hasAttackingFrey()
             },
             handler: () => {

--- a/server/game/cards/locations/06/thetwins.js
+++ b/server/game/cards/locations/06/thetwins.js
@@ -4,9 +4,9 @@ class TheTwins extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             condition: () => (
-                this.game.currentChallenge && 
-                this.game.currentChallenge.attackingPlayer === this.controller && 
-                this.controller.getNumberOfChallengesInitiated() === 3 &&
+                this.game.currentChallenge &&
+                this.game.currentChallenge.attackingPlayer === this.controller &&
+                this.game.currentChallenge.number === 3 &&
                 this.hasAttackingFrey()),
             match: card => card === this.controller.activePlot,
             effect: ability.effects.modifyClaim(1)

--- a/server/game/cards/plots/02/forthewatch.js
+++ b/server/game/cards/plots/02/forthewatch.js
@@ -2,11 +2,14 @@ const PlotCard = require('../../../plotcard.js');
 
 class ForTheWatch extends PlotCard {
     setupCardAbilities(ability) {
+        // TODO: This effect will need to be reworked for Melee, as it currently
+        // checks how many challenges the attacker has made, not how many have
+        // been initiated against the defending player.
         this.persistentEffect({
             condition: () => (
                 this.game.currentChallenge &&
                 this.game.currentChallenge.defendingPlayer === this.controller &&
-                this.game.currentChallenge.attackingPlayer.getNumberOfChallengesInitiated() <= 1
+                this.game.currentChallenge.number <= 1
             ),
             targetType: 'player',
             targetController: 'opponent',

--- a/server/game/cards/plots/04/battleofoxcross.js
+++ b/server/game/cards/plots/04/battleofoxcross.js
@@ -7,7 +7,7 @@ class BattleOfOxcross extends PlotCard {
             condition: () =>
                 this.game.currentChallenge
                 && this.game.currentChallenge.attackingPlayer === this.controller
-                && this.game.currentChallenge.attackingPlayer.getNumberOfChallengesInitiated() <= 1,
+                && this.game.currentChallenge.number <= 1,
             match: (card) =>
                 card.getType() === 'character'
                 && card.getCost() >= 4,

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -15,7 +15,7 @@ class Challenge {
         this.defenders = [];
         this.defenderStrength = 0;
         this.defenderStrengthModifier = 0;
-        this.stealthData = [],
+        this.stealthData = [];
         this.events = new EventRegistrar(game, this);
         this.registerEvents(['onCardLeftPlay']);
     }

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -3,12 +3,13 @@ const Player = require('./player.js');
 const EventRegistrar = require('./eventregistrar.js');
 
 class Challenge {
-    constructor(game, attackingPlayer, defendingPlayer, challengeType) {
+    constructor(game, properties) {
         this.game = game;
-        this.attackingPlayer = attackingPlayer;
-        this.isSinglePlayer = !defendingPlayer;
-        this.defendingPlayer = defendingPlayer || this.singlePlayerDefender();
-        this.challengeType = challengeType;
+        this.attackingPlayer = properties.attackingPlayer;
+        this.isSinglePlayer = !properties.defendingPlayer;
+        this.defendingPlayer = properties.defendingPlayer || this.singlePlayerDefender();
+        this.challengeType = properties.challengeType;
+        this.number = properties.number;
         this.attackers = [];
         this.attackerStrength = 0;
         this.attackerStrengthModifier = 0;

--- a/server/game/gamesteps/challengephase.js
+++ b/server/game/gamesteps/challengephase.js
@@ -55,12 +55,17 @@ class ChallengePhase extends Phase {
             return;
         }
 
-        var defendingPlayer = this.chooseOpponent(attackingPlayer);
+        let defendingPlayer = this.chooseOpponent(attackingPlayer);
         if(defendingPlayer && !defendingPlayer.activePlot.canChallenge(attackingPlayer, challengeType)) {
             return;
         }
 
-        var challenge = new Challenge(this.game, attackingPlayer, defendingPlayer, challengeType);
+        let challenge = new Challenge(this.game, {
+            attackingPlayer: attackingPlayer,
+            defendingPlayer: defendingPlayer,
+            challengeType: challengeType,
+            number: attackingPlayer.getNumberOfChallengesInitiated() + 1
+        });
         this.game.currentChallenge = challenge;
         this.game.queueStep(new ChallengeFlow(this.game, challenge));
         this.game.queueStep(new SimpleStep(this.game, () => this.cleanupChallenge()));

--- a/test/server/cards/agendas/02060-thelordofthecrossing.spec.js
+++ b/test/server/cards/agendas/02060-thelordofthecrossing.spec.js
@@ -6,7 +6,7 @@ describe('The Lord of the Crossing', function() {
         beforeEach(function() {
             const deck = this.buildDeck('baratheon', [
                 'The Lord of the Crossing',
-                'A Noble Cause',
+                'A Noble Cause', 'Blood of the Dragon',
                 'Selyse Baratheon', 'Bastard in Hiding', 'Fiery Followers'
             ]);
             this.player1.selectDeck(deck);
@@ -23,16 +23,16 @@ describe('The Lord of the Crossing', function() {
             this.player1.clickCard(this.followers);
 
             this.completeSetup();
-
-            this.player1.selectPlot('A Noble Cause');
-            this.player2.selectPlot('A Noble Cause');
-            this.selectFirstPlayer(this.player1);
-
-            this.completeMarshalPhase();
         });
 
         describe('on challenge 1', function() {
             beforeEach(function() {
+                this.player1.selectPlot('A Noble Cause');
+                this.player2.selectPlot('A Noble Cause');
+                this.selectFirstPlayer(this.player1);
+
+                this.completeMarshalPhase();
+
                 this.player1.clickPrompt('Military');
                 this.player1.clickCard(this.followers);
                 this.player1.clickPrompt('Done');
@@ -58,6 +58,12 @@ describe('The Lord of the Crossing', function() {
 
         describe('on challenge 2', function() {
             beforeEach(function() {
+                this.player1.selectPlot('A Noble Cause');
+                this.player2.selectPlot('A Noble Cause');
+                this.selectFirstPlayer(this.player1);
+
+                this.completeMarshalPhase();
+
                 this.player1.clickPrompt('Military');
                 this.player1.clickCard(this.followers);
                 this.player1.clickPrompt('Done');
@@ -92,6 +98,12 @@ describe('The Lord of the Crossing', function() {
 
         describe('on challenge 3', function() {
             beforeEach(function() {
+                this.player1.selectPlot('A Noble Cause');
+                this.player2.selectPlot('A Noble Cause');
+                this.selectFirstPlayer(this.player1);
+
+                this.completeMarshalPhase();
+
                 this.player1.clickPrompt('Military');
                 this.player1.clickCard(this.followers);
                 this.player1.clickPrompt('Done');
@@ -142,6 +154,31 @@ describe('The Lord of the Crossing', function() {
                     // 3 from unopposed challenges, 1 from LotC
                     expect(this.player1Object.getTotalPower()).toBe(4);
                 });
+            });
+        });
+
+        describe('when Blood of the Dragon is in play', function() {
+            beforeEach(function() {
+                this.player1.selectPlot('A Noble Cause');
+                this.player2.selectPlot('Blood of the Dragon');
+                this.selectFirstPlayer(this.player1);
+
+                this.completeMarshalPhase();
+
+                this.player1.clickPrompt('Intrigue');
+                this.player1.clickCard(this.selyse);
+                this.player1.clickPrompt('Done');
+                this.skipActionWindow();
+                this.player2.clickPrompt('Done');
+                this.skipActionWindow();
+
+                this.player1.clickPrompt('Military');
+                this.player1.clickCard(this.followers);
+                this.player1.clickPrompt('Done');
+            });
+
+            it('should not apply the -1 STR penalty from the first challenge and kill the character', function() {
+                expect(this.followers.location).not.toBe('dead pile');
             });
         });
     });

--- a/test/server/challenge/determinewinner.spec.js
+++ b/test/server/challenge/determinewinner.spec.js
@@ -22,7 +22,7 @@ describe('Challenge', function() {
         this.attackerCard = new DrawCard(this.attackingPlayer, {});
         this.defenderCard = new DrawCard(this.defendingPlayer, {});
 
-        this.challenge = new Challenge(this.gameSpy, this.attackingPlayer, this.defendingPlayer, 'military');
+        this.challenge = new Challenge(this.gameSpy, { attackingPlayer: this.attackingPlayer, defendingPlayer: this.defendingPlayer, challengeType: 'military' });
     });
 
     describe('determineWinner()', function() {

--- a/test/server/challenge/removefromchallenge.spec.js
+++ b/test/server/challenge/removefromchallenge.spec.js
@@ -22,7 +22,7 @@ describe('Challenge', function() {
         this.defenderCard = new DrawCard(this.defendingPlayer, {});
         spyOn(this.defenderCard, 'getStrength').and.returnValue(3);
 
-        this.challenge = new Challenge(this.gameSpy, this.attackingPlayer, this.defendingPlayer, 'military');
+        this.challenge = new Challenge(this.gameSpy, { attackingPlayer: this.attackingPlayer, defendingPlayer: this.defendingPlayer, challengeType: 'military' });
         this.challenge.addAttackers([this.attackerCard]);
         this.challenge.addDefenders([this.defenderCard]);
     });


### PR DESCRIPTION
Previously, Lord of the Crossing's STR bonuses were calculated based on
the number of challenges initiated by the player. This lead to a bug
where after attackers were picked but before the challenge was
initiated, the attackers would get the -1 STR penalty. If the opponent
had Blood of the Dragon at the time, this could kill the attackers.

Now, the challenge number is calculated up front and remains constant for
the entire challenge, preventing such bugs.

Fixes #1169 