### PR TITLE
Recalculate effects when traits change

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -421,7 +421,7 @@ class BaseCard {
     }
 
     addTrait(trait) {
-        var lowerCaseTrait = trait.toLowerCase();
+        let lowerCaseTrait = trait.toLowerCase();
 
         if(!lowerCaseTrait || lowerCaseTrait === '') {
             return;
@@ -432,6 +432,8 @@ class BaseCard {
         } else {
             this.traits[lowerCaseTrait]++;
         }
+
+        this.game.raiseMergedEvent('onCardTraitChanged', { card: this });
     }
 
     addFaction(faction) {
@@ -454,6 +456,7 @@ class BaseCard {
 
     removeTrait(trait) {
         this.traits[trait.toLowerCase()]--;
+        this.game.raiseMergedEvent('onCardTraitChanged', { card: this });
     }
 
     removeFaction(faction) {

--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -6,7 +6,7 @@ class EffectEngine {
     constructor(game) {
         this.game = game;
         this.events = new EventRegistrar(game, this);
-        this.events.register(['onCardMoved', 'onCardFactionChanged', 'onCardTakenControl', 'onCardBlankToggled', 'onChallengeFinished', 'onPhaseEnded', 'onAtEndOfPhase', 'onRoundEnded']);
+        this.events.register(['onCardMoved', 'onCardTraitChanged', 'onCardFactionChanged', 'onCardTakenControl', 'onCardBlankToggled', 'onChallengeFinished', 'onPhaseEnded', 'onAtEndOfPhase', 'onRoundEnded']);
         this.effects = [];
         this.recalculateEvents = {};
         this.customDurationEvents = [];
@@ -67,14 +67,22 @@ class EffectEngine {
         this.addTargetForPersistentEffects(card, 'play area');
     }
 
+    onCardTraitChanged(event) {
+        this.recalculateTargetingChange(event.card);
+    }
+
     onCardFactionChanged(event) {
+        this.recalculateTargetingChange(event.card);
+    }
+
+    recalculateTargetingChange(card) {
         _.each(this.effects, effect => {
-            if(effect.duration === 'persistent' && effect.hasTarget(event.card) && !effect.isValidTarget(event.card)) {
-                effect.removeTarget(event.card);
+            if(effect.duration === 'persistent' && effect.hasTarget(card) && !effect.isValidTarget(card)) {
+                effect.removeTarget(card);
             }
         });
 
-        this.addTargetForPersistentEffects(event.card, 'play area');
+        this.addTargetForPersistentEffects(card, 'play area');
     }
 
     addTargetForPersistentEffects(card, targetLocation) {

--- a/test/server/card/drawcard.canAttach.spec.js
+++ b/test/server/card/drawcard.canAttach.spec.js
@@ -6,7 +6,7 @@ const DrawCard = require('../../../server/game/drawcard.js');
 describe('DrawCard', function() {
     beforeEach(function() {
         this.owner = {
-            game: jasmine.createSpyObj('game', ['raiseEvent'])
+            game: jasmine.createSpyObj('game', ['raiseEvent', 'raiseMergedEvent'])
         };
     });
 

--- a/test/server/integration/traitchange.spec.js
+++ b/test/server/integration/traitchange.spec.js
@@ -1,0 +1,78 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('trait change', function() {
+    integration(function() {
+        describe('effect recalculation', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('martell', [
+                    'A Tourney for the King',
+                    'Arianne Martell', 'Knighted'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.character = this.player1.findCardByName('Arianne Martell', 'hand');
+                this.knighted = this.player1.findCardByName('Knighted', 'hand');
+
+            });
+
+            describe('when gaining a trait after the effect has come into play', function() {
+                beforeEach(function() {
+                    this.player1.clickCard(this.character);
+                    this.completeSetup();
+
+                    this.player1.selectPlot('A Tourney for the King');
+                    this.player2.selectPlot('A Tourney for the King');
+                    this.selectFirstPlayer(this.player1);
+
+                    this.player1.clickCard(this.knighted);
+                    this.player1.clickCard(this.character);
+                    expect(this.character.hasTrait('Knight')).toBe(true);
+
+                    this.completeMarshalPhase();
+
+                    this.unopposedChallenge(this.player1, 'Intrigue', this.character);
+                    this.player1.clickPrompt('Apply Claim');
+                });
+
+                it('should apply the effect to the character', function() {
+                    // Renown from A Tourney for the King
+                    expect(this.character.power).toBe(1);
+                });
+            });
+
+            describe('when losing a trait after the effect has come into play', function() {
+                beforeEach(function() {
+                    this.player1.clickCard(this.character);
+                    this.player1.clickCard(this.knighted);
+                    this.completeSetup();
+
+                    this.player1.clickCard(this.knighted);
+                    this.player1.clickCard(this.character);
+
+                    expect(this.character.hasTrait('Knight')).toBe(true);
+
+                    this.player1.selectPlot('A Tourney for the King');
+                    this.player2.selectPlot('A Tourney for the King');
+                    this.selectFirstPlayer(this.player1);
+
+                    this.completeMarshalPhase();
+
+                    this.player1.dragCard(this.knighted, 'discard pile');
+                    expect(this.character.hasTrait('Knight')).toBe(false);
+
+                    this.unopposedChallenge(this.player1, 'Intrigue', this.character);
+                    this.player1.clickPrompt('Apply Claim');
+                });
+
+                it('should not apply the effect to the character', function() {
+                    // No renown from A Tourney for the King since no longer a Knight
+                    expect(this.character.power).toBe(0);
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Previously, if an effect were already in play that was limited to cards
with a certain trait, and a card already in play gained or lost that
trait, the effect would not be applied or removed from that card. For
example, characters that gained the 'Knight' trait while Tourney for the
King was revealed did not gain the renown keyword.

Now, when a card gains or loses a trait, effects for that card are
recalculated in a similar manner to the way they are recalculated for
faction changes.

Fixes #1027.