### PR TITLE
Reword action window prompts

### DIFF
--- a/server/game/gamesteps/actionwindow.js
+++ b/server/game/gamesteps/actionwindow.js
@@ -22,9 +22,9 @@ class ActionWindow extends PlayerOrderPrompt {
 
     activePrompt() {
         return {
-            menuTitle: 'Any actions or reactions?',
+            menuTitle: 'Initiate an action, or pass',
             buttons: [
-                { text: 'Done' }
+                { text: 'Pass' }
             ],
             promptTitle: this.title
         };

--- a/server/game/gamesteps/actionwindow.js
+++ b/server/game/gamesteps/actionwindow.js
@@ -22,7 +22,7 @@ class ActionWindow extends PlayerOrderPrompt {
 
     activePrompt() {
         return {
-            menuTitle: 'Initiate an action, or pass',
+            menuTitle: 'Initiate an action',
             buttons: [
                 { text: 'Pass' }
             ],

--- a/test/helpers/gameflowwrapper.js
+++ b/test/helpers/gameflowwrapper.js
@@ -77,7 +77,7 @@ class GameFlowWrapper {
     }
 
     skipActionWindow() {
-        this.eachPlayerInFirstPlayerOrder(player => player.clickPrompt('Done'));
+        this.eachPlayerInFirstPlayerOrder(player => player.clickPrompt('Pass'));
     }
 
     getPromptedPlayer(title) {

--- a/test/server/cards/characters/01/01183-randylltarly.spec.js
+++ b/test/server/cards/characters/01/01183-randylltarly.spec.js
@@ -83,7 +83,7 @@ describe('Randyll Tarly', function() {
                 this.player1.clickPrompt('Done');
 
                 // Pass action window
-                this.player1.clickPrompt('Done');
+                this.player1.clickPrompt('Pass');
 
                 // Activate Dracarys
                 this.player2.clickCard('Dracarys!', 'hand');
@@ -93,8 +93,8 @@ describe('Randyll Tarly', function() {
                 this.player2.clickCard(this.randyll);
 
                 // Complete action window
-                this.player1.clickPrompt('Done');
-                this.player2.clickPrompt('Done');
+                this.player1.clickPrompt('Pass');
+                this.player2.clickPrompt('Pass');
 
                 // No defenders
                 this.player2.clickPrompt('Done');

--- a/test/server/cards/characters/04/04025-dolorousedd.spec.js
+++ b/test/server/cards/characters/04/04025-dolorousedd.spec.js
@@ -36,7 +36,7 @@ describe('Dolorous Edd', function() {
             this.player2.clickPrompt('Done');
 
             // Skip player 2's action window
-            this.player2.clickPrompt('Done');
+            this.player2.clickPrompt('Pass');
 
             this.player1.clickCard('Dolorous Edd', 'hand');
 
@@ -48,7 +48,7 @@ describe('Dolorous Edd', function() {
         describe('when the player wins the challenge Edd enters', function() {
             beforeEach(function() {
                 this.player2.clickCard('Grand Maester Pycelle', 'play area');
-                this.player2.clickPrompt('Pass');
+                this.player2.clickPrompt('Done');
 
                 // Skip player 2's action window
                 this.player2.clickPrompt('Pass');

--- a/test/server/cards/characters/04/04025-dolorousedd.spec.js
+++ b/test/server/cards/characters/04/04025-dolorousedd.spec.js
@@ -48,16 +48,16 @@ describe('Dolorous Edd', function() {
         describe('when the player wins the challenge Edd enters', function() {
             beforeEach(function() {
                 this.player2.clickCard('Grand Maester Pycelle', 'play area');
-                this.player2.clickPrompt('Done');
+                this.player2.clickPrompt('Pass');
 
                 // Skip player 2's action window
-                this.player2.clickPrompt('Done');
+                this.player2.clickPrompt('Pass');
 
                 this.player1.clickCard('Dolorous Edd', 'hand');
 
                 // Complete the action window
-                this.player2.clickPrompt('Done');
-                this.player1.clickPrompt('Done');
+                this.player2.clickPrompt('Pass');
+                this.player1.clickPrompt('Pass');
 
                 // Do not explicitly defend
                 expect(this.player1).toHavePrompt('Select defenders');
@@ -87,13 +87,13 @@ describe('Dolorous Edd', function() {
                 this.player2.clickPrompt('Done');
 
                 // Skip player 2's action window
-                this.player2.clickPrompt('Done');
+                this.player2.clickPrompt('Pass');
 
                 this.player1.clickCard('Dolorous Edd', 'hand');
 
                 // Complete the action window
-                this.player2.clickPrompt('Done');
-                this.player1.clickPrompt('Done');
+                this.player2.clickPrompt('Pass');
+                this.player1.clickPrompt('Pass');
 
                 // Do not explicitly defend
                 expect(this.player1).toHavePrompt('Select defenders');

--- a/test/server/cards/characters/04/04085-craster.spec.js
+++ b/test/server/cards/characters/04/04085-craster.spec.js
@@ -64,7 +64,7 @@ describe('Craster', function() {
             describe('when sacrificing Craster in the following phase', function() {
                 beforeEach(function() {
                     // Clear plot phase by passing on the action window.
-                    this.player1.clickPrompt('Done');
+                    this.player1.clickPrompt('Pass');
 
                     this.player1.clickMenu(this.craster, 'Sacrifice to resurrect');
                 });

--- a/test/server/cards/locations/01/01061-theredkeep.spec.js
+++ b/test/server/cards/locations/01/01061-theredkeep.spec.js
@@ -41,7 +41,7 @@ describe('The Red Keep', function() {
             });
 
             it('should remove the strength bonus if blanked mid-challenge', function() {
-                this.player1.clickPrompt('Done');
+                this.player1.clickPrompt('Pass');
                 this.player2.clickCard('Nightmares', 'hand');
                 this.player2.clickCard(this.redKeep);
 
@@ -49,7 +49,7 @@ describe('The Red Keep', function() {
             });
 
             it('should not keep the strength bonus if all characters removed from the challenge', function() {
-                this.player1.clickPrompt('Done');
+                this.player1.clickPrompt('Pass');
                 this.player2.clickCard('Areo Hotah', 'hand');
                 this.player2.clickPrompt('Areo Hotah');
                 this.player2.clickCard(this.character);

--- a/test/server/cards/plots/01/01013-headsonspikes.spec.js
+++ b/test/server/cards/plots/01/01013-headsonspikes.spec.js
@@ -32,7 +32,7 @@ describe('Heads on Spikes', function() {
                 this.player2.selectPlot('Sneak Attack');
                 this.selectFirstPlayer(this.player1);
 
-                this.skipActionWindow();
+                this.completeMarshalPhase();
             });
 
             it('should discard a card from the opponent hand', function() {

--- a/test/server/cards/plots/01/01013-headsonspikes.spec.js
+++ b/test/server/cards/plots/01/01013-headsonspikes.spec.js
@@ -63,7 +63,7 @@ describe('Heads on Spikes', function() {
                 this.player2.selectPlot('Sneak Attack');
                 this.selectFirstPlayer(this.player1);
 
-                this.skipActionWindow();
+                this.completeMarshalPhase();
             });
 
             it('should discard a card from the opponent hand', function() {

--- a/test/server/integration/effects.spec.js
+++ b/test/server/integration/effects.spec.js
@@ -36,11 +36,11 @@ describe('effects', function() {
 
                 expect(this.jhogo.getStrength()).toBe(4);
 
-                this.player1.clickPrompt('Done');
+                this.player1.clickPrompt('Pass');
                 this.player2.clickCard('Nightmares', 'hand');
                 this.player2.clickCard(this.jhogo);
-                this.player1.clickPrompt('Done');
-                this.player2.clickPrompt('Done');
+                this.player1.clickPrompt('Pass');
+                this.player2.clickPrompt('Pass');
 
                 expect(this.jhogo.getStrength()).toBe(3);
 


### PR DESCRIPTION
* Remove reactions from the title and use singular 'action' to better match their use.
* Pass instead of Done in the button matches the implementation of the reaction and interrupt windows and mirrors the language used in the RRG.