### PR TITLE
Restrict Pleasure Barge draw

### DIFF
--- a/server/game/cards/locations/02/pleasurebarge.js
+++ b/server/game/cards/locations/02/pleasurebarge.js
@@ -1,7 +1,23 @@
 const DrawCard = require('../../../drawcard.js');
 
-// TODO: "have not yet drawn cards this phase" check
+class DrawTracker {
+    constructor(game, player) {
+        this.hasDrawnCardsThisPhase = false;
+        game.on('onCardsDrawn', event => { 
+            if(event.player === player) { 
+                this.hasDrawnCardsThisPhase = true;
+            }
+        });
+        game.on('onPhaseEnded', () => this.hasDrawnCardsThisPhase = false);
+    }
+}
+
 class PleasureBarge extends DrawCard {
+    constructor(owner, cardData) {
+        super(owner, cardData);
+        this.tracker = new DrawTracker(this.game, this.controller);
+    }
+
     setupCardAbilities(ability) {
         this.plotModifiers({
             gold: -1
@@ -12,7 +28,8 @@ class PleasureBarge extends DrawCard {
         });
         this.reaction({
             when: {
-                onCardEntersPlay: event => event.card === this && event.playingType === 'marshal'
+                onCardEntersPlay: event => event.card === this && event.playingType === 'marshal' &&
+                                           !this.tracker.hasDrawnCardsThisPhase
             },
             handler: () => {
                 this.controller.drawCardsToHand(3);

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -205,9 +205,12 @@ class Player extends Spectator {
             numCards = this.drawDeck.size();
         }
 
-        var cards = this.drawDeck.first(numCards);
-        _.each(cards, card => {
-            this.moveCard(card, 'hand');
+        let cards = this.drawDeck.first(numCards);
+
+        this.game.raiseMergedEvent('onCardsDrawn', { cards: cards, player: this }, () => {
+            _.each(cards, card => {
+                this.moveCard(card, 'hand');
+            });
         });
 
         if(this.drawDeck.size() === 0) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -207,11 +207,13 @@ class Player extends Spectator {
 
         let cards = this.drawDeck.first(numCards);
 
-        this.game.raiseMergedEvent('onCardsDrawn', { cards: cards, player: this }, () => {
-            _.each(cards, card => {
-                this.moveCard(card, 'hand');
-            });
+        _.each(cards, card => {
+            this.moveCard(card, 'hand');
         });
+
+        if(this.game.currentPhase !== 'setup') {
+            this.game.raiseMergedEvent('onCardsDrawn', { cards: cards, player: this });
+        }
 
         if(this.drawDeck.size() === 0) {
             this.game.playerDecked(this);


### PR DESCRIPTION
* Pleasure Barge should only trigger when the player has not drawn any cards yet that phase.