### PR TITLE
Convert challenge events to merged style

### DIFF
--- a/server/game/cards/agendas/theconclave.js
+++ b/server/game/cards/agendas/theconclave.js
@@ -13,7 +13,7 @@ class TheConclave extends AgendaCard {
     setupCardAbilities() {
         this.reaction({
             when : {
-                afterChallenge: (event, challenge) => challenge.winner === this.controller && this.hasParticipatingMaester(challenge)
+                afterChallenge: ({challenge}) => challenge.winner === this.controller && this.hasParticipatingMaester(challenge)
             },
             target: {
                 activePromptTitle: 'Choose Conclave card to swap with top of deck',

--- a/server/game/cards/agendas/thelordofthecrossing.js
+++ b/server/game/cards/agendas/thelordofthecrossing.js
@@ -29,7 +29,8 @@ class TheLordOfTheCrossing extends AgendaCard {
         return 0;
     }
 
-    afterChallenge(e, challenge) {
+    afterChallenge(event) {
+        let challenge = event.challenge;
         if(challenge.attackingPlayer !== this.controller) {
             return;
         }

--- a/server/game/cards/agendas/therainsofcastamere.js
+++ b/server/game/cards/agendas/therainsofcastamere.js
@@ -13,7 +13,7 @@ class TheRainsOfCastamere extends AgendaCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     !this.owner.faction.kneeled &&
                     challenge.challengeType === 'intrigue' &&
                     challenge.winner === this.owner &&

--- a/server/game/cards/attachments/01/ice.js
+++ b/server/game/cards/attachments/01/ice.js
@@ -7,7 +7,7 @@ class Ice extends DrawCard {
         });
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     challenge.winner === this.controller &&
                     challenge.challengeType === 'military' &&
                     challenge.isParticipating(this.parent)

--- a/server/game/cards/attachments/01/throwingaxe.js
+++ b/server/game/cards/attachments/01/throwingaxe.js
@@ -4,7 +4,7 @@ class ThrowingAxe extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.winner === this.controller && challenge.isAttacking(this.parent)
+                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isAttacking(this.parent)
             },
             limit: ability.limit.perPhase(1),
             handler: () => {

--- a/server/game/cards/attachments/02/kingrobertswarhammer.js
+++ b/server/game/cards/attachments/02/kingrobertswarhammer.js
@@ -9,7 +9,7 @@ class KingRobertsWarhammer extends DrawCard {
         });
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.winner === this.controller && challenge.isAttacking(this.parent)
+                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isAttacking(this.parent)
             },
             handler: () => {
                 this.game.promptForSelect(this.controller, {

--- a/server/game/cards/attachments/02/paidoff.js
+++ b/server/game/cards/attachments/02/paidoff.js
@@ -4,7 +4,7 @@ class PaidOff extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.challengeType === 'intrigue' && !this.parent.kneeled && challenge.winner === this.controller
+                afterChallenge: ({challenge}) => challenge.challengeType === 'intrigue' && !this.parent.kneeled && challenge.winner === this.controller
             },
             handler: () => {
                 this.parent.controller.kneelCard(this.parent);

--- a/server/game/cards/attachments/03/motley.js
+++ b/server/game/cards/attachments/03/motley.js
@@ -8,7 +8,7 @@ class Motley extends DrawCard {
         this.reaction({
             when: {
                 onAttackersDeclared: event => event.challenge.isAttacking(this.parent),
-                onDefendersDeclared: (event, challenge) => challenge.isDefending(this.parent)
+                onDefendersDeclared: event => event.challenge.isDefending(this.parent)
             },
             handler: () => {
                 this.parent.controller.discardAtRandom(1);

--- a/server/game/cards/attachments/06/corsairsdirk.js
+++ b/server/game/cards/attachments/06/corsairsdirk.js
@@ -8,9 +8,9 @@ class CorsairsDirk extends DrawCard {
 
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => (
-                    challenge.winner === this.controller && 
-                    challenge.isAttacking(this.parent) && 
+                afterChallenge: ({challenge}) => (
+                    challenge.winner === this.controller &&
+                    challenge.isAttacking(this.parent) &&
                     this.opponentHasGold())
             },
             handler: () => {

--- a/server/game/cards/attachments/07/lingeringvenom.js
+++ b/server/game/cards/attachments/07/lingeringvenom.js
@@ -4,7 +4,7 @@ class LingeringVenom extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.loser === this.controller
+                afterChallenge: ({challenge}) => challenge.loser === this.controller
             },
             handler: () => {
                 this.addToken('venom', 1);

--- a/server/game/cards/attachments/08/oathkeeper.js
+++ b/server/game/cards/attachments/08/oathkeeper.js
@@ -8,7 +8,7 @@ class Oathkeeper extends DrawCard {
 
         this.reaction({
             when: {
-                afterChallenge: (e, challenge) => challenge.winner === this.controller &&
+                afterChallenge: ({challenge}) => challenge.winner === this.controller &&
                                                   challenge.strengthDifference >= 5 &&
                                                   challenge.isParticipating(this.parent)
             },

--- a/server/game/cards/characters/01/ashagreyjoy.js
+++ b/server/game/cards/characters/01/ashagreyjoy.js
@@ -4,7 +4,7 @@ class AshaGreyjoy extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => this.controller === challenge.winner && challenge.isParticipating(this) && challenge.isUnopposed()
+                afterChallenge: ({challenge}) => this.controller === challenge.winner && challenge.isParticipating(this) && challenge.isUnopposed()
             },
             handler: () => {
                 this.controller.standCard(this);

--- a/server/game/cards/characters/01/maestercaleotte.js
+++ b/server/game/cards/characters/01/maestercaleotte.js
@@ -4,7 +4,7 @@ class MaesterCaleotte extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.loser === this.controller && challenge.isParticipating(this)
+                afterChallenge: ({challenge}) => challenge.loser === this.controller && challenge.isParticipating(this)
             },
             target: {
                 activePromptTitle: 'Select a character',

--- a/server/game/cards/characters/01/maesterlomys.js
+++ b/server/game/cards/characters/01/maesterlomys.js
@@ -4,7 +4,7 @@ class MaesterLomys extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.winner === this.controller && challenge.defendingPlayer === this.controller && challenge.challengeType === 'intrigue'
+                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.defendingPlayer === this.controller && challenge.challengeType === 'intrigue'
             },
             handler: () => {
                 this.game.currentChallenge.loser.discardAtRandom(1);

--- a/server/game/cards/characters/01/rattleshirtsraiders.js
+++ b/server/game/cards/characters/01/rattleshirtsraiders.js
@@ -4,7 +4,7 @@ class RattleshirtsRaiders extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     challenge.attackingPlayer === this.controller &&
                     challenge.winner === this.controller &&
                     challenge.isAttacking(this)

--- a/server/game/cards/characters/01/rhaegal.js
+++ b/server/game/cards/characters/01/rhaegal.js
@@ -6,7 +6,7 @@ class Rhaegal extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     challenge.winner === this.controller &&
                     _.any(challenge.getWinnerCards(), card => card.hasTrait('Stormborn'))
                 )

--- a/server/game/cards/characters/01/serjorahmormont.js
+++ b/server/game/cards/characters/01/serjorahmormont.js
@@ -4,7 +4,7 @@ class SerJorahMormont extends DrawCard {
     setupCardAbilities() {
         this.forcedReaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.winner === this.controller && challenge.isParticipating(this)
+                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isParticipating(this)
             },
             handler: () => {
                 this.addToken('betrayal', 1);

--- a/server/game/cards/characters/01/theongreyjoy.js
+++ b/server/game/cards/characters/01/theongreyjoy.js
@@ -4,7 +4,7 @@ class TheonGreyjoy extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.winner === this.controller && challenge.isParticipating(this) && challenge.isUnopposed()
+                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isParticipating(this) && challenge.isUnopposed()
             },
             handler: () => {
                 this.modifyPower(1);

--- a/server/game/cards/characters/01/thequeenofthorns.js
+++ b/server/game/cards/characters/01/thequeenofthorns.js
@@ -4,7 +4,7 @@ class TheQueenOfThorns extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.winner === this.controller && challenge.isParticipating(this) && challenge.challengeType === 'intrigue'
+                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isParticipating(this) && challenge.challengeType === 'intrigue'
             },
             target: {
                 activePromptTitle: 'Select a character',

--- a/server/game/cards/characters/01/theredviper.js
+++ b/server/game/cards/characters/01/theredviper.js
@@ -4,7 +4,7 @@ class TheRedViper extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.winner === this.controller && challenge.isAttacking(this) && challenge.strengthDifference >= 5
+                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isAttacking(this) && challenge.strengthDifference >= 5
             },
             handler: () => {
                 var power = Math.trunc(this.game.currentChallenge.strengthDifference / 5);

--- a/server/game/cards/characters/02/butterbumps.js
+++ b/server/game/cards/characters/02/butterbumps.js
@@ -4,7 +4,7 @@ class Butterbumps extends DrawCard {
     setupCardAbilities() {
         this.forcedReaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.loser === this.controller && challenge.isParticipating(this)
+                afterChallenge: ({challenge}) => challenge.loser === this.controller && challenge.isParticipating(this)
             },
             handler: () => {
                 this.controller.discardAtRandom(1);

--- a/server/game/cards/characters/02/dagmercleftjaw.js
+++ b/server/game/cards/characters/02/dagmercleftjaw.js
@@ -4,10 +4,10 @@ class DagmerCleftjaw extends DrawCard {
     setupCardAbilities() {
         this.interrupt({
             when: {
-                onClaimApplied: (event, challenge) => (
-                    challenge.winner === this.controller &&
-                    challenge.isAttacking(this) &&
-                    challenge.attackers.length === 1)
+                onClaimApplied: event => (
+                    event.challenge.winner === this.controller &&
+                    event.challenge.isAttacking(this) &&
+                    event.challenge.attackers.length === 1)
             },
             handler: context => {
                 context.skipHandler();

--- a/server/game/cards/characters/02/mirrimazduur.js
+++ b/server/game/cards/characters/02/mirrimazduur.js
@@ -4,10 +4,10 @@ class MirriMazDuur extends DrawCard {
     setupCardAbilities() {
         this.interrupt({
             when: {
-                onClaimApplied: (event, challenge) => (
-                    challenge.winner === this.controller &&
-                    challenge.isAttacking(this) &&
-                    challenge.attackers.length === 1
+                onClaimApplied: event => (
+                    event.challenge.winner === this.controller &&
+                    event.challenge.isAttacking(this) &&
+                    event.challenge.attackers.length === 1
                 )
             },
             handler: context => {

--- a/server/game/cards/characters/02/moonboy.js
+++ b/server/game/cards/characters/02/moonboy.js
@@ -4,7 +4,7 @@ class MoonBoy extends DrawCard {
     setupCardAbilities() {
         this.forcedReaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.loser === this.controller && challenge.isParticipating(this)
+                afterChallenge: ({challenge}) => challenge.loser === this.controller && challenge.isParticipating(this)
             },
             handler: () => {
                 this.game.addMessage('{0} is forced to discard 1 card at random after losing a challenge in which {1} was participating', this.controller, this);

--- a/server/game/cards/characters/02/royalentourage.js
+++ b/server/game/cards/characters/02/royalentourage.js
@@ -5,7 +5,7 @@ class RoyalEntourage extends DrawCard {
     setupCardAbilities() {
         this.forcedReaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.loser === this.controller && challenge.challengeType === 'intrigue'
+                afterChallenge: ({challenge}) => challenge.loser === this.controller && challenge.challengeType === 'intrigue'
             },
             handler: () => {
                 this.controller.kneelCard(this);

--- a/server/game/cards/characters/02/thehound.js
+++ b/server/game/cards/characters/02/thehound.js
@@ -4,7 +4,7 @@ class TheHound extends DrawCard {
     setupCardAbilities() {
         this.forcedReaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.winner === this.controller && challenge.isParticipating(this)
+                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isParticipating(this)
             },
             handler: () => {
                 this.game.promptWithMenu(this.controller, this, {

--- a/server/game/cards/characters/02/thereader.js
+++ b/server/game/cards/characters/02/thereader.js
@@ -6,7 +6,7 @@ class TheReader extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     challenge.winner === this.controller &&
                     challenge.isUnopposed() &&
                     _.any(challenge.getWinnerCards(), card => card.isFaction('greyjoy') && card.isUnique())

--- a/server/game/cards/characters/02/tyenesand.js
+++ b/server/game/cards/characters/02/tyenesand.js
@@ -4,7 +4,7 @@ class TyeneSand extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     challenge.challengeType === 'intrigue' &&
                     challenge.winner === this.controller &&
                     challenge.isAttacking(this)

--- a/server/game/cards/characters/02/will.js
+++ b/server/game/cards/characters/02/will.js
@@ -4,7 +4,7 @@ class Will extends DrawCard {
     setupCardAbilities() {
         this.forcedReaction({
             when: {
-                afterChallenge: (e, challenge) => this.controller === challenge.loser && challenge.isUnopposed()
+                afterChallenge: ({challenge}) => this.controller === challenge.loser && challenge.isUnopposed()
             },
             handler: () => {
                 this.game.promptForSelect(this.controller, {

--- a/server/game/cards/characters/03/kingrobbshost.js
+++ b/server/game/cards/characters/03/kingrobbshost.js
@@ -4,7 +4,7 @@ class KingRobbsHost extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     challenge.challengeType === 'military' &&
                     challenge.winner === this.controller &&
                     challenge.isParticipating(this) &&

--- a/server/game/cards/characters/03/theblackfish.js
+++ b/server/game/cards/characters/03/theblackfish.js
@@ -10,9 +10,9 @@ class TheBlackfish extends DrawCard {
 
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => (
-                    challenge.winner === this.controller && 
-                    challenge.challengeType === 'military' && 
+                afterChallenge: ({challenge}) => (
+                    challenge.winner === this.controller &&
+                    challenge.challengeType === 'military' &&
                     challenge.isAttackerTheWinner()
                 )
             },

--- a/server/game/cards/characters/04/dolorousedd.js
+++ b/server/game/cards/characters/04/dolorousedd.js
@@ -17,7 +17,7 @@ class DolorousEdd extends DrawCard {
                 // Manually kneel Edd, since he enters play that way - should not fire a kneeling event.
                 this.kneeled = true;
                 this.game.currentChallenge.addDefender(this);
-                this.game.once('afterChallenge', (event, challenge) => this.promptOnWin(challenge));
+                this.game.once('afterChallenge', event => this.promptOnWin(event.challenge));
             }
         });
     }

--- a/server/game/cards/characters/04/eliasand.js
+++ b/server/game/cards/characters/04/eliasand.js
@@ -4,7 +4,7 @@ class EliaSand extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => this.controller === challenge.loser
+                afterChallenge: ({challenge}) => this.controller === challenge.loser
             },
             limit: ability.limit.perPhase(2),
             target: {

--- a/server/game/cards/characters/04/jaqenhghar.js
+++ b/server/game/cards/characters/04/jaqenhghar.js
@@ -31,7 +31,7 @@ class JaqenHGhar extends DrawCard {
         });
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     challenge.winner === this.controller &&
                     challenge.isAttacking(this) &&
                     challenge.attackers.length === 1

--- a/server/game/cards/characters/04/pyatpree.js
+++ b/server/game/cards/characters/04/pyatpree.js
@@ -4,7 +4,7 @@ class PyatPree extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.winner === this.controller && challenge.isParticipating(this)
+                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isParticipating(this)
             },
             handler: () => {
                 this.game.promptForDeckSearch(this.controller, {

--- a/server/game/cards/characters/04/qhorinhalfhand.js
+++ b/server/game/cards/characters/04/qhorinhalfhand.js
@@ -4,7 +4,7 @@ class QhorinHalfhand extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     challenge.challengeType === 'military' &&
                     challenge.winner === this.controller &&
                     challenge.isParticipating(this)

--- a/server/game/cards/characters/04/roosebolton.js
+++ b/server/game/cards/characters/04/roosebolton.js
@@ -6,7 +6,7 @@ class RooseBolton extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.winner === this.controller && challenge.isAttacking(this)
+                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isAttacking(this)
             },
             handler: () => {
                 this.game.promptForSelect(this.controller, {

--- a/server/game/cards/characters/04/salladhorsaan.js
+++ b/server/game/cards/characters/04/salladhorsaan.js
@@ -4,7 +4,7 @@ class SalladhorSaan extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     challenge.winner === this.controller &&
                     challenge.isParticipating(this))
             },

--- a/server/game/cards/characters/04/spearmaiden.js
+++ b/server/game/cards/characters/04/spearmaiden.js
@@ -16,7 +16,7 @@ class Spearmaiden extends DrawCard {
             handler: context => {
                 this.game.addMessage('{0} chooses {1} as the target for {2}', this.controller, context.target, this);
 
-                this.game.once('afterChallenge', (event, challenge) => this.resolveIfWinBy5(challenge, context));
+                this.game.once('afterChallenge', event => this.resolveIfWinBy5(event.challenge, context));
             }
         });
     }

--- a/server/game/cards/characters/04/thorensmallwood.js
+++ b/server/game/cards/characters/04/thorensmallwood.js
@@ -4,7 +4,7 @@ class ThorenSmallwood extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.winner === this.controller && !challenge.isAttackerTheWinner()
+                afterChallenge: ({challenge}) => challenge.winner === this.controller && !challenge.isAttackerTheWinner()
             },
             handler: () => {
                 this.game.addPower(this.controller, 1);

--- a/server/game/cards/characters/04/whiteraven.js
+++ b/server/game/cards/characters/04/whiteraven.js
@@ -6,7 +6,7 @@ class WhiteRaven extends DrawCard {
     setupCardAbilities() {
         this.forcedReaction({
             when: {
-                afterChallenge: (e, challenge) => challenge.loser === this.controller && challenge.challengeType === 'power'
+                afterChallenge: ({challenge}) => challenge.loser === this.controller && challenge.challengeType === 'power'
             },
             handler: () => {
                 this.game.addMessage('{0} is forced by {1} to sacrifice {1}', this.controller, this);

--- a/server/game/cards/characters/05/alayaya.js
+++ b/server/game/cards/characters/05/alayaya.js
@@ -4,9 +4,9 @@ class Alayaya extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (e, challenge) => (
-                    challenge.winner === this.controller && 
-                    challenge.isParticipating(this) && 
+                afterChallenge: ({challenge}) => (
+                    challenge.winner === this.controller &&
+                    challenge.isParticipating(this) &&
                     this.opponentHasGold())
             },
             handler: () => {

--- a/server/game/cards/characters/05/serbarristanselmy.js
+++ b/server/game/cards/characters/05/serbarristanselmy.js
@@ -4,7 +4,7 @@ class SerBarristanSelmy extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (e, challenge) =>
+                afterChallenge: ({challenge}) =>
                     challenge.winner === this.controller
                     && challenge.isParticipating(this)
                     && this.game.getOtherPlayer(this.controller)

--- a/server/game/cards/characters/05/timettsonoftimett.js
+++ b/server/game/cards/characters/05/timettsonoftimett.js
@@ -4,7 +4,7 @@ class TimettSonOfTimett extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     challenge.winner === this.controller &&
                     challenge.isAttacking(this))
             },

--- a/server/game/cards/characters/05/trystanemartell.js
+++ b/server/game/cards/characters/05/trystanemartell.js
@@ -4,7 +4,7 @@ class TrystaneMartell extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => this.controller === challenge.loser && challenge.isParticipating(this)
+                afterChallenge: ({challenge}) => this.controller === challenge.loser && challenge.isParticipating(this)
             },
             handler: () => {
                 this.game.promptForSelect(this.controller, {

--- a/server/game/cards/characters/05/tyrionlannister.js
+++ b/server/game/cards/characters/05/tyrionlannister.js
@@ -4,7 +4,7 @@ class TyrionLannister extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.winner === this.controller
+                afterChallenge: ({challenge}) => challenge.winner === this.controller
             },
             cost: ability.costs.returnToHand(card => this.isAttackingClansman(card)),
             limit: ability.limit.perPhase(2),

--- a/server/game/cards/characters/06/ellariasand.js
+++ b/server/game/cards/characters/06/ellariasand.js
@@ -6,7 +6,7 @@ class EllariaSand extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => this.controller === challenge.loser && challenge.isParticipating(this)
+                afterChallenge: ({challenge}) => this.controller === challenge.loser && challenge.isParticipating(this)
             },
             cost: ability.costs.discardGold(),
             handler: () => {

--- a/server/game/cards/characters/06/ficklebannerman.js
+++ b/server/game/cards/characters/06/ficklebannerman.js
@@ -4,7 +4,7 @@ class FickleBannerman extends DrawCard {
     setupCardAbilities() {
         this.forcedReaction({
             when: {
-                afterChallenge: (e, challenge) => challenge.loser === this.controller && challenge.challengeType === 'power'
+                afterChallenge: ({challenge}) => challenge.loser === this.controller && challenge.challengeType === 'power'
             },
             handler: () => {
                 this.game.promptWithMenu(this.controller, this, {

--- a/server/game/cards/characters/06/freybastard.js
+++ b/server/game/cards/characters/06/freybastard.js
@@ -4,7 +4,7 @@ class FreyBastard extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.winner === this.controller && this.getNumberOfAttackingFreys() >= 2
+                afterChallenge: ({challenge}) => challenge.winner === this.controller && this.getNumberOfAttackingFreys() >= 2
             },
             cost: ability.costs.discardGold(),
             handler: () => {

--- a/server/game/cards/characters/06/knightofthereach.js
+++ b/server/game/cards/characters/06/knightofthereach.js
@@ -4,8 +4,8 @@ class KnightOfTheReach extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (e, challenge) => (
-                    challenge.winner === this.controller && 
+                afterChallenge: ({challenge}) => (
+                    challenge.winner === this.controller &&
                     challenge.isParticipating(this) &&
                     this.hasSingleParticipatingChar())
             },

--- a/server/game/cards/characters/06/maesterofsunspear.js
+++ b/server/game/cards/characters/06/maesterofsunspear.js
@@ -4,7 +4,7 @@ class MaesterOfSunspear extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => this.controller === challenge.loser && challenge.isParticipating(this)
+                afterChallenge: ({challenge}) => this.controller === challenge.loser && challenge.isParticipating(this)
             },
             target: {
                 activePromptTitle: 'Select an attachment',

--- a/server/game/cards/characters/06/seraxellflorent.js
+++ b/server/game/cards/characters/06/seraxellflorent.js
@@ -4,7 +4,7 @@ class SerAxellFlorent extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.winner === this.controller && challenge.isParticipating(this)
+                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isParticipating(this)
             },
             cost: ability.costs.discardGold(),
             target: {

--- a/server/game/cards/characters/06/stonecrows.js
+++ b/server/game/cards/characters/06/stonecrows.js
@@ -4,7 +4,7 @@ class StoneCrows extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     challenge.winner === this.controller &&
                     challenge.isAttacking(this) &&
                     challenge.defenders.length >= 1)

--- a/server/game/cards/characters/07/grenn.js
+++ b/server/game/cards/characters/07/grenn.js
@@ -4,7 +4,7 @@ class Grenn extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     challenge.winner === this.controller &&
                     challenge.isAttacking(this)) &&
                     this.opponentHasFactionPower()

--- a/server/game/cards/characters/07/jonsnow.js
+++ b/server/game/cards/characters/07/jonsnow.js
@@ -6,7 +6,7 @@ class JonSnow extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.winner === this.controller && challenge.isParticipating(this)
+                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isParticipating(this)
             },
             limit: ability.limit.perPhase(1),
             handler: () => {

--- a/server/game/cards/characters/07/oldbearmormont.js
+++ b/server/game/cards/characters/07/oldbearmormont.js
@@ -4,7 +4,7 @@ class OldBearMormont extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (e, challenge) => challenge.winner === this.controller && challenge.isParticipating(this)
+                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isParticipating(this)
             },
             handler: () => {
                 this.game.promptForSelect(this.controller, {

--- a/server/game/cards/characters/07/pyp.js
+++ b/server/game/cards/characters/07/pyp.js
@@ -4,7 +4,7 @@ class Pyp extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.winner === this.controller && challenge.isAttacking(this)
+                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isAttacking(this)
             },
             target: {
                 activePromptTitle: 'Select a character',

--- a/server/game/cards/events/01/doransgame.js
+++ b/server/game/cards/events/01/doransgame.js
@@ -5,7 +5,7 @@ class DoransGame extends DrawCard {
         this.reaction({
             max: ability.limit.perChallenge(1),
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     challenge.winner === this.controller &&
                     challenge.challengeType === 'intrigue' &&
                     challenge.strengthDifference >= 5

--- a/server/game/cards/events/01/forthenorth.js
+++ b/server/game/cards/events/01/forthenorth.js
@@ -22,12 +22,12 @@ class ForTheNorth extends DrawCard {
         });
     }
 
-    afterChallenge(event, challenge) {
+    afterChallenge(event) {
         if(!this.selectedCard) {
             return;
         }
 
-        if(challenge.winner === this.controller) {
+        if(event.challenge.winner === this.controller) {
             this.controller.drawCardsToHand(1);
 
             this.game.addMessage('{0} uses {1} to draw 1 card',

--- a/server/game/cards/events/01/likewarmrain.js
+++ b/server/game/cards/events/01/likewarmrain.js
@@ -4,7 +4,7 @@ class LikeWarmRain extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => this.controller === challenge.loser && challenge.challengeType === 'intrigue' && challenge.defendingPlayer === this.controller
+                afterChallenge: ({challenge}) => this.controller === challenge.loser && challenge.challengeType === 'intrigue' && challenge.defendingPlayer === this.controller
             },
             max: ability.limit.perChallenge(1),
             cost: ability.costs.kneel(card => card.getType() === 'character' && card.hasTrait('Direwolf')),

--- a/server/game/cards/events/01/olennascunning.js
+++ b/server/game/cards/events/01/olennascunning.js
@@ -4,7 +4,7 @@ class OlennasCunning extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     ['intrigue', 'power'].includes(challenge.challengeType) &&
                     challenge.winner === this.controller
                 )

--- a/server/game/cards/events/01/oursisthefury.js
+++ b/server/game/cards/events/01/oursisthefury.js
@@ -21,12 +21,12 @@ class OursIsTheFury extends DrawCard {
         });
     }
 
-    afterChallenge(event, challenge) {
+    afterChallenge(event) {
         if(!this.selectedCard) {
             return;
         }
 
-        if(challenge.winner === this.controller) {
+        if(event.challenge.winner === this.controller) {
             this.controller.standCard(this.selectedCard);
 
             this.game.addMessage('{0} uses {1} to stand {2} as the challenge was won', this.controller, this, this.selectedCard);

--- a/server/game/cards/events/01/puttothesword.js
+++ b/server/game/cards/events/01/puttothesword.js
@@ -5,7 +5,7 @@ class PutToTheSword extends DrawCard {
         this.reaction({
             max: ability.limit.perChallenge(1),
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     challenge.challengeType === 'military' &&
                     challenge.winner === this.controller &&
                     challenge.attackingPlayer === this.controller &&

--- a/server/game/cards/events/01/puttothetorch.js
+++ b/server/game/cards/events/01/puttothetorch.js
@@ -5,7 +5,7 @@ class PutToTheTorch extends DrawCard {
         this.reaction({
             max: ability.limit.perChallenge(1),
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     challenge.challengeType === 'military' &&
                     challenge.winner === this.controller &&
                     challenge.attackingPlayer === this.controller &&

--- a/server/game/cards/events/01/superiorclaim.js
+++ b/server/game/cards/events/01/superiorclaim.js
@@ -5,7 +5,7 @@ class SuperiorClaim extends DrawCard {
         this.reaction({
             max: ability.limit.perChallenge(1),
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     challenge.challengeType === 'power' &&
                     challenge.winner === this.controller &&
                     challenge.strengthDifference >= 5

--- a/server/game/cards/events/01/tearsoflys.js
+++ b/server/game/cards/events/01/tearsoflys.js
@@ -5,7 +5,7 @@ class TearsOfLys extends DrawCard {
         this.reaction({
             max: ability.limit.perChallenge(1),
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     challenge.attackingPlayer === this.controller &&
                     challenge.winner === this.controller &&
                     challenge.challengeType === 'intrigue'

--- a/server/game/cards/events/01/theswordinthedarkness.js
+++ b/server/game/cards/events/01/theswordinthedarkness.js
@@ -6,7 +6,7 @@ class TheSwordInTheDarkness extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     challenge.winner === this.controller &&
                     challenge.defendingPlayer === this.controller &&
                     challenge.strengthDifference >= 5 &&

--- a/server/game/cards/events/01/unbowedunbentunbroken.js
+++ b/server/game/cards/events/01/unbowedunbentunbroken.js
@@ -5,7 +5,7 @@ class UnbowedUnbentUnbroken extends DrawCard {
         this.reaction({
             max: ability.limit.perChallenge(1),
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     !this.controller.firstPlayer &&
                     challenge.defendingPlayer === this.controller &&
                     challenge.loser === this.controller

--- a/server/game/cards/events/01/wedonotsow.js
+++ b/server/game/cards/events/01/wedonotsow.js
@@ -5,7 +5,7 @@ class WeDoNotSow extends DrawCard {
         this.reaction({
             max: ability.limit.perChallenge(1),
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     challenge.winner === this.controller &&
                     challenge.isUnopposed()
                 )

--- a/server/game/cards/events/02/ladysansasrose.js
+++ b/server/game/cards/events/02/ladysansasrose.js
@@ -4,7 +4,7 @@ class LadySansasRose extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     challenge.winner === this.controller &&
                     this.hasSingleParticipatingChar() &&
                     this.hasParticipatingKnight())

--- a/server/game/cards/events/02/loot.js
+++ b/server/game/cards/events/02/loot.js
@@ -6,7 +6,7 @@ class Loot extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     this.controller === challenge.winner
                     && challenge.isUnopposed()
                     && this.opponentHasGold()

--- a/server/game/cards/events/02/supportofthepeople.js
+++ b/server/game/cards/events/02/supportofthepeople.js
@@ -4,7 +4,7 @@ class SupportOfThePeople extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     challenge.challengeType === 'power' &&
                     challenge.winner === this.controller &&
                     challenge.strengthDifference >= 5

--- a/server/game/cards/events/02/trialbycombat.js
+++ b/server/game/cards/events/02/trialbycombat.js
@@ -5,10 +5,10 @@ class TrialByCombat extends DrawCard {
     setupCardAbilities() {
         this.interrupt({
             when: {
-                onClaimApplied: (event, challenge) => (
-                    challenge.winner === this.controller &&
-                    challenge.attackingPlayer === this.controller &&
-                    challenge.challengeType === 'intrigue'
+                onClaimApplied: event => (
+                    event.challenge.winner === this.controller &&
+                    event.challenge.attackingPlayer === this.controller &&
+                    event.challenge.challengeType === 'intrigue'
                 )
             },
             handler: context => {

--- a/server/game/cards/events/02/vengeanceforelia.js
+++ b/server/game/cards/events/02/vengeanceforelia.js
@@ -5,7 +5,7 @@ class VengeanceForElia extends DrawCard {
     setupCardAbilities() {
         this.interrupt({
             when: {
-                onClaimApplied: (event, challenge) => challenge.defendingPlayer === this.controller
+                onClaimApplied: event => event.challenge.defendingPlayer === this.controller
             },
             handler: context => {
                 let opponent = this.game.getOtherPlayer(this.controller);

--- a/server/game/cards/events/03/hisvipereyes.js
+++ b/server/game/cards/events/03/hisvipereyes.js
@@ -4,7 +4,7 @@ class HisViperEyes extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     challenge.defendingPlayer === this.controller &&
                     challenge.loser === this.controller &&
                     ['military', 'power'].includes(challenge.challengeType) &&

--- a/server/game/cards/events/04/blesshimwithsalt.js
+++ b/server/game/cards/events/04/blesshimwithsalt.js
@@ -25,12 +25,12 @@ class BlessHimWithSalt extends DrawCard {
         });
     }
 
-    afterChallenge(event, challenge) {
+    afterChallenge(event) {
         if(!this.selectedCard) {
             return;
         }
 
-        if(challenge.winner === this.controller) {
+        if(event.challenge.winner === this.controller) {
             this.controller.drawCardsToHand(1);
 
             this.game.addMessage('{0} uses {1} to draw 1 card',

--- a/server/game/cards/events/04/burningonthesand.js
+++ b/server/game/cards/events/04/burningonthesand.js
@@ -4,7 +4,7 @@ class BurningOnTheSand extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.loser === this.controller && challenge.isUnopposed()
+                afterChallenge: ({challenge}) => challenge.loser === this.controller && challenge.isUnopposed()
             },
             handler: () => {
                 this.untilEndOfChallenge(ability => ({

--- a/server/game/cards/events/04/relentlessassault.js
+++ b/server/game/cards/events/04/relentlessassault.js
@@ -4,7 +4,7 @@ class RelentlessAssault extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     challenge.winner === this.controller &&
                     challenge.attackingPlayer === this.controller &&
                     challenge.strengthDifference >= 5

--- a/server/game/cards/events/04/shierakqiya.js
+++ b/server/game/cards/events/04/shierakqiya.js
@@ -4,7 +4,7 @@ class ShierakQiya extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     challenge.challengeType === 'power' &&
                     challenge.winner === this.controller &&
                     challenge.strengthDifference >= 5

--- a/server/game/cards/events/04/tarredheads.js
+++ b/server/game/cards/events/04/tarredheads.js
@@ -4,8 +4,8 @@ class TarredHeads extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => (
-                    challenge.challengeType === 'power' && 
+                afterChallenge: ({challenge}) => (
+                    challenge.challengeType === 'power' &&
                     challenge.winner === this.controller &&
                     this.opponentHasCards())
             },

--- a/server/game/cards/events/04/thescorpionssting.js
+++ b/server/game/cards/events/04/thescorpionssting.js
@@ -4,8 +4,8 @@ class TheScorpionsSting extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => (
-                    challenge.loser === this.controller && 
+                afterChallenge: ({challenge}) => (
+                    challenge.loser === this.controller &&
                     this.controller.getNumberOfUsedPlots() >= 1 &&
                     this.hasMartellCharacter())
             },

--- a/server/game/cards/events/04/tyrionschain.js
+++ b/server/game/cards/events/04/tyrionschain.js
@@ -5,7 +5,7 @@ class TyrionsChain extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     challenge.winner === this.controller &&
                     this.hasParticipatingUniqueLannister() &&
                     this.game.anyPlotHasTrait('War')

--- a/server/game/cards/events/04/withouthisbeard.js
+++ b/server/game/cards/events/04/withouthisbeard.js
@@ -6,8 +6,8 @@ class WithoutHisBeard extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (e, challenge) => (
-                    challenge.winner === this.controller && 
+                afterChallenge: ({challenge}) => (
+                    challenge.winner === this.controller &&
                     challenge.challengeType === 'intrigue' &&
                     this.opponentHasCardsInHand())
             },

--- a/server/game/cards/events/05/insidiousscheme.js
+++ b/server/game/cards/events/05/insidiousscheme.js
@@ -4,10 +4,10 @@ class InsidiousScheme extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onClaimApplied: (event, challenge) => (
-                    challenge.challengeType === 'intrigue' &&
-                    challenge.winner === this.controller &&
-                    challenge.strengthDifference >= 5)
+                onClaimApplied: event => (
+                    event.challenge.challengeType === 'intrigue' &&
+                    event.challenge.winner === this.controller &&
+                    event.challenge.strengthDifference >= 5)
             },
             handler: () => {
                 let opponent = this.game.getOtherPlayer(this.controller);

--- a/server/game/cards/events/05/thecouncilconsents.js
+++ b/server/game/cards/events/05/thecouncilconsents.js
@@ -6,8 +6,8 @@ class TheCouncilConsents extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => (
-                    challenge.challengeType === 'intrigue' && 
+                afterChallenge: ({challenge}) => (
+                    challenge.challengeType === 'intrigue' &&
                     challenge.strengthDifference >= 5 &&
                     this.anySmallCouncilCharacterInPlay())
             },

--- a/server/game/cards/events/06/adragonisnoslave.js
+++ b/server/game/cards/events/06/adragonisnoslave.js
@@ -23,7 +23,7 @@ class ADragonIsNoSlave extends DrawCard {
         this.reaction({
             location: 'discard pile',
             when: {
-                afterChallenge: (event, challenge) => challenge.winner === this.controller && this.hasParticipatingDragonOrDany()
+                afterChallenge: ({challenge}) => challenge.winner === this.controller && this.hasParticipatingDragonOrDany()
             },
             ignoreEventCosts: true,
             cost: ability.costs.payGold(1),

--- a/server/game/cards/events/06/allmenarefools.js
+++ b/server/game/cards/events/06/allmenarefools.js
@@ -7,8 +7,8 @@ class AllMenAreFools extends DrawCard {
         this.reaction({
             max: ability.limit.perChallenge(1),
             when: {
-                afterChallenge: (event, challenge) => (
-                    challenge.winner === this.controller && 
+                afterChallenge: ({challenge}) => (
+                    challenge.winner === this.controller &&
                     challenge.strengthDifference >= 5 &&
                     this.hasLady())
             },

--- a/server/game/cards/events/06/attackfromthemountains.js
+++ b/server/game/cards/events/06/attackfromthemountains.js
@@ -4,7 +4,7 @@ class AttackFromTheMountains extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.winner === this.controller && this.hasAttackingClansman()
+                afterChallenge: ({challenge}) => challenge.winner === this.controller && this.hasAttackingClansman()
             },
             target: {
                 activePromptTitle: 'Select a character',

--- a/server/game/cards/events/06/dornishrevenge.js
+++ b/server/game/cards/events/06/dornishrevenge.js
@@ -22,7 +22,7 @@ class DornishRevenge extends DrawCard {
                 this.game.addMessage('{0} plays {1} to force {2} to be declared as a defender this challenge, if able', 
                     this.controller, this, context.target);
 
-                this.game.once('afterChallenge:interrupt', (event, challenge) => this.resolveIfWinBy5(challenge));
+                this.game.once('afterChallenge:interrupt', event => this.resolveIfWinBy5(event.challenge));
             }
         });
     }

--- a/server/game/cards/events/06/freyhospitality.js
+++ b/server/game/cards/events/06/freyhospitality.js
@@ -4,9 +4,9 @@ class FreyHospitality extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.winner === this.controller &&
-                                                      challenge.number === 3 &&
-                                                      this.hasAttackingFrey()
+                afterChallenge: ({challenge}) => challenge.winner === this.controller &&
+                                                 challenge.number === 3 &&
+                                                 this.hasAttackingFrey()
             },
             handler: () => {
                 let numTargets = this.game.currentChallenge.strengthDifference >= 20 ? 3 : 1;
@@ -17,8 +17,8 @@ class FreyHospitality extends DrawCard {
                     activePromptTitle: 'Select character(s)',
                     source: this,
                     gameAction: 'kill',
-                    cardCondition: card => card.location === 'play area' && 
-                                           card.controller !== this.controller && 
+                    cardCondition: card => card.location === 'play area' &&
+                                           card.controller !== this.controller &&
                                            card.getType() === 'character',
                     onSelect: (player, cards) => this.targetsSelected(player, cards)
                 });
@@ -30,7 +30,7 @@ class FreyHospitality extends DrawCard {
         if(this.game.currentChallenge.strengthDifference >= 20 && cards.length !== 3) {
             return false;
         }
-        
+
         this.game.killCharacters(cards);
         this.game.addMessage('{0} plays {1} to kill {2}', this.controller, this, cards);
 
@@ -38,8 +38,8 @@ class FreyHospitality extends DrawCard {
     }
 
     hasAttackingFrey() {
-        return this.controller.anyCardsInPlay(card => this.game.currentChallenge.isAttacking(card) && 
-                                                      card.hasTrait('House Frey') && 
+        return this.controller.anyCardsInPlay(card => this.game.currentChallenge.isAttacking(card) &&
+                                                      card.hasTrait('House Frey') &&
                                                       card.getType() === 'character');
     }
 }

--- a/server/game/cards/events/06/guardingtherealm.js
+++ b/server/game/cards/events/06/guardingtherealm.js
@@ -19,7 +19,7 @@ class GuardingTheRealm extends DrawCard {
         this.reaction({
             location: 'discard pile',
             when: {
-                afterChallenge: (event, challenge) => challenge.winner === this.controller && !challenge.isAttackerTheWinner()
+                afterChallenge: ({challenge}) => challenge.winner === this.controller && !challenge.isAttackerTheWinner()
             },
             ignoreEventCosts: true,
             cost: ability.costs.payGold(1),

--- a/server/game/cards/events/06/olennasmachinations.js
+++ b/server/game/cards/events/06/olennasmachinations.js
@@ -19,7 +19,7 @@ class OlennasMachinations extends DrawCard {
         this.reaction({
             location: 'discard pile',
             when: {
-                afterChallenge: (event, challenge) => challenge.winner === this.controller && challenge.challengeType === 'intrigue' &&
+                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.challengeType === 'intrigue' &&
                                                       challenge.strengthDifference >= 5
             },
             ignoreEventCosts: true,

--- a/server/game/cards/events/06/paytheironprice.js
+++ b/server/game/cards/events/06/paytheironprice.js
@@ -19,7 +19,7 @@ class PayTheIronPrice extends DrawCard {
         this.reaction({
             location: 'discard pile',
             when: {
-                afterChallenge: (event, challenge) => this.controller === challenge.winner && challenge.isUnopposed()
+                afterChallenge: ({challenge}) => this.controller === challenge.winner && challenge.isUnopposed()
             },
             ignoreEventCosts: true,
             cost: ability.costs.payGold(1),

--- a/server/game/cards/events/06/theprincesplan.js
+++ b/server/game/cards/events/06/theprincesplan.js
@@ -27,7 +27,7 @@ class ThePrincesPlan extends DrawCard {
         this.reaction({
             location: 'discard pile',
             when: {
-                afterChallenge: (event, challenge) => challenge.loser === this.controller
+                afterChallenge: ({challenge}) => challenge.loser === this.controller
             },
             ignoreEventCosts: true,
             cost: ability.costs.payGold(1),

--- a/server/game/cards/events/07/raidingthebayofice.js
+++ b/server/game/cards/events/07/raidingthebayofice.js
@@ -4,7 +4,7 @@ class RaidingTheBayOfIce extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.winner === this.controller && challenge.attackingPlayer === this.controller
+                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.attackingPlayer === this.controller
             },
             cost: ability.costs.kneel(card => card.hasTrait('Warship') && card.getType() === 'location'),
             target: {

--- a/server/game/cards/events/07/scalingthewall.js
+++ b/server/game/cards/events/07/scalingthewall.js
@@ -4,7 +4,7 @@ class ScalingTheWall extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     challenge.winner === this.controller &&
                     challenge.attackingPlayer === this.controller &&
                     this.hasAttackingWildling()

--- a/server/game/cards/locations/01/dothrakisea.js
+++ b/server/game/cards/locations/01/dothrakisea.js
@@ -4,7 +4,7 @@ class DothrakiSea extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.winner === this.controller && challenge.challengeType === 'power'
+                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.challengeType === 'power'
             },
             cost: ability.costs.sacrificeSelf(),
             target: {

--- a/server/game/cards/locations/01/ghastongrey.js
+++ b/server/game/cards/locations/01/ghastongrey.js
@@ -4,7 +4,7 @@ class GhastonGrey extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.loser === this.controller && 
+                afterChallenge: ({challenge}) => challenge.loser === this.controller &&
                                                       challenge.defendingPlayer === this.controller
             },
             cost: [

--- a/server/game/cards/locations/01/greatkraken.js
+++ b/server/game/cards/locations/01/greatkraken.js
@@ -8,7 +8,7 @@ class GreatKraken extends DrawCard {
         });
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => this.controller === challenge.winner && challenge.isUnopposed()
+                afterChallenge: ({challenge}) => this.controller === challenge.winner && challenge.isUnopposed()
             },
             limit: ability.limit.perRound(2),
             choices: {

--- a/server/game/cards/locations/01/lannisport.js
+++ b/server/game/cards/locations/01/lannisport.js
@@ -4,7 +4,7 @@ class Lannisport extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.challengeType === 'intrigue' && challenge.winner === this.controller
+                afterChallenge: ({challenge}) => challenge.challengeType === 'intrigue' && challenge.winner === this.controller
             },
             handler: () => {
                 this.controller.drawCardsToHand(1);

--- a/server/game/cards/locations/01/plazaofpunishment.js
+++ b/server/game/cards/locations/01/plazaofpunishment.js
@@ -5,7 +5,7 @@ class PlazaOfPunishment extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) =>
+                afterChallenge: ({challenge}) =>
                     challenge.winner === this.controller
                     && challenge.challengeType === 'power'
             },

--- a/server/game/cards/locations/01/sunspear.js
+++ b/server/game/cards/locations/01/sunspear.js
@@ -4,7 +4,7 @@ class Sunspear extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.loser === this.controller && challenge.defendingPlayer === this.controller
+                afterChallenge: ({challenge}) => challenge.loser === this.controller && challenge.defendingPlayer === this.controller
             },
             cost: ability.costs.kneelSelf(),
             handler: () => {

--- a/server/game/cards/locations/01/themander.js
+++ b/server/game/cards/locations/01/themander.js
@@ -4,7 +4,7 @@ class TheMander extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     challenge.winner === this.controller &&
                     challenge.strengthDifference >= 5)
             },

--- a/server/game/cards/locations/01/thewall.js
+++ b/server/game/cards/locations/01/thewall.js
@@ -4,7 +4,7 @@ class TheWall extends DrawCard {
     setupCardAbilities(ability) {
         this.forcedReaction({
             when: {
-                afterChallenge: (e, challenge) => this.controller === challenge.loser && !this.kneeled && challenge.isUnopposed()
+                afterChallenge: ({challenge}) => this.controller === challenge.loser && !this.kneeled && challenge.isUnopposed()
             },
             handler: () => {
                 this.game.addMessage('{0} is forced to kneel {1} because they lost an unopposed challenge', this.controller, this);

--- a/server/game/cards/locations/02/kingswood.js
+++ b/server/game/cards/locations/02/kingswood.js
@@ -14,7 +14,7 @@ class Kingswood extends DrawCard {
 
         this.forcedReaction({
             when: {
-                afterChallenge: (e, challenge) => challenge.loser === this.controller && challenge.challengeType === 'power'
+                afterChallenge: ({challenge}) => challenge.loser === this.controller && challenge.challengeType === 'power'
             },
             handler: () => {
                 this.game.addMessage('{0} is forced by {1} to sacrifice {1}', this.controller, this);

--- a/server/game/cards/locations/02/shadowblacklane.js
+++ b/server/game/cards/locations/02/shadowblacklane.js
@@ -4,7 +4,7 @@ class ShadowblackLane extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (e, challenge) => challenge.winner === this.controller && challenge.challengeType === 'intrigue'
+                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.challengeType === 'intrigue'
             },
             cost: ability.costs.kneelFactionCard(),
             handler: () => {

--- a/server/game/cards/locations/02/smallcouncilchamber.js
+++ b/server/game/cards/locations/02/smallcouncilchamber.js
@@ -8,7 +8,7 @@ class SmallCouncilChamber extends DrawCard {
         });
         this.reaction({
             when: {
-                afterChallenge: (e, challenge) => challenge.winner === this.controller && challenge.challengeType === 'intrigue'
+                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.challengeType === 'intrigue'
             },
             handler: () => {
                 this.game.addMessage('{0} gains 1 power on {1}', this.controller, this);

--- a/server/game/cards/locations/02/streetofsilk.js
+++ b/server/game/cards/locations/02/streetofsilk.js
@@ -6,7 +6,7 @@ class StreetOfSilk extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (e, challenge) => challenge.winner === this.controller && this.hasParticipatingLordOrLady()
+                afterChallenge: ({challenge}) => challenge.winner === this.controller && this.hasParticipatingLordOrLady()
             },
             cost: ability.costs.kneelFactionCard(),
             handler: () => {

--- a/server/game/cards/locations/02/streetofsteel.js
+++ b/server/game/cards/locations/02/streetofsteel.js
@@ -4,7 +4,7 @@ class StreetOfSteel extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (e, challenge) => challenge.winner === this.controller && challenge.challengeType === 'military'
+                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.challengeType === 'military'
             },
             cost: ability.costs.kneelFactionCard(),
             handler: () => {

--- a/server/game/cards/locations/02/streetofthesisters.js
+++ b/server/game/cards/locations/02/streetofthesisters.js
@@ -5,7 +5,7 @@ class StreetOfTheSisters extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (e, challenge) =>
+                afterChallenge: ({challenge}) =>
                     challenge.winner === this.controller
                     && challenge.challengeType === 'power'
                     && challenge.strengthDifference >= 5

--- a/server/game/cards/locations/02/theboneway.js
+++ b/server/game/cards/locations/02/theboneway.js
@@ -4,7 +4,7 @@ class TheBoneway extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.loser === this.controller
+                afterChallenge: ({challenge}) => challenge.loser === this.controller
             },
             handler: () => {
                 this.addToken('vengeance', 1);

--- a/server/game/cards/locations/02/theseastonechair.js
+++ b/server/game/cards/locations/02/theseastonechair.js
@@ -4,10 +4,10 @@ class TheSeastoneChair extends DrawCard {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onClaimApplied: (event, challenge) => (
-                    challenge.isUnopposed() &&
-                    challenge.challengeType === 'military' &&
-                    challenge.attackingPlayer === this.controller)
+                onClaimApplied: event => (
+                    event.challenge.isUnopposed() &&
+                    event.challenge.challengeType === 'military' &&
+                    event.challenge.attackingPlayer === this.controller)
             },
             cost: ability.costs.kneelFactionCard(),
             handler: context => {

--- a/server/game/cards/locations/03/theshadowtower.js
+++ b/server/game/cards/locations/03/theshadowtower.js
@@ -4,7 +4,7 @@ class TheShadowTower extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.winner === this.controller && challenge.defendingPlayer === this.controller
+                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.defendingPlayer === this.controller
             },
             cost: ability.costs.kneelSelf(),
             handler: () => {

--- a/server/game/cards/locations/03/towerofthehand.js
+++ b/server/game/cards/locations/03/towerofthehand.js
@@ -4,7 +4,7 @@ class TowerOfTheHand extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.challengeType === 'intrigue' && challenge.winner === this.controller
+                afterChallenge: ({challenge}) => challenge.challengeType === 'intrigue' && challenge.winner === this.controller
             },
             cost: [
                 ability.costs.kneelSelf(),

--- a/server/game/cards/locations/04/thehauntedforest.js
+++ b/server/game/cards/locations/04/thehauntedforest.js
@@ -14,7 +14,7 @@ class TheHauntedForest extends DrawCard {
         });
         this.forcedReaction({
             when: {
-                afterChallenge: (e, challenge) => this.controller === challenge.loser && !this.kneeled
+                afterChallenge: ({challenge}) => this.controller === challenge.loser && !this.kneeled
             },
             handler: () => {
                 this.game.addMessage('{0} is forced to kneel {1} because they lost a challenge', this.controller, this);

--- a/server/game/cards/locations/04/theprincespass.js
+++ b/server/game/cards/locations/04/theprincespass.js
@@ -4,7 +4,7 @@ class ThePrincesPass extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.loser === this.controller && challenge.defendingPlayer === this.controller
+                afterChallenge: ({challenge}) => challenge.loser === this.controller && challenge.defendingPlayer === this.controller
             },
             cost: ability.costs.kneelSelf(),
             target: {

--- a/server/game/cards/locations/05/oldwyk.js
+++ b/server/game/cards/locations/05/oldwyk.js
@@ -20,7 +20,7 @@ class OldWyk extends DrawCard {
                 this.game.addMessage('{0} kneels {1} to put {2} into play from their dead pile as an attacker',
                     this.controller, this, card);
 
-                this.game.once('afterChallenge', (event, challenge) => this.resolveAfterChallenge(challenge, card));
+                this.game.once('afterChallenge', event => this.resolveAfterChallenge(event.challenge, card));
             }
         });
     }

--- a/server/game/cards/locations/07/thefrozenshore.js
+++ b/server/game/cards/locations/07/thefrozenshore.js
@@ -6,7 +6,7 @@ class TheFrozenShore extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => (
+                afterChallenge: ({challenge}) => (
                     challenge.winner === this.controller &&
                     this.getNumOfAttackingWildlings(challenge) > 0 &&
                     this.getNumOfWinterPlots() > 0

--- a/server/game/cards/locations/07/thehoneywine.js
+++ b/server/game/cards/locations/07/thehoneywine.js
@@ -4,8 +4,8 @@ class TheHoneywine extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (e, challenge) => (
-                    challenge.winner === this.controller && 
+                afterChallenge: ({challenge}) => (
+                    challenge.winner === this.controller &&
                     challenge.attackingPlayer === this.controller &&
                     challenge.strengthDifference >= 5)
             },

--- a/server/game/cards/plots/01/aclashofkings.js
+++ b/server/game/cards/plots/01/aclashofkings.js
@@ -4,7 +4,7 @@ class AClashOfKings extends PlotCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (e, challenge) => (
+                afterChallenge: ({challenge}) => (
                     challenge.winner === this.controller &&
                     challenge.challengeType === 'power' &&
                     challenge.loser.faction.power > 0

--- a/server/game/cards/plots/02/riseofthekraken.js
+++ b/server/game/cards/plots/02/riseofthekraken.js
@@ -4,7 +4,7 @@ class RiseOfTheKraken extends PlotCard {
     setupCardAbilities() {
         this.interrupt({
             when: {
-                onUnopposedWin: (e, challenge) => challenge.winner === this.controller
+                onUnopposedWin: event => event.challenge.winner === this.controller
             },
             handler: () => {
                 this.game.addMessage('{0} uses {1} to gain an additional power from winning an unopposed challenge', this.controller, this);

--- a/server/game/cards/plots/02/thelongplan.js
+++ b/server/game/cards/plots/02/thelongplan.js
@@ -4,7 +4,7 @@ class TheLongPlan extends PlotCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => challenge.loser === this.controller
+                afterChallenge: ({challenge}) => challenge.loser === this.controller
             },
             handler: () => {
                 this.game.addMessage('{0} uses {1} to gain 1 gold from losing a challenge', this.controller, this);

--- a/server/game/cards/plots/02/wardensofthewest.js
+++ b/server/game/cards/plots/02/wardensofthewest.js
@@ -4,7 +4,7 @@ class WardensOfTheWest extends PlotCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: (event, challenge) => {
+                afterChallenge: ({challenge}) => {
                     return challenge.winner === this.controller && challenge.challengeType === 'intrigue' && this.controller.gold >= 2;
                 }
             },

--- a/server/game/cards/plots/06/latesummerfeast.js
+++ b/server/game/cards/plots/06/latesummerfeast.js
@@ -4,7 +4,7 @@ class LateSummerFeast extends PlotCard {
     setupCardAbilities() {
         this.forcedReaction({
             when: {
-                afterChallenge: (e, challenge) => challenge.winner === this.controller
+                afterChallenge: ({challenge}) => challenge.winner === this.controller
             },
             handler: () => {
                 var otherPlayer = this.game.getOtherPlayer(this.controller);

--- a/server/game/cards/plots/06/theredwedding.js
+++ b/server/game/cards/plots/06/theredwedding.js
@@ -4,7 +4,7 @@ class TheRedWedding extends PlotCard {
     setupCardAbilities() {
         this.interrupt({
             when: {
-                afterChallenge: (event, challenge) => challenge.attackingPlayer === challenge.winner
+                afterChallenge: ({challenge}) => challenge.attackingPlayer === challenge.winner
             },
             player: () => this.game.currentChallenge.winner,
             target: {

--- a/server/game/cards/plots/07/namedaytourney.js
+++ b/server/game/cards/plots/07/namedaytourney.js
@@ -4,8 +4,8 @@ class NameDayTourney extends PlotCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: (e, challenge) => (
-                    challenge.winner === this.controller && 
+                afterChallenge: ({challenge}) => (
+                    challenge.winner === this.controller &&
                     this.hasParticipatingKnight() &&
                     this.hasSingleParticipatingChar())
             },

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -190,7 +190,7 @@ class ChallengeFlow extends BaseStep {
                 this.challenge.winner, this.challenge.challengeType, this.challenge.winnerStrength, this.challenge.loserStrength);
         }
 
-        this.game.raiseEvent('afterChallenge', this.challenge);
+        this.game.raiseMergedEvent('afterChallenge', { challenge: this.challenge });
     }
 
     unopposedPower() {

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -233,7 +233,7 @@ class ChallengeFlow extends BaseStep {
             return false;
         }
 
-        this.game.raiseEvent('onClaimApplied', this.challenge, () => {
+        this.game.raiseMergedEvent('onClaimApplied', { challenge: this.challenge }, () => {
             this.game.queueStep(new ApplyClaim(this.game, this.challenge));
         });
 

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -202,7 +202,7 @@ class ChallengeFlow extends BaseStep {
                 this.game.addPower(this.challenge.winner, 1);
             }
 
-            this.game.raiseEvent('onUnopposedWin', this.challenge);
+            this.game.raiseMergedEvent('onUnopposedWin', { challenge: this.challenge });
         }
     }
 

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -247,7 +247,7 @@ class ChallengeFlow extends BaseStep {
     }
 
     completeChallenge() {
-        this.game.raiseEvent('onChallengeFinished', this.challenge);
+        this.game.raiseMergedEvent('onChallengeFinished', { challenge: this.challenge });
 
         this.resetCards();
 

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -165,7 +165,7 @@ class ChallengeFlow extends BaseStep {
 
         this.challenge.addDefenders(defenders);
 
-        this.game.raiseEvent('onDefendersDeclared', this.challenge);
+        this.game.raiseMergedEvent('onDefendersDeclared', { challenge: this.challenge });
 
         return true;
     }

--- a/test/server/cards/agendas/05045-therainsofcastamere.spec.js
+++ b/test/server/cards/agendas/05045-therainsofcastamere.spec.js
@@ -101,8 +101,8 @@ describe('The Rains of Castamere', function() {
 
     describe('afterChallenge()', function() {
         beforeEach(function() {
-            this.event = {};
             this.challenge = { challengeType: 'intrigue', winner: this.player, strengthDifference: 5 };
+            this.event = { challenge: this.challenge };
             this.reaction = this.agenda.abilities.reactions[0];
         });
 
@@ -112,7 +112,7 @@ describe('The Rains of Castamere', function() {
             });
 
             it('should not trigger', function() {
-                expect(this.reaction.when.afterChallenge(this.event, this.challenge)).toBe(false);
+                expect(this.reaction.when.afterChallenge(this.event)).toBe(false);
             });
         });
 
@@ -122,7 +122,7 @@ describe('The Rains of Castamere', function() {
             });
 
             it('should not trigger', function() {
-                expect(this.reaction.when.afterChallenge(this.event, this.challenge)).toBe(false);
+                expect(this.reaction.when.afterChallenge(this.event)).toBe(false);
             });
         });
 
@@ -132,7 +132,7 @@ describe('The Rains of Castamere', function() {
             });
 
             it('should not trigger', function() {
-                expect(this.reaction.when.afterChallenge(this.event, this.challenge)).toBe(false);
+                expect(this.reaction.when.afterChallenge(this.event)).toBe(false);
             });
         });
 
@@ -142,13 +142,13 @@ describe('The Rains of Castamere', function() {
             });
 
             it('should not trigger', function() {
-                expect(this.reaction.when.afterChallenge(this.event, this.challenge)).toBe(false);
+                expect(this.reaction.when.afterChallenge(this.event)).toBe(false);
             });
         });
 
         describe('when all triggering criteria are met', function() {
             it('should trigger', function() {
-                expect(this.reaction.when.afterChallenge(this.event, this.challenge)).toBe(true);
+                expect(this.reaction.when.afterChallenge(this.event)).toBe(true);
             });
 
             it('should register the ability', function() {

--- a/test/server/effectengine.spec.js
+++ b/test/server/effectengine.spec.js
@@ -289,7 +289,7 @@ describe('EffectEngine', function () {
         describe('when an effect has untilEndOfChallenge duration', function() {
             beforeEach(function() {
                 this.effectSpy.duration = 'untilEndOfChallenge';
-                this.engine.onChallengeFinished({}, {});
+                this.engine.onChallengeFinished({ challenge: {} });
             });
 
             it('should cancel the effect', function() {
@@ -305,7 +305,7 @@ describe('EffectEngine', function () {
         describe('when an effect has a non-untilEndOfChallenge duration', function() {
             beforeEach(function() {
                 this.effectSpy.duration = 'persistent';
-                this.engine.onChallengeFinished({}, {});
+                this.engine.onChallengeFinished({ challenge: {} });
             });
 
             it('should not cancel the effect', function() {


### PR DESCRIPTION
Converts all of the remaining challenge events to merged events.

I don't particularly like using destructuring for parameters of the afterChallenge handlers. However, there are over 100 cards that use that event and updating each one manually would have been far more error prone and time consuming.

Finally, since we're already touching all of the afterChallenge events, this would be a good opportunity to rename the event. I was thinking of something like `onChallengeWinnerDetermined` as being more descriptive, but it's a bit long. Open to suggestions.