### PR TITLE
Update attachment card implementations

### DIFF
--- a/server/game/cards/attachments/01/bodyguard.js
+++ b/server/game/cards/attachments/01/bodyguard.js
@@ -5,13 +5,25 @@ class BodyGuard extends DrawCard {
         this.interrupt({
             canCancel: true,
             when: {
-                onCharactersKilled: event => event.cards.includes(this.parent) && event.allowSave,
-                onCardsDiscarded: event => event.cards.includes(this.parent) && event.allowSave
+                onCharactersKilled: event => {
+                    if(event.cards.includes(this.parent) && event.allowSave) {
+                        this.parentCard = this.parent;
+                        return true;
+                    }
+                    return false;
+                },
+                onCardsDiscarded: event => {
+                    if(event.cards.includes(this.parent) && event.allowSave) {
+                        this.parentCard = this.parent;
+                        return true;
+                    }
+                    return false;
+                }
             },
             cost: ability.costs.sacrificeSelf(),
             handler: context => {
-                context.event.saveCard(this.parent);
-                this.game.addMessage('{0} sacrifices {1} to save {2}', this.controller, this, this.parent);
+                context.event.saveCard(this.parentCard);
+                this.game.addMessage('{0} sacrifices {1} to save {2}', this.controller, this, this.parentCard);
             }
         });
     }

--- a/server/game/cards/attachments/01/bodyguard.js
+++ b/server/game/cards/attachments/01/bodyguard.js
@@ -1,17 +1,17 @@
 const DrawCard = require('../../../drawcard.js');
 
 class BodyGuard extends DrawCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.interrupt({
             canCancel: true,
             when: {
                 onCharactersKilled: event => event.cards.includes(this.parent) && event.allowSave,
                 onCardsDiscarded: event => event.cards.includes(this.parent) && event.allowSave
             },
+            cost: ability.costs.sacrificeSelf(),
             handler: context => {
                 context.event.saveCard(this.parent);
                 this.game.addMessage('{0} sacrifices {1} to save {2}', this.controller, this, this.parent);
-                this.controller.sacrificeCard(this);
             }
         });
     }

--- a/server/game/cards/attachments/01/heartsbane.js
+++ b/server/game/cards/attachments/01/heartsbane.js
@@ -3,25 +3,17 @@ const DrawCard = require('../../../drawcard.js');
 class Heartsbane extends DrawCard {
     setupCardAbilities(ability) {
         this.action({
-            title: 'Kneel this card to give attached character +3 STR',
-            condition: () =>
-                this.parent
-                && this.game.currentChallenge
-                && this.game.currentChallenge.isParticipating(this.parent),
+            title: 'Give attached character +3 STR',
+            condition: () => this.parent && this.game.currentChallenge && this.game.currentChallenge.isParticipating(this.parent),
             cost: ability.costs.kneelSelf(),
-            method: 'kneel'
+            handler: () => {
+                this.untilEndOfChallenge(ability => ({
+                    match: card => card === this.parent,
+                    effect: ability.effects.modifyStrength(3)
+                }));
+                this.game.addMessage('{0} kneels {1} to give {2} +3 STR until the end of the challenge', this.controller, this, this.parent);
+            }
         });
-    }
-
-    kneel(player) {
-        this.untilEndOfChallenge(ability => ({
-            match: card => card === this.parent,
-            effect: ability.effects.modifyStrength(3)
-        }));
-
-        this.game.addMessage('{0} kneels {1} to give {2} +3 STR until the end of the challenge', player, this, this.parent);
-
-        return true;
     }
 
     canAttach(player, card) {

--- a/server/game/cards/attachments/01/throwingaxe.js
+++ b/server/game/cards/attachments/01/throwingaxe.js
@@ -7,26 +7,17 @@ class ThrowingAxe extends DrawCard {
                 afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isAttacking(this.parent)
             },
             limit: ability.limit.perPhase(1),
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    activePromptTitle: 'Select a character',
-                    source: this,
-                    cardCondition: card => card.location === 'play area' && this.game.currentChallenge.isDefending(card),
-                    gameAction: 'kill',
-                    onSelect: (p, card) => this.onCardSelected(p, card)
-                });
+            cost: ability.costs.sacrificeSelf(),
+            target: {
+                activePromptTitle: 'Select a character',
+                cardCondition: card => card.location === 'play area' && this.game.currentChallenge.isDefending(card),
+                gameAction: 'kill'
+            },
+            handler: context => {
+                context.target.controller.killCharacter(context.target);
+                this.game.addMessage('{0} sacrifices {1} to kill {2}', this.controller, this, context.target);
             }
         });
-    }
-
-    onCardSelected(player, card) {
-        player.sacrificeCard(this);
-
-        card.controller.killCharacter(card);
-
-        this.game.addMessage('{0} sacrifices {1} to kill {2}', player, this, card);
-
-        return true;
     }
 
     canAttach(player, card) {

--- a/server/game/cards/attachments/02/drownedgodsblessing.js
+++ b/server/game/cards/attachments/02/drownedgodsblessing.js
@@ -12,7 +12,7 @@ class DrownedGodsBlessing extends DrawCard {
     }
 
     canAttach(player, card) {
-        if(card.getType() !== 'character') {
+        if(card.getType() !== 'character' || !card.isFaction('greyjoy')) {
             return false;
         }
 

--- a/server/game/cards/attachments/02/kingrobertswarhammer.js
+++ b/server/game/cards/attachments/02/kingrobertswarhammer.js
@@ -11,35 +11,26 @@ class KingRobertsWarhammer extends DrawCard {
             when: {
                 afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isAttacking(this.parent)
             },
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    numCards: 99,
-                    activePromptTitle: 'Select characters',
-                    source: this,
-                    maxStat: () => this.parent.getStrength(),
-                    cardStat: card => card.getStrength(),
-                    cardCondition: card => card.location === 'play area' && card.getType() === 'character' && !card.kneeled,
-                    gameAction: 'kneel',
-                    onSelect: (player, cards) => this.onSelect(player, cards),
-                    onCancel: (player) => this.cancelSelection(player)
+            target: {
+                activePromptTitle: 'Select character(s)',
+                cardCondition: card => card.location === 'play area' && card.getType() === 'character' && !card.kneeled,
+                numCards: 99,
+                maxStat: () => this.parent.getStrength(),
+                cardStat: card => card.getStrength(),
+                multiSelect: true,
+                gameAction: 'kneel'
+            },
+            handler: context => {
+                _.each(context.target, card => {
+                    card.controller.kneelCard(card);
                 });
+
+                this.game.addMessage('{0} uses {1} to kneel {2}', this.controller, this, context.target);
+                // King Robert's Warhammer specifically has its sacrifice as a then-effect, not a cost
+                this.controller.sacrificeCard(this);
+                this.game.addMessage('{0} then sacrifices {1}', this.controller, this);
             }
         });
-    }
-
-    onSelect(player, cards) {
-        _.each(cards, card => {
-            card.controller.kneelCard(card);
-        });
-
-        this.game.addMessage('{0} sacrifices {1} to kneel {2}', player, this, cards);
-        this.controller.sacrificeCard(this);
-
-        return true;
-    }
-
-    cancelSelection(player) {
-        this.game.addMessage('{0} cancels the resolution of {1}', player, this);
     }
 
     canAttach(player, card) {

--- a/server/game/cards/attachments/02/maesterschain.js
+++ b/server/game/cards/attachments/02/maesterschain.js
@@ -3,10 +3,17 @@ const DrawCard = require('../../../drawcard.js');
 class MaestersChain extends DrawCard {
     setupCardAbilities(ability) {
         this.action({
-            title: 'Kneel to discard condition',
+            title: 'Discard condition attachment',
             phase: 'dominance',
             cost: ability.costs.kneelSelf(),
-            method: 'kneel'
+            target: {
+                activePromptTitle: 'Select an attachment',
+                cardCondition: card => card.location === 'play area' && card.getType() === 'attachment' && card.hasTrait('condition')
+            },
+            handler: context => {
+                context.target.owner.discardCard(context.target);
+                this.game.addMessage('{0} kneels {1} to discard {2}', this.controller, this, context.target);
+            }
         });
     }
 
@@ -15,24 +22,6 @@ class MaestersChain extends DrawCard {
             return false;
         }
         return super.canAttach(player, card);
-    }
-    
-    kneel(player) {
-        this.game.promptForSelect(player, {
-            activePromptTitle: 'Select an attachment',
-            source: this,
-            cardCondition: card => card.location === 'play area' && card.getType() === 'attachment' && card.hasTrait('condition'),
-            onSelect: (p, card) => this.onCardSelected(p, card)
-        });
-        return true;
-    }
-
-    onCardSelected(player, card) {
-        player.discardCard(card);
-
-        this.game.addMessage('{0} uses {1} to discard {2}', player, this, card);
-
-        return true;
     }
 }
 

--- a/server/game/cards/attachments/02/mareinheat.js
+++ b/server/game/cards/attachments/02/mareinheat.js
@@ -4,7 +4,8 @@ class MareInHeat extends DrawCard {
     setupCardAbilities(ability) {
         this.action({
             title: 'Remove character from challenge',
-            condition: () => this.game.currentChallenge && this.hasSingleParticipatingChar(),
+            condition: () => this.game.currentChallenge && this.game.currentChallenge.isParticipating(this.parent) &&
+                             this.hasSingleParticipatingChar(),
             cost: ability.costs.kneelSelf(),
             target: {
                 activePromptTitle: 'Select a character',

--- a/server/game/cards/attachments/02/mareinheat.js
+++ b/server/game/cards/attachments/02/mareinheat.js
@@ -3,11 +3,27 @@ const DrawCard = require('../../../drawcard.js');
 class MareInHeat extends DrawCard {
     setupCardAbilities(ability) {
         this.action({
-            title: 'Kneel this card to remove a character from a challenge',
-            condition: () => this.game.currentChallenge,
+            title: 'Remove character from challenge',
+            condition: () => this.game.currentChallenge && this.hasSingleParticipatingChar(),
             cost: ability.costs.kneelSelf(),
-            method: 'kneel'
+            target: {
+                activePromptTitle: 'Select a character',
+                cardCondition: card => card.getType() === 'character' && card.location === 'play area' &&
+                                       this.game.currentChallenge.isParticipating(card) &&
+                                       card.getStrength() > this.parent.getStrength()
+            },
+            handler: context => {
+                this.game.currentChallenge.removeFromChallenge(context.target);
+                this.game.addMessage('{0} kneels {1} to remove {2} from the challenge', this.controller, this, context.target);
+            }
         });
+    }
+
+    hasSingleParticipatingChar() {
+        if(this.game.currentChallenge.attackingPlayer === this.controller) {
+            return this.game.currentChallenge.attackers.length === 1;
+        }
+        return this.game.currentChallenge.defenders.length === 1;
     }
 
     canAttach(player, card) {
@@ -16,27 +32,6 @@ class MareInHeat extends DrawCard {
         }
 
         return super.canAttach(player, card);
-    }
-
-    kneel(player) {
-        this.game.promptForSelect(player, {
-            cardCondition: card => this.cardCondition(card),
-            activePromptTitle: 'Select character',
-            source: this,
-            onSelect: (player, card) => this.onCardSelected(player, card)
-        });
-    }
-
-    cardCondition(card) {
-        return card.getType() === 'character' && card.location === 'play area' && this.game.currentChallenge.isParticipating(card) && card.getStrength() > this.parent.getStrength();
-    }
-
-    onCardSelected(player, card) {
-        this.game.currentChallenge.removeFromChallenge(card);
-
-        this.game.addMessage('{0} kneels {1} to remove {2} from the challenge', player, this, card);
-
-        return true;
     }
 }
 

--- a/server/game/cards/attachments/02/paidoff.js
+++ b/server/game/cards/attachments/02/paidoff.js
@@ -36,11 +36,9 @@ class PaidOff extends DrawCard {
         }
 
         this.game.transferGold(this.controller, player, 1);
-
         player.standCard(this.parent);
 
-        this.game.addMessage('{0} pays 1 gold for {1} to stand {2}',
-            player, this, this.parent);
+        this.game.addMessage('{0} pays 1 gold for {1} to stand {2}', player, this, this.parent);
 
         return true;
     }
@@ -48,20 +46,6 @@ class PaidOff extends DrawCard {
     cancel(player) {
         this.game.addMessage('{0} does not pay 1 gold for {1} so {2} remains kneeled',
             player, this, this.parent);
-
-        return true;
-    }
-
-    cardCondition(card) {
-        return card.getType() === 'character' && card.location === 'play area' && this.game.currentChallenge.isParticipating(card) && card.getStrength() > this.parent.getStrength();
-    }
-
-    onCardSelected(player, card) {
-        player.kneelCard(this);
-
-        this.game.currentChallenge.removeFromChallenge(card);
-
-        this.game.addMessage('{0} kneels {1} to remove {2} from the challenge', player, this, card);
 
         return true;
     }

--- a/server/game/cards/attachments/02/stinkingdrunk.js
+++ b/server/game/cards/attachments/02/stinkingdrunk.js
@@ -7,9 +7,9 @@ class StinkingDrunk extends DrawCard {
                 onCardStood: event => event.card === this.parent
             },
             cost: ability.costs.sacrificeSelf(),
-            handler: () => {
-                this.game.addMessage('{0} sacrifices {1} to kneel {2}', this.controller, this, this.parent);
-                this.parent.controller.kneelCard(this.parent);
+            handler: context => {
+                this.game.addMessage('{0} sacrifices {1} to kneel {2}', this.controller, this, context.event.card);
+                this.parent.controller.kneelCard(context.event.card);
             }
         });
     }

--- a/server/game/cards/attachments/02/stinkingdrunk.js
+++ b/server/game/cards/attachments/02/stinkingdrunk.js
@@ -1,16 +1,15 @@
 const DrawCard = require('../../../drawcard.js');
 
 class StinkingDrunk extends DrawCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.reaction({
             when: {
                 onCardStood: event => event.card === this.parent
             },
+            cost: ability.costs.sacrificeSelf(),
             handler: () => {
                 this.game.addMessage('{0} sacrifices {1} to kneel {2}', this.controller, this, this.parent);
-
                 this.parent.controller.kneelCard(this.parent);
-                this.owner.sacrificeCard(this);
             }
         });
     }

--- a/server/game/cards/attachments/02/thesilversteed.js
+++ b/server/game/cards/attachments/02/thesilversteed.js
@@ -15,6 +15,7 @@ class TheSilverSteed extends DrawCard {
                 onRenown: event => event.card === this.parent
             },
             handler: () => {
+                // The sacrifice here is specifically an effect, not a cost
                 this.controller.sacrificeCard(this);
 
                 this.untilEndOfPhase(ability => ({
@@ -23,7 +24,7 @@ class TheSilverSteed extends DrawCard {
                     effect: ability.effects.modifyChallengeTypeLimit('power', 1)
                 }));
 
-                this.game.addMessage('{0} sacrifices {1} to be able to initiate an additional {2} challenge this phase', this.controller, this, 'power');
+                this.game.addMessage('{0} sacrifices {1} and is able to initiate an additional {2} challenge this phase', this.controller, this, 'power');
             }
         });
     }

--- a/server/game/cards/attachments/03/greendreams.js
+++ b/server/game/cards/attachments/03/greendreams.js
@@ -26,12 +26,12 @@ class GreenDreams extends DrawCard {
 
     placeOnBottom(player, arg) {
         if(arg === 'no') {
-            this.game.addMessage('{0} declines to use {1} to move the top card of their deck to the bottom', this.controller, this);
+            this.game.addMessage('{0} does not put the top card of their deck on the bottom', this.controller);
             return true;
         }
 
         this.controller.moveCard(this.topCard, 'draw deck', { bottom: true });
-        this.game.addMessage('{0} uses {1} to move the top card of their deck to the bottom', this.controller, this);
+        this.game.addMessage('{0} puts the top card of their deck on the bottom', this.controller, this);
 
         return true;
     }

--- a/server/game/cards/attachments/03/needle.js
+++ b/server/game/cards/attachments/03/needle.js
@@ -8,13 +8,18 @@ class Needle extends DrawCard {
 
         this.interrupt({
             when: {
-                onSacrificed: event => event.card === this.parent
+                onSacrificed: event => {
+                    if(event.card === this.parent) {
+                        this.parentCard = this.parent;
+                        return true;
+                    }
+                }
             },
-            handler: (context) => {
+            cost: ability.costs.sacrificeSelf(),
+            handler: context => {
                 context.skipHandler();
-                this.game.addMessage('{0} uses {1} to return {2} to their hand instead of their discard pile', this.controller, this, this.parent);
-                this.controller.returnCardToHand(this.parent, false);
-                this.controller.sacrificeCard(this);
+                this.game.addMessage('{0} sacrifices {1} to return {2} to their hand', this.controller, this, this.parentCard);
+                this.controller.returnCardToHand(this.parentCard, false);
             }
         });
     }

--- a/server/game/cards/attachments/03/needle.js
+++ b/server/game/cards/attachments/03/needle.js
@@ -8,18 +8,13 @@ class Needle extends DrawCard {
 
         this.interrupt({
             when: {
-                onSacrificed: event => {
-                    if(event.card === this.parent) {
-                        this.parentCard = this.parent;
-                        return true;
-                    }
-                }
+                onSacrificed: event => event.card === this.parent
             },
             cost: ability.costs.sacrificeSelf(),
             handler: context => {
                 context.skipHandler();
-                this.game.addMessage('{0} sacrifices {1} to return {2} to their hand', this.controller, this, this.parentCard);
-                this.controller.returnCardToHand(this.parentCard, false);
+                this.game.addMessage('{0} sacrifices {1} to return {2} to their hand', this.controller, this, context.event.card);
+                this.controller.returnCardToHand(context.event.card, false);
             }
         });
     }

--- a/server/game/cards/attachments/04/beggarking.js
+++ b/server/game/cards/attachments/04/beggarking.js
@@ -19,16 +19,15 @@ class BeggarKing extends DrawCard {
             },
             cost: ability.costs.kneelSelf(),
             handler: () => {
-                var gold = 1;
+                let gold = 1;
 
-                var otherPlayer = this.game.getOtherPlayer(this.controller);
-                if(!otherPlayer || !otherPlayer.anyCardsInPlay(card => card.hasTrait('King'))) {
+                let opponent = this.game.getOtherPlayer(this.controller);
+                if(!opponent || !opponent.anyCardsInPlay(card => card.hasTrait('King'))) {
                     gold = 2;
                 }
 
                 this.game.addGold(this.controller, gold);
-
-                this.game.addMessage('{0} uses {1} to gain {2} gold', this.controller, this, gold);
+                this.game.addMessage('{0} kneels {1} to gain {2} gold', this.controller, this, gold);
             }
         });
     }

--- a/server/game/cards/attachments/04/kingbeyondthewall.js
+++ b/server/game/cards/attachments/04/kingbeyondthewall.js
@@ -22,7 +22,7 @@ class KingBeyondTheWall extends DrawCard {
     }
 
     hasLessTotalPower() {
-        var otherPlayer = this.game.getOtherPlayer(this.controller);
+        let otherPlayer = this.game.getOtherPlayer(this.controller);
         if(!otherPlayer) {
             return false;
         }

--- a/server/game/cards/attachments/04/motherofdragons.js
+++ b/server/game/cards/attachments/04/motherofdragons.js
@@ -3,30 +3,21 @@ const DrawCard = require('../../../drawcard.js');
 class MotherOfDragons extends DrawCard {
     setupCardAbilities(ability) {
         this.action({
-            title: 'Kneel Mother of Dragons to add attached character to challenge',
-            condition: () =>
-                this.game.currentChallenge && 
-                this.controller.anyCardsInPlay(
-                    card => this.game.currentChallenge.isParticipating(card) &&
-                            card.hasTrait('Dragon')) &&
-                this.parent.canParticipateInChallenge(),
+            title: 'Add attached character to the challenge',
+            condition: () => this.game.currentChallenge && this.parent.canParticipateInChallenge() &&
+                             this.controller.anyCardsInPlay(card => this.game.currentChallenge.isParticipating(card) && card.hasTrait('Dragon')),
             cost: ability.costs.kneelSelf(),
-            method: 'addToChallenge'
+            handler: () => {
+                let challenge = this.game.currentChallenge;
+
+                if(challenge.attackingPlayer === this.controller) {
+                    challenge.addAttacker(this.parent, false);
+                } else {
+                    challenge.addDefender(this.parent, false);
+                }
+                this.game.addMessage('{0} kneels {1} to have {2} participate in the challenge on their side', this.controller, this, this.parent);
+            }
         });
-    }
-
-    addToChallenge(player) {
-        var challenge = this.game.currentChallenge;
-
-        if(challenge.attackingPlayer === player) {
-            challenge.addAttacker(this.parent);
-            this.game.addMessage('{0} uses {1} to add {2} to the challenge as an attacker with strength {3}', this.controller, this, this.parent, this.parent.getStrength());
-        } else {
-            challenge.addDefender(this.parent);
-            this.game.addMessage('{0} uses {1} to add {2} to the challenge as a defender with strength {3}', this.controller, this, this.parent, this.parent.getStrength());
-        }
-
-        this.controller.standCard(this.parent);
     }
 
     canAttach(player, card) {

--- a/server/game/cards/attachments/04/venomousblade.js
+++ b/server/game/cards/attachments/04/venomousblade.js
@@ -5,32 +5,22 @@ class VenomousBlade extends DrawCard {
         this.whileAttached({
             effect: ability.effects.modifyStrength(1)
         });
-
+        //TODO: uses target API but doesn't 'target' per the game rules (doesn't use the word choose)
         this.reaction({
             when: {
                 onCardEntersPlay: event => event.card === this
             },
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    activePromptTitle: 'Select a character',
-                    source: this,
-                    cardCondition: card => (
-                        card.location === 'play area' &&
-                        card.getType() === 'character' &&
-                        card.getPrintedStrength() <= 2),
-                    onSelect: (p, card) => this.onCardSelected(p, card)
-                });
+            target: {
+                activePromptTitle: 'Select a character',
+                cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.getPrintedStrength() <= 2
+            },
+            handler: context => {
+                this.atEndOfPhase(ability => ({
+                    match: context.target,
+                    effect: ability.effects.poison
+                }));
             }
         });
-    }
-
-    onCardSelected(player, card) {
-        this.atEndOfPhase(ability => ({
-            match: card,
-            effect: ability.effects.poison
-        }));
-
-        return true;
     }
 
     canAttach(player, card) {

--- a/server/game/cards/attachments/05/disputedclaim.js
+++ b/server/game/cards/attachments/05/disputedclaim.js
@@ -4,7 +4,7 @@ class DisputedClaim extends DrawCard {
     setupCardAbilities(ability) {
         this.whileAttached({
             condition: () => {
-                var otherPlayer = this.game.getOtherPlayer(this.controller);
+                let otherPlayer = this.game.getOtherPlayer(this.controller);
                 if(!otherPlayer || this.controller.faction.power > otherPlayer.faction.power) {
                     return true;
                 }

--- a/server/game/cards/attachments/05/shieldoflannisport.js
+++ b/server/game/cards/attachments/05/shieldoflannisport.js
@@ -23,7 +23,7 @@ class ShieldOfLannisport extends DrawCard {
     }
 
     canAttach(player, card) {
-        if(card.getType() !== 'character') {
+        if(card.getType() !== 'character' || !card.isFaction('lannister') || (!card.hasTrait('Lord') && !card.hasTrait('Lady'))) {
             return false;
         }
 

--- a/server/game/cards/attachments/06/corsairsdirk.js
+++ b/server/game/cards/attachments/06/corsairsdirk.js
@@ -15,8 +15,7 @@ class CorsairsDirk extends DrawCard {
             },
             handler: () => {
                 let opponent = this.game.getOtherPlayer(this.controller);
-                this.game.addGold(opponent, -1);
-                this.game.addGold(this.controller, 1);
+                this.game.transferGold(this.controller, opponent, 1);
                 this.game.addMessage('{0} uses {1} to move 1 gold from {2}\'s gold pool to their own', 
                     this.controller, this, opponent);
             }

--- a/server/game/cards/attachments/07/catapultonthewall.js
+++ b/server/game/cards/attachments/07/catapultonthewall.js
@@ -3,14 +3,14 @@ const DrawCard = require('../../../drawcard.js');
 class CatapultOnTheWall extends DrawCard {
     setupCardAbilities(ability) {
         this.action({
-            title: 'Kneel Catapult and attached character',
+            title: 'Kill attacking character',
             condition: () => this.game.currentChallenge,
             cost: [
                 ability.costs.kneelSelf(),
                 ability.costs.kneelParent()
             ],
             target: {
-                activePromptTitle: 'Select character to kill',
+                activePromptTitle: 'Select a character',
                 cardCondition: card => this.game.currentChallenge.isAttacking(card) && card.getStrength() <= 4
             },
             handler: context => {

--- a/server/game/cards/attachments/07/weirwoodbow.js
+++ b/server/game/cards/attachments/07/weirwoodbow.js
@@ -3,7 +3,7 @@ const DrawCard = require('../../../drawcard.js');
 class WeirwoodBow extends DrawCard {
     setupCardAbilities(ability) {
         this.action({
-            title: 'Kneel Weirwood Bow to give -2 STR',
+            title: 'Give defending character -2 STR',
             cost: ability.costs.kneelSelf(),
             condition: () => this.game.currentChallenge,
             target: {

--- a/server/game/cards/attachments/08/oathkeeper.js
+++ b/server/game/cards/attachments/08/oathkeeper.js
@@ -8,9 +8,8 @@ class Oathkeeper extends DrawCard {
 
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller &&
-                                                  challenge.strengthDifference >= 5 &&
-                                                  challenge.isParticipating(this.parent)
+                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.strengthDifference >= 5 &&
+                                                 challenge.isParticipating(this.parent)
             },
             cost: ability.costs.sacrificeSelf(),
             handler: () => {


### PR DESCRIPTION
* Updates all currently implemented attachments
* Converts implementations to use the cost and/or target API.
* Makes sure the ability can only trigger or initiate if it would change the game state
* Standardises action labels, prompt titles and chat messages.
* Changes actions to use a handler instead of method, where needed.
* Fixes canAttach() methods to match the card limitations.
* Changes var into let where possible.
* Invokes game.transferGold() instead of two times invoking game.addGold().