### PR TITLE
Prevent Ours is the Fury double adding characters to challenge

### DIFF
--- a/server/game/cards/events/01/oursisthefury.js
+++ b/server/game/cards/events/01/oursisthefury.js
@@ -6,15 +6,14 @@ class OursIsTheFury extends DrawCard {
             title: 'Add knelt Baratheon as defender',
             condition: () => this.game.currentChallenge && this.game.currentChallenge.defendingPlayer === this.controller,
             target: {
-                activePromptTitle: 'Select character',
-                cardCondition: card => card.kneeled && card.controller === this.controller && card.isFaction('baratheon') && card.canParticipateInChallenge()
+                activePromptTitle: 'Select a character',
+                cardCondition: card => card.location === 'play area' && card.kneeled && card.controller === this.controller &&
+                                       card.isFaction('baratheon') && card.canParticipateInChallenge()
             },
             handler: context => {
                 this.selectedCard = context.target;
-
                 this.game.currentChallenge.addDefender(context.target);
-
-                this.game.addMessage('{0} uses {1} to add {2} to the challenge as a defender', context.player, this, context.target);
+                this.game.addMessage('{0} plays {1} to add {2} to the challenge as a defender', context.player, this, context.target);
 
                 this.game.once('afterChallenge', this.afterChallenge.bind(this));
             }
@@ -28,8 +27,7 @@ class OursIsTheFury extends DrawCard {
 
         if(event.challenge.winner === this.controller) {
             this.controller.standCard(this.selectedCard);
-
-            this.game.addMessage('{0} uses {1} to stand {2} as the challenge was won', this.controller, this, this.selectedCard);
+            this.game.addMessage('{0} uses {1} to stand {2}', this.controller, this, this.selectedCard);
         }
 
         this.selectedCard = undefined;

--- a/server/game/cards/events/01/oursisthefury.js
+++ b/server/game/cards/events/01/oursisthefury.js
@@ -12,7 +12,11 @@ class OursIsTheFury extends DrawCard {
             },
             handler: context => {
                 this.selectedCard = context.target;
-                this.game.currentChallenge.addDefender(context.target);
+
+                if(!this.game.currentChallenge.defenders.includes(this.selectCard)) {
+                    this.game.currentChallenge.addDefender(context.target);
+                }
+
                 this.game.addMessage('{0} plays {1} to add {2} to the challenge as a defender', context.player, this, context.target);
 
                 this.game.once('afterChallenge', this.afterChallenge.bind(this));

--- a/server/game/cards/events/01/oursisthefury.js
+++ b/server/game/cards/events/01/oursisthefury.js
@@ -13,7 +13,7 @@ class OursIsTheFury extends DrawCard {
             handler: context => {
                 this.selectedCard = context.target;
 
-                if(!this.game.currentChallenge.defenders.includes(this.selectCard)) {
+                if(!this.game.currentChallenge.isDefending(this.selectedCard)) {
                     this.game.currentChallenge.addDefender(context.target);
                 }
 

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -56,10 +56,6 @@ class Challenge {
     }
 
     addDefender(defender, kneel = true) {
-        if(this.defenders.includes(defender)) {
-            return;
-        }
-
         this.defenders.push(defender);
         this.markAsParticipating([defender], 'defender', kneel);
         this.calculateStrength();

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -56,6 +56,10 @@ class Challenge {
     }
 
     addDefender(defender, kneel = true) {
+        if(this.defenders.includes(defender)) {
+            return;
+        }
+
         this.defenders.push(defender);
         this.markAsParticipating([defender], 'defender', kneel);
         this.calculateStrength();


### PR DESCRIPTION
* Previously, when Ours is the Fury was played on a character that was already participating in the challenge, that character's strength would be added again. This PR fixes that by adding a check to challenge.addDefender.
* Fixes #1273.