### PR TITLE
Convert Long Plan to a persistent effect

### DIFF
--- a/server/game/cards/plots/02/thelongplan.js
+++ b/server/game/cards/plots/02/thelongplan.js
@@ -1,7 +1,7 @@
 const PlotCard = require('../../../plotcard.js');
 
 class TheLongPlan extends PlotCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.reaction({
             when: {
                 afterChallenge: ({challenge}) => challenge.loser === this.controller
@@ -11,15 +11,9 @@ class TheLongPlan extends PlotCard {
                 this.game.addGold(this.controller, 1);
             }
         });
-        // TODO: This is a hack, really the ability should be a persistent effect.
-        this.forcedInterrupt({
-            when: {
-                onUnspentGoldReturned: event => event.player === this.controller
-            },
-            handler: context => {
-                context.skipHandler();
-                // Do nothing - just needed to prevent gold from being returned.
-            }
+        this.persistentEffect({
+            targetType: 'player',
+            effect: ability.effects.doesNotReturnUnspentGold()
         });
     }
 }

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -242,6 +242,16 @@ const Effects = {
             }
         };
     },
+    doesNotReturnUnspentGold: function() {
+        return {
+            apply: function(player) {
+                player.doesNotReturnUnspentGold = true;
+            },
+            unapply: function(player) {
+                player.doesNotReturnUnspentGold = false;
+            }
+        };
+    },
     addStealthLimit: function(value) {
         return {
             apply: function(card) {

--- a/server/game/gamesteps/taxationphase.js
+++ b/server/game/gamesteps/taxationphase.js
@@ -17,9 +17,9 @@ class TaxationPhase extends Phase {
 
     returnGold() {
         _.each(this.game.getPlayersInFirstPlayerOrder(), player => {
-            this.game.raiseMergedEvent('onUnspentGoldReturned', { player: player }, () => {
+            if(!player.doesNotReturnUnspentGold) {
                 player.taxation();
-            });
+            }
         });
     }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -39,6 +39,7 @@ class Player extends Spectator {
         this.playableLocations = _.map(['marshal', 'play', 'ambush'], playingType => new PlayableLocation(playingType, this, 'hand'));
         this.usedPlotsModifier = 0;
         this.cannotGainGold = false;
+        this.doesNotReturnUnspentGold = false;
         this.cannotGainChallengeBonus = false;
         this.cannotTriggerCardAbilities = false;
         this.cannotMarshalOrPutIntoPlayByTitle = [];


### PR DESCRIPTION
* Previously, Long Plan's ability to keep unspent gold during taxation was implemented as a hacky interrupt, causing it to trigger the timed interrupt window. This PR fixes that by converting this ability to a persistent effect.

* Fixes #1279.