### PR TITLE
Add `chooseOpponent` option for abilities

### DIFF
--- a/server/game/baseability.js
+++ b/server/game/baseability.js
@@ -22,6 +22,7 @@ class BaseAbility {
     constructor(properties) {
         this.cost = this.buildCost(properties.cost);
         this.targets = this.buildTargets(properties);
+        this.chooseOpponentFunc = properties.chooseOpponent;
     }
 
     buildCost(cost) {
@@ -103,6 +104,18 @@ class BaseAbility {
         _.each(this.cost, cost => {
             cost.unpay(context);
         });
+    }
+
+    needsChooseOpponent() {
+        return !!this.chooseOpponentFunc;
+    }
+
+    canChooseOpponent(opponent) {
+        if(_.isFunction(this.chooseOpponentFunc)) {
+            return this.chooseOpponentFunc(opponent);
+        }
+
+        return this.chooseOpponentFunc === true;
     }
 
     /**

--- a/server/game/baseability.js
+++ b/server/game/baseability.js
@@ -106,10 +106,30 @@ class BaseAbility {
         });
     }
 
+    /**
+     * Returns whether the ability requires an opponent to be chosen.
+     */
     needsChooseOpponent() {
         return !!this.chooseOpponentFunc;
     }
 
+    /**
+     * Returns whether there are opponents that can be chosen, if the ability
+     * requires that an opponent be chosen.
+     */
+    canResolveOpponents(context) {
+        if(!this.needsChooseOpponent()) {
+            return true;
+        }
+
+        return _.any(context.game.getPlayers(), player => {
+            return player !== context.player && this.canChooseOpponent(player);
+        });
+    }
+
+    /**
+     * Returns whether a specific player can be chosen as an opponent.
+     */
     canChooseOpponent(opponent) {
         if(_.isFunction(this.chooseOpponentFunc)) {
             return this.chooseOpponentFunc(opponent);

--- a/server/game/cards/characters/01/thequeensassassin.js
+++ b/server/game/cards/characters/01/thequeensassassin.js
@@ -6,18 +6,9 @@ class TheQueensAssassin extends DrawCard {
             when: {
                 onCardEntersPlay: event => event.card === this && event.playingType === 'ambush'
             },
-            handler: () => {
-                var otherPlayer = this.game.getOtherPlayer(this.controller);
-
-                if(!otherPlayer) {
-                    return;
-                }
-
-                if(this.controller.hand.size() <= otherPlayer.hand.size()) {
-                    return;
-                }
-
-                this.game.promptForSelect(otherPlayer, {
+            chooseOpponent: opponent => opponent.hand.size() < this.controller.hand.size(),
+            handler: context => {
+                this.game.promptForSelect(context.opponent, {
                     activePromptTitle: 'Select a character',
                     source: this,
                     cardCondition: card => card.location === 'play area' && card.controller !== this.controller && card.getType() === 'character',
@@ -25,7 +16,7 @@ class TheQueensAssassin extends DrawCard {
                     onSelect: (p, card) => this.onCardSelected(p, card)
                 });
 
-                this.game.addMessage('{0} uses {1} to force {2} to choose and kill a character', this.controller, this, otherPlayer);
+                this.game.addMessage('{0} uses {1} to force {2} to choose and kill a character', this.controller, this, context.opponent);
             }
         });
     }

--- a/server/game/cards/characters/01/thetickler.js
+++ b/server/game/cards/characters/01/thetickler.js
@@ -5,30 +5,22 @@ class TheTickler extends DrawCard {
         this.action({
             title: 'Discard opponents top card',
             phase: 'dominance',
+            chooseOpponent: true,
             cost: ability.costs.kneelSelf(),
-            method: 'kneel'
+            handler: context => {
+                context.opponent.discardFromDraw(1, cards => {
+                    let topCard = cards[0];
+                    this.game.addMessage('{0} uses {1} to discard the top card of {2}\'s deck', this.controller, this, context.opponent);
+
+                    this.game.promptForSelect(this.controller, {
+                        activePromptTitle: 'Select a copy of ' + topCard.name,
+                        source: this,
+                        cardCondition: card => card.location === 'play area' && card.name === topCard.name,
+                        onSelect: (p, card) => this.onCardSelected(p, card)
+                    });
+                });
+            }
         });
-    }
-
-    kneel(player) {
-        var otherPlayer = this.game.getOtherPlayer(player);
-        if(!otherPlayer) {
-            return true;
-        }
-
-        otherPlayer.discardFromDraw(1, cards => {
-            var topCard = cards[0];
-            this.game.addMessage('{0} uses {1} to discard the top card of {2}\'s deck', player, this, otherPlayer);
-
-            this.game.promptForSelect(player, {
-                activePromptTitle: 'Select a copy of ' + topCard.name,
-                source: this,
-                cardCondition: card => card.location === 'play area' && card.name === topCard.name,
-                onSelect: (p, card) => this.onCardSelected(p, card)
-            });
-        });
-
-        return true;
     }
 
     onCardSelected(player, card) {

--- a/server/game/cards/characters/06/melisandre.js
+++ b/server/game/cards/characters/06/melisandre.js
@@ -4,10 +4,11 @@ class Melisandre extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onDominanceDetermined: event => this.controller === event.winner && this.opponentHasCardsInHand()
+                onDominanceDetermined: event => this.controller === event.winner
             },
-            handler: () => {
-                let otherPlayer = this.game.getOtherPlayer(this.controller);
+            chooseOpponent: opponent => opponent.hand.size() >= 1,
+            handler: context => {
+                let otherPlayer = context.opponent;
                 let buttons = otherPlayer.hand.map(card => {
                     return { method: 'cardSelected', card: card };
                 });
@@ -24,12 +25,13 @@ class Melisandre extends DrawCard {
     }
 
     cardSelected(player, cardId) {
-        let otherPlayer = this.game.getOtherPlayer(player);
-        let card = otherPlayer.findCardByUuid(otherPlayer.hand, cardId);
+        let card = this.game.findAnyCardInAnyList(cardId);
 
         if(!card) {
             return false;
         }
+
+        let otherPlayer = card.controller;
 
         otherPlayer.discardCards([card], true, () => {
             let charMessage = '';
@@ -44,16 +46,6 @@ class Melisandre extends DrawCard {
         });
 
         return true;
-    }
-
-    opponentHasCardsInHand() {
-        let otherPlayer = this.game.getOtherPlayer(this.controller);
-
-        if(!otherPlayer) {
-            return false;
-        }
-
-        return otherPlayer.hand.size() >= 1;
     }
 }
 

--- a/server/game/cards/characters/07/maesteraemon.js
+++ b/server/game/cards/characters/07/maesteraemon.js
@@ -3,12 +3,16 @@ const DrawCard = require('../../../drawcard.js');
 
 class MaesterAemon extends DrawCard {
     setupCardAbilities() {
+        // TODO: For Melee, the challenge check should be updated to look at
+        // which challenges haven't been initiated against you instead of which
+        // a single opponent has initiated.
         this.interrupt({
             when: {
                 onPhaseEnded: event => event.phase === 'challenge' && !this.allChallengesInitiatedByOpponent()
             },
-            handler: () => {
-                let otherPlayer = this.game.getOtherPlayer(this.controller);
+            chooseOpponent: true,
+            handler: context => {
+                let otherPlayer = context.opponent;
                 let buttons = [];
 
                 if(otherPlayer.getNumberOfChallengesInitiatedByType('military') === 0) {

--- a/server/game/cards/characters/08/queensmen.js
+++ b/server/game/cards/characters/08/queensmen.js
@@ -6,12 +6,9 @@ class QueensMen extends DrawCard {
             when: {
                 onCardEntersPlay: event => event.card === this && event.playingType === 'marshal'
             },
-            handler: () => {
-                let opponent = this.game.getOtherPlayer(this.controller);
-
-                if(!opponent) {
-                    return;
-                }
+            chooseOpponent: opponent => opponent.hand.size() > 1,
+            handler: context => {
+                let opponent = context.opponent;
 
                 let buttons = opponent.hand.map(card => {
                     return { card: card, method: 'cardSelected' };
@@ -31,8 +28,8 @@ class QueensMen extends DrawCard {
     }
 
     cardSelected(player, cardId) {
-        let opponent = this.game.getOtherPlayer(this.controller);
-        let toDiscard = opponent.findCardByUuid(opponent.hand, cardId);
+        let toDiscard = this.game.findAnyCardInAnyList(cardId);
+        let opponent = toDiscard.controller;
         this.game.addMessage('{0} uses {1} to look at {2}\'s hand', this.controller, this, opponent);
 
         if(toDiscard && toDiscard.getType() !== 'character' && this.controller.anyCardsInPlay(card => !card.isFaction('baratheon') && card.getType() === 'character' && !card.kneeled)) {

--- a/server/game/cards/events/01/seeninflames.js
+++ b/server/game/cards/events/01/seeninflames.js
@@ -5,17 +5,10 @@ class SeenInFlames extends DrawCard {
         this.action({
             title: 'Discard from opponent\'s hand',
             phase: 'challenge',
-            condition: () => (
-                this.controller.anyCardsInPlay(card => card.hasTrait('R\'hllor')) &&
-                this.opponentHasCards()
-            ),
+            condition: () => this.controller.anyCardsInPlay(card => card.hasTrait('R\'hllor')),
+            chooseOpponent: opponent => !opponent.hand.isEmpty(),
             handler: context => {
-                let otherPlayer = this.game.getOtherPlayer(context.player);
-                if(!otherPlayer) {
-                    return;
-                }
-
-                let buttons = otherPlayer.hand.map(card => {
+                let buttons = context.opponent.hand.map(card => {
                     return { method: 'cardSelected', card: card };
                 });
 
@@ -30,21 +23,13 @@ class SeenInFlames extends DrawCard {
         });
     }
 
-    opponentHasCards() {
-        let otherPlayer = this.game.getOtherPlayer(this.controller);
-        return otherPlayer && !otherPlayer.hand.isEmpty();
-    }
-
     cardSelected(player, cardId) {
-        var otherPlayer = this.game.getOtherPlayer(player);
-        if(!otherPlayer) {
-            return false;
-        }
-
-        var card = otherPlayer.findCardByUuid(otherPlayer.hand, cardId);
+        let card = this.game.findAnyCardInAnyList(cardId);
         if(!card) {
             return false;
         }
+
+        let otherPlayer = card.controller;
 
         otherPlayer.discardCard(card);
 

--- a/server/game/cards/events/02/vengeanceforelia.js
+++ b/server/game/cards/events/02/vengeanceforelia.js
@@ -7,11 +7,9 @@ class VengeanceForElia extends DrawCard {
             when: {
                 onClaimApplied: event => event.challenge.defendingPlayer === this.controller
             },
+            chooseOpponent: true,
             handler: context => {
-                let opponent = this.game.getOtherPlayer(this.controller);
-                if(!opponent) {
-                    return;
-                }
+                let opponent = context.opponent;
 
                 context.skipHandler();
 
@@ -21,7 +19,7 @@ class VengeanceForElia extends DrawCard {
                     challengeType: this.game.currentChallenge.challengeType,
                     claim: this.game.currentChallenge.claim,
                     loser: opponent,
-                    winner: opponent
+                    winner: this.game.currentChallenge.winner
                 };
 
                 this.game.queueStep(new ApplyClaim(this.game, replacementChallenge));

--- a/server/game/cards/events/04/nightgathers.js
+++ b/server/game/cards/events/04/nightgathers.js
@@ -5,17 +5,13 @@ class NightGathers extends DrawCard {
         this.action({
             title: 'Allow marshaling from opponent discard',
             phase: 'marshal',
-            handler: () => {
-                let opponent = this.game.getOtherPlayer(this.controller);
-                if(!opponent) {
-                    return;
-                }
-
-                this.game.addMessage('{0} plays {1} to allow cards from {2}\'s discard pile to be marshaled', this.controller, this, opponent);
+            chooseOpponent: opponent => opponent.getTotalReserve() < this.controller.getTotalReserve(),
+            handler: context => {
+                this.game.addMessage('{0} plays {1} to allow cards from {2}\'s discard pile to be marshaled', this.controller, this, context.opponent);
                 this.untilEndOfPhase(ability => ({
                     targetType: 'player',
                     targetController: 'current',
-                    effect: ability.effects.canMarshalFrom(opponent, 'discard pile')
+                    effect: ability.effects.canMarshalFrom(context.opponent, 'discard pile')
                 }));
 
             }

--- a/server/game/cards/events/04/thedragonstail.js
+++ b/server/game/cards/events/04/thedragonstail.js
@@ -4,18 +4,15 @@ class TheDragonsTail extends DrawCard {
     setupCardAbilities() {
         this.action({
             title: 'Both you and opponent draw 2 cards',
-            handler: () => {
-                let opponent = this.game.getOtherPlayer(this.controller);
-
-                if(!opponent) {
-                    return;
-                }
+            chooseOpponent: true,
+            handler: context => {
+                let opponent = context.opponent;
 
                 this.controller.drawCardsToHand(2);
                 opponent.drawCardsToHand(2);
 
-                this.game.addMessage('{0} uses {1} to make both players draw 2 cards',
-                    this.controller, this);
+                this.game.addMessage('{0} uses {1} to make both themself and {2} draw 2 cards',
+                    this.controller, this, opponent);
             }
         });
     }

--- a/server/game/cards/events/05/alannisteralwayspayshisdebts.js
+++ b/server/game/cards/events/05/alannisteralwayspayshisdebts.js
@@ -5,7 +5,10 @@ class ALannisterAlwaysPaysHisDebts extends DrawCard {
         this.action({
             max: ability.limit.perPhase(1),
             title: 'Raise challenge limit',
+            // TODO: This condition and opponent choice should be limited to
+            // players who won a challenge against the current player for Melee.
             condition: () => this.hasLostChallenge(),
+            chooseOpponent: true,
             phase: 'challenge',
             handler: () => {
                 this.untilEndOfPhase(ability => ({

--- a/server/game/cards/events/06/plunder.js
+++ b/server/game/cards/events/06/plunder.js
@@ -6,21 +6,16 @@ class Plunder extends DrawCard {
             title: 'Gain gold',
             condition: () => this.getGold() >= 1 && !this.controller.cannotGainGold,
             cost: ability.costs.kneelFactionCard(),
-            handler: () => {
-                let gold = this.getGold();
+            chooseOpponent: true,
+            handler: context => {
+                let gold = this.getGold(context.opponent);
                 this.game.addGold(this.controller, gold);
-                this.game.addMessage('{0} uses {1} and kneels their faction card to gain {2} gold', this.controller, this, gold);
+                this.game.addMessage('{0} uses {1} and kneels their faction card to choose {2} and gain {3} gold', this.controller, this, context.opponent, gold);
             }
         });
     }
 
-    getGold() {
-        let opponent = this.game.getOtherPlayer(this.controller);
-
-        if(!opponent) {
-            return 0;
-        }
-
+    getGold(opponent) {
         return opponent.allCards.reduce((num, card) => {
             if(card.location === 'discard pile' && (card.getType() === 'location' || card.getType() === 'attachment')) {
                 return num + 1;

--- a/server/game/cards/events/06/thedornishmanswife.js
+++ b/server/game/cards/events/06/thedornishmanswife.js
@@ -4,58 +4,44 @@ class TheDornishmansWife extends DrawCard {
     setupCardAbilities() {
         this.action({
             title: 'Gain gold/power/card',
-            condition: () => this.opponentHasMorePower() || this.opponentHasMoreCardsInHand() || this.opponentControlsMoreCharacters(),
-            handler: () => {
+            chooseOpponent: opponent => (
+                this.opponentHasMorePower(opponent) ||
+                this.opponentHasMoreCardsInHand(opponent) ||
+                this.opponentControlsMoreCharacters(opponent)
+            ),
+            handler: context => {
                 let bonusMessage = [];
 
-                if(this.opponentHasMorePower()) {
+                if(this.opponentHasMorePower(context.opponent)) {
                     this.game.addGold(this.controller, 2);
                     bonusMessage.push('gain 2 gold');
                 }
 
-                if(this.opponentHasMoreCardsInHand()) {
+                if(this.opponentHasMoreCardsInHand(context.opponent)) {
                     this.game.addPower(this.controller, 1);
                     bonusMessage.push('gain 1 power for their faction');
                 }
 
-                if(this.opponentControlsMoreCharacters()) {
+                if(this.opponentControlsMoreCharacters(context.opponent)) {
                     this.controller.drawCardsToHand(1);
                     bonusMessage.push('draw 1 card');
                 }
 
-                this.game.addMessage('{0} uses {1} to {2}',
-                    this.controller, this, bonusMessage);
+                this.game.addMessage('{0} uses {1} to choose {2} and {3}',
+                    this.controller, this, context.player, bonusMessage);
             }
         });
     }
 
-    opponentHasMorePower() {
-        let opponent = this.game.getOtherPlayer(this.controller);
-
-        if(!opponent || opponent.getTotalPower() <= this.controller.getTotalPower()) {
-            return false;
-        }
-
-        return true;
+    opponentHasMorePower(opponent) {
+        return opponent.getTotalPower() > this.controller.getTotalPower();
     }
 
-    opponentHasMoreCardsInHand() {
-        let opponent = this.game.getOtherPlayer(this.controller);
-
-        if(!opponent || opponent.hand.size() <= this.controller.hand.size()) {
-            return false;
-        }
-
-        return true;
+    opponentHasMoreCardsInHand(opponent) {
+        return opponent.hand.size() > this.controller.hand.size();
     }
 
-    opponentControlsMoreCharacters() {
-        let opponent = this.game.getOtherPlayer(this.controller);
-
-        if(!opponent) {
-            return false;
-        }
-
+    opponentControlsMoreCharacters(opponent) {
         let ownChars = this.controller.filterCardsInPlay(card => {
             return card.getType() === 'character';
         });
@@ -64,11 +50,7 @@ class TheDornishmansWife extends DrawCard {
             return card.getType() === 'character';
         });
 
-        if(oppChars.length <= ownChars.length) {
-            return false;
-        }
-
-        return true;
+        return oppChars.length > ownChars.length;
     }
 }
 

--- a/server/game/cards/locations/04/houseoftheundying.js
+++ b/server/game/cards/locations/04/houseoftheundying.js
@@ -8,17 +8,13 @@ class HouseOfTheUndying extends DrawCard {
             title: 'Control opponent\'s dead characters',
             phase: 'challenge',
             cost: ability.costs.removeSelfFromGame(),
-            handler: context => this.controlDeadCharacters(context.player)
+            chooseOpponent: opponent => opponent.deadPile.size() > 0,
+            handler: context => this.controlDeadCharacters(context.player, context.opponent)
         });
     }
 
-    controlDeadCharacters(currentController) {
-        var opponent = this.game.getOtherPlayer(currentController);
-        if(!opponent) {
-            return;
-        }
-
-        var eligibleCharacters = opponent.deadPile.filter(card => {
+    controlDeadCharacters(currentController, opponent) {
+        let eligibleCharacters = opponent.deadPile.filter(card => {
             if(!card.isUnique()) {
                 return true;
             }

--- a/server/game/cards/locations/04/thefrostfangs.js
+++ b/server/game/cards/locations/04/thefrostfangs.js
@@ -6,14 +6,10 @@ class TheFrostfangs extends DrawCard {
             when: {
                 onCardEntersPlay: event => event.card === this
             },
-            handler: () => {
-                var otherPlayer = this.game.getOtherPlayer(this.controller);
-                if(!otherPlayer) {
-                    return;
-                }
-
-                this.game.addMessage('{0} uses {1} to give control of {1} to {2}', this.controller, this, otherPlayer);
-                this.game.takeControl(otherPlayer, this);
+            chooseOpponent: true,
+            handler: context => {
+                this.game.addMessage('{0} uses {1} to give control of {1} to {2}', this.controller, this, context.opponent);
+                this.game.takeControl(context.opponent, this);
             }
         });
         this.plotModifiers({

--- a/server/game/cards/locations/05/bridgeofskulls.js
+++ b/server/game/cards/locations/05/bridgeofskulls.js
@@ -4,17 +4,13 @@ class BridgeOfSkulls extends DrawCard {
     setupCardAbilities() {
         this.interrupt({
             when: {
-                onPhaseEnded: event =>
-                    event.phase === 'challenge'
-                    && this.game.getOtherPlayer(this.controller)
-                    && this.game.getOtherPlayer(this.controller)
-                        .getNumberOfChallengesInitiatedByType('military') < 1
+                onPhaseEnded: event => event.phase === 'challenge'
             },
-            handler: () => {
-                var opponent = this.game.getOtherPlayer(this.controller);
-                if(!opponent) {
-                    return true;
-                }
+            // TODO: For Melee, this should check that they did not initiate a
+            // challenge specifically against you, not in general.
+            chooseOpponent: player => player.getNumberOfChallengesInitiatedByType('military') < 1,
+            handler: context => {
+                let opponent = context.opponent;
 
                 opponent.discardAtRandom(1);
 

--- a/server/game/cards/locations/07/queenscrown.js
+++ b/server/game/cards/locations/07/queenscrown.js
@@ -7,12 +7,9 @@ class Queenscrown extends DrawCard {
         this.action({
             title: 'Reveal top 3 cards of opponent\'s deck',
             cost: ability.costs.kneelSelf(),
-            handler: () => {
-                let opponent = this.game.getOtherPlayer(this.controller);
-
-                if(!opponent) {
-                    return;
-                }
+            chooseOpponent: true,
+            handler: context => {
+                let opponent = context.opponent;
 
                 this.remainingCards = opponent.drawDeck.first(3);
                 this.game.addMessage('{0} kneels {1} to reveal {2} from the top of {3}\'s deck', this.controller, this, this.remainingCards, opponent);

--- a/server/game/cards/plots/01/callingthebanners.js
+++ b/server/game/cards/plots/01/callingthebanners.js
@@ -3,14 +3,9 @@ const PlotCard = require('../../../plotcard.js');
 class CallingTheBanners extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
-            handler: () => {
-                let otherPlayer = this.game.getOtherPlayer(this.controller);
-
-                if(!otherPlayer) {
-                    return;
-                }
-
-                let characterCount = otherPlayer.getNumberOfCardsInPlay(card => card.getType() === 'character');
+            chooseOpponent: true,
+            handler: context => {
+                let characterCount = context.opponent.getNumberOfCardsInPlay(card => card.getType() === 'character');
 
                 if(characterCount <= 0) {
                     return;

--- a/server/game/cards/plots/01/headsonspikes.js
+++ b/server/game/cards/plots/01/headsonspikes.js
@@ -3,12 +3,9 @@ const PlotCard = require('../../../plotcard.js');
 class HeadsOnSpikes extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
-            handler: () => {
-                var otherPlayer = this.game.getOtherPlayer(this.controller);
-
-                if(!otherPlayer) {
-                    return true;
-                }
+            chooseOpponent: true,
+            handler: context => {
+                let otherPlayer = context.opponent;
 
                 if(otherPlayer.hand.size() === 0) {
                     return true;

--- a/server/game/cards/plots/04/battleoftheblackwater.js
+++ b/server/game/cards/plots/04/battleoftheblackwater.js
@@ -5,13 +5,13 @@ const PlotCard = require('../../../plotcard.js');
 class BattleOfTheBlackwater extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
-            handler: () => {
-                _.each(this.game.getPlayersInFirstPlayerOrder(), player => {
-                    this.removeAllDupes(player);
-                });
+            chooseOpponent: true,
+            handler: context => {
+                this.removeAllDupes(this.controller);
+                this.removeAllDupes(context.opponent);
 
-                this.game.addMessage('{0} uses {1} to have both players discard each duplicate they control', 
-                    this.controller, this);
+                this.game.addMessage('{0} uses {1} to have themself and {2} discard each duplicate they control',
+                    this.controller, this, context.opponent);
             }
         });
     }

--- a/server/game/cards/plots/04/summerharvest.js
+++ b/server/game/cards/plots/04/summerharvest.js
@@ -3,13 +3,9 @@ const PlotCard = require('../../../plotcard.js');
 class SummerHarvest extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
-            handler: () => {
-                var otherPlayer = this.game.getOtherPlayer(this.controller);
-                if(!otherPlayer) {
-                    return true;
-                }
-
-                this.baseIncome = otherPlayer.activePlot.getIncome(true) + 2;
+            chooseOpponent: true,
+            handler: context => {
+                this.baseIncome = context.opponent.activePlot.getIncome(true) + 2;
             }
         });
     }

--- a/server/game/cards/plots/06/duel.js
+++ b/server/game/cards/plots/06/duel.js
@@ -3,11 +3,9 @@ const PlotCard = require('../../../plotcard.js');
 class Duel extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
-            handler: () => {
-                let opponent = this.game.getOtherPlayer(this.controller);
-                if(!opponent) {
-                    return;
-                }
+            chooseOpponent: true,
+            handler: context => {
+                let opponent = context.opponent;
 
                 if(this.notEnoughTargets()) {
                     return;

--- a/server/game/gamesteps/abilityresolver.js
+++ b/server/game/gamesteps/abilityresolver.js
@@ -3,6 +3,7 @@ const _ = require('underscore');
 const BaseStep = require('./basestep.js');
 const GamePipeline = require('../gamepipeline.js');
 const SimpleStep = require('./simplestep.js');
+const ChooseOpponentPrompt = require('./chooseopponentprompt.js');
 
 class AbilityResolver extends BaseStep {
     constructor(game, ability, context) {
@@ -19,6 +20,7 @@ class AbilityResolver extends BaseStep {
             new SimpleStep(game, () => this.payCosts()),
             new SimpleStep(game, () => this.game.popAbilityContext()),
             new SimpleStep(game, () => this.game.pushAbilityContext('card', context.source, 'effect')),
+            new SimpleStep(game, () => this.chooseOpponents()),
             new SimpleStep(game, () => this.resolveTargets()),
             new SimpleStep(game, () => this.waitForTargetResolution()),
             new SimpleStep(game, () => this.executeHandler()),
@@ -87,6 +89,26 @@ class AbilityResolver extends BaseStep {
         }
 
         this.ability.payCosts(this.context);
+    }
+
+    chooseOpponents() {
+        if(this.cancelled || !this.ability.needsChooseOpponent()) {
+            return;
+        }
+
+
+        if(!_.any(this.game.getPlayers(), player => player !== this.context.player && this.ability.canChooseOpponent(player))) {
+            this.cancelled = true;
+            return;
+        }
+
+        this.game.queueStep(new ChooseOpponentPrompt(this.game, this.context.player, {
+            condition: opponent => this.ability.canChooseOpponent(opponent),
+            onSelect: opponent => {
+                this.context.opponent = opponent;
+            },
+            source: this.context.source
+        }));
     }
 
     resolveTargets() {

--- a/server/game/gamesteps/abilityresolver.js
+++ b/server/game/gamesteps/abilityresolver.js
@@ -96,12 +96,6 @@ class AbilityResolver extends BaseStep {
             return;
         }
 
-
-        if(!_.any(this.game.getPlayers(), player => player !== this.context.player && this.ability.canChooseOpponent(player))) {
-            this.cancelled = true;
-            return;
-        }
-
         this.game.queueStep(new ChooseOpponentPrompt(this.game, this.context.player, {
             condition: opponent => this.ability.canChooseOpponent(opponent),
             onSelect: opponent => {

--- a/server/game/gamesteps/abilityresolver.js
+++ b/server/game/gamesteps/abilityresolver.js
@@ -107,6 +107,9 @@ class AbilityResolver extends BaseStep {
             onSelect: opponent => {
                 this.context.opponent = opponent;
             },
+            onCancel: () => {
+                this.cancelled = true;
+            },
             source: this.context.source
         }));
     }

--- a/server/game/gamesteps/chooseopponentprompt.js
+++ b/server/game/gamesteps/chooseopponentprompt.js
@@ -10,6 +10,7 @@ class ChooseOpponentPrompt extends BaseStep {
         this.player = player;
         this.condition = properties.condition || (() => true);
         this.onSelect = properties.onSelect;
+        this.onCancel = properties.onCancel || (() => true);
         this.source = properties.source;
     }
 
@@ -17,6 +18,7 @@ class ChooseOpponentPrompt extends BaseStep {
         let otherPlayers = _.filter(this.game.getPlayers(), player => player !== this.player && this.condition(player));
 
         if(otherPlayers.length === 0) {
+            this.onCancel();
             return;
         }
 
@@ -28,6 +30,7 @@ class ChooseOpponentPrompt extends BaseStep {
         let buttons = _.map(otherPlayers, player => {
             return { text: player.name, arg: player.name, method: 'selectPlayer' };
         });
+        buttons.push({ text: 'Cancel', method: 'cancel' });
         this.game.promptWithMenu(this.player, this, {
             activePrompt: {
                 menuTitle: 'Select an opponent',
@@ -46,6 +49,11 @@ class ChooseOpponentPrompt extends BaseStep {
         }
 
         this.onSelect(selectedPlayer);
+        return true;
+    }
+
+    cancel() {
+        this.onCancel();
         return true;
     }
 }

--- a/server/game/gamesteps/chooseopponentprompt.js
+++ b/server/game/gamesteps/chooseopponentprompt.js
@@ -4,7 +4,7 @@ const BaseStep = require('./basestep.js');
 /**
  * Prompt that asks the current player to select an opponent.
  */
-class SelectOpponentPrompt extends BaseStep {
+class ChooseOpponentPrompt extends BaseStep {
     constructor(game, player, properties) {
         super(game);
         this.player = player;
@@ -50,4 +50,4 @@ class SelectOpponentPrompt extends BaseStep {
     }
 }
 
-module.exports = SelectOpponentPrompt;
+module.exports = ChooseOpponentPrompt;

--- a/server/game/gamesteps/selectopponentprompt.js
+++ b/server/game/gamesteps/selectopponentprompt.js
@@ -1,0 +1,53 @@
+const _ = require('underscore');
+const BaseStep = require('./basestep.js');
+
+/**
+ * Prompt that asks the current player to select an opponent.
+ */
+class SelectOpponentPrompt extends BaseStep {
+    constructor(game, player, properties) {
+        super(game);
+        this.player = player;
+        this.condition = properties.condition || (() => true);
+        this.onSelect = properties.onSelect;
+        this.source = properties.source;
+    }
+
+    continue() {
+        let otherPlayers = _.filter(this.game.getPlayers(), player => player !== this.player && this.condition(player));
+
+        if(otherPlayers.length === 0) {
+            return;
+        }
+
+        if(otherPlayers.length === 1) {
+            this.onSelect(otherPlayers[0]);
+            return;
+        }
+
+        let buttons = _.map(otherPlayers, player => {
+            return { text: player.name, arg: player.name, method: 'selectPlayer' };
+        });
+        this.game.promptWithMenu(this.player, this, {
+            activePrompt: {
+                menuTitle: 'Select an opponent',
+                buttons: buttons
+            },
+            waitingPromptTitle: 'Waiting for player to select an opponent',
+            source: this.source
+        });
+    }
+
+    selectPlayer(player, selectedPlayerName) {
+        let selectedPlayer = this.game.getPlayerByName(selectedPlayerName);
+
+        if(!selectedPlayer) {
+            return false;
+        }
+
+        this.onSelect(selectedPlayer);
+        return true;
+    }
+}
+
+module.exports = SelectOpponentPrompt;

--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -102,7 +102,7 @@ class TriggeredAbility extends BaseAbility {
             return false;
         }
 
-        if(!this.canPayCosts(context) || !this.canResolveTargets(context)) {
+        if(!this.canResolveOpponents(context) || !this.canPayCosts(context) || !this.canResolveTargets(context)) {
             return false;
         }
 

--- a/test/helpers/gameflowwrapper.js
+++ b/test/helpers/gameflowwrapper.js
@@ -7,8 +7,11 @@ const PlayerInteractionWrapper = require('./playerinteractionwrapper.js');
 
 class GameFlowWrapper {
     constructor() {
-        var gameRouter = jasmine.createSpyObj('gameRouter', ['gameWon', 'playerLeft']);
-        var details = {
+        let gameRouter = jasmine.createSpyObj('gameRouter', ['gameWon', 'handleError', 'playerLeft']);
+        gameRouter.handleError.and.callFake((game, error) => {
+            throw error;
+        });
+        let details = {
             name: 'player1\'s game',
             id: 12345,
             owner: 'player1',

--- a/test/server/gamesteps/abilityresolver.spec.js
+++ b/test/server/gamesteps/abilityresolver.spec.js
@@ -11,7 +11,7 @@ describe('AbilityResolver', function() {
                 handler(params);
             }
         });
-        this.ability = jasmine.createSpyObj('ability', ['isAction', 'isCardAbility', 'isPlayableEventAbility', 'resolveCosts', 'payCosts', 'resolveTargets', 'executeHandler']);
+        this.ability = jasmine.createSpyObj('ability', ['isAction', 'isCardAbility', 'isPlayableEventAbility', 'needsChooseOpponent', 'resolveCosts', 'payCosts', 'resolveTargets', 'executeHandler']);
         this.ability.isCardAbility.and.returnValue(true);
         this.source = { source: 1 };
         this.player = { player: 1 };

--- a/test/server/integration/takecontrol.spec.js
+++ b/test/server/integration/takecontrol.spec.js
@@ -429,7 +429,7 @@ describe('take control', function() {
         describe('put into play under control + abilities', function() {
             beforeEach(function() {
                 const deck = this.buildDeck('greyjoy', [
-                    'Snowed Under',
+                    'Snowed Under', 'A Storm of Swords',
                     'Night Gathers...', 'Lost Ranger', 'Old Forest Hunter'
                 ]);
                 this.player1.selectDeck(deck);
@@ -447,7 +447,7 @@ describe('take control', function() {
                 this.completeSetup();
 
                 this.player1.selectPlot('Snowed Under');
-                this.player2.selectPlot('Snowed Under');
+                this.player2.selectPlot('A Storm of Swords');
 
                 this.selectFirstPlayer(this.player1);
 


### PR DESCRIPTION
Cards that require the player to choose an opponent can now add a `chooseOpponent` property. This can either be `true` if there are no restrictions on which opponent can be chosen, or a function that returns true for opponents that can be chosen. Once chosen, the opponent's player object is available via `context.opponent`.

In single player games, such abilities cannot be triggered because there are no opponents.

In two player games, the opponent will automatically be selected if there are any eligible, maintaining existing behavior.

In future Melee games, the player will be prompted to choose the opponent they want to target with the ability.

Partial for #1237 