### PR TITLE
Prevent double adding defenders

### DIFF
--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -141,7 +141,8 @@ class ChallengeFlow extends BaseStep {
     allowAsDefender(card) {
         return this.challenge.defendingPlayer === card.controller &&
             card.canDeclareAsDefender(this.challenge.challengeType) &&
-            this.mustBeDeclaredAsDefender(card);
+            this.mustBeDeclaredAsDefender(card) &&
+            !this.challenge.isDefending(card);
     }
 
     mustBeDeclaredAsDefender(card) {


### PR DESCRIPTION
* Previously, it was possible to use Dolorous Edd's ability to put him into play defending, stand him with Castle Black, and then select him again to essentially have him defend twice. This PR fixes that by disallowing characters that are already defending to be selected as defenders.

* Fixes #1285.