### PR TITLE
Only allow triggering of D. Edd when he can be put into play

### DIFF
--- a/server/game/cards/characters/04/dolorousedd.js
+++ b/server/game/cards/characters/04/dolorousedd.js
@@ -8,7 +8,8 @@ class DolorousEdd extends DrawCard {
             condition: () => (
                 this.game.currentChallenge &&
                 this.game.currentChallenge.challengeType === 'intrigue' &&
-                this.game.currentChallenge.defendingPlayer === this.controller
+                this.game.currentChallenge.defendingPlayer === this.controller &&
+                this.controller.canPutIntoPlay(this)
             ),
             cost: ability.costs.kneelFactionCard(),
             handler: () => {
@@ -16,7 +17,7 @@ class DolorousEdd extends DrawCard {
                 this.controller.putIntoPlay(this);
                 // Manually kneel Edd, since he enters play that way - should not fire a kneeling event.
                 this.kneeled = true;
-                this.game.currentChallenge.addDefender(this);
+                this.game.currentChallenge.addDefender(this, false);
                 this.game.once('afterChallenge', event => this.promptOnWin(event.challenge));
             }
         });


### PR DESCRIPTION
Previously, when Dolorous Edd couldn't be put into play for whatever reason, his ability could still trigger, causing him to remain in hand but still added as defender. This PR fixes that by having the canPutIntoPlay check as a play condition.