### PR TITLE
Allow drag-drop from additional card piles

### DIFF
--- a/client/GameBoard.jsx
+++ b/client/GameBoard.jsx
@@ -279,6 +279,7 @@ export class InnerGameBoard extends React.Component {
         let cards = [];
         let disablePopup = false;
         let title;
+        let source = 'agenda';
 
         // Alliance
         if(player.agenda.code === '06018') {
@@ -286,6 +287,7 @@ export class InnerGameBoard extends React.Component {
         } else if(player.agenda.code === '09045') {
             let pile = player.additionalPiles['conclave'];
             cards = pile.cards;
+            source = 'conclave';
             title = 'Conclave';
             disablePopup = !isMe;
         }
@@ -297,11 +299,12 @@ export class InnerGameBoard extends React.Component {
                 cards={ cards }
                 disablePopup={ disablePopup }
                 onCardClick={ this.onCardClick }
+                onDragDrop={ this.onDragDrop }
                 onMenuItemClick={ this.onMenuItemClick }
                 onMouseOut={ this.onMouseOut }
                 onMouseOver={ this.onMouseOver }
                 popupLocation={ popupLocation }
-                source='agenda'
+                source={ source }
                 title={ title }
                 topCard={ player.agenda } />
         );
@@ -318,9 +321,11 @@ export class InnerGameBoard extends React.Component {
             <AdditionalCardPile
                 className='plot'
                 isMe={ isMe }
+                onDragDrop={ this.onDragDrop }
                 onMouseOut={ this.onMouseOut }
                 onMouseOver={ this.onMouseOver }
                 pile={ schemePile }
+                source='scheme plots'
                 spectating={ this.state.spectating }
                 title='Schemes' />
         );

--- a/client/GameComponents/AdditionalCardPile.jsx
+++ b/client/GameComponents/AdditionalCardPile.jsx
@@ -8,7 +8,7 @@ class AdditionalCardPile extends React.Component {
         var topCard = _.last(this.props.pile.cards);
         if(this.props.pile.isPrivate) {
             topCard = { facedown: true, kneeled: true };
-        } else if(topCard.facedown) {
+        } else if(topCard && topCard.facedown) {
             topCard.kneeled = true;
         }
 

--- a/client/GameComponents/AdditionalCardPile.jsx
+++ b/client/GameComponents/AdditionalCardPile.jsx
@@ -16,9 +16,10 @@ class AdditionalCardPile extends React.Component {
             <CardCollection
                 className={ this.props.className }
                 title={ this.props.title }
-                source='additional'
+                source={ this.props.source }
                 cards={ this.props.pile.cards }
                 topCard={ topCard }
+                onDragDrop={ this.props.onDragDrop }
                 onMouseOver={ this.props.onMouseOver }
                 onMouseOut={ this.props.onMouseOut }
                 popupLocation={ this.props.isMe || this.props.spectating ? 'top' : 'bottom' }
@@ -32,9 +33,11 @@ AdditionalCardPile.displayName = 'AdditionalCardPile';
 AdditionalCardPile.propTypes = {
     className: React.PropTypes.string,
     isMe: React.PropTypes.bool,
+    onDragDrop: React.PropTypes.func,
     onMouseOut: React.PropTypes.func,
     onMouseOver: React.PropTypes.func,
     pile: React.PropTypes.object,
+    source: React.PropTypes.string,
     spectating: React.PropTypes.bool,
     title: React.PropTypes.string
 };

--- a/client/GameComponents/PlayerRow.jsx
+++ b/client/GameComponents/PlayerRow.jsx
@@ -62,9 +62,11 @@ class PlayerRow extends React.Component {
             <AdditionalCardPile
                 className='additional-cards'
                 isMe={ this.props.isMe }
+                onDragDrop={ this.props.onDragDrop }
                 onMouseOut={ this.props.onMouseOut }
                 onMouseOver={ this.props.onMouseOver }
                 pile={ pile }
+                source='out of game'
                 spectating={ this.props.spectating }
                 title='Out of Game' />
         );

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -315,19 +315,19 @@ class Game extends EventEmitter {
     }
 
     drop(playerName, cardId, source, target) {
-        var player = this.getPlayerByName(playerName);
+        let player = this.getPlayerByName(playerName);
+        let card = this.findAnyCardInAnyList(cardId);
 
-        if(!player) {
+        if(!player || !card) {
             return;
         }
 
-        if(player.drop(cardId, source, target)) {
+        if(player.drop(card, source, target)) {
             var movedCard = 'a card';
             if(!_.isEmpty(_.intersection(['dead pile', 'discard pile', 'out of game', 'play area'],
                 [source, target]))) {
                 // log the moved card only if it moved from/to a public place
-                var card = this.findAnyCardInAnyList(cardId);
-                if(card && this.currentPhase !== 'setup') {
+                if(this.currentPhase !== 'setup') {
                     movedCard = card;
                 }
             }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -679,24 +679,31 @@ class Player extends Spectator {
         this.showDeck = true;
     }
 
-    isValidDropCombination(source, target) {
-        if(source === 'plot deck' && target !== 'revealed plots') {
+    isValidDropCombination(card, target) {
+        const PlotCardTypes = ['plot'];
+        const DrawDeckCardTypes = ['attachment', 'character', 'event', 'location'];
+        const AllowedTypesForPile = {
+            'active plot': PlotCardTypes,
+            'dead pile': ['character'],
+            'discard pile': DrawDeckCardTypes,
+            'draw deck': DrawDeckCardTypes,
+            'hand': DrawDeckCardTypes,
+            'out of game': DrawDeckCardTypes.concat(PlotCardTypes),
+            'play area': ['attachment', 'character', 'location'],
+            'plot deck': PlotCardTypes,
+            'revealed plots': PlotCardTypes,
+            // Agenda specific piles
+            'scheme plots': PlotCardTypes,
+            'conclave': DrawDeckCardTypes
+        };
+
+        let allowedTypes = AllowedTypesForPile[target];
+
+        if(!allowedTypes) {
             return false;
         }
 
-        if(source === 'revealed plots' && target !== 'plot deck') {
-            return false;
-        }
-
-        if(target === 'plot deck' && source !== 'revealed plots') {
-            return false;
-        }
-
-        if(target === 'revealed plots' && source !== 'plot deck') {
-            return false;
-        }
-
-        return source !== target;
+        return allowedTypes.includes(card.getType());
     }
 
     getSourceList(source) {
@@ -759,23 +766,19 @@ class Player extends Spectator {
     }
 
     drop(card, source, target) {
-        if(!this.isValidDropCombination(source, target)) {
-            return false;
-        }
-
         if(!card) {
             return false;
         }
 
+        if(!this.isValidDropCombination(card, target)) {
+            return false;
+        }
+
+        if(source === target) {
+            return false;
+        }
+
         if(card.controller !== this) {
-            return false;
-        }
-
-        if(target === 'dead pile' && card.getType() !== 'character') {
-            return false;
-        }
-
-        if(target === 'play area' && card.getType() === 'event') {
             return false;
         }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -758,30 +758,13 @@ class Player extends Spectator {
         }
     }
 
-    drop(cardId, source, target) {
+    drop(card, source, target) {
         if(!this.isValidDropCombination(source, target)) {
             return false;
         }
 
-        var sourceList = this.getSourceList(source);
-        var card = this.findCardByUuid(sourceList, cardId);
-
         if(!card) {
-            if(source === 'play area') {
-                var otherPlayer = this.game.getOtherPlayer(this);
-
-                if(!otherPlayer) {
-                    return false;
-                }
-
-                card = otherPlayer.findCardInPlayByUuid(cardId);
-
-                if(!card) {
-                    return false;
-                }
-            } else {
-                return false;
-            }
+            return false;
         }
 
         if(card.controller !== this) {

--- a/test/server/player/drop.spec.js
+++ b/test/server/player/drop.spec.js
@@ -19,6 +19,7 @@ describe('Player', () => {
 
             this.cardSpy = jasmine.createSpyObj('card', ['getType', 'leavesPlay', 'moveTo']);
             this.cardSpy.controller = this.cardSpy.owner = this.player;
+            this.cardSpy.getType.and.returnValue('character');
             this.cardSpy.attachments = _([]);
             this.cardSpy.dupes = _([]);
         });
@@ -268,6 +269,7 @@ describe('Player', () => {
                 beforeEach(function() {
                     this.cardSpy2 = jasmine.createSpyObj('card', ['getType', 'moveTo']);
                     this.cardSpy2.controller = this.player;
+                    this.cardSpy2.getType.and.returnValue('event');
                     this.player.hand.push(this.cardSpy2);
                     this.cardSpy2.location = 'hand';
 

--- a/test/server/player/drop.spec.js
+++ b/test/server/player/drop.spec.js
@@ -18,10 +18,19 @@ describe('Player', () => {
             this.gameSpy.playersAndSpectators[this.player.name] = this.player;
 
             this.cardSpy = jasmine.createSpyObj('card', ['getType', 'leavesPlay', 'moveTo']);
-            this.cardSpy.uuid = '1111';
             this.cardSpy.controller = this.cardSpy.owner = this.player;
             this.cardSpy.attachments = _([]);
             this.cardSpy.dupes = _([]);
+        });
+
+        describe('when no card is pased', function() {
+            beforeEach(function() {
+                this.dropSucceeded = this.player.drop(null, 'hand', 'draw deck');
+            });
+
+            it('should return false', function() {
+                expect(this.dropSucceeded).toBe(false);
+            });
         });
 
         describe('when dragging a card from hand to play area', function() {
@@ -30,23 +39,11 @@ describe('Player', () => {
                 this.cardSpy.location = 'hand';
             });
 
-            describe('when the card is not in the hand', function() {
-                beforeEach(function() {
-                    this.dropSucceeded = this.player.drop('', 'hand', 'play area');
-                });
-
-                it('should return false and not change the game state', function() {
-                    expect(this.dropSucceeded).toBe(false);
-                    expect(this.player.cardsInPlay.size()).toBe(0);
-                    expect(this.player.hand.size()).toBe(1);
-                });
-            });
-
             describe('when the card is in hand and a character', function() {
                 beforeEach(function() {
                     this.cardSpy.getType.and.returnValue('character');
 
-                    this.dropSucceeded = this.player.drop(this.cardSpy.uuid, 'hand', 'play area');
+                    this.dropSucceeded = this.player.drop(this.cardSpy, 'hand', 'play area');
                 });
 
                 it('should return true and add the card to the play area', function() {
@@ -59,7 +56,7 @@ describe('Player', () => {
                 beforeEach(function() {
                     this.cardSpy.getType.and.returnValue('location');
 
-                    this.dropSucceeded = this.player.drop(this.cardSpy.uuid, 'hand', 'play area');
+                    this.dropSucceeded = this.player.drop(this.cardSpy, 'hand', 'play area');
                 });
 
                 it('should return true and add the card to the play area', function() {
@@ -72,7 +69,7 @@ describe('Player', () => {
                 beforeEach(function() {
                     this.cardSpy.getType.and.returnValue('event');
 
-                    this.dropSucceeded = this.player.drop(this.cardSpy.uuid, 'hand', 'play area');
+                    this.dropSucceeded = this.player.drop(this.cardSpy, 'hand', 'play area');
                 });
 
                 it('should return false and not add the card to the play area', function() {
@@ -85,7 +82,7 @@ describe('Player', () => {
                 beforeEach(function() {
                     this.cardSpy.getType.and.returnValue('attachment');
 
-                    this.dropSucceeded = this.player.drop(this.cardSpy.uuid, 'hand', 'play area');
+                    this.dropSucceeded = this.player.drop(this.cardSpy, 'hand', 'play area');
                 });
 
                 it('should return true and play the card', function() {
@@ -101,22 +98,11 @@ describe('Player', () => {
                 this.cardSpy.location = 'hand';
             });
 
-            describe('when the card is not in hand', function() {
-                beforeEach(function() {
-                    this.dropSucceeded = this.player.drop('', 'hand', 'dead pile');
-                });
-
-                it('should return false and not update the game state', function() {
-                    expect(this.dropSucceeded).toBe(false);
-                    expect(this.player.deadPile.size()).toBe(0);
-                });
-            });
-
             describe('when the card is in hand and is a location', function() {
                 beforeEach(function() {
                     this.cardSpy.getType.and.returnValue('location');
 
-                    this.dropSucceeded = this.player.drop(this.cardSpy.uuid, 'hand', 'dead pile');
+                    this.dropSucceeded = this.player.drop(this.cardSpy, 'hand', 'dead pile');
                 });
 
                 it('should return false and not update the game state', function() {
@@ -129,7 +115,7 @@ describe('Player', () => {
                 beforeEach(function() {
                     this.cardSpy.getType.and.returnValue('attachment');
 
-                    this.dropSucceeded = this.player.drop(this.cardSpy.uuid, 'hand', 'dead pile');
+                    this.dropSucceeded = this.player.drop(this.cardSpy, 'hand', 'dead pile');
                 });
 
                 it('should return false and not update the game state', function() {
@@ -142,7 +128,7 @@ describe('Player', () => {
                 beforeEach(function() {
                     this.cardSpy.getType.and.returnValue('event');
 
-                    this.dropSucceeded = this.player.drop(this.cardSpy.uuid, 'hand', 'dead pile');
+                    this.dropSucceeded = this.player.drop(this.cardSpy, 'hand', 'dead pile');
                 });
 
                 it('should return false and not update the game state', function() {
@@ -155,7 +141,7 @@ describe('Player', () => {
                 beforeEach(function() {
                     this.cardSpy.getType.and.returnValue('character');
 
-                    this.dropSucceeded = this.player.drop(this.cardSpy.uuid, 'hand', 'dead pile');
+                    this.dropSucceeded = this.player.drop(this.cardSpy, 'hand', 'dead pile');
                 });
 
                 it('should return true and put the character in the dead pile', function() {
@@ -171,22 +157,11 @@ describe('Player', () => {
                 this.cardSpy.location = 'hand';
             });
 
-            describe('when the card is not in hand', function() {
-                beforeEach(function() {
-                    this.dropSucceeded = this.player.drop('', 'hand', 'discard pile');
-                });
-
-                it('should return false and not update the game state', function() {
-                    expect(this.dropSucceeded).toBe(false);
-                    expect(this.player.discardPile.size()).toBe(0);
-                });
-            });
-
             describe('when the card is in hand and is a location', function() {
                 beforeEach(function() {
                     this.cardSpy.getType.and.returnValue('location');
 
-                    this.dropSucceeded = this.player.drop(this.cardSpy.uuid, 'hand', 'discard pile');
+                    this.dropSucceeded = this.player.drop(this.cardSpy, 'hand', 'discard pile');
                 });
 
                 it('should return true and update the game state', function() {
@@ -199,7 +174,7 @@ describe('Player', () => {
                 beforeEach(function() {
                     this.cardSpy.getType.and.returnValue('attachment');
 
-                    this.dropSucceeded = this.player.drop(this.cardSpy.uuid, 'hand', 'discard pile');
+                    this.dropSucceeded = this.player.drop(this.cardSpy, 'hand', 'discard pile');
                 });
 
                 it('should return true and update the game state', function() {
@@ -212,7 +187,7 @@ describe('Player', () => {
                 beforeEach(function() {
                     this.cardSpy.getType.and.returnValue('event');
 
-                    this.dropSucceeded = this.player.drop(this.cardSpy.uuid, 'hand', 'discard pile');
+                    this.dropSucceeded = this.player.drop(this.cardSpy, 'hand', 'discard pile');
                 });
 
                 it('should return true and update the game state', function() {
@@ -225,7 +200,7 @@ describe('Player', () => {
                 beforeEach(function() {
                     this.cardSpy.getType.and.returnValue('character');
 
-                    this.dropSucceeded = this.player.drop(this.cardSpy.uuid, 'hand', 'discard pile');
+                    this.dropSucceeded = this.player.drop(this.cardSpy, 'hand', 'discard pile');
                 });
 
                 it('should return true and put the character in the dead pile', function() {
@@ -241,21 +216,10 @@ describe('Player', () => {
                 this.cardSpy.location = 'hand';
             });
 
-            describe('when the card is not in hand', function() {
-                beforeEach(function() {
-                    this.dropSucceeded = this.player.drop('', 'hand', 'draw deck');
-                });
-
-                it('should return false and not update the game state', function() {
-                    expect(this.dropSucceeded).toBe(false);
-                    expect(this.player.drawDeck.size()).toBe(0);
-                });
-            });
-
             describe('when the card is in hand and is a location', function() {
                 beforeEach(function() {
                     this.cardSpy.getType.and.returnValue('location');
-                    this.dropSucceeded = this.player.drop(this.cardSpy.uuid, 'hand', 'draw deck');
+                    this.dropSucceeded = this.player.drop(this.cardSpy, 'hand', 'draw deck');
                 });
 
                 it('should return true and put the card in the draw deck', function() {
@@ -267,7 +231,7 @@ describe('Player', () => {
             describe('when the card is in hand and is an attachment', function() {
                 beforeEach(function() {
                     this.cardSpy.getType.and.returnValue('attachment');
-                    this.dropSucceeded = this.player.drop(this.cardSpy.uuid, 'hand', 'draw deck');
+                    this.dropSucceeded = this.player.drop(this.cardSpy, 'hand', 'draw deck');
                 });
 
                 it('should return true and put the card in the draw deck', function() {
@@ -279,7 +243,7 @@ describe('Player', () => {
             describe('when the card is in hand and is an event', function() {
                 beforeEach(function() {
                     this.cardSpy.getType.and.returnValue('event');
-                    this.dropSucceeded = this.player.drop(this.cardSpy.uuid, 'hand', 'draw deck');
+                    this.dropSucceeded = this.player.drop(this.cardSpy, 'hand', 'draw deck');
                 });
 
                 it('should return true and put the card in the draw deck', function() {
@@ -291,7 +255,7 @@ describe('Player', () => {
             describe('when the card is in hand and is a character', function() {
                 beforeEach(function() {
                     this.cardSpy.getType.and.returnValue('character');
-                    this.dropSucceeded = this.player.drop(this.cardSpy.uuid, 'hand', 'draw deck');
+                    this.dropSucceeded = this.player.drop(this.cardSpy, 'hand', 'draw deck');
                 });
 
                 it('should return true and put the card in the draw deck', function() {
@@ -303,13 +267,12 @@ describe('Player', () => {
             describe('when two cards are dragged to the draw deck', function() {
                 beforeEach(function() {
                     this.cardSpy2 = jasmine.createSpyObj('card', ['getType', 'moveTo']);
-                    this.cardSpy2.uuid = '2222';
                     this.cardSpy2.controller = this.player;
                     this.player.hand.push(this.cardSpy2);
                     this.cardSpy2.location = 'hand';
 
-                    this.player.drop(this.cardSpy.uuid, 'hand', 'draw deck');
-                    this.dropSucceeded = this.player.drop(this.cardSpy2.uuid, 'hand', 'draw deck');
+                    this.player.drop(this.cardSpy, 'hand', 'draw deck');
+                    this.dropSucceeded = this.player.drop(this.cardSpy2, 'hand', 'draw deck');
                 });
 
                 it('should put the cards in the draw deck in the correct order', function() {
@@ -325,20 +288,9 @@ describe('Player', () => {
                 this.cardSpy.location = 'play area';
             });
 
-            describe('when the card is not in play', function() {
-                beforeEach(function() {
-                    this.dropSucceeded = this.player.drop('', 'play area', 'discard pile');
-                });
-
-                it('should return false and not update the game state', function() {
-                    expect(this.dropSucceeded).toBe(false);
-                    expect(this.player.cardsInPlay.size()).toBe(1);
-                });
-            });
-
             describe('when the card is in play', function() {
                 beforeEach(function() {
-                    this.dropSucceeded = this.player.drop(this.cardSpy.uuid, 'play area', 'discard pile');
+                    this.dropSucceeded = this.player.drop(this.cardSpy, 'play area', 'discard pile');
                 });
 
                 it('should return true and put the card in the discard pile', function() {
@@ -358,7 +310,7 @@ describe('Player', () => {
             it('should rely on killCharacter to maintain event order', function() {
                 spyOn(this.player, 'killCharacter');
 
-                var result = this.player.drop(this.cardSpy.uuid, 'play area', 'dead pile');
+                let result = this.player.drop(this.cardSpy, 'play area', 'dead pile');
                 expect(result).toBe(true);
                 expect(this.player.killCharacter).toHaveBeenCalledWith(this.cardSpy, false);
             });


### PR DESCRIPTION
* Passes card directly into Player.drop to better match current style practices.
* Reworks drag-drop validity to be based on type instead of source location. This is because the out of game pile can contain both draw and plot cards, so dragging them out from there needs to check the type vs target location.
* Adds proper source and drag handler to the piles client side.

Fixes #1216 

Edit: Also fixes #1303 by renaming the pile source to 'conclave' for the Conclave pile.