### PR TITLE
Only prompt choices for forced reactions if real choice

### DIFF
--- a/server/game/cards/characters/02/gendry.js
+++ b/server/game/cards/characters/02/gendry.js
@@ -17,6 +17,11 @@ class Gendry extends DrawCard {
                 onDominanceDetermined: event => event.winner && this.controller !== event.winner
             },
             handler: () => {
+                if(this.power < 1) {
+                    this.sacrificeBastard(this.controller);
+                    return;
+                }
+
                 this.game.promptWithMenu(this.controller, this, {
                     activePrompt: {
                         menuTitle: 'Discard a power from ' + this.name + '?',
@@ -46,6 +51,7 @@ class Gendry extends DrawCard {
             onSelect: (player, card) => {
                 card.controller.sacrificeCard(card);
                 this.game.addMessage('{0} is forced by {1} to sacrifice {2}', player, this, card);
+                return true;
             }
         });
 

--- a/server/game/cards/characters/02/thehound.js
+++ b/server/game/cards/characters/02/thehound.js
@@ -7,6 +7,11 @@ class TheHound extends DrawCard {
                 afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isParticipating(this)
             },
             handler: () => {
+                if(this.controller.hand.size() < 1) {
+                    this.returnToHand(this.controller);
+                    return;
+                }
+
                 this.game.promptWithMenu(this.controller, this, {
                     activePrompt: {
                         menuTitle: 'Discard 1 card at random for ' + this.name + '?',

--- a/server/game/cards/characters/06/secondsons.js
+++ b/server/game/cards/characters/06/secondsons.js
@@ -7,9 +7,14 @@ class SecondSons extends DrawCard {
                 onPhaseEnded: event => event.phase === 'challenge'
             },
             handler: () => {
+                if(!this.hasToken('gold')) {
+                    this.sacrifice();
+                    return;
+                }
+
                 this.game.promptWithMenu(this.controller, this, {
                     activePrompt: {
-                        menuTitle: 'Discard a gold from ' + this.name + '?',
+                        menuTitle: 'Discard 1 gold from ' + this.name + '?',
                         buttons: [
                             { text: 'Yes', method: 'discardGold' },
                             { text: 'No', method: 'sacrifice' }


### PR DESCRIPTION
Previously, the "less bad" choice for forced reactions such as these could still be chosen, leaving the possibility of illegal plays. This PR fixes that by only prompting such choices if both options are a possibility.