### PR TITLE
Override min reserve when manually setting reserve

### DIFF
--- a/server/game/game.js
+++ b/server/game/game.js
@@ -425,6 +425,11 @@ class Game extends EventEmitter {
             target = player.activePlot.cardData;
         }
 
+        // Ensure that manually setting reserve isn't limited by any min reserve effects
+        if(stat === 'reserve') {
+            player.minReserve = 0;
+        }
+
         if(stat === 'claim' && _.isNumber(player.activePlot.claimSet)) {
             player.activePlot.claimSet += value;
 


### PR DESCRIPTION
Previously, if a minimum reserve was set by something like Wraiths in
their Midst, it was impossible to go below that reserve even when
setting it manually. Now, any adjustment to reserve will get rid of the
minimum requirement. This behavior is more in line with other overrides
and should help players get past the NaN reserve bug while we track it
down.