### PR TITLE
Reset lasting effects when card leaves play

### DIFF
--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -40,9 +40,8 @@ class EffectEngine {
     }
 
     onCardMoved(event) {
-        let originalArea = event.originalLocation === 'hand' ? 'hand' : 'play area';
         let newArea = event.newLocation === 'hand' ? 'hand' : 'play area';
-        this.removeTargetFromPersistentEffects(event.card, originalArea);
+        this.removeTargetFromEffects(event.card, event.originalLocation);
         this.unapplyAndRemove(effect => effect.duration === 'persistent' && effect.source === event.card && (effect.location === event.originalLocation || event.parentChanged));
         this.addTargetForPersistentEffects(event.card, newArea);
     }
@@ -94,9 +93,10 @@ class EffectEngine {
         });
     }
 
-    removeTargetFromPersistentEffects(card, targetLocation) {
+    removeTargetFromEffects(card, location) {
+        let area = location === 'hand' ? 'hand' : 'play area';
         _.each(this.effects, effect => {
-            if(effect.targetLocation === targetLocation && effect.location !== 'any') {
+            if(effect.targetLocation === area && effect.location !== 'any' || location === 'play area' && effect.duration !== 'persistent') {
                 effect.removeTarget(card);
             }
         });

--- a/test/server/integration/leavingplay.spec.js
+++ b/test/server/integration/leavingplay.spec.js
@@ -1,0 +1,55 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('leaving play', function() {
+    integration(function() {
+        describe('when a lasting effect has been applied to the card', function() {
+            beforeEach(function() {
+                const deck1 = this.buildDeck('thenightswatch', [
+                    'Trading with the Pentoshi',
+                    'Old Bear Mormont (Core)'
+                ]);
+                const deck2 = this.buildDeck('baratheon', [
+                    'Trading with the Pentoshi',
+                    'Drogon', 'Dracarys!'
+                ]);
+                this.player1.selectDeck(deck1);
+                this.player2.selectDeck(deck2);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.character = this.player1.findCardByName('Old Bear Mormont', 'hand');
+
+                this.player1.clickCard(this.character);
+                this.player2.clickCard('Drogon', 'hand');
+
+                this.completeSetup();
+
+                this.player1.selectPlot('Trading with the Pentoshi');
+                this.player2.selectPlot('Trading with the Pentoshi');
+                this.selectFirstPlayer(this.player1);
+                this.selectPlotOrder(this.player1);
+
+                this.completeMarshalPhase();
+
+                this.player1.clickPrompt('Power');
+                this.player1.clickCard(this.character);
+                this.player1.clickPrompt('Done');
+
+                this.player1.clickPrompt('Pass');
+                this.player2.clickCard('Dracarys!');
+                this.player2.clickCard('Drogon', 'play area');
+                this.player2.clickCard(this.character);
+
+                expect(this.character.getStrength()).toBe(2);
+
+                this.player1.dragCard(this.character, 'hand');
+                this.player1.dragCard(this.character, 'play area');
+            });
+
+            it('should reset the lasting effect', function() {
+                expect(this.character.getStrength()).toBe(6);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Previously, only persistent effects were removed when a card left the
play area. This lead to bugs where a card that left play but entered
play again during the period for a lasting effect would continue to have
that effect. With burn effects, this would lead to the card re-entering
play with the strength penalty still in place.

Fixes #844 
Fixes #1321 