### PR TITLE
Implement /move-bottom chatcommand

### DIFF
--- a/client/About.jsx
+++ b/client/About.jsx
@@ -53,6 +53,7 @@ class About extends React.Component {
                         <li>/give-control - Give control of a card to your opponent.  Use with caution</li>
                         <li>/give-icon x - Give a character an x icon; where 'x' is one of 'military', 'intrigue', 'power'</li>
                         <li>/kill - Manually kill a character.  Use with caution</li>
+                        <li>/move-bottom - Move a card to the bottom of your deck</li>
                         <li>/pillage - Discards the top card from your deck</li>
                         <li>/power x - Sets the power of a card to x</li>
                         <li>/strength x - Sets the strength of a card to x</li>

--- a/server/game/chatcommands.js
+++ b/server/game/chatcommands.js
@@ -28,7 +28,8 @@ class ChatCommands {
             '/bestow': this.bestow,
             '/disconnectme': this.disconnectMe,
             '/add-faction': this.addFaction,
-            '/remove-faction': this.removeFaction
+            '/remove-faction': this.removeFaction,
+            '/move-bottom': this.moveBottom
         };
         this.tokens = [
             'power',
@@ -386,6 +387,19 @@ class ChatCommands {
                 card.removeFaction(faction);
 
                 this.game.addMessage('{0} uses the /remove-faction command to remove the {1} keyword from {2}', p, faction, card);
+                return true;
+            }
+        });
+    }
+
+    moveBottom(player) {
+        this.game.promptForSelect(player, {
+            activePromptTitle: 'Select a card',
+            waitingPromptTitle: 'Waiting for opponent to move a card to the bottom of his deck',
+            cardCondition: card => card.controller === player && card.owner === player,
+            onSelect: (p, card) => {
+                player.moveCard(card, 'draw deck', { bottom: true });
+                this.game.addMessage('{0} uses the /move-bottom command to move {1} to the bottom of their deck', p, card);
                 return true;
             }
         });


### PR DESCRIPTION
This chatcommand makes sure you can move a card to the bottom of your deck when for example a character was automatically saved against your will.