### PR TITLE
Record Roose Bolton's strength before sacrificing

### DIFF
--- a/server/game/cards/characters/04/roosebolton.js
+++ b/server/game/cards/characters/04/roosebolton.js
@@ -6,7 +6,7 @@ class RooseBolton extends DrawCard {
             when: {
                 afterChallenge: event => {
                     if(event.challenge.winner === this.controller && event.challenge.isAttacking(this)) {
-                        this.str = this.getStrength();
+                        this.strengthAtInitiation = this.getStrength();
                         return true;
                     }
                     return false;
@@ -17,7 +17,7 @@ class RooseBolton extends DrawCard {
                 activePromptTitle: 'Select character(s)',
                 numCards: 99,
                 multiSelect: true,
-                maxStat: () => this.str,
+                maxStat: () => this.strengthAtInitiation,
                 cardStat: card => card.getStrength(),
                 cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.controller !== this.controller,
                 gameAction: 'kill'

--- a/server/game/cards/characters/04/roosebolton.js
+++ b/server/game/cards/characters/04/roosebolton.js
@@ -4,14 +4,20 @@ class RooseBolton extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: event => event.challenge.winner === this.controller && event.challenge.isAttacking(this)
+                afterChallenge: event => {
+                    if(event.challenge.winner === this.controller && event.challenge.isAttacking(this)) {
+                        this.str = this.getStrength();
+                        return true;
+                    }
+                    return false;
+                }
             },
             cost: ability.costs.sacrificeSelf(),
             target: {
                 activePromptTitle: 'Select character(s)',
                 numCards: 99,
                 multiSelect: true,
-                maxStat: () => this.getStrength(),
+                maxStat: () => this.str,
                 cardStat: card => card.getStrength(),
                 cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.controller !== this.controller,
                 gameAction: 'kill'


### PR DESCRIPTION
Previously, because costs are paid before resolution, any strength buffs on Roose had worn off by the time targets were chosen. This PR fixes that by recording his strength at the point of initiation of his ability.