### PR TITLE
Do not remove card from play until interrupts

### DIFF
--- a/test/helpers/integrationhelper.js
+++ b/test/helpers/integrationhelper.js
@@ -3,10 +3,10 @@
 
 const _ = require('underscore');
 
+require('./objectformatters.js');
+
 const DeckBuilder = require('./deckbuilder.js');
 const GameFlowWrapper = require('./gameflowwrapper.js');
-const BaseCard = require('../../server/game/basecard.js');
-const Player = require('../../server/game/player.js');
 
 const ProxiedGameFlowWrapperMethods = [
     'startGame', 'keepStartingHands', 'skipSetupPhase', 'selectFirstPlayer',
@@ -16,18 +16,6 @@ const ProxiedGameFlowWrapperMethods = [
 ];
 
 const deckBuilder = new DeckBuilder();
-
-// Add custom toString methods for better Jasmine output
-function formatObject(...keys) {
-    return function() {
-        let properties = _.pick(this, ...keys);
-        let formattedProperties = _.map(_.pairs(properties), ([key, value]) => key + ': ' + jasmine.pp(value));
-        return this.constructor.name + '({ ' + formattedProperties.join(', ') + ' })';
-    };
-}
-
-BaseCard.prototype.toString = formatObject('name', 'location');
-Player.prototype.toString = formatObject('name');
 
 var customMatchers = {
     toHavePrompt: function(util, customEqualityMatchers) {

--- a/test/helpers/integrationhelper.js
+++ b/test/helpers/integrationhelper.js
@@ -5,6 +5,8 @@ const _ = require('underscore');
 
 const DeckBuilder = require('./deckbuilder.js');
 const GameFlowWrapper = require('./gameflowwrapper.js');
+const BaseCard = require('../../server/game/basecard.js');
+const Player = require('../../server/game/player.js');
 
 const ProxiedGameFlowWrapperMethods = [
     'startGame', 'keepStartingHands', 'skipSetupPhase', 'selectFirstPlayer',
@@ -14,6 +16,18 @@ const ProxiedGameFlowWrapperMethods = [
 ];
 
 const deckBuilder = new DeckBuilder();
+
+// Add custom toString methods for better Jasmine output
+function formatObject(...keys) {
+    return function() {
+        let properties = _.pick(this, ...keys);
+        let formattedProperties = _.map(_.pairs(properties), ([key, value]) => key + ': ' + jasmine.pp(value));
+        return this.constructor.name + '({ ' + formattedProperties.join(', ') + ' })';
+    };
+}
+
+BaseCard.prototype.toString = formatObject('name', 'location');
+Player.prototype.toString = formatObject('name');
 
 var customMatchers = {
     toHavePrompt: function(util, customEqualityMatchers) {

--- a/test/helpers/objectformatters.js
+++ b/test/helpers/objectformatters.js
@@ -1,0 +1,24 @@
+/* global jasmine */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+const _ = require('underscore');
+
+const BaseCard = require('../../server/game/basecard.js');
+const Game = require('../../server/game/game.js');
+const Player = require('../../server/game/player.js');
+
+// Add custom toString methods for better Jasmine output
+function formatObject(...keys) {
+    return function() {
+        let properties = _.pick(this, ...keys);
+        let formattedProperties = _.map(_.pairs(properties), ([key, value]) => key + ': ' + jasmine.pp(value));
+        return this.constructor.name + '({ ' + formattedProperties.join(', ') + ' })';
+    };
+}
+
+BaseCard.prototype.toString = formatObject('name', 'location');
+Player.prototype.toString = formatObject('name');
+
+Game.prototype.toString = function() {
+    return 'Game';
+};

--- a/test/server/cards/characters/01/01142-branstark.spec.js
+++ b/test/server/cards/characters/01/01142-branstark.spec.js
@@ -1,12 +1,12 @@
 /* global describe, it, expect, beforeEach, integration */
 /* eslint camelcase: 0, no-invalid-this: 0 */
 
-describe('Bran Stark', function() {
+describe('Bran Stark (Core)', function() {
     integration(function() {
         beforeEach(function() {
             const deck1 = this.buildDeck('stark', [
                 'Sneak Attack',
-                'Bran Stark',
+                'Bran Stark (Core)',
                 'Lady'
             ]);
             const deck2 = this.buildDeck('baratheon', [

--- a/test/server/cards/events/03/03024-aryasgift.spec.js
+++ b/test/server/cards/events/03/03024-aryasgift.spec.js
@@ -6,7 +6,7 @@ describe('Arya\'s Gift', function() {
         beforeEach(function() {
             const deck = this.buildDeck('stark', [
                 'A Noble Cause',
-                'Winterfell Steward', 'Bran Stark', 'Milk of the Poppy', 'Arya\'s Gift'
+                'Winterfell Steward', 'Bran Stark (Core)', 'Milk of the Poppy', 'Arya\'s Gift'
             ]);
 
             this.player1.selectDeck(deck);

--- a/test/server/integration/leavingplay.spec.js
+++ b/test/server/integration/leavingplay.spec.js
@@ -51,5 +51,53 @@ describe('leaving play', function() {
                 expect(this.character.getStrength()).toBe(6);
             });
         });
+
+        describe('when there is a cancel interrupt to the card leaving play', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('thenightswatch', [
+                    'A Game of Thrones', 'Political Disaster',
+                    'The Wall', 'Improved Fortifications'
+                ]);
+
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.location = this.player1.findCardByName('The Wall', 'hand');
+                this.attachment = this.player1.findCardByName('Improved Fortifications', 'hand');
+
+                this.player1.clickCard(this.location);
+                this.player1.clickCard(this.attachment);
+
+                this.completeSetup();
+
+                this.player1.clickCard(this.attachment);
+                this.player1.clickCard(this.location);
+
+                this.player1.selectPlot('Political Disaster');
+                this.player2.selectPlot('A Game of Thrones');
+
+                this.selectFirstPlayer(this.player1);
+
+                // Do not select the location to be saved from Political Disaster
+                this.player1.clickPrompt('Done');
+
+                // Player 2 does not have any locations so no action is taken
+            });
+
+            it('should prompt to use the interrupt and not have the card leave play immediately', function() {
+                expect(this.player1).toHavePromptButton('Improved Fortifications');
+                expect(this.location.location).toBe('play area');
+                expect(this.player1Object.cardsInPlay).toContain(this.location);
+            });
+
+            it('should stop the card from leaving play once the ability is triggered', function() {
+                this.player1.clickPrompt('Improved Fortifications');
+                expect(this.location.location).toBe('play area');
+                expect(this.player1Object.cardsInPlay).toContain(this.location);
+                expect(this.attachment.location).toBe('discard pile');
+            });
+        });
     });
 });

--- a/test/server/integration/reducers.spec.js
+++ b/test/server/integration/reducers.spec.js
@@ -6,7 +6,7 @@ describe('reducer cards', function() {
         beforeEach(function() {
             const deck = this.buildDeck('stark', [
                 'Power Behind the Throne',
-                'Winterfell Steward', 'Heart Tree Grove', 'Bran Stark'
+                'Winterfell Steward', 'Heart Tree Grove', 'Bran Stark (Core)'
             ]);
             this.player1.selectDeck(deck);
             this.player2.selectDeck(deck);


### PR DESCRIPTION
Previously, when a card was moved, it would immediately be moved to the
target pile. In the case of abilities like dupes and Improved
Fortifications, this would move the card before the interrupt prompted,
preventing the save from working properly.

Necessary to consolidate dupe logic properly for #1231 

Also adds test-only `toString` methods for cards, players and game to make test output less awful.