### PR TITLE
Always remove card leaving play from challenge

### DIFF
--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -244,9 +244,7 @@ class Challenge {
     }
 
     onCardLeftPlay(event) {
-        if(!this.winnerDetermined) {
-            this.removeFromChallenge(event.card);
-        }
+        this.removeFromChallenge(event.card);
     }
 
     registerEvents(events) {

--- a/test/server/cards/characters/02/02093-mirrimazduur.spec.js
+++ b/test/server/cards/characters/02/02093-mirrimazduur.spec.js
@@ -1,0 +1,83 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('Mirri Maz Duur', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck1 = this.buildDeck('targaryen', [
+                'Marching Orders',
+                'Mirri Maz Duur', 'The Hound', 'Targaryen Loyalist'
+            ]);
+            const deck2 = this.buildDeck('targaryen', [
+                'Marching Orders',
+                'Targaryen Loyalist'
+            ]);
+            this.player1.selectDeck(deck1);
+            this.player2.selectDeck(deck2);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.mirri = this.player1.findCardByName('Mirri Maz Duur', 'hand');
+            this.hound = this.player1.findCardByName('The Hound', 'hand');
+            this.character = this.player2.findCardByName('Targaryen Loyalist');
+
+            this.player1.clickCard(this.mirri);
+            this.player2.clickCard(this.character);
+            this.completeSetup();
+
+            this.player1.selectPlot('Marching Orders');
+            this.player2.selectPlot('Marching Orders');
+            this.selectFirstPlayer(this.player1);
+
+            this.player1.clickCard(this.hound);
+
+            this.completeMarshalPhase();
+        });
+
+        describe('when claim is applied while Mirri attacks alone', function() {
+            beforeEach(function() {
+                this.player1.clickPrompt('Power');
+                this.player1.clickCard(this.mirri);
+                this.player1.clickPrompt('Done');
+
+                this.skipActionWindow();
+
+                this.player2.clickPrompt('Done');
+
+                this.skipActionWindow();
+
+                this.player1.clickPrompt('Apply Claim');
+            });
+
+            it('should allow a character to be killed', function() {
+                this.player1.clickPrompt('Mirri Maz Duur');
+                this.player1.clickCard(this.character);
+                expect(this.character.location).toBe('dead pile');
+            });
+        });
+
+        describe('when a card leaves play after the challenge is won', function() {
+            beforeEach(function() {
+                this.player1.clickPrompt('Power');
+                this.player1.clickCard(this.mirri);
+                this.player1.clickCard(this.hound);
+                this.player1.clickPrompt('Done');
+
+                this.skipActionWindow();
+
+                this.player2.clickPrompt('Done');
+
+                this.skipActionWindow();
+
+                // Choose not to discard a card so the Hound returns to hand
+                this.player1.clickPrompt('No');
+
+                this.player1.clickPrompt('Apply Claim');
+            });
+
+            it('should consider Mirri to be attacking alone', function() {
+                expect(this.player1).toHavePromptButton('Mirri Maz Duur');
+            });
+        });
+    });
+});


### PR DESCRIPTION
Previously when a card left play during a challenge, if the winner had
already been determined then the card would still be considered
participating. This caused bugs where if the participants were checked
after winner had been determined, the phantom card could effect the
outcome. For example, if the Hound and Mirri Maz Duur were in a
challenge and the Hound leaves plays during the D of DUCK due to his
forced reaction, then Mirri should be considered attacking alone at the
C step, allowing her ability to trigger.

Fixes #1341 