### PR TITLE
Fix timing of automatic dupe saves

### DIFF
--- a/server/game/event.js
+++ b/server/game/event.js
@@ -14,6 +14,10 @@ class Event {
         }
     }
 
+    allowAutomaticSave() {
+        return this.allowSave && this.automaticSaveWithDupe && !!(this.card || this.cards);
+    }
+
     cancel() {
         this.cancelled = true;
     }
@@ -27,9 +31,17 @@ class Event {
             return;
         }
 
+        this.removeCard(card);
         card.markAsSaved();
-        this.cards = _.reject(this.cards, c => c === card);
         card.game.raiseEvent('onCardSaved', { card: card });
+    }
+
+    removeCard(card) {
+        if(!this.cards) {
+            return;
+        }
+
+        this.cards = _.reject(this.cards, c => c === card);
 
         if(_.isEmpty(this.cards)) {
             this.cancel();

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -663,6 +663,18 @@ class Game extends EventEmitter {
         this.queueStep(new SimultaneousEventWindow(this, cards, properties));
     }
 
+    saveWithDupe(card) {
+        let player = card.controller;
+        if(player.removeDuplicate(card)) {
+            card.markAsSaved();
+            this.addMessage('{0} discards a duplicate to save {1}', player, card);
+            this.raiseEvent('onCardSaved', { card: card });
+            return true;
+        }
+
+        return false;
+    }
+
     killCharacters(cards, allowSave = true) {
         this.queueStep(new KillCharacters(this, cards, allowSave));
     }

--- a/server/game/gamesteps/eventwindow.js
+++ b/server/game/gamesteps/eventwindow.js
@@ -14,6 +14,7 @@ class EventWindow extends BaseStep {
         this.pipeline = new GamePipeline();
         this.pipeline.initialise([
             new SimpleStep(game, () => this.cancelInterrupts()),
+            new SimpleStep(game, () => this.automaticSaveWithDupes()),
             new SimpleStep(game, () => this.forcedInterrupts()),
             new SimpleStep(game, () => this.interrupts()),
             new SimpleStep(game, () => this.executeHandler()),
@@ -51,6 +52,16 @@ class EventWindow extends BaseStep {
             abilityType: 'cancelinterrupt',
             event: this.event
         });
+    }
+
+    automaticSaveWithDupes() {
+        if(this.event.cancelled || !this.event.allowAutomaticSave()) {
+            return;
+        }
+
+        if(this.event.card && this.game.saveWithDupe(this.event.card)) {
+            this.event.cancel();
+        }
     }
 
     forcedInterrupts() {

--- a/server/game/gamesteps/killcharacters.js
+++ b/server/game/gamesteps/killcharacters.js
@@ -20,7 +20,8 @@ class KillCharacters extends BaseStep {
             this.game.raiseSimultaneousEvent(killable, {
                 eventName: 'onCharactersKilled',
                 params: {
-                    allowSave: this.allowSave
+                    allowSave: this.allowSave,
+                    automaticSaveWithDupe: true
                 },
                 handler: event => this.handleMultipleKills(event),
                 perCardEventName: 'onCharacterKilled',
@@ -53,11 +54,6 @@ class KillCharacters extends BaseStep {
             this.game.addMessage('{0} controlled by {1} cannot be killed',
                 card, card.controller);
             this.event.saveCard(card);
-        } else if(!card.dupes.isEmpty() && this.event.allowSave) {
-            if(card.controller.removeDuplicate(card)) {
-                this.game.addMessage('{0} discards a duplicate to save {1}', card.controller, card);
-                this.event.saveCard(card);
-            }
         }
     }
 

--- a/server/game/gamesteps/simultaneouseventwindow.js
+++ b/server/game/gamesteps/simultaneouseventwindow.js
@@ -18,6 +18,7 @@ class SimultaneousEventWindow extends BaseStep {
         this.pipeline.initialise([
             new SimpleStep(game, () => this.openWindow('cancelinterrupt')),
             new SimpleStep(game, () => this.perCardWindow('cancelinterrupt')),
+            new SimpleStep(game, () => this.automaticSaveWithDupes()),
             new SimpleStep(game, () => this.openWindow('forcedinterrupt')),
             new SimpleStep(game, () => this.perCardWindow('forcedinterrupt')),
             new SimpleStep(game, () => this.openWindow('interrupt')),
@@ -92,6 +93,19 @@ class SimultaneousEventWindow extends BaseStep {
                 abilityType: abilityType,
                 event: event
             });
+        });
+    }
+
+    automaticSaveWithDupes() {
+        if(this.event.cancelled || !this.event.allowAutomaticSave()) {
+            return;
+        }
+
+        this.filterOutCancelledEvents();
+        _.each(this.event.cards, card => {
+            if(this.game.saveWithDupe(card)) {
+                this.event.removeCard(card);
+            }
         });
     }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -974,6 +974,8 @@ class Player extends Spectator {
     moveCard(card, targetLocation, options = {}) {
         let targetPile = this.getSourceList(targetLocation);
 
+        options = _.extend({ allowSave: false, bottom: false, isDupe: false }, options);
+
         if(!targetPile) {
             return;
         }
@@ -986,7 +988,9 @@ class Player extends Spectator {
 
             var params = {
                 player: this,
-                card: card
+                card: card,
+                allowSave: options.allowSave,
+                automaticSaveWithDupe: true
             };
 
             this.game.raiseEvent('onCardLeftPlay', params, () => {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -924,20 +924,10 @@ class Player extends Spectator {
     }
 
     removeAttachment(attachment, allowSave = true) {
-        if(allowSave && !attachment.dupes.isEmpty() && this.removeDuplicate(attachment)) {
-            this.game.addMessage('{0} discards a duplicate to save {1}', this, attachment);
-            this.game.raiseEvent('onCardSaved', { card: attachment });
-            return;
-        }
-
-        while(attachment.dupes.size() > 0) {
-            this.removeDuplicate(attachment, true);
-        }
-
         if(attachment.isTerminal()) {
-            attachment.owner.moveCard(attachment, 'discard pile');
+            attachment.owner.moveCard(attachment, 'discard pile', { allowSave: allowSave });
         } else {
-            attachment.owner.moveCard(attachment, 'hand');
+            attachment.owner.moveCard(attachment, 'hand', { allowSave: allowSave });
         }
     }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -886,16 +886,7 @@ class Player extends Spectator {
 
     returnCardToHand(card, allowSave = true) {
         this.game.applyGameAction('returnToHand', card, card => {
-            if(!card.dupes.isEmpty() && allowSave) {
-                if(!this.removeDuplicate(card)) {
-                    this.moveCard(card, 'hand');
-                } else {
-                    this.game.addMessage('{0} discards a duplicate to save {1}', this, card);
-                    this.game.raiseEvent('onCardSaved', { card: card });
-                }
-            } else {
-                this.moveCard(card, 'hand');
-            }
+            this.moveCard(card, 'hand', { allowSave: allowSave });
         });
     }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -848,14 +848,6 @@ class Player extends Spectator {
     }
 
     discardCard(card, allowSave = true) {
-        if(!card.dupes.isEmpty() && allowSave) {
-            if(this.removeDuplicate(card)) {
-                this.game.addMessage('{0} discards a duplicate to save {1}', this, card);
-                this.game.raiseEvent('onCardSaved', { card: card });
-                return;
-            }
-        }
-
         this.discardCards([card], allowSave);
     }
 
@@ -865,6 +857,7 @@ class Player extends Spectator {
                 player: this,
                 cards: cards,
                 allowSave: allowSave,
+                automaticSaveWithDupe: true,
                 originalLocation: cards[0].location
             };
             this.game.raiseEvent('onCardsDiscarded', params, event => {
@@ -883,6 +876,7 @@ class Player extends Spectator {
             player: this,
             card: card,
             allowSave: allowSave,
+            automaticSaveWithDupe: true,
             originalLocation: card.location
         };
         this.game.raiseEvent('onCardDiscarded', params, event => {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -892,16 +892,7 @@ class Player extends Spectator {
 
     moveCardToBottomOfDeck(card, allowSave = true) {
         this.game.applyGameAction('moveToBottomOfDeck', card, card => {
-            if(!card.dupes.isEmpty() && allowSave) {
-                if(!this.removeDuplicate(card)) {
-                    this.moveCard(card, 'draw deck', { bottom: true });
-                } else {
-                    this.game.addMessage('{0} discards a duplicate to save {1}', this, card);
-                    this.game.raiseEvent('onCardSaved', { card: card });
-                }
-            } else {
-                this.moveCard(card, 'draw deck', { bottom: true });
-            }
+            this.moveCard(card, 'draw deck', { bottom: true, allowSave: allowSave });
         });
     }
 

--- a/test/server/player/discardcards.spec.js
+++ b/test/server/player/discardcards.spec.js
@@ -46,7 +46,7 @@ describe('Player', function () {
 
         describe('when cards are passed', function() {
             beforeEach(function() {
-                this.eventOuterParams = { player: this.player, cards: [this.card1, this.card2], allowSave: false, originalLocation: 'loc' };
+                this.eventOuterParams = { player: this.player, cards: [this.card1, this.card2], allowSave: false, automaticSaveWithDupe: true, originalLocation: 'loc' };
                 this.player.discardCards([this.card1, this.card2], false, this.callbackSpy);
             });
 
@@ -59,8 +59,8 @@ describe('Player', function () {
                     this.gameSpy.queueSimpleStep.and.callFake(callback => {
                         this.simpleStepCallback = callback;
                     });
-                    this.eventInnerParams1 = { player: this.player, card: this.card1, allowSave: false, originalLocation: 'loc' };
-                    this.eventInnerParams2 = { player: this.player, card: this.card2, allowSave: false, originalLocation: 'loc' };
+                    this.eventInnerParams1 = { player: this.player, card: this.card1, allowSave: false, automaticSaveWithDupe: true, originalLocation: 'loc' };
+                    this.eventInnerParams2 = { player: this.player, card: this.card2, allowSave: false, automaticSaveWithDupe: true, originalLocation: 'loc' };
                     this.onCardsDiscardedHandler = this.gameSpy.raiseEvent.calls.mostRecent().args[2];
                     this.onCardsDiscardedHandler(this.eventOuterParams);
                 });
@@ -96,72 +96,37 @@ describe('Player', function () {
     });
 
     describe('discardCard()', function () {
-        describe('when the card has dupes', function() {
-            beforeEach(function() {
-                this.dupe = createCardSpy(3, this.player);
-                this.card1.removeDuplicate.and.returnValue(this.dupe);
-                this.card1.dupes.push(this.dupe);
-            });
-
-            describe('and the discard can be saved', function() {
-                beforeEach(function() {
-                    this.player.discardCard(this.card1, true);
-                });
-
-                it('should not raise the onCardsDiscarded event', function() {
-                    expect(this.gameSpy.raiseEvent).not.toHaveBeenCalledWith('onCardsDiscarded', jasmine.any(Object), jasmine.any(Function));
-                });
-
-                it('should remove the dupe', function() {
-                    expect(this.card1.removeDuplicate).toHaveBeenCalled();
-                });
-            });
-
-            describe('and the discard cannot be saved', function() {
-                beforeEach(function() {
-                    this.eventOuterParams = { player: this.player, cards: [this.card1], allowSave: false, originalLocation: 'loc' };
-                    this.player.discardCard(this.card1, false);
-                });
-
-                it('should raise the onCardsDiscarded event', function() {
-                    expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onCardsDiscarded', this.eventOuterParams, jasmine.any(Function));
-                });
-            });
+        beforeEach(function() {
+            this.eventOuterParams = { player: this.player, cards: [this.card1], allowSave: false, automaticSaveWithDupe: true, originalLocation: 'loc' };
+            this.player.discardCard(this.card1, false);
         });
 
-        describe('when the card has no dupes', function() {
+        it('should raise the onCardsDiscarded event', function() {
+            expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onCardsDiscarded', this.eventOuterParams, jasmine.any(Function));
+        });
+
+        describe('the onCardsDiscarded handler', function() {
             beforeEach(function() {
-                this.eventOuterParams = { player: this.player, cards: [this.card1], allowSave: false, originalLocation: 'loc' };
-                this.player.discardCard(this.card1, false);
+                this.gameSpy.queueSimpleStep.and.callFake(callback => {
+                    this.simpleStepCallback = callback;
+                });
+                this.eventInnerParams1 = { player: this.player, card: this.card1, allowSave: false, automaticSaveWithDupe: true, originalLocation: 'loc' };
+                this.onCardsDiscardedHandler = this.gameSpy.raiseEvent.calls.mostRecent().args[2];
+                this.onCardsDiscardedHandler(this.eventOuterParams);
             });
 
-            it('should raise the onCardsDiscarded event', function() {
-                expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onCardsDiscarded', this.eventOuterParams, jasmine.any(Function));
+            it('should raise the onCardDiscarded event for each card', function() {
+                expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onCardDiscarded', this.eventInnerParams1, jasmine.any(Function));
             });
 
-            describe('the onCardsDiscarded handler', function() {
+            describe('the onCardDiscarded handler', function() {
                 beforeEach(function() {
-                    this.gameSpy.queueSimpleStep.and.callFake(callback => {
-                        this.simpleStepCallback = callback;
-                    });
-                    this.eventInnerParams1 = { player: this.player, card: this.card1, allowSave: false, originalLocation: 'loc' };
-                    this.onCardsDiscardedHandler = this.gameSpy.raiseEvent.calls.mostRecent().args[2];
-                    this.onCardsDiscardedHandler(this.eventOuterParams);
+                    this.onCardDiscardedHandler = this.gameSpy.raiseEvent.calls.mostRecent().args[2];
+                    this.onCardDiscardedHandler(this.eventInnerParams1);
                 });
 
-                it('should raise the onCardDiscarded event for each card', function() {
-                    expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onCardDiscarded', this.eventInnerParams1, jasmine.any(Function));
-                });
-
-                describe('the onCardDiscarded handler', function() {
-                    beforeEach(function() {
-                        this.onCardDiscardedHandler = this.gameSpy.raiseEvent.calls.mostRecent().args[2];
-                        this.onCardDiscardedHandler(this.eventInnerParams1);
-                    });
-
-                    it('should move the card to discard', function() {
-                        expect(this.player.moveCard).toHaveBeenCalledWith(this.card1, 'discard pile');
-                    });
+                it('should move the card to discard', function() {
+                    expect(this.player.moveCard).toHaveBeenCalledWith(this.card1, 'discard pile');
                 });
             });
         });

--- a/test/server/player/removeattachment.spec.js
+++ b/test/server/player/removeattachment.spec.js
@@ -34,102 +34,34 @@ describe('Player', function() {
             spyOn(this.attachment, 'isTerminal');
         });
 
-        describe('when the attachment has a duplicate', function() {
+        describe('when the attachment is terminal', function() {
             beforeEach(function() {
-                this.dupe = new DrawCard(this.attachmentOwner, {});
-                this.attachment.addDuplicate(this.dupe);
+                this.attachment.isTerminal.and.returnValue(true);
                 this.player.removeAttachment(this.attachment);
             });
 
-            it('should remove the dupe', function() {
-                expect(this.attachment.dupes).not.toContain(this.dupe);
+            it('should leave play', function() {
+                expect(this.attachment.leavesPlay).toHaveBeenCalled();
             });
 
-            it('should place the dupe in the owners discard pile', function() {
-                expect(this.attachmentOwner.discardPile).toContain(this.dupe);
+            it('should remove the attachment from its parent', function() {
+                expect(this.card.attachments).not.toContain(this.attachment);
             });
 
-            it('should not remove the attachment', function() {
-                expect(this.card.attachments).toContain(this.attachment);
+            it('should unset its parent property', function() {
+                expect(this.attachment.parent).toBeUndefined();
             });
 
-            it('should not have the attachment leave play', function() {
-                expect(this.attachment.leavesPlay).not.toHaveBeenCalled();
-            });
-
-            it('should not move the attachment', function() {
-                expect(this.attachment.parent).toBe(this.card);
+            it('should return the attachment to its owners discard pile', function() {
                 expect(this.attachmentOwner.hand).not.toContain(this.attachment);
-                expect(this.attachmentOwner.discardPile).not.toContain(this.attachment);
+                expect(this.attachmentOwner.discardPile).toContain(this.attachment);
             });
         });
 
-        describe('when the attachment has no duplicates', function() {
-            describe('when the attachment is terminal', function() {
-                beforeEach(function() {
-                    this.attachment.isTerminal.and.returnValue(true);
-                    this.player.removeAttachment(this.attachment);
-                });
-
-                it('should leave play', function() {
-                    expect(this.attachment.leavesPlay).toHaveBeenCalled();
-                });
-
-                it('should remove the attachment from its parent', function() {
-                    expect(this.card.attachments).not.toContain(this.attachment);
-                });
-
-                it('should unset its parent property', function() {
-                    expect(this.attachment.parent).toBeUndefined();
-                });
-
-                it('should return the attachment to its owners discard pile', function() {
-                    expect(this.attachmentOwner.hand).not.toContain(this.attachment);
-                    expect(this.attachmentOwner.discardPile).toContain(this.attachment);
-                });
-            });
-
-            describe('when the attachment is not terminal', function() {
-                beforeEach(function() {
-                    this.attachment.isTerminal.and.returnValue(false);
-                    this.player.removeAttachment(this.attachment);
-                });
-
-                it('should leave play', function() {
-                    expect(this.attachment.leavesPlay).toHaveBeenCalled();
-                });
-
-                it('should remove the attachment from its parent', function() {
-                    expect(this.card.attachments).not.toContain(this.attachment);
-                });
-
-                it('should unset its parent property', function() {
-                    expect(this.attachment.parent).toBeUndefined();
-                });
-
-                it('should return the attachment to its owners hand', function() {
-                    expect(this.attachmentOwner.hand).toContain(this.attachment);
-                    expect(this.attachmentOwner.discardPile).not.toContain(this.attachment);
-                });
-            });
-        });
-
-        describe('when the removal cannot be saved', function() {
+        describe('when the attachment is not terminal', function() {
             beforeEach(function() {
-                this.dupe = new DrawCard(this.attachmentOwner, {});
-                this.dupe2 = new DrawCard(this.attachmentOwner, {});
-                this.attachment.addDuplicate(this.dupe);
-                this.attachment.addDuplicate(this.dupe2);
-                this.player.removeAttachment(this.attachment, false);
-            });
-
-            it('should remove all dupes', function() {
-                expect(this.attachment.dupes.size()).toBe(0);
-            });
-
-            it('should place all dupes in the owners discard pile', function() {
-                expect(this.attachmentOwner.discardPile).toContain(this.dupe);
-                expect(this.attachmentOwner.discardPile).toContain(this.dupe2);
+                this.attachment.isTerminal.and.returnValue(false);
+                this.player.removeAttachment(this.attachment);
             });
 
             it('should leave play', function() {


### PR DESCRIPTION
* Ensures that automatic saves with dupes happens after cancellation interrupts have fired but before the normal interrupts (previously was done inside the handler, allowing onCharacterKilled interrupts to fire even though the card was later saved)
* Cleans up logic by making cards leaving play cancellable using dupes directly.

Fixes #1231