### PR TITLE
Remove old override style modifyClaim

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -405,10 +405,6 @@ class BaseCard {
         return this.cardData.faction_code;
     }
 
-    modifyClaim(player, type, claim) {
-        return claim;
-    }
-
     setBlank() {
         var before = this.isBlank();
         this.blankCount++;

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -219,14 +219,7 @@ class Challenge {
     }
 
     getClaim() {
-        var claim = this.winner.getClaim();
-        claim = this.winner.modifyClaim(this.winner, this.challengeType, claim);
-
-        if(!this.isSinglePlayer) {
-            claim = this.loser.modifyClaim(this.winner, this.challengeType, claim);
-        }
-
-        return claim;
+        return this.winner.getClaim();
     }
 
     getWinnerCards() {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -196,15 +196,6 @@ class Player extends Spectator {
         this.game.raiseEvent('onUsedPlotsModified', { player: this });
     }
 
-    modifyClaim(winner, challengeType, claim) {
-        claim = this.activePlot.modifyClaim(winner, challengeType, claim);
-        this.cardsInPlay.each(card => {
-            claim = card.modifyClaim(winner, challengeType, claim);
-        });
-
-        return claim;
-    }
-
     drawCardsToHand(numCards) {
         if(numCards > this.drawDeck.size()) {
             numCards = this.drawDeck.size();


### PR DESCRIPTION
Modifying claim has been entirely converted to effects. There's no
longer a need for the method you used to have to override to implement
claim modification.

Fixes THRONETEKI-1A1