### PR TITLE
Simultaneously raise kneel event during challenges

### DIFF
--- a/server/game/cards/attachments/04/motherofdragons.js
+++ b/server/game/cards/attachments/04/motherofdragons.js
@@ -11,9 +11,9 @@ class MotherOfDragons extends DrawCard {
                 let challenge = this.game.currentChallenge;
 
                 if(challenge.attackingPlayer === this.controller) {
-                    challenge.addAttacker(this.parent, false);
+                    challenge.addAttacker(this.parent);
                 } else {
-                    challenge.addDefender(this.parent, false);
+                    challenge.addDefender(this.parent);
                 }
                 this.game.addMessage('{0} kneels {1} to have {2} participate in the challenge on their side', this.controller, this, this.parent);
             }

--- a/server/game/cards/attachments/07/summer.js
+++ b/server/game/cards/attachments/07/summer.js
@@ -9,9 +9,9 @@ class Summer extends DrawCard {
             limit: ability.limit.perChallenge(1),
             handler: () => {
                 if(this.game.currentChallenge.attackingPlayer === this.controller) {
-                    this.game.currentChallenge.addAttacker(this.parent, false);
+                    this.game.currentChallenge.addAttacker(this.parent);
                 } else {
-                    this.game.currentChallenge.addDefender(this.parent, false);
+                    this.game.currentChallenge.addDefender(this.parent);
                 }
                 this.game.addMessage('{0} uses {1} and kneels {2} to have {2} participate in the challenge on their side',
                     this.controller, this, this.parent);

--- a/server/game/cards/characters/04/dolorousedd.js
+++ b/server/game/cards/characters/04/dolorousedd.js
@@ -17,7 +17,7 @@ class DolorousEdd extends DrawCard {
                 this.controller.putIntoPlay(this);
                 // Manually kneel Edd, since he enters play that way - should not fire a kneeling event.
                 this.kneeled = true;
-                this.game.currentChallenge.addDefender(this, false);
+                this.game.currentChallenge.addDefender(this);
                 this.game.once('afterChallenge', event => this.promptOnWin(event.challenge));
             }
         });

--- a/server/game/cards/characters/05/moonbrothers.js
+++ b/server/game/cards/characters/05/moonbrothers.js
@@ -14,15 +14,14 @@ class MoonBrothers extends DrawCard {
             handler: () => {
                 this.controller.putIntoPlay(this);
                 this.game.currentChallenge.addAttacker(this);
-                this.kneeled = false;
-                this.game.addMessage('{0} kneels their faction card to put {1} into play participating  as an attacker', 
+                this.game.addMessage('{0} kneels their faction card to put {1} into play participating as an attacker', 
                     this.controller, this);
             }
         });
     }
 
     hasAttackingClansman() {
-        var cards = this.controller.filterCardsInPlay(card => {
+        let cards = this.controller.filterCardsInPlay(card => {
             return card.hasTrait('Clansman') && card.getType() === 'character' && this.game.currentChallenge.isAttacking(card);
         });
 

--- a/server/game/cards/characters/09/margaerytyrell.js
+++ b/server/game/cards/characters/09/margaerytyrell.js
@@ -19,7 +19,7 @@ class MargaeryTyrell extends DrawCard {
             },
             handler: context => {
                 context.target.controller.kneelCard(context.target);
-                this.game.currentChallenge.addDefender(context.target, false);
+                this.game.currentChallenge.addDefender(context.target);
 
                 this.game.addMessage('{0} uses {1} to kneel {2} and have them participate in the current challenge as a defender', 
                     this.controller, this, context.target);

--- a/server/game/cards/locations/05/oldwyk.js
+++ b/server/game/cards/locations/05/oldwyk.js
@@ -15,9 +15,11 @@ class OldWyk extends DrawCard {
                 let card = _.last(this.controller.deadPile.filter(c => c.hasTrait('Drowned God')));
 
                 this.controller.putIntoPlay(card);
+                //Manually kneel instead of firing kneel event as character is put into play knelt
+                this.kneeled = true;
                 this.game.currentChallenge.addAttacker(card);
 
-                this.game.addMessage('{0} kneels {1} to put {2} into play from their dead pile as an attacker',
+                this.game.addMessage('{0} kneels {1} to put {2} into play from their dead pile knelt as an attacker',
                     this.controller, this, card);
 
                 this.game.once('afterChallenge', event => this.resolveAfterChallenge(event.challenge, card));

--- a/server/game/cards/plots/02/wardensofthenorth.js
+++ b/server/game/cards/plots/02/wardensofthenorth.js
@@ -9,7 +9,7 @@ class WardensOfTheNorth extends PlotCard {
             condition: () => this.isStarkCardParticipatingInChallenge(),
             cost: ability.costs.kneel(card => card.getType() === 'character' && card.isFaction('stark') && card.canParticipateInChallenge()),
             handler: context => {
-                var card = context.kneelingCostCard;
+                let card = context.kneelingCostCard;
                 if(this.game.currentChallenge.attackingPlayer === context.player) {
                     this.game.currentChallenge.addAttacker(card);
                 } else {

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -37,27 +37,27 @@ class Challenge {
         this.attackingPlayer.initiateChallenge(this.challengeType);
     }
 
-    addAttackers(attackers, kneel = true) {
+    addAttackers(attackers) {
         this.attackers = this.attackers.concat(attackers);
-        this.markAsParticipating(attackers, 'attacker', kneel);
+        this.markAsParticipating(attackers);
         this.calculateStrength();
     }
 
-    addAttacker(attacker, kneel = true) {
+    addAttacker(attacker) {
         this.attackers.push(attacker);
-        this.markAsParticipating([attacker], 'attacker', kneel);
+        this.markAsParticipating([attacker]);
         this.calculateStrength();
     }
 
-    addDefenders(defenders, kneel = true) {
+    addDefenders(defenders) {
         this.defenders = this.defenders.concat(defenders);
-        this.markAsParticipating(defenders, 'defender', kneel);
+        this.markAsParticipating(defenders);
         this.calculateStrength();
     }
 
-    addDefender(defender, kneel = true) {
+    addDefender(defender) {
         this.defenders.push(defender);
-        this.markAsParticipating([defender], 'defender', kneel);
+        this.markAsParticipating([defender]);
         this.calculateStrength();
     }
 
@@ -72,12 +72,8 @@ class Challenge {
         this.game.raiseEvent('onRemovedFromChallenge', { card: card });
     }
 
-    markAsParticipating(cards, participantType, kneel) {
+    markAsParticipating(cards) {
         _.each(cards, card => {
-            if(kneel && !card.kneeled && !card.challengeOptions.doesNotKneelAs[participantType]) {
-                card.controller.kneelCard(card);
-            }
-
             card.inChallenge = true;
         });
     }

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -72,7 +72,7 @@ const Effects = {
             apply: function(card, context) {
                 let challenge = context.game.currentChallenge;
                 if(card.canParticipateInChallenge()) {
-                    challenge.addAttacker(card, false);
+                    challenge.addAttacker(card);
                 }
             },
             unapply: function(card, context) {

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -62,7 +62,7 @@ class ChallengeFlow extends BaseStep {
 
     chooseAttackers(player, attackers) {
         this.attackersToKneel = [];
-        this.challenge.addAttackers(attackers, false);
+        this.challenge.addAttackers(attackers);
 
         _.each(attackers, card => {
             if(!card.kneeled && !card.challengeOptions.doesNotKneelAs['attacker']) {
@@ -183,7 +183,7 @@ class ChallengeFlow extends BaseStep {
         }
 
         let defendersToKneel = [];
-        this.challenge.addDefenders(defenders, false);
+        this.challenge.addDefenders(defenders);
 
         _.each(defenders, card => {
             if(!card.kneeled && !card.challengeOptions.doesNotKneelAs['defender']) {

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -182,14 +182,14 @@ class ChallengeFlow extends BaseStep {
             defenders = defenders.concat(this.forcedDefenders);
         }
 
-        this.defendersToKneel = [];
+        let defendersToKneel = [];
         this.challenge.addDefenders(defenders, false);
 
         _.each(defenders, card => {
             if(!card.kneeled && !card.challengeOptions.doesNotKneelAs['defender']) {
                 this.game.applyGameAction('kneel', card, card => {
                     card.kneeled = true;
-                    this.defendersToKneel.push(card);
+                    defendersToKneel.push(card);
                 });
             }
         });
@@ -198,13 +198,13 @@ class ChallengeFlow extends BaseStep {
             { name: 'onDefendersDeclared', params: { challenge: this.challenge } }
         ];
 
-        let kneelEvents = _.map(this.defendersToKneel, card => {
+        let kneelEvents = _.map(defendersToKneel, card => {
             return { name: 'onCardKneeled', params: { player: this.challenge.defendingPlayer, card: card} };
         });
 
         this.game.raiseAtomicEvent(events.concat(kneelEvents));
 
-        this.defendersToKneel = undefined;
+        defendersToKneel = undefined;
 
         return true;
     }


### PR DESCRIPTION
Previously, the onCardKneeled event for kneeling an attacker/defender was raised before any of the other challenge initiation/declare defenders events. This made it for example impossible to prevent a Satin trigger with Winterfell. This PR fixes that by raising onCardKneeled simultaneously with the other associated challenge events.