### PR TITLE
Check attachments when faction / traits removed

### DIFF
--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -282,10 +282,24 @@ class DrawCard extends BaseCard {
         return true;
     }
 
+    removeTrait(trait) {
+        super.removeTrait(trait);
+        this.enforceAttachmentValidity();
+    }
+
+    removeFaction(faction) {
+        super.removeFaction(faction);
+        this.enforceAttachmentValidity();
+    }
+
     clearBlank() {
         super.clearBlank();
+        this.enforceAttachmentValidity();
+    }
+
+    enforceAttachmentValidity() {
         this.attachments.each(attachment => {
-            if(!this.allowAttachment(attachment)) {
+            if(!this.allowAttachment(attachment) || !attachment.canAttach(this.controller, this)) {
                 this.controller.discardCard(attachment, false);
             }
         });

--- a/test/server/card/drawcard.clearblank.spec.js
+++ b/test/server/card/drawcard.clearblank.spec.js
@@ -20,7 +20,8 @@ describe('DrawCard', function() {
 
         describe('when the card has attachments', function() {
             beforeEach(function() {
-                this.attachment = {};
+                this.attachment = jasmine.createSpyObj('attachment', ['canAttach']);
+                this.attachment.canAttach.and.returnValue(true);
                 this.card.attachments.push(this.attachment);
             });
 


### PR DESCRIPTION
When a faction or trait is removed from the card, it is possible that
attachments on that card are no longer validly attached and must be
discarded.

Fixes #1319 