### PR TITLE
Do not prompt when Fickle Bannerman has no gold

### DIFF
--- a/server/game/cards/characters/06/ficklebannerman.js
+++ b/server/game/cards/characters/06/ficklebannerman.js
@@ -4,9 +4,14 @@ class FickleBannerman extends DrawCard {
     setupCardAbilities() {
         this.forcedReaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.loser === this.controller && challenge.challengeType === 'power'
+                afterChallenge: event => event.challenge.loser === this.controller && event.challenge.challengeType === 'power'
             },
             handler: () => {
+                if(!this.hasToken('gold')) {
+                    this.loseControl();
+                    return;
+                }
+
                 this.game.promptWithMenu(this.controller, this, {
                     activePrompt: {
                         menuTitle: 'Discard a gold from ' + this.name + '?',


### PR DESCRIPTION
Previously, if the Fickle Bannerman had no gold tokens on the card, the
player would still be prompted and if they selected to discard a
non-existent gold token, they would keep control.