### PR TITLE
Set correct cardtype for event+attach saves

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -68,6 +68,7 @@ class BaseCard {
         this.setupCardAbilities(AbilityDsl);
 
         this.factions = {};
+        this.cardTypeSet = undefined;
         this.addFaction(cardData.faction_code);
     }
 
@@ -335,6 +336,7 @@ class BaseCard {
     }
 
     leavesPlay() {
+        this.cardTypeSet = undefined;
         this.tokens = {};
     }
 
@@ -397,7 +399,15 @@ class BaseCard {
         return this.blankCount > 0;
     }
 
+    setCardType(cardType) {
+        this.cardTypeSet = cardType;
+    }
+
     getType() {
+        return this.cardTypeSet || this.getPrintedType();
+    }
+
+    getPrintedType() {
         return this.cardData.type_code;
     }
 

--- a/server/game/cards/events/01/risenfromthesea.js
+++ b/server/game/cards/events/01/risenfromthesea.js
@@ -14,6 +14,7 @@ class RisenFromTheSea extends DrawCard {
             handler: context => {
                 context.event.saveCard(context.target);
                 this.controller.attach(this.controller, this, context.target, 'play');
+                this.setCardType('attachment');
 
                 this.game.addMessage('{0} plays {1} to save {2}', this.controller, this, context.target);
             }

--- a/server/game/cards/events/02/bloodmagicritual.js
+++ b/server/game/cards/events/02/bloodmagicritual.js
@@ -9,12 +9,12 @@ class BloodMagicRitual extends DrawCard {
             },
             location: 'hand',
             target: {
-                activePromptTitle: 'Select character to save',
                 cardCondition: (card, context) => context.event.cards.includes(card) && !card.hasTrait('Army')
             },
             handler: context => {
                 context.event.saveCard(context.target);
                 context.target.controller.attach(this.controller, this, context.target, 'play');
+                this.setCardType('attachment');
 
                 this.game.addMessage('{0} plays {1} to save {2}', this.controller, this, context.target);
             }

--- a/server/game/cards/plots/03/weaponsatthedoor.js
+++ b/server/game/cards/plots/03/weaponsatthedoor.js
@@ -18,7 +18,7 @@ class WeaponsAtTheDoor extends PlotCard {
 
     returnCardsToHand(player) {
         player.allCards.each(card => {
-            if(card.getType() === 'attachment' && card.parent) {
+            if(card.getPrintedType() === 'attachment' && card.parent) {
                 player.returnCardToHand(card);
             }
         });


### PR DESCRIPTION
Previously, after playing and attaching a Risen from the Sea/Blood Magic Ritual to a character, these cards still retained their event cardtype. This made it for example impossible to discard these cards with Confiscation. This PR fixes that by setting the correct cardtype as long as these cards remain in play.