### PR TITLE
Track whether /cancel-prompt used

### DIFF
--- a/server/game/chatcommands.js
+++ b/server/game/chatcommands.js
@@ -303,6 +303,7 @@ class ChatCommands {
     cancelPrompt(player) {
         this.game.addMessage('{0} uses the /cancel-prompt to skip the current step.', player);
         this.game.pipeline.cancelStep();
+        this.game.cancelPromptUsed = true;
     }
 
     setToken(player, args) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -53,6 +53,7 @@ class Game extends EventEmitter {
         this.abilityCardStack = [];
         this.abilityWindowStack = [];
         this.password = details.password;
+        this.cancelPromptUsed = false;
         this.claim = {
             isApplying: false,
             type: undefined
@@ -887,7 +888,8 @@ class Game extends EventEmitter {
                     };
                 }),
                 started: this.started,
-                winner: this.winner ? this.winner.name : undefined
+                winner: this.winner ? this.winner.name : undefined,
+                cancelPromptUsed: this.cancelPromptUsed
             };
         }
 


### PR DESCRIPTION
Adds a flag to debug data about whether the /cancel-prompt command has
been used. This should allow a better understanding of which errors are
caused because the user canceled something and which are general errors.