### PR TITLE
Fix /cancel-prompt

### DIFF
--- a/server/game/gamesteps/abilityresolver.js
+++ b/server/game/gamesteps/abilityresolver.js
@@ -46,6 +46,7 @@ class AbilityResolver extends BaseStep {
     }
 
     cancelStep() {
+        this.cancelled = true;
         this.pipeline.cancelStep();
     }
 


### PR DESCRIPTION
Set the resolution of an ability to be cancelled when cancel-prompt is used, so that the prompt does not continue or try to invoke a handler with no targets selected

@ystros this almost certainly has consequences I haven't thought about, but it does work in the one tiny circumstance I managed to reproduce and doesn't break any tests...