### PR TITLE
Reset ability limits when cards leave play

### DIFF
--- a/server/game/abilitylimit.js
+++ b/server/game/abilitylimit.js
@@ -47,6 +47,7 @@ class RepeatableAbilityLimit extends FixedAbilityLimit {
 
     unregisterEvents(eventEmitter) {
         eventEmitter.removeListener(this.eventName, this.resetHandler);
+        this.reset();
     }
 }
 

--- a/test/server/abilitylimit.spec.js
+++ b/test/server/abilitylimit.spec.js
@@ -54,6 +54,12 @@ describe('AbilityLimit', function () {
             this.limit.unregisterEvents(this.eventEmitterSpy);
             expect(this.eventEmitterSpy.removeListener).toHaveBeenCalledWith('onEventForReset', jasmine.any(Function));
         });
+
+        it('should reset the count to 0', function() {
+            this.limit.increment();
+            this.limit.unregisterEvents(this.eventEmitterSpy);
+            expect(this.limit.useCount).toBe(0);
+        });
     });
 
     describe('resetting the use count', function() {

--- a/test/server/integration/leavingplay.spec.js
+++ b/test/server/integration/leavingplay.spec.js
@@ -99,5 +99,44 @@ describe('leaving play', function() {
                 expect(this.attachment.location).toBe('discard pile');
             });
         });
+
+        describe('when a card ability limit has been reached', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('baratheon', [
+                    'Trading with the Pentoshi',
+                    'Melisandre (Core)', 'Dragonstone Faithful', 'Dragonstone Faithful'
+                ]);
+
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.character = this.player1.findCardByName('Melisandre', 'hand');
+                [this.chud1, this.chud2] = this.player2.filterCardsByName('Dragonstone Faithful', 'hand');
+
+                this.player2.clickCard(this.chud1);
+                this.player2.clickCard(this.chud2);
+
+                this.completeSetup();
+
+                this.player1.selectPlot('Trading with the Pentoshi');
+                this.player2.selectPlot('Trading with the Pentoshi');
+
+                this.selectFirstPlayer(this.player1);
+                this.selectPlotOrder(this.player1);
+
+                this.player1.clickCard(this.character);
+                this.player1.clickPrompt('Melisandre');
+                this.player1.clickCard(this.chud1);
+
+                this.player1.dragCard(this.character, 'hand');
+                this.player1.clickCard(this.character);
+            });
+
+            it('should reset after leaving play', function() {
+                expect(this.player1).toHavePromptButton('Melisandre');
+            });
+        });
     });
 });


### PR DESCRIPTION
Cards leaving play unregister the event listeners for their ability
limits, so whenever an ability is unregistered, the limit is now reset.

Fixes #1098 