### PR TITLE
Allow multiple reactions from a card in a window

### DIFF
--- a/server/game/gamesteps/triggeredabilitywindow.js
+++ b/server/game/gamesteps/triggeredabilitywindow.js
@@ -21,10 +21,12 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
         let context = ability.createContext(event);
         let player = context.player;
         let choiceTexts = ability.getChoices(context);
+        let abilityGroupId = uuid.v1();
 
         _.each(choiceTexts, choiceText => {
             this.abilityChoices.push({
                 id: uuid.v1(),
+                abilityGroupId: abilityGroupId,
                 player: player,
                 ability: ability,
                 card: ability.card,
@@ -140,7 +142,7 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
         choice.context.choice = choice.choice;
         this.game.resolveAbility(choice.ability, choice.context);
 
-        this.abilityChoices = _.reject(this.abilityChoices, ability => ability.card === choice.card);
+        this.abilityChoices = _.reject(this.abilityChoices, ability => ability.abilityGroupId === choice.abilityGroupId);
 
         // Always rotate player order without filtering, in case an ability is
         // triggered that could then make another ability eligible after it is

--- a/test/server/gamesteps/triggeredabilitywindow.spec.js
+++ b/test/server/gamesteps/triggeredabilitywindow.spec.js
@@ -46,10 +46,10 @@ describe('TriggeredAbilityWindow', function() {
             this.context3 = { context: 3 };
 
             this.window.abilityChoices = [
-                { id: '1', ability: this.ability1Spy, card: this.abilityCard1, choice: 'choice1', context: this.context1, player: this.player1Spy, text: 'My Choice 1' },
-                { id: '2', ability: this.ability1Spy, card: this.abilityCard1, choice: 'choice2', context: this.context1, player: this.player1Spy, text: 'My Choice 2' },
-                { id: '3', ability: this.ability2Spy, card: this.abilityCard2, choice: 'default', context: this.context2, player: this.player1Spy, text: 'default' },
-                { id: '4', ability: this.ability3Spy, card: this.abilityCard3, choice: 'default', context: this.context3, player: this.player2Spy, text: 'default' }
+                { id: '1', abilityGroupId: 1, ability: this.ability1Spy, card: this.abilityCard1, choice: 'choice1', context: this.context1, player: this.player1Spy, text: 'My Choice 1' },
+                { id: '2', abilityGroupId: 1, ability: this.ability1Spy, card: this.abilityCard1, choice: 'choice2', context: this.context1, player: this.player1Spy, text: 'My Choice 2' },
+                { id: '3', abilityGroupId: 2, ability: this.ability2Spy, card: this.abilityCard2, choice: 'default', context: this.context2, player: this.player1Spy, text: 'default' },
+                { id: '4', abilityGroupId: 3, ability: this.ability3Spy, card: this.abilityCard3, choice: 'default', context: this.context3, player: this.player2Spy, text: 'default' }
             ];
         };
 
@@ -301,7 +301,7 @@ describe('TriggeredAbilityWindow', function() {
                 expect(this.gameSpy.resolveAbility).toHaveBeenCalledWith(this.ability1Spy, this.context1);
             });
 
-            it('should remove all choices for that card', function() {
+            it('should remove all choices for that ability grouping', function() {
                 let remainingIds = _.pluck(this.window.abilityChoices, 'id');
                 expect(remainingIds).toEqual(['3', '4']);
             });

--- a/test/server/integration/challengesphase.spec.js
+++ b/test/server/integration/challengesphase.spec.js
@@ -149,6 +149,15 @@ describe('challenges phase', function() {
                 expect(this.player1).toHavePromptButton('Marya Seaworth - Kneel Hedge Knight');
                 expect(this.player1).toHavePromptButton('Marya Seaworth - Kneel Lannisport Merchant');
             });
+
+            it('should allow multiple reactions from the same card to be triggered', function() {
+                this.initiateChallenge();
+                this.player1.clickPrompt('Marya Seaworth - Kneel Hedge Knight');
+                this.player1.clickPrompt('Marya Seaworth - Kneel Lannisport Merchant');
+
+                expect(this.knight.kneeled).toBe(true);
+                expect(this.merchant.kneeled).toBe(true);
+            });
         });
     });
 });


### PR DESCRIPTION
Previously, it was assumed that if a prompt had multiple choices from
the same card in a single window that it was because the card offered
multiple choices (e.g. The Reader, LoCR Tyrion). Thus, if the player
clicked one of the options, the others were removed.

However, now that the challenge initiation window contains choices for
multiple events, it's possible to have the same card produce multiple
independent choices. For example, Marya Seaworth can trigger separately
for each card bypassed by stealth. The previous implementation only
allowed one instance of her ability to be triggered. The prompt now
treats them as separate abilities instead of separate choices for the
same ability, and allows all of them to be triggered.