### PR TITLE
Allow optional keywords + choosing order

### DIFF
--- a/client/Profile.jsx
+++ b/client/Profile.jsx
@@ -27,6 +27,7 @@ class InnerProfile extends React.Component {
             promptedActionWindows: this.props.user.promptedActionWindows,
             validation: {},
             windowTimer: this.props.user.settings.windowTimer,
+            keywordSettings: this.props.user.settings.keywordSettings,
             timerSettings: this.props.user.settings.timerSettings,
             selectedBackground: this.props.user.settings.background
         };
@@ -78,6 +79,14 @@ class InnerProfile extends React.Component {
         this.setState(newState);
     }
 
+    onKeywordSettingToggle(field, event) {
+        var newState = {};
+        newState.keywordSettings = this.state.keywordSettings;
+
+        newState.keywordSettings[field] = event.target.checked;
+        this.setState(newState);
+    }
+
     onSaveClick(event) {
         event.preventDefault();
 
@@ -106,6 +115,7 @@ class InnerProfile extends React.Component {
                         settings: {
                             disableGravatar: this.state.disableGravatar,
                             windowTimer: this.state.windowTimer,
+                            keywordSettings: this.state.keywordSettings,
                             timerSettings: this.state.timerSettings,
                             background: this.state.selectedBackground
                         }
@@ -257,6 +267,17 @@ class InnerProfile extends React.Component {
                                         onChange={ this.onTimerSettingToggle.bind(this, 'events') } checked={ this.state.timerSettings.events } />
                                     <Checkbox name='timerSettings.abilities' noGroup label={ 'Show timer for card abilities' } fieldClass='col-sm-6'
                                         onChange={ this.onTimerSettingToggle.bind(this, 'abilities') } checked={ this.state.timerSettings.abilities } />
+                                </div>
+                            </div>
+                            <div className='panel-title text-center'>
+                                Keywords
+                            </div>
+                            <div className='panel'>
+                                <div className='form-group'>
+                                    <Checkbox name='keywordSettings.chooseOrder' noGroup label={ 'Choose order of keywords' } fieldClass='col-sm-6'
+                                        onChange={ this.onKeywordSettingToggle.bind(this, 'chooseOrder') } checked={ this.state.keywordSettings.chooseOrder } />
+                                    <Checkbox name='keywordSettings.chooseCards' noGroup label={ 'Make keywords optional' } fieldClass='col-sm-6'
+                                        onChange={ this.onKeywordSettingToggle.bind(this, 'chooseCards') } checked={ this.state.keywordSettings.chooseCards } />
                                 </div>
                             </div>
                         </div>

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -1,6 +1,7 @@
 const _ = require('underscore');
 const Player = require('./player.js');
 const EventRegistrar = require('./eventregistrar.js');
+const Settings = require('../settings.js');
 
 class Challenge {
     constructor(game, properties) {
@@ -22,7 +23,7 @@ class Challenge {
     }
 
     singlePlayerDefender() {
-        var dummyPlayer = new Player('', { name: 'Dummy Player' }, false, this.game);
+        let dummyPlayer = new Player('', Settings.getUserWithDefaultsSet({ name: 'Dummy Player' }), false, this.game);
         dummyPlayer.initialise();
         dummyPlayer.startPlotPhase();
         return dummyPlayer;

--- a/server/game/gamesteps/keywordwindow.js
+++ b/server/game/gamesteps/keywordwindow.js
@@ -69,13 +69,36 @@ class KeywordWindow extends BaseStep {
         let ability = GameKeywords[keyword];
         let participantsWithKeyword = this.getParticipantsForKeyword(keyword, ability);
 
-        if(keyword === 'pillage' && _.size(participantsWithKeyword) > 1) {
-            this.promptForPillageOrder(ability, participantsWithKeyword);
-        } else {
-            this.resolveAbility(ability, participantsWithKeyword);
+        if(participantsWithKeyword.length === 0) {
+            return;
         }
 
-        this.game.checkWinCondition(this.challenge.winner);
+        if(this.challenge.winner.keywordSettings.chooseCards) {
+            let cards = _.pluck(participantsWithKeyword, 'card');
+            this.game.promptForSelect(this.challenge.winner, {
+                ordered: true,
+                multiSelect: true,
+                numCards: 0,
+                activePromptTitle: 'Select ' + keyword + ' cards',
+                cardCondition: card => cards.includes(card),
+                onSelect: (player, selectedCards) => {
+                    let finalParticipants = _.map(selectedCards, card => _.find(participantsWithKeyword, participant => participant.card === card));
+
+                    this.resolveAbility(ability, finalParticipants);
+                    this.game.checkWinCondition(this.challenge.winner);
+
+                    return true;
+                }
+            });
+        } else {
+            if(keyword === 'pillage' && _.size(participantsWithKeyword) > 1) {
+                this.promptForPillageOrder(ability, participantsWithKeyword);
+            } else {
+                this.resolveAbility(ability, participantsWithKeyword);
+            }
+
+            this.game.checkWinCondition(this.challenge.winner);
+        }
     }
 
     getParticipantsForKeyword(keyword, ability) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -46,15 +46,7 @@ class Player extends Spectator {
         this.abilityMaxByTitle = {};
         this.standPhaseRestrictions = [];
         this.mustChooseAsClaim = [];
-        this.promptedActionWindows = user.promptedActionWindows || {
-            plot: false,
-            draw: false,
-            challengeBegin: false,
-            attackersDeclared: true,
-            defendersDeclared: true,
-            dominance: false,
-            standing: false
-        };
+        this.promptedActionWindows = user.promptedActionWindows;
 
         this.createAdditionalPile('out of game');
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -46,6 +46,7 @@ class Player extends Spectator {
         this.abilityMaxByTitle = {};
         this.standPhaseRestrictions = [];
         this.mustChooseAsClaim = [];
+        this.keywordSettings = Object.assign({}, user.settings ? user.settings.keywordSettings : {});
         this.promptedActionWindows = user.promptedActionWindows;
 
         this.createAdditionalPile('out of game');

--- a/server/settings.js
+++ b/server/settings.js
@@ -9,6 +9,10 @@ const defaultWindows = {
     taxation: false
 };
 
+const defaultKeywordSettings = {
+    chooseOrder: false
+};
+
 const defaultSettings = {
     disableGravatar: false,
     windowTimer: 10,
@@ -28,6 +32,7 @@ function getUserWithDefaultsSet(user) {
     }
 
     userToReturn.settings = Object.assign({}, defaultSettings, userToReturn.settings);
+    userToReturn.settings.keywordSettings = Object.assign({}, defaultKeywordSettings, userToReturn.settings.keywordSettings);
     userToReturn.settings.timerSettings = Object.assign({}, defaultTimerSettings, userToReturn.settings.timerSettings);
     userToReturn.permissions = Object.assign({}, userToReturn.permissions);
     userToReturn.promptedActionWindows = Object.assign({}, defaultWindows, userToReturn.promptedActionWindows);

--- a/server/settings.js
+++ b/server/settings.js
@@ -10,7 +10,8 @@ const defaultWindows = {
 };
 
 const defaultKeywordSettings = {
-    chooseOrder: false
+    chooseOrder: false,
+    chooseCards: false
 };
 
 const defaultSettings = {

--- a/test/helpers/gameflowwrapper.js
+++ b/test/helpers/gameflowwrapper.js
@@ -4,6 +4,7 @@ const _ = require('underscore');
 
 const Game = require('../../server/game/game.js');
 const PlayerInteractionWrapper = require('./playerinteractionwrapper.js');
+const Settings = require('../../server/settings.js');
 
 class GameFlowWrapper {
     constructor() {
@@ -17,8 +18,8 @@ class GameFlowWrapper {
             owner: 'player1',
             saveGameId: 12345,
             players: [
-                { id: '111', user: { username: 'player1' } },
-                { id: '222', user: { username: 'player2' } }
+                { id: '111', user: Settings.getUserWithDefaultsSet({ username: 'player1' }) },
+                { id: '222', user: Settings.getUserWithDefaultsSet({ username: 'player2' }) }
             ]
         };
         this.game = new Game(details, { router: gameRouter });

--- a/test/helpers/playerinteractionwrapper.js
+++ b/test/helpers/playerinteractionwrapper.js
@@ -131,6 +131,10 @@ class PlayerInteractionWrapper {
     togglePromptedActionWindow(window, value) {
         this.player.promptedActionWindows[window] = value;
     }
+
+    toggleKeywordSettings(setting, value) {
+        this.player.keywordSettings[setting] = value;
+    }
 }
 
 module.exports = PlayerInteractionWrapper;

--- a/test/server/gamesteps/actionwindow.spec.js
+++ b/test/server/gamesteps/actionwindow.spec.js
@@ -4,13 +4,14 @@
 const ActionWindow = require('../../../server/game/gamesteps/actionwindow.js');
 const Game = require('../../../server/game/game.js');
 const Player = require('../../../server/game/player.js');
+const Settings = require('../../../server/settings.js');
 
 describe('ActionWindow', function() {
     beforeEach(function() {
         this.gameRepository = jasmine.createSpyObj('gameRepository', ['save']);
         this.game = new Game('1', 'Test Game', { gameRepository: this.gameRepository });
-        this.player1 = new Player('1', { username: 'Player 1' }, true, this.game);
-        this.player2 = new Player('2', { username: 'Player 2' }, false, this.game);
+        this.player1 = new Player('1', Settings.getUserWithDefaultsSet({ username: 'Player 1' }), true, this.game);
+        this.player2 = new Player('2', Settings.getUserWithDefaultsSet({ username: 'Player 2' }), false, this.game);
         this.player2.firstPlayer = true;
         this.game.playersAndSpectators[this.player1.name] = this.player1;
         this.game.playersAndSpectators[this.player2.name] = this.player2;

--- a/test/server/integration/challengesphase.spec.js
+++ b/test/server/integration/challengesphase.spec.js
@@ -159,5 +159,101 @@ describe('challenges phase', function() {
                 expect(this.merchant.kneeled).toBe(true);
             });
         });
+
+        describe('when cards have keywords', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('tyrell', [
+                    'Sneak Attack',
+                    'Renly Baratheon (FFH)', 'Brienne of Tarth', 'Ser Garlan Tyrell (OR)', 'Garden Caretaker'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.renly = this.player1.findCardByName('Renly Baratheon', 'hand');
+                this.brienne = this.player1.findCardByName('Brienne of Tarth', 'hand');
+                this.garlan = this.player1.findCardByName('Ser Garlan Tyrell', 'hand');
+                this.chud = this.player1.findCardByName('Garden Caretaker', 'hand');
+
+                this.player1.dragCard(this.renly, 'play area');
+                this.player1.dragCard(this.brienne, 'play area');
+                this.player1.dragCard(this.garlan, 'play area');
+
+                this.completeSetup();
+
+                this.player1.selectPlot('Sneak Attack');
+                this.player2.selectPlot('Sneak Attack');
+                this.selectFirstPlayer(this.player2);
+
+                // Put the remaining card back in draw deck for insight
+                this.player1.dragCard(this.chud, 'draw deck');
+
+                this.completeMarshalPhase();
+
+                // Skip player 2's challenges
+                this.player2.clickPrompt('Done');
+
+                this.player1.clickPrompt('Power');
+                this.player1.clickCard(this.renly);
+                this.player1.clickCard(this.brienne);
+                this.player1.clickCard(this.garlan);
+                this.player1.clickPrompt('Done');
+
+                this.skipActionWindow();
+
+                // No defenders
+                this.player2.clickPrompt('Done');
+
+                this.skipActionWindow();
+            });
+
+            describe('when no settings are set', function() {
+                beforeEach(function() {
+                    this.player1.clickPrompt('Apply Claim');
+                    // Pass on Renly's ability
+                    this.player1.clickPrompt('Pass');
+                });
+
+                it('should apply all keywords automatically', function() {
+                    expect(this.chud.location).toBe('hand');
+                    expect(this.renly.power).toBe(1);
+                    expect(this.brienne.power).toBe(1);
+                    expect(this.garlan.power).toBe(1);
+                });
+            });
+
+            describe('and the first player wants to choose keyword order', function() {
+                beforeEach(function() {
+                    this.player2.toggleKeywordSettings('chooseOrder', true);
+
+                    this.player1.clickPrompt('Apply Claim');
+                });
+
+                it('should allow the first player to choose the order', function() {
+                    this.player2.clickPrompt('Insight');
+                    // Pass on Renly's ability
+                    this.player1.clickPrompt('Pass');
+
+                    expect(this.chud.location).toBe('hand');
+                    // No Renown power yet
+                    expect(this.player2).toHavePromptButton('Renown');
+                    expect(this.renly.power).toBe(0);
+                    expect(this.brienne.power).toBe(0);
+                    expect(this.garlan.power).toBe(0);
+                });
+
+                it('should allow the first player to process all keywords automatically', function() {
+                    this.player2.clickPrompt('Automatic');
+                    // Pass on Renly's ability
+                    this.player1.clickPrompt('Pass');
+
+                    expect(this.chud.location).toBe('hand');
+                    expect(this.renly.power).toBe(1);
+                    expect(this.brienne.power).toBe(1);
+                    expect(this.garlan.power).toBe(1);
+                });
+            });
+        });
     });
 });

--- a/test/server/integration/challengesphase.spec.js
+++ b/test/server/integration/challengesphase.spec.js
@@ -254,6 +254,30 @@ describe('challenges phase', function() {
                     expect(this.garlan.power).toBe(1);
                 });
             });
+
+            describe('and the winner wants to choose which cards', function() {
+                beforeEach(function() {
+                    this.player1.toggleKeywordSettings('chooseCards', true);
+
+                    this.player1.clickPrompt('Apply Claim');
+                });
+
+                it('should allow the winner to choose cards', function() {
+                    expect(this.player1).toHavePrompt('Select insight cards');
+                    this.player1.clickPrompt('Done');
+
+                    expect(this.chud.location).toBe('draw deck');
+
+                    expect(this.player1).toHavePrompt('Select renown cards');
+                    this.player1.clickCard(this.renly);
+                    this.player1.clickCard(this.garlan);
+                    this.player1.clickPrompt('Done');
+
+                    expect(this.renly.power).toBe(1);
+                    expect(this.brienne.power).toBe(0);
+                    expect(this.garlan.power).toBe(1);
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
* Adds profile options for choosing the order keywords are resolved as well as making keywords optional.
* When keywords are set as optional, the challenge winner are prompted to select which cards they want to trigger the individual keywords on. Clicking 'Done' without selecting any cards will skip that keyword.
![screen shot 2017-08-25 at 8 28 07 pm](https://user-images.githubusercontent.com/145077/29738277-d4d953da-89d3-11e7-996b-b4a45b510c94.png)
* When the first player has the option on to choose order, they get a prompt allowing to choose which keyword to resolve next. Choosing 'automatic' resolves all keywords without further prompting.
![screen shot 2017-08-25 at 8 23 48 pm](https://user-images.githubusercontent.com/145077/29738252-3b79c490-89d3-11e7-8f40-63ddfeff3e69.png)
* Does not add the keyword settings to the in-game options yet (which is where it would be most useful), because significant restyling would be required to fit it at lower screen resolutions and that would conflict with the gameboard UI redo.

Resolves #526 