### PR TITLE
remove the about-container class from about and profile pages

### DIFF
--- a/client/About.jsx
+++ b/client/About.jsx
@@ -9,7 +9,7 @@ class About extends React.Component {
                 <div className='panel-title text-center'>
                     About The Iron Throne - Help and information
                 </div>
-                <div className='panel about-container'>
+                <div className='panel'>
                     <a className='btn btn-danger btn-lg pull-right' target='_blank' href='https://github.com/cryogen/throneteki/issues'>Report Problems</a>
                     <h3>What is this?</h3>
 

--- a/client/HowToPlay.jsx
+++ b/client/HowToPlay.jsx
@@ -9,7 +9,7 @@ class HowToPlay extends React.Component {
                 <div className='panel-title text-center'>
                     How To Play on The Iron Throne
                 </div>
-                <div className='panel about-container'>
+                <div className='panel'>
                     <a className='btn btn-danger btn-lg pull-right' target='_blank' href='https://github.com/cryogen/throneteki/issues'>Report Problems</a>
 
                     <p>This guide is aimed at players familiar with the A Game of Thrones: The Card Game 2nd Edition who want to start playing online using The Iron Throne platform. If you are new to this cardgame in general, there is a <a href='https://www.youtube.com/watch?v=A1s54Wlgfyo' target='_blank'>helpful tutorial video</a>, a <a href='https://images-cdn.fantasyflightgames.com/filer_public/ba/2a/ba2a5ea6-a3cd-4772-a603-6f1906f63053/gt01_learn-to-play-web.pdf' target='_blank'>Learn To Play guide</a>, and a <a href='http://thronesdb.com/rulesreference' target='_blank'>Rules Reference Guide</a> to help you out.</p>

--- a/client/Profile.jsx
+++ b/client/Profile.jsx
@@ -203,7 +203,7 @@ class InnerProfile extends React.Component {
 
         return (
             <div className='col-sm-8 col-sm-offset-2 profile full-height'>
-                <div className='about-container'>
+                <div>
                     { this.state.errorMessage ? <AlertPanel type='error' message={ this.state.errorMessage } /> : null }
                     { this.state.successMessage ? <AlertPanel type='success' message={ this.state.successMessage } /> : null }
                     <form className='form form-horizontal'>


### PR DESCRIPTION
Doing so removes the overkill vertical scroll bar from the About, How to Play,
and Profile pages.