### PR TITLE
Snapshot card state when killed or sacrificed

### DIFF
--- a/server/game/cards/attachments/04/theboyking.js
+++ b/server/game/cards/attachments/04/theboyking.js
@@ -7,7 +7,7 @@ class TheBoyKing extends DrawCard {
         });
         this.reaction({
             when: {
-                onCharacterKilled: event => event.card.getCost() <= 3
+                onCharacterKilled: event => event.card.getPrintedCost() <= 3
             },
             cost: ability.costs.kneelSelf(),
             handler: () => {

--- a/server/game/cards/characters/01/joffreybaratheon.js
+++ b/server/game/cards/characters/01/joffreybaratheon.js
@@ -4,7 +4,10 @@ class JoffreyBaratheon extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onCharacterKilled: event => event.card.getType() === 'character' && (event.card.hasTrait('Lord') || event.card.hasTrait('Lady'))
+                onCharacterKilled: event => (
+                    event.card.getType() === 'character' &&
+                    (event.cardStateWhenKilled.hasTrait('Lord') || event.cardStateWhenKilled.hasTrait('Lady'))
+                )
             },
             limit: ability.limit.perRound(3),
             handler: () => {

--- a/server/game/cards/characters/01/robbstark.js
+++ b/server/game/cards/characters/01/robbstark.js
@@ -6,7 +6,7 @@ class RobbStark extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onCharacterKilled: event => this.isStarkCharacter(event.card),
+                onCharacterKilled: event => this.isStarkCharacter(event.cardStateWhenKilled),
                 onSacrificed: event => this.isStarkCharacter(event.card)
             },
             limit: ability.limit.perRound(1),
@@ -25,8 +25,7 @@ class RobbStark extends DrawCard {
         return (
             card.controller === this.controller &&
             card.isFaction('stark') &&
-            card.getType() === 'character' &&
-            card !== this
+            card.getType() === 'character'
         );
     }
 }

--- a/server/game/cards/characters/01/robbstark.js
+++ b/server/game/cards/characters/01/robbstark.js
@@ -7,7 +7,7 @@ class RobbStark extends DrawCard {
         this.reaction({
             when: {
                 onCharacterKilled: event => this.isStarkCharacter(event.cardStateWhenKilled),
-                onSacrificed: event => this.isStarkCharacter(event.card)
+                onSacrificed: event => this.isStarkCharacter(event.cardStateWhenSacrificed)
             },
             limit: ability.limit.perRound(1),
             handler: () => {

--- a/server/game/cards/characters/03/aryastark.js
+++ b/server/game/cards/characters/03/aryastark.js
@@ -5,8 +5,8 @@ class AryaStark extends DrawCard {
         this.reaction({
             when: {
                 onCharacterKilled: event => (
-                    this.controller === event.card.controller &&
-                    event.card.isFaction('stark'))
+                    event.cardStateWhenKilled.controller === this.controller &&
+                    event.cardStateWhenKilled.isFaction('stark'))
             },
             cost: ability.costs.sacrificeSelf(),
             handler: () => {

--- a/server/game/cards/characters/03/catelynstark.js
+++ b/server/game/cards/characters/03/catelynstark.js
@@ -4,8 +4,8 @@ class CatelynStark extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onSacrificed: event => this.starkCharacterSacrificedOrKilled(event, event.card),
-                onCharacterKilled: event => this.starkCharacterSacrificedOrKilled(event, event.card)
+                onSacrificed: event => this.starkCharacterSacrificedOrKilled(event.card),
+                onCharacterKilled: event => this.starkCharacterSacrificedOrKilled(event.cardStateWhenKilled)
             },
             limit: ability.limit.perRound(2),
             handler: () => {
@@ -19,10 +19,9 @@ class CatelynStark extends DrawCard {
         });
     }
 
-    starkCharacterSacrificedOrKilled(event, card) {
+    starkCharacterSacrificedOrKilled(card) {
         return (
             this.controller === card.controller &&
-            card !== this &&
             card.isFaction('stark') &&
             card.getType() === 'character'
         );

--- a/server/game/cards/characters/03/catelynstark.js
+++ b/server/game/cards/characters/03/catelynstark.js
@@ -4,7 +4,7 @@ class CatelynStark extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onSacrificed: event => this.starkCharacterSacrificedOrKilled(event.card),
+                onSacrificed: event => this.starkCharacterSacrificedOrKilled(event.cardStateWhenSacrificed),
                 onCharacterKilled: event => this.starkCharacterSacrificedOrKilled(event.cardStateWhenKilled)
             },
             limit: ability.limit.perRound(2),

--- a/server/game/cards/characters/06/margaerytyrell.js
+++ b/server/game/cards/characters/06/margaerytyrell.js
@@ -4,9 +4,11 @@ class MargaeryTyrell extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onCharacterKilled: event => {
-                    return event.card.isUnique() && (event.card.hasTrait('king') || event.card.hasTrait('lord')) && event.card.controller === this.controller;
-                }
+                onCharacterKilled: event => (
+                    event.card.isUnique() &&
+                    (event.cardStateWhenKilled.hasTrait('king') || event.cardStateWhenKilled.hasTrait('lord')) &&
+                    event.cardStateWhenKilled.controller === this.controller
+                )
             },
             limit: ability.limit.perRound(1),
             handler: () => {

--- a/server/game/cards/events/02/funeralpyre.js
+++ b/server/game/cards/events/02/funeralpyre.js
@@ -4,7 +4,7 @@ class FuneralPyre extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onCharacterKilled: event => event.card.hasTrait('Lord') || event.card.hasTrait('Lady')
+                onCharacterKilled: event => event.cardStateWhenKilled.hasTrait('Lord') || event.cardStateWhenKilled.hasTrait('Lady')
             },
             cost: ability.costs.kneelFactionCard(),
             handler: () => {

--- a/server/game/cards/events/03/ashardaswinter.js
+++ b/server/game/cards/events/03/ashardaswinter.js
@@ -4,17 +4,17 @@ class AsHardAsWinter extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onSacrificed: event => this.checkConditionsAndSaveCharacter(event.card),
-                onCharacterKilled: (event) => this.checkConditionsAndSaveCharacter(event.card)
+                onSacrificed: event => this.hasUsedWinterPlot() && this.starkCharacterSacrificedOrKilled(event.card),
+                onCharacterKilled: event => this.hasUsedWinterPlot() && this.starkCharacterSacrificedOrKilled(event.cardStateWhenKilled)
             },
 
             target: {
                 activePromptTitle: 'Select a character',
-                cardCondition: card => (
+                cardCondition: (card, context) => (
                     card.location === 'hand' &&
                     card.getType() === 'character' &&
-                    card.isFaction('stark') && 
-                    card.getCost() <= this.triggerCard.getCost()
+                    card.isFaction('stark') &&
+                    card.getCost() <= context.event.card.getCost()
                 )
             },
 
@@ -23,16 +23,6 @@ class AsHardAsWinter extends DrawCard {
                 this.game.addMessage('{0} uses {1} to put into play {2} for free in reaction to a {3} character being sacrificed or killed', this.controller, this, context.target, 'stark');
             }
         });
-    }
-
-    checkConditionsAndSaveCharacter(card) {
-        if(this.hasUsedWinterPlot() && this.starkCharacterSacrificedOrKilled(card)) {
-            this.triggerCard = card;
-
-            return true;
-        }
-
-        return false;
     }
 
     hasUsedWinterPlot() {

--- a/server/game/cards/events/03/ashardaswinter.js
+++ b/server/game/cards/events/03/ashardaswinter.js
@@ -4,7 +4,7 @@ class AsHardAsWinter extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onSacrificed: event => this.hasUsedWinterPlot() && this.starkCharacterSacrificedOrKilled(event.card),
+                onSacrificed: event => this.hasUsedWinterPlot() && this.starkCharacterSacrificedOrKilled(event.cardStateWhenSacrificed),
                 onCharacterKilled: event => this.hasUsedWinterPlot() && this.starkCharacterSacrificedOrKilled(event.cardStateWhenKilled)
             },
 

--- a/server/game/cards/events/06/thenorthremembers.js
+++ b/server/game/cards/events/06/thenorthremembers.js
@@ -20,7 +20,7 @@ class TheNorthRemembers extends DrawCard {
         this.reaction({
             location: 'discard pile',
             when: {
-                onCharacterKilled: event => event.card.controller === this.controller
+                onCharacterKilled: event => event.cardStateWhenKilled.controller === this.controller
             },
             ignoreEventCosts: true,
             cost: ability.costs.payGold(1),

--- a/server/game/cards/locations/02/winterfellcrypt.js
+++ b/server/game/cards/locations/02/winterfellcrypt.js
@@ -4,8 +4,8 @@ class WinterfellCrypt extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onSacrificed: event => this.triggerCondition(event),
-                onCharacterKilled: event => this.triggerCondition(event)
+                onSacrificed: event => this.triggerCondition(event.card),
+                onCharacterKilled: event => this.triggerCondition(event.cardStateWhenKilled)
             },
             cost: ability.costs.sacrificeSelf(),
             target: {
@@ -25,9 +25,9 @@ class WinterfellCrypt extends DrawCard {
         });
     }
 
-    triggerCondition(event) {
-        return (event.card.controller === this.controller && event.card.isUnique() && event.card.isFaction('stark') &&
-                event.card.getType() === 'character' && this.game.currentPhase === 'challenge');
+    triggerCondition(card) {
+        return (card.controller === this.controller && card.isUnique() && card.isFaction('stark') &&
+                card.getType() === 'character' && this.game.currentPhase === 'challenge');
     }
 }
 

--- a/server/game/cards/locations/02/winterfellcrypt.js
+++ b/server/game/cards/locations/02/winterfellcrypt.js
@@ -4,7 +4,7 @@ class WinterfellCrypt extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onSacrificed: event => this.triggerCondition(event.card),
+                onSacrificed: event => this.triggerCondition(event.cardStateWhenSacrificed),
                 onCharacterKilled: event => this.triggerCondition(event.cardStateWhenKilled)
             },
             cost: ability.costs.sacrificeSelf(),

--- a/server/game/cards/plots/07/thewhiteshadows.js
+++ b/server/game/cards/plots/07/thewhiteshadows.js
@@ -4,7 +4,7 @@ class TheWhiteShadows extends PlotCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onCharacterKilled: event => this.controller !== event.card.controller
+                onCharacterKilled: event => this.controller !== event.cardStateWhenKilled.controller
             },
             handler: context => {
                 this.controller.putIntoPlay(context.event.card);

--- a/server/game/cardsnapshot.js
+++ b/server/game/cardsnapshot.js
@@ -1,0 +1,68 @@
+const _ = require('underscore');
+
+class CardSnapshot {
+    constructor(card) {
+        this.controller = card.controller;
+        this.factions = _.clone(card.factions);
+        this.keywords = _.clone(card.keywords);
+        this.location = card.location;
+        this.parent = card.parent;
+        this.power = card.power;
+        this.strength = card.getStrength();
+        this.tokens = _.clone(card.tokens);
+        this.traits = _.clone(card.traits);
+        this.type = card.getType();
+
+        this.proxyCardMethods(card);
+    }
+
+    proxyCardMethods(card) {
+        const proxiedMethods = [
+            'getCost', 'getPrintedCost', 'getPrintedFaction', 'getPrintedType',
+            'hasPrintedKeyword', 'isLoyal', 'isUnique'
+        ];
+
+        proxiedMethods.forEach(method => {
+            this[method] = (...args) => {
+                card[method](...args);
+            };
+        });
+    }
+
+    getFactions() {
+        return _.keys(this.factions);
+    }
+
+    getStrength() {
+        return this.strength;
+    }
+
+    getType() {
+        return this.type;
+    }
+
+    hasKeyword(keyword) {
+        let keywordCount = this.keywords[keyword.toLowerCase()] || 0;
+        return keywordCount > 0;
+    }
+
+    hasToken(type) {
+        return !!this.tokens[type];
+    }
+
+    hasTrait(trait) {
+        return !!this.traits[trait.toLowerCase()];
+    }
+
+    isFaction(faction) {
+        let normalizedFaction = faction.toLowerCase();
+
+        if(normalizedFaction === 'neutral') {
+            return !!this.factions[normalizedFaction] && _.size(this.factions) === 1;
+        }
+
+        return !!this.factions[normalizedFaction];
+    }
+}
+
+module.exports = CardSnapshot;

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -1,6 +1,7 @@
 const _ = require('underscore');
 
 const BaseCard = require('./basecard.js');
+const CardSnapshot = require('./cardsnapshot.js');
 const SetupCardAction = require('./setupcardaction.js');
 const MarshalCardAction = require('./marshalcardaction.js');
 const AmbushCardAction = require('./ambushcardaction.js');
@@ -56,6 +57,10 @@ class DrawCard extends BaseCard {
         };
         this.stealthLimit = 1;
         this.minCost = 0;
+    }
+
+    createSnapshot() {
+        return new CardSnapshot(this);
     }
 
     canBeDuplicated() {

--- a/server/game/gamesteps/killcharacters.js
+++ b/server/game/gamesteps/killcharacters.js
@@ -92,6 +92,7 @@ class KillCharacters extends BaseStep {
             return;
         }
 
+        event.cardStateWhenKilled = card.createSnapshot();
         player.moveCard(card, 'dead pile');
         this.game.addMessage('{0} kills {1}', player, card);
     }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -843,7 +843,8 @@ class Player extends Spectator {
 
     sacrificeCard(card) {
         this.game.applyGameAction('sacrifice', card, card => {
-            this.game.raiseEvent('onSacrificed', { player: this, card: card }, () => {
+            this.game.raiseEvent('onSacrificed', { player: this, card: card }, event => {
+                event.cardStateWhenSacrificed = card.createSnapshot();
                 this.moveCard(card, 'discard pile');
             });
         });


### PR DESCRIPTION
Previously, card abilities that reacted to cards being killed could fire
inappropriately or not at all. The controller for cards under take
control would revert to their owners before the ability would fire.
Additionally, if the ability depended on traits or other effects
contributed by attachments, those traits would be lost before the
ability fired (e.g. AMaF Margaery reacting to a card being killed with a
King attachment).

Now, the onCharacterKilled event automatically records the state of the
card being killed on the `cardStateWhenKilled` property.

It is also snapshots for the onSacrificed event on the `cardStateWhenSacrificed` property.

Fixes #837 
Fixes #1222 
Fixes #1386 
Partial for #1351 