### PR TITLE
Add a callback for moveCard 

### DIFF
--- a/server/game/cards/characters/01/benjenstark.js
+++ b/server/game/cards/characters/01/benjenstark.js
@@ -15,8 +15,9 @@ class BenjenStark extends DrawCard {
                 this.game.addMessage('{0} uses {1} to gain 2 power for their faction and shuffles {1} back into their deck instead of placing it in their dead pile', this.controller, this);
 
                 this.game.addPower(this.controller, 2);
-                this.controller.moveCard(this, 'draw deck');
-                this.controller.shuffleDrawDeck();
+                this.controller.moveCard(this, 'draw deck', {}, () => {
+                    this.controller.shuffleDrawDeck();
+                });
             }
         });
     }

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -509,9 +509,10 @@ const Effects = {
             unapply: function(card, context) {
                 if(card.location === 'play area' && context.shuffleIntoDeckIfStillInPlay.includes(card)) {
                     context.shuffleIntoDeckIfStillInPlay = _.reject(context.shuffleIntoDeckIfStillInPlay, c => c === card);
-                    card.owner.moveCard(card, 'draw deck');
-                    card.owner.shuffleDrawDeck();
-                    context.game.addMessage('{0} shuffles {1} into their deck at the end of the phase because of {2}', card.owner, card, context.source);
+                    card.owner.moveCard(card, 'draw deck', {}, () => {
+                        card.owner.shuffleDrawDeck();
+                        context.game.addMessage('{0} shuffles {1} into their deck at the end of the phase because of {2}', card.owner, card, context.source);
+                    });
                 }
             }
         };

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -961,7 +961,7 @@ class Player extends Spectator {
         this.faction.cardData.strength = 0;
     }
 
-    moveCard(card, targetLocation, options = {}) {
+    moveCard(card, targetLocation, options = {}, callback) {
         let targetPile = this.getSourceList(targetLocation);
 
         options = _.extend({ allowSave: false, bottom: false, isDupe: false }, options);
@@ -985,11 +985,18 @@ class Player extends Spectator {
 
             this.game.raiseEvent('onCardLeftPlay', params, () => {
                 this.synchronousMoveCard(card, targetLocation, options);
+
+                if(callback) {
+                    callback();
+                }
             });
             return;
         }
 
         this.synchronousMoveCard(card, targetLocation, options);
+        if(callback) {
+            callback();
+        }
     }
 
     synchronousMoveCard(card, targetLocation, options = {}) {


### PR DESCRIPTION
because it's not always synchronous and modify card effects to use the callback when shuffling cards into deck from the play area

Fixes cards like benjen stark who liked to put himself to the top of the deck instead of shuffling.  Could be extended to every use of shuffle but only really matters for cards in play