### PR TITLE
Remove additional pile mechanism

### DIFF
--- a/client/GameBoard.jsx
+++ b/client/GameBoard.jsx
@@ -245,7 +245,7 @@ export class InnerGameBoard extends React.Component {
             return [];
         }
 
-        let sortedCards = _.sortBy(player.cardsInPlay, card => {
+        let sortedCards = _.sortBy(player.cardPiles.cardsInPlay, card => {
             return card.type;
         });
 
@@ -278,7 +278,7 @@ export class InnerGameBoard extends React.Component {
 
         return (
             <CardPile
-                cards={ player.schemePlots }
+                cards={ player.cardPiles.schemePlots }
                 className='plot'
                 disablePopup={ !isMe }
                 onCardClick={ this.onCardClick }
@@ -300,20 +300,20 @@ export class InnerGameBoard extends React.Component {
             <div className='plot-group'>
                 { this.getSchemePile(otherPlayer, false) }
                 <CardPile className={ otherPlayer && otherPlayer.plotSelected ? 'plot plot-selected' : 'plot' }
-                    title='Plots' source='plot deck' cards={ otherPlayer ? otherPlayer.plotDeck : [] }
+                    title='Plots' source='plot deck' cards={ otherPlayer ? otherPlayer.cardPiles.plotDeck : [] }
                     topCard={ { facedown: true, kneeled: true } } orientation='horizontal'
                     onMouseOver={ this.onMouseOver } onMouseOut={ this.onMouseOut } disableMouseOver disablePopup
                     onCardClick={ this.onCardClick } orientation='horizontal' />
-                <CardPile className='plot' title='Used Plots' source='revealed plots' cards={ otherPlayer ? otherPlayer.plotDiscard : [] }
+                <CardPile className='plot' title='Used Plots' source='revealed plots' cards={ otherPlayer ? otherPlayer.cardPiles.plotDiscard : [] }
                     topCard={ otherPlayer ? otherPlayer.activePlot : undefined } orientation='horizontal' onMouseOver={ this.onMouseOver }
                     onMouseOut={ this.onMouseOut } onCardClick={ this.onCardClick } />
             </div>
             <div className='plot-group our-side'>
-                <CardPile className='plot' title='Used Plots' source='revealed plots' cards={ thisPlayer.plotDiscard } topCard={ thisPlayer.activePlot }
+                <CardPile className='plot' title='Used Plots' source='revealed plots' cards={ thisPlayer.cardPiles.plotDiscard } topCard={ thisPlayer.activePlot }
                     onMouseOver={ this.onMouseOver } onMouseOut={ this.onMouseOut } orientation='horizontal' onMenuItemClick={ this.onMenuItemClick }
                     onCardClick={ this.onCardClick } onDragDrop={ this.onDragDrop } />
                 <CardPile className={ thisPlayer.plotSelected ? 'plot plot-selected' : 'plot' }
-                    title='Plots' source='plot deck' cards={ thisPlayer.plotDeck } topCard={ { facedown: true, kneeled: true } } orientation='horizontal'
+                    title='Plots' source='plot deck' cards={ thisPlayer.cardPiles.plotDeck } topCard={ { facedown: true, kneeled: true } } orientation='horizontal'
                     onMouseOver={ this.onMouseOver } onMouseOut={ this.onMouseOut } onCardClick={ this.onCardClick } onDragDrop={ this.onDragDrop }
                     closeOnClick />
                 { this.getSchemePile(thisPlayer, !this.state.spectating) }
@@ -446,17 +446,17 @@ export class InnerGameBoard extends React.Component {
                         <div className='player-home-row'>
                             <PlayerRow
                                 agenda={ otherPlayer ? otherPlayer.agenda : null }
-                                bannerCards={ otherPlayer ? otherPlayer.bannerCards : [] }
-                                conclavePile={ otherPlayer ? otherPlayer.conclavePile : [] }
+                                bannerCards={ otherPlayer ? otherPlayer.cardPiles.bannerCards : [] }
+                                conclavePile={ otherPlayer ? otherPlayer.cardPiles.conclavePile : [] }
                                 faction={ otherPlayer ? otherPlayer.faction : null }
-                                hand={ otherPlayer ? otherPlayer.hand : [] } isMe={ false }
+                                hand={ otherPlayer ? otherPlayer.cardPiles.hand : [] } isMe={ false }
                                 numDrawCards={ otherPlayer ? otherPlayer.numDrawCards : 0 }
-                                discardPile={ otherPlayer ? otherPlayer.discardPile : [] }
-                                deadPile={ otherPlayer ? otherPlayer.deadPile : [] }
+                                discardPile={ otherPlayer ? otherPlayer.cardPiles.discardPile : [] }
+                                deadPile={ otherPlayer ? otherPlayer.cardPiles.deadPile : [] }
                                 onCardClick={ this.onCardClick }
                                 onMouseOver={ this.onMouseOver }
                                 onMouseOut={ this.onMouseOut }
-                                outOfGamePile={ otherPlayer ? otherPlayer.outOfGamePile : [] } />
+                                outOfGamePile={ otherPlayer ? otherPlayer.cardPiles.outOfGamePile : [] } />
                         </div>
                         <div className='board-inner'>
                             <div className='prompt-area'>
@@ -485,10 +485,10 @@ export class InnerGameBoard extends React.Component {
                         <div className='player-home-row our-side'>
                             <PlayerRow isMe={ !this.state.spectating }
                                 agenda={ thisPlayer.agenda }
-                                bannerCards={ thisPlayer.bannerCards }
-                                conclavePile={ thisPlayer.conclavePile }
+                                bannerCards={ thisPlayer.cardPiles.bannerCards }
+                                conclavePile={ thisPlayer.cardPiles.conclavePile }
                                 faction={ thisPlayer.faction }
-                                hand={ thisPlayer.hand }
+                                hand={ thisPlayer.cardPiles.hand }
                                 onCardClick={ this.onCardClick }
                                 onMouseOver={ this.onMouseOver }
                                 onMouseOut={ this.onMouseOut }
@@ -496,12 +496,12 @@ export class InnerGameBoard extends React.Component {
                                 onDrawClick={ this.onDrawClick }
                                 onFactionCardClick={ this.onFactionCardClick.bind(this) }
                                 onShuffleClick={ this.onShuffleClick }
-                                outOfGamePile={ thisPlayer.outOfGamePile }
+                                outOfGamePile={ thisPlayer.cardPiles.outOfGamePile }
                                 showDrawDeck={ this.state.showDrawDeck }
-                                drawDeck={ thisPlayer.drawDeck }
+                                drawDeck={ thisPlayer.cardPiles.drawDeck }
                                 onDragDrop={ this.onDragDrop }
-                                discardPile={ thisPlayer.discardPile }
-                                deadPile={ thisPlayer.deadPile }
+                                discardPile={ thisPlayer.cardPiles.discardPile }
+                                deadPile={ thisPlayer.cardPiles.deadPile }
                                 spectating={ this.state.spectating }
                                 onMenuItemClick={ this.onMenuItemClick } />
                         </div>

--- a/client/GameBoard.jsx
+++ b/client/GameBoard.jsx
@@ -272,15 +272,13 @@ export class InnerGameBoard extends React.Component {
     }
 
     getSchemePile(player, isMe) {
-        let schemePile = player && player.additionalPiles['scheme plots'];
-
-        if(!schemePile) {
+        if(!player || !player.agenda || player.agenda.code !== '05045') {
             return;
         }
 
         return (
             <CardPile
-                cards={ schemePile.cards }
+                cards={ player.schemePlots }
                 className='plot'
                 disablePopup={ !isMe }
                 onCardClick={ this.onCardClick }
@@ -447,9 +445,9 @@ export class InnerGameBoard extends React.Component {
                     <div className='board-middle'>
                         <div className='player-home-row'>
                             <PlayerRow
-                                additionalPiles={ otherPlayer ? otherPlayer.additionalPiles : {} }
                                 agenda={ otherPlayer ? otherPlayer.agenda : null }
                                 bannerCards={ otherPlayer ? otherPlayer.bannerCards : [] }
+                                conclavePile={ otherPlayer ? otherPlayer.conclavePile : [] }
                                 faction={ otherPlayer ? otherPlayer.faction : null }
                                 hand={ otherPlayer ? otherPlayer.hand : [] } isMe={ false }
                                 numDrawCards={ otherPlayer ? otherPlayer.numDrawCards : 0 }
@@ -457,7 +455,8 @@ export class InnerGameBoard extends React.Component {
                                 deadPile={ otherPlayer ? otherPlayer.deadPile : [] }
                                 onCardClick={ this.onCardClick }
                                 onMouseOver={ this.onMouseOver }
-                                onMouseOut={ this.onMouseOut } />
+                                onMouseOut={ this.onMouseOut }
+                                outOfGamePile={ otherPlayer ? otherPlayer.outOfGamePile : [] } />
                         </div>
                         <div className='board-inner'>
                             <div className='prompt-area'>
@@ -485,9 +484,9 @@ export class InnerGameBoard extends React.Component {
                         </div>
                         <div className='player-home-row our-side'>
                             <PlayerRow isMe={ !this.state.spectating }
-                                additionalPiles={ thisPlayer.additionalPiles }
                                 agenda={ thisPlayer.agenda }
                                 bannerCards={ thisPlayer.bannerCards }
+                                conclavePile={ thisPlayer.conclavePile }
                                 faction={ thisPlayer.faction }
                                 hand={ thisPlayer.hand }
                                 onCardClick={ this.onCardClick }
@@ -497,6 +496,7 @@ export class InnerGameBoard extends React.Component {
                                 onDrawClick={ this.onDrawClick }
                                 onFactionCardClick={ this.onFactionCardClick.bind(this) }
                                 onShuffleClick={ this.onShuffleClick }
+                                outOfGamePile={ thisPlayer.outOfGamePile }
                                 showDrawDeck={ this.state.showDrawDeck }
                                 drawDeck={ thisPlayer.drawDeck }
                                 onDragDrop={ this.onDragDrop }

--- a/client/GameComponents/PlayerRow.jsx
+++ b/client/GameComponents/PlayerRow.jsx
@@ -51,15 +51,15 @@ class PlayerRow extends React.Component {
     }
 
     getOutOfGamePile() {
-        let pile = this.props.additionalPiles['out of game'];
+        let pile = this.props.outOfGamePile;
 
-        if(!pile || pile.cards.length === 0) {
+        if(pile.length === 0) {
             return;
         }
 
         return (
             <CardPile
-                cards={ pile.cards }
+                cards={ pile }
                 className='additional-cards'
                 onCardClick={ this.props.onCardClick }
                 onDragDrop={ this.props.onDragDrop }
@@ -88,8 +88,7 @@ class PlayerRow extends React.Component {
             cards = this.props.bannerCards;
             title = 'Banners';
         } else if(this.props.agenda.code === '09045') {
-            let pile = this.props.additionalPiles['conclave'];
-            cards = pile.cards;
+            cards = this.props.conclavePile;
             source = 'conclave';
             title = 'Conclave';
             disablePopup = !this.props.isMe;
@@ -160,9 +159,9 @@ class PlayerRow extends React.Component {
 
 PlayerRow.displayName = 'PlayerRow';
 PlayerRow.propTypes = {
-    additionalPiles: React.PropTypes.object,
     agenda: React.PropTypes.object,
     bannerCards: React.PropTypes.array,
+    conclavePile: React.PropTypes.array,
     deadPile: React.PropTypes.array,
     discardPile: React.PropTypes.array,
     drawDeck: React.PropTypes.array,
@@ -178,6 +177,7 @@ PlayerRow.propTypes = {
     onMouseOut: React.PropTypes.func,
     onMouseOver: React.PropTypes.func,
     onShuffleClick: React.PropTypes.func,
+    outOfGamePile: React.PropTypes.array,
     plotDeck: React.PropTypes.array,
     power: React.PropTypes.number,
     showDrawDeck: React.PropTypes.bool,

--- a/server/game/cards/agendas/theconclave.js
+++ b/server/game/cards/agendas/theconclave.js
@@ -6,7 +6,6 @@ class TheConclave extends AgendaCard {
     constructor(owner, cardData) {
         super(owner, cardData);
 
-        this.owner.createAdditionalPile('conclave', { isPrivate: true });
         this.registerEvents(['onPlayerKeepHandOrMulligan']);
     }
 

--- a/server/game/cards/agendas/therainsofcastamere.js
+++ b/server/game/cards/agendas/therainsofcastamere.js
@@ -41,7 +41,6 @@ class TheRainsOfCastamere extends AgendaCard {
     }
 
     onDecksPrepared() {
-        this.owner.createAdditionalPile('scheme plots', { isPrivate: true });
         var schemePartition = this.owner.plotDeck.partition(card => card.hasTrait('Scheme'));
         this.schemes = schemePartition[0];
         this.owner.plotDeck = _(schemePartition[1]);

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -749,8 +749,8 @@ class Player extends Spectator {
             case 'out of game':
                 return this.outOfGamePile;
             // Agenda specific piles
-            case 'schemes plots':
-                return this.schemesPlots;
+            case 'scheme plots':
+                return this.schemePlots;
             case 'conclave':
                 return this.conclavePile;
         }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -1201,28 +1201,30 @@ class Player extends Spectator {
         let state = {
             activePlot: this.activePlot ? this.activePlot.getSummary(activePlayer) : undefined,
             agenda: this.agenda ? this.agenda.getSummary(activePlayer) : undefined,
-            bannerCards: this.getSummaryForCardList(this.bannerCards, activePlayer),
-            cardsInPlay: this.getSummaryForCardList(this.cardsInPlay, activePlayer),
-            conclavePile: this.getSummaryForCardList(this.conclavePile, activePlayer, true),
-            deadPile: this.getSummaryForCardList(this.deadPile, activePlayer).reverse(),
-            discardPile: this.getSummaryForCardList(this.discardPile, activePlayer).reverse(),
+            cardPiles: {
+                bannerCards: this.getSummaryForCardList(this.bannerCards, activePlayer),
+                cardsInPlay: this.getSummaryForCardList(this.cardsInPlay, activePlayer),
+                conclavePile: this.getSummaryForCardList(this.conclavePile, activePlayer, true),
+                deadPile: this.getSummaryForCardList(this.deadPile, activePlayer).reverse(),
+                discardPile: this.getSummaryForCardList(this.discardPile, activePlayer).reverse(),
+                hand: this.getSummaryForCardList(this.hand, activePlayer, true),
+                outOfGamePile: this.getSummaryForCardList(this.outOfGamePile, activePlayer, false),
+                plotDeck: this.getSummaryForCardList(this.plotDeck, activePlayer, true),
+                plotDiscard: this.getSummaryForCardList(this.plotDiscard, activePlayer),
+                schemePlots: this.getSummaryForCardList(this.schemePlots, activePlayer, true)
+            },
             disconnected: this.disconnected,
             faction: this.faction.getSummary(activePlayer),
             firstPlayer: this.firstPlayer,
-            hand: this.getSummaryForCardList(this.hand, activePlayer, true),
             id: this.id,
             keywordSettings: this.keywordSettings,
             left: this.left,
             numDrawCards: this.drawDeck.size(),
             name: this.name,
             numPlotCards: this.plotDeck.size(),
-            outOfGamePile: this.getSummaryForCardList(this.outOfGamePile, activePlayer, false),
             phase: this.phase,
-            plotDeck: this.getSummaryForCardList(this.plotDeck, activePlayer, true),
-            plotDiscard: this.getSummaryForCardList(this.plotDiscard, activePlayer),
             plotSelected: !!this.selectedPlot,
             promptedActionWindows: this.promptedActionWindows,
-            schemePlots: this.getSummaryForCardList(this.schemePlots, activePlayer, true),
             stats: this.getStats(isActivePlayer),
             timerSettings: this.timerSettings,
             user: _.omit(this.user, ['password', 'email'])
@@ -1230,7 +1232,7 @@ class Player extends Spectator {
 
         if(this.showDeck) {
             state.showDeck = true;
-            state.drawDeck = this.getSummaryForCardList(this.drawDeck, activePlayer);
+            state.cardPiles.drawDeck = this.getSummaryForCardList(this.drawDeck, activePlayer);
         }
 
         return _.extend(state, promptState);

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -24,7 +24,11 @@ class Player extends Spectator {
         this.cardsInPlay = _([]);
         this.deadPile = _([]);
         this.discardPile = _([]);
-        this.additionalPiles = {};
+        this.outOfGamePile = _([]);
+
+        // Agenda specific piles
+        this.schemePlots = _([]);
+        this.conclavePile = _([]);
 
         this.faction = new DrawCard(this, {});
 
@@ -52,8 +56,6 @@ class Player extends Spectator {
         this.timerSettings = user.settings.timerSettings || {};
         this.timerSettings.windowTimer = user.settings.windowTimer;
         this.keywordSettings = user.settings.keywordSettings;
-
-        this.createAdditionalPile('out of game');
 
         this.promptState = new PlayerPromptState();
     }
@@ -744,15 +746,14 @@ class Player extends Spectator {
                 return this.plotDeck;
             case 'revealed plots':
                 return this.plotDiscard;
-            default:
-                if(this.additionalPiles[source]) {
-                    return this.additionalPiles[source].cards;
-                }
+            case 'out of game':
+                return this.outOfGamePile;
+            // Agenda specific piles
+            case 'schemes plots':
+                return this.schemesPlots;
+            case 'conclave':
+                return this.conclavePile;
         }
-    }
-
-    createAdditionalPile(name, properties = {}) {
-        this.additionalPiles[name] = _.extend({ cards: _([]) }, properties);
     }
 
     updateSourceList(source, targetList) {
@@ -778,10 +779,15 @@ class Player extends Spectator {
             case 'revealed plots':
                 this.plotDiscard = targetList;
                 break;
-            default:
-                if(this.additionalPiles[source]) {
-                    this.additionalPiles[source].cards = targetList;
-                }
+            case 'out of game':
+                this.outOfGamePile = targetList;
+                break;
+            // Agenda specific piles
+            case 'scheme plots':
+                this.schemePlots = targetList;
+                break;
+            case 'conclave':
+                this.conclavePile = targetList;
         }
     }
 
@@ -1194,13 +1200,10 @@ class Player extends Spectator {
         let promptState = isActivePlayer ? this.promptState.getState() : {};
         let state = {
             activePlot: this.activePlot ? this.activePlot.getSummary(activePlayer) : undefined,
-            additionalPiles: _.mapObject(this.additionalPiles, pile => ({
-                isPrivate: pile.isPrivate,
-                cards: this.getSummaryForCardList(pile.cards, activePlayer, pile.isPrivate)
-            })),
             agenda: this.agenda ? this.agenda.getSummary(activePlayer) : undefined,
             bannerCards: this.getSummaryForCardList(this.bannerCards, activePlayer),
             cardsInPlay: this.getSummaryForCardList(this.cardsInPlay, activePlayer),
+            conclavePile: this.getSummaryForCardList(this.conclavePile, activePlayer, true),
             deadPile: this.getSummaryForCardList(this.deadPile, activePlayer).reverse(),
             discardPile: this.getSummaryForCardList(this.discardPile, activePlayer).reverse(),
             disconnected: this.disconnected,
@@ -1213,13 +1216,15 @@ class Player extends Spectator {
             numDrawCards: this.drawDeck.size(),
             name: this.name,
             numPlotCards: this.plotDeck.size(),
+            outOfGamePile: this.getSummaryForCardList(this.outOfGamePile, activePlayer, false),
             phase: this.phase,
             plotDeck: this.getSummaryForCardList(this.plotDeck, activePlayer, true),
             plotDiscard: this.getSummaryForCardList(this.plotDiscard, activePlayer),
             plotSelected: !!this.selectedPlot,
             promptedActionWindows: this.promptedActionWindows,
-            timerSettings: this.timerSettings,
+            schemePlots: this.getSummaryForCardList(this.schemePlots, activePlayer, true),
             stats: this.getStats(isActivePlayer),
+            timerSettings: this.timerSettings,
             user: _.omit(this.user, ['password', 'email'])
         };
 

--- a/test/client/GameBoard.spec.jsx
+++ b/test/client/GameBoard.spec.jsx
@@ -37,8 +37,8 @@ describe('the <GameBoard /> component', function() {
 
         component = ReactDOM.render(<InnerGameBoard />, node);
 
-        state.games.currentGame.players['1'] = { id: 1, name: '1', timerSettings: {} };
-        state.games.currentGame.players['2'] = { id: 2, name: '2', timerSettings: {} };
+        state.games.currentGame.players['1'] = { id: 1, name: '1', cardPiles: {}, timerSettings: {} };
+        state.games.currentGame.players['2'] = { id: 2, name: '2', cardPiles: {}, timerSettings: {} };
         state.socket.socket = jasmine.createSpyObj('socket', ['emit']);
         state.auth.username = '1';
         state.socket.username = '1';
@@ -60,7 +60,7 @@ describe('the <GameBoard /> component', function() {
     describe('when player has cards in play', function() {
         describe('that include locations followed by characters', function() {
             beforeEach(function() {
-                state.games.currentGame.players['1'].cardsInPlay = [
+                state.games.currentGame.players['1'].cardPiles.cardsInPlay = [
                     { uuid: '1', code: '00001', type: 'location', label: 'Test Location' },
                     { uuid: '2', code: '00002', type: 'character', label: 'Test Character' }
                 ];
@@ -79,7 +79,7 @@ describe('the <GameBoard /> component', function() {
 
         describe('that include characters followed by locations', function() {
             beforeEach(function() {
-                state.games.currentGame.players['1'].cardsInPlay = [
+                state.games.currentGame.players['1'].cardPiles.cardsInPlay = [
                     { uuid: '1', code: '00002', type: 'character', label: 'Test Character' },
                     { uuid: '2', code: '00001', type: 'location', label: 'Test Location' }
                 ];
@@ -98,7 +98,7 @@ describe('the <GameBoard /> component', function() {
 
         describe('that include characters mixed with locations', function() {
             beforeEach(function() {
-                state.games.currentGame.players['1'].cardsInPlay = [
+                state.games.currentGame.players['1'].cardPiles.cardsInPlay = [
                     { uuid: '2', code: '00002', type: 'character', label: 'Test Character' },
                     { uuid: '1', code: '00001', type: 'location', label: 'Test Location' },
                     { uuid: '3', code: '00003', type: 'character', label: 'Test Character2' }
@@ -121,11 +121,11 @@ describe('the <GameBoard /> component', function() {
     describe('when other player has cards in play', function() {
         describe('that include locations followed by characters', function() {
             beforeEach(function() {
-                state.games.currentGame.players['1'].cardsInPlay = [
+                state.games.currentGame.players['1'].cardPiles.cardsInPlay = [
                     { uuid: '1', code: '00001', type: 'location', label: 'Test Location' },
                     { uuid: '2', code: '00002', type: 'character', label: 'Test Character' }
                 ];
-                state.games.currentGame.players['2'].cardsInPlay = [
+                state.games.currentGame.players['2'].cardPiles.cardsInPlay = [
                     { uuid: '3', code: '00001', type: 'location', label: 'Test Location' },
                     { uuid: '4', code: '00002', type: 'character', label: 'Test Character' }
                 ];
@@ -144,11 +144,11 @@ describe('the <GameBoard /> component', function() {
 
         describe('that include characters followed by locations', function() {
             beforeEach(function() {
-                state.games.currentGame.players['1'].cardsInPlay = [
+                state.games.currentGame.players['1'].cardPiles.cardsInPlay = [
                     { uuid: '2', code: '00002', type: 'character', label: 'Test Character' },
                     { uuid: '1', code: '00001', type: 'location', label: 'Test Location' }
                 ];
-                state.games.currentGame.players['2'].cardsInPlay = [
+                state.games.currentGame.players['2'].cardPiles.cardsInPlay = [
                     { uuid: '4', code: '00002', type: 'character', label: 'Test Character' },
                     { uuid: '3', code: '00001', type: 'location', label: 'Test Location' }
                 ];
@@ -167,12 +167,12 @@ describe('the <GameBoard /> component', function() {
 
         describe('that include characters mixed with locations', function() {
             beforeEach(function() {
-                state.games.currentGame.players['1'].cardsInPlay = [
+                state.games.currentGame.players['1'].cardPiles.cardsInPlay = [
                     { uuid: '2', code: '00002', type: 'character', label: 'Test Character' },
                     { uuid: '1', code: '00001', type: 'location', label: 'Test Location' },
                     { uuid: '3', code: '00003', type: 'character', label: 'Test Character2' }
                 ];
-                state.games.currentGame.players['2'].cardsInPlay = [
+                state.games.currentGame.players['2'].cardPiles.cardsInPlay = [
                     { uuid: '5', code: '00002', type: 'character', label: 'Test Character' },
                     { uuid: '4', code: '00001', type: 'location', label: 'Test Location' },
                     { uuid: '6', code: '00003', type: 'character', label: 'Test Character2' }
@@ -193,11 +193,11 @@ describe('the <GameBoard /> component', function() {
 
         describe('when the control is re-rendered', function() {
             beforeEach(function() {
-                state.games.currentGame.players['1'].cardsInPlay = [
+                state.games.currentGame.players['1'].cardPiles.cardsInPlay = [
                     { uuid: '1', code: '00001', type: 'location', label: 'Test Location' },
                     { uuid: '2', code: '00002', type: 'character', label: 'Test Character' }
                 ];
-                state.games.currentGame.players['2'].cardsInPlay = [
+                state.games.currentGame.players['2'].cardPiles.cardsInPlay = [
                     { uuid: '3', code: '00001', type: 'location', label: 'Test Location' },
                     { uuid: '4', code: '00002', type: 'character', label: 'Test Character' }
                 ];
@@ -220,7 +220,7 @@ describe('the <GameBoard /> component', function() {
         describe('when there is no menu and the plot is clicked', function() {
             it('should show the used plot popup', function() {
                 state.games.state.players['1'].activePlot = { code: '00001' };
-                state.games.state.players['1'].plotDiscard = [];
+                state.games.state.players['1'].cardPiles.plotDiscard = [];
 
                 component = ReactDOM.render(<Provider store={ store }><GameBoard /></Provider>, node);
                 component = TestUtils.findRenderedComponentWithType(component, GameBoard).getWrappedInstance();
@@ -241,7 +241,7 @@ describe('the <GameBoard /> component', function() {
         xdescribe('when there is a menu and the plot is clicked', function() {
             beforeEach(function() {
                 state.games.state.players['1'].activePlot = { code: '00001', menu: [{ text: 'Test', command: 'plot', method: 'testMethod', arg: 'test' }] };
-                state.games.state.players['1'].plotDiscard = [];
+                state.games.state.players['1'].cardPiles.plotDiscard = [];
 
                 component = ReactDOM.render(<Provider store={ store }><GameBoard /></Provider>, node);
                 component = TestUtils.findRenderedComponentWithType(component, GameBoard).getWrappedInstance();

--- a/test/client/GameBoard.spec.jsx
+++ b/test/client/GameBoard.spec.jsx
@@ -37,8 +37,8 @@ describe('the <GameBoard /> component', function() {
 
         component = ReactDOM.render(<InnerGameBoard />, node);
 
-        state.games.currentGame.players['1'] = { id: 1, name: '1', additionalPiles: {}, timerSettings: {} };
-        state.games.currentGame.players['2'] = { id: 2, name: '2', additionalPiles: {}, timerSettings: {} };
+        state.games.currentGame.players['1'] = { id: 1, name: '1', timerSettings: {} };
+        state.games.currentGame.players['2'] = { id: 2, name: '2', timerSettings: {} };
         state.socket.socket = jasmine.createSpyObj('socket', ['emit']);
         state.auth.username = '1';
         state.socket.username = '1';

--- a/test/server/cards/agendas/05045-therainsofcastamere.spec.js
+++ b/test/server/cards/agendas/05045-therainsofcastamere.spec.js
@@ -30,7 +30,7 @@ describe('The Rains of Castamere', function() {
         this.scheme1 = scheme('3333');
         this.scheme2 = scheme('4444');
 
-        this.player = jasmine.createSpyObj('player', ['createAdditionalPile', 'flipPlotFaceup', 'removeActivePlot', 'kneelCard', 'moveCard']);
+        this.player = jasmine.createSpyObj('player', ['flipPlotFaceup', 'removeActivePlot', 'kneelCard', 'moveCard']);
         this.player.game = this.gameSpy;
         this.player.faction = {};
 
@@ -42,10 +42,6 @@ describe('The Rains of Castamere', function() {
             this.player.plotDeck = _([this.plot1, this.scheme1, this.plot2, this.scheme2]);
 
             this.agenda.onDecksPrepared();
-        });
-
-        it('should create the schemes plot pile', function() {
-            expect(this.player.createAdditionalPile).toHaveBeenCalledWith('scheme plots', { isPrivate: true });
         });
 
         it('should remove the schemes from the players plot deck', function() {

--- a/test/server/cards/cancreatecards.spec.js
+++ b/test/server/cards/cancreatecards.spec.js
@@ -8,7 +8,7 @@ const cards = require('../../../server/game/cards');
 describe('All Cards', function() {
     beforeEach(function() {
         this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener', 'addPower', 'addMessage', 'addEffect', 'getOtherPlayer']);
-        this.playerSpy = jasmine.createSpyObj('player', ['createAdditionalPile', 'registerAbilityMax']);
+        this.playerSpy = jasmine.createSpyObj('player', ['registerAbilityMax']);
         this.playerSpy.game = this.gameSpy;
     });
 


### PR DESCRIPTION
Removes the ability to create additional piles and nests all agenda
specific piles at the same level as the other piles under the
`Player` object.