### PR TITLE
Implement cost function for Renly Baratheon's (FFH) reaction

### DIFF
--- a/server/game/cards/04.3 FFH/RenlyBaratheon.js
+++ b/server/game/cards/04.3 FFH/RenlyBaratheon.js
@@ -9,26 +9,15 @@ class RenlyBaratheon extends DrawCard {
             match: this,
             effect: ability.effects.cannotBeSaved()
         });
+
         this.reaction({
             when: {
-                onInsight: event => {
-                    if(event.source.controller !== this.controller) {
-                        return false;
-                    }
-
-                    // postpone the check about drawn card loyalty, to avoid
-                    // leaking game state to the opponent
-                    return true;
-                }
+                onInsight: event => event.source.controller === this.controller && event.card.isLoyal()
             },
+            cost: ability.costs.revealSpecific(context => context.event.card),
             handler: context => {
-                let drawnCard = context.event.drawnCard;
-                if(drawnCard.isLoyal()) {
-                    this.controller.drawCardsToHand(1);
-
-                    this.game.addMessage('{0} uses {1} to reveal {2} and draw a card',
-                        this.controller, this, drawnCard);
-                }
+                this.controller.drawCardsToHand(1);
+                this.game.addMessage('{0} uses {1} to draw 1 card', this.controller, this, context.event.card);
             }
         });
     }

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -304,6 +304,20 @@ const Costs = {
         };
     },
     /**
+     * Cost that reveals a specific card passed into the function
+     */
+    revealSpecific: function(cardFunc) {
+        return {
+            canPay: function() {
+                return true;
+            },
+            pay: function(context) {
+                let card = cardFunc(context);
+                context.game.addMessage('{0} reveals {1} from their hand', context.player, card);
+            }
+        };
+    },
+    /**
      * Cost that requires revealing a certain number of cards in hand that match
      * the passed condition predicate function.
      */

--- a/server/game/insightkeyword.js
+++ b/server/game/insightkeyword.js
@@ -17,7 +17,7 @@ class InsightKeyword extends BaseAbility {
     executeHandler(context) {
         let {game, challenge, source} = context;
         let drawn = challenge.winner.drawCardsToHand(1);
-        game.raiseEvent('onInsight', { challenge: challenge, source: source, drawnCard: drawn });
+        game.raiseEvent('onInsight', { challenge: challenge, source: source, card: drawn });
         game.addMessage('{0} draws a card from Insight on {1}', challenge.winner, source);
     }
 }

--- a/test/server/integration/challengesphase.spec.js
+++ b/test/server/integration/challengesphase.spec.js
@@ -211,8 +211,6 @@ describe('challenges phase', function() {
             describe('when no settings are set', function() {
                 beforeEach(function() {
                     this.player1.clickPrompt('Apply Claim');
-                    // Pass on Renly's ability
-                    this.player1.clickPrompt('Pass');
                 });
 
                 it('should apply all keywords automatically', function() {
@@ -232,8 +230,6 @@ describe('challenges phase', function() {
 
                 it('should allow the first player to choose the order', function() {
                     this.player2.clickPrompt('Insight');
-                    // Pass on Renly's ability
-                    this.player1.clickPrompt('Pass');
 
                     expect(this.chud.location).toBe('hand');
                     // No Renown power yet
@@ -245,8 +241,6 @@ describe('challenges phase', function() {
 
                 it('should allow the first player to process all keywords automatically', function() {
                     this.player2.clickPrompt('Automatic');
-                    // Pass on Renly's ability
-                    this.player1.clickPrompt('Pass');
 
                     expect(this.chud.location).toBe('hand');
                     expect(this.renly.power).toBe(1);


### PR DESCRIPTION
* Solves the issue where a cancel (Treachery, Begging Brothers) could be baited when there was nothing to trigger in the first place.
* Makes sure that when it does get cancelled, the right card was revealed as it is a cost (previously, the revealing of the card got cancelled as well).