### PR TITLE
Explicitly recalculate state after claim

### DIFF
--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -26,6 +26,7 @@ class ChallengeFlow extends BaseStep {
             new SimpleStep(this.game, () => this.determineWinner()),
             new SimpleStep(this.game, () => this.unopposedPower()),
             new SimpleStep(this.game, () => this.beforeClaim()),
+            new SimpleStep(this.game, () => game.reapplyStateDependentEffects()),
             () => new KeywordWindow(this.game, this.challenge),
             new SimpleStep(this.game, () => this.completeChallenge())
         ]);

--- a/test/server/cards/characters/05/05007-ChellaDaughterOfCheyk.spec.js
+++ b/test/server/cards/characters/05/05007-ChellaDaughterOfCheyk.spec.js
@@ -1,0 +1,53 @@
+/* global describe, it, expect, beforeEach, integration */
+/* eslint camelcase: 0, no-invalid-this: 0 */
+
+describe('Chella Daughter of Cheyk', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck1 = this.buildDeck('lannister', [
+                'A Clash of Kings',
+                'Chella Daughter of Cheyk'
+            ]);
+            const deck2 = this.buildDeck('lannister', [
+                'A Clash of Kings',
+                'Hedge Knight'
+            ]);
+            this.player1.selectDeck(deck1);
+            this.player2.selectDeck(deck2);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.chella = this.player1.findCardByName('Chella Daughter of Cheyk', 'hand');
+            this.chud = this.player2.findCardByName('Hedge Knight', 'hand');
+
+            this.player1.clickCard(this.chella);
+            this.player2.clickCard(this.chud);
+            this.completeSetup();
+
+            this.player1.selectPlot('A Clash of Kings');
+            this.player2.selectPlot('A Clash of Kings');
+            this.selectFirstPlayer(this.player1);
+
+            this.completeMarshalPhase();
+        });
+
+        describe('when Chella gains the 3rd ear after military claim', function() {
+            beforeEach(function() {
+                this.chella.addToken('ear', 2);
+
+                this.unopposedChallenge(this.player1, 'military', this.chella);
+                this.player1.clickPrompt('Apply Claim');
+                this.player2.clickCard(this.chud);
+                this.player1.clickPrompt('Chella Daughter of Cheyk');
+
+                expect(this.chella.tokens.ear).toBe(3);
+            });
+
+            it('should immediately give Chella renown + intimidate', function() {
+                expect(this.chella.power).toBe(1);
+                expect(this.chella.hasKeyword('renown')).toBe(true);
+                expect(this.chella.hasKeyword('intimidate')).toBe(true);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Certain effects, such as Chella's 3 ear token ability, can activate
after claim has been applied but before keywords are resolved. Thus, an
explicit recalculation is needed between those two steps.

Fixes #1305 