### PR TITLE
Activate effects at the end of setup phase

### DIFF
--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -57,7 +57,7 @@ class Effect {
         this.effect = this.buildEffect(properties.effect);
         this.targets = [];
         this.context = { game: game, source: source };
-        this.active = true;
+        this.active = !source.facedown;
         this.recalculateWhen = properties.recalculateWhen || [];
         this.isConditional = !!properties.condition || !_.isEmpty(properties.recalculateWhen);
         this.isStateDependent = this.isConditional || this.effect.isStateDependent;

--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -127,6 +127,14 @@ class EffectEngine {
         this.unapplyAndRemove(effect => effect.duration === 'untilEndOfRound');
     }
 
+    activatePersistentEffects() {
+        let targets = this.getTargets();
+        let persistentEffects = this.effects.filter(effect => effect.duration === 'persistent');
+        for(let effect of persistentEffects) {
+            effect.setActive(true, targets);
+        }
+    }
+
     registerRecalculateEvents(eventNames) {
         _.each(eventNames, eventName => {
             if(!this.recalculateEvents[eventName]) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -851,6 +851,10 @@ class Game extends EventEmitter {
         this.addMessage('{0} has reconnected', player);
     }
 
+    activatePersistentEffects() {
+        this.effectEngine.activatePersistentEffects();
+    }
+
     reapplyStateDependentEffects() {
         this.effectEngine.reapplyStateDependentEffects();
     }

--- a/server/game/gamesteps/setupphase.js
+++ b/server/game/gamesteps/setupphase.js
@@ -15,7 +15,8 @@ class SetupPhase extends Phase {
             new SimpleStep(game, () => this.startGame()),
             new SetupCardsPrompt(game),
             new SimpleStep(game, () => this.setupDone()),
-            new CheckAttachmentsPrompt(game)
+            new CheckAttachmentsPrompt(game),
+            new SimpleStep(game, () => game.activatePersistentEffects())
         ]);
     }
 

--- a/test/server/integration/setup.spec.js
+++ b/test/server/integration/setup.spec.js
@@ -78,7 +78,7 @@ describe('setup phase', function() {
 
         describe('when a card is limited', function() {
             beforeEach(function() {
-                const deck = this.buildDeck('tyrell', ['The Roseroad', 'The Arbor', 'The Arbor']);
+                const deck = this.buildDeck('tyrell', ['Elinor Tyrell', 'The Roseroad', 'The Arbor', 'The Arbor']);
                 this.player1.selectDeck(deck);
                 this.player2.selectDeck(deck);
                 this.startGame();
@@ -102,6 +102,15 @@ describe('setup phase', function() {
 
                 expect(this.arbor1.location).toBe('play area');
                 expect(this.arbor2.location).toBe('hand');
+            });
+
+            it('should not allow effects from facedown cards to allow more limited cards', function() {
+                this.player1.clickCard('Elinor Tyrell', 'hand');
+                this.player1.clickCard(this.roseroad);
+                this.player1.clickCard(this.arbor1);
+
+                expect(this.roseroad.location).toBe('play area');
+                expect(this.arbor1.location).toBe('hand');
             });
         });
 


### PR DESCRIPTION
Previously, effects of cards placed during setup were immediately
active, even if not immediately visible to the player. This led to bugs
such as Elinor Tyrell allowing an extra limited card to be played during
setup.

Now, when an effect is created, its `active` property is determined by
whether or not the source of the effect is facedown. Thus, cards placed
in setup will not be active immediately. At the end of setup, all
persistent effects are explicitly activated.

Fixes #1174 
More general fix than #1375 