### PR TITLE
Jon Snow (WotN): do not prompt if there are no kneeling targets

### DIFF
--- a/server/game/cards/03 WotN/JonSnow.js
+++ b/server/game/cards/03 WotN/JonSnow.js
@@ -8,7 +8,12 @@ class JonSnow extends DrawCard {
             cost: ability.costs.sacrifice(card => card.isFaction('stark') && card.getType() === 'character'),
             target: {
                 activePromptTitle: 'Select a character',
-                cardCondition: card => card.location === 'play area' && card.isUnique() && card.isFaction('stark') && card.getType() === 'character',
+                cardCondition: card =>
+                    card.location === 'play area'
+                    && card.kneeled
+                    && card.isUnique()
+                    && card.isFaction('stark')
+                    && card.getType() === 'character',
                 gameAction: 'stand'
             },
             handler: context => {


### PR DESCRIPTION
This often happens when there are kneeling characters at the time Jon Snow is
triggered, but not at the time it resolves, e.g., because Robb Stark (core) was
used.