### PR TITLE
Implement basic title cards for Melee

### DIFF
--- a/client/GameBoard.jsx
+++ b/client/GameBoard.jsx
@@ -450,13 +450,15 @@ export class InnerGameBoard extends React.Component {
                                 conclavePile={ otherPlayer ? otherPlayer.cardPiles.conclavePile : [] }
                                 faction={ otherPlayer ? otherPlayer.faction : null }
                                 hand={ otherPlayer ? otherPlayer.cardPiles.hand : [] } isMe={ false }
+                                isMelee={ this.props.currentGame.isMelee }
                                 numDrawCards={ otherPlayer ? otherPlayer.numDrawCards : 0 }
                                 discardPile={ otherPlayer ? otherPlayer.cardPiles.discardPile : [] }
                                 deadPile={ otherPlayer ? otherPlayer.cardPiles.deadPile : [] }
                                 onCardClick={ this.onCardClick }
                                 onMouseOver={ this.onMouseOver }
                                 onMouseOut={ this.onMouseOut }
-                                outOfGamePile={ otherPlayer ? otherPlayer.cardPiles.outOfGamePile : [] } />
+                                outOfGamePile={ otherPlayer ? otherPlayer.cardPiles.outOfGamePile : [] }
+                                title={ otherPlayer ? otherPlayer.title : null } />
                         </div>
                         <div className='board-inner'>
                             <div className='prompt-area'>
@@ -489,6 +491,7 @@ export class InnerGameBoard extends React.Component {
                                 conclavePile={ thisPlayer.cardPiles.conclavePile }
                                 faction={ thisPlayer.faction }
                                 hand={ thisPlayer.cardPiles.hand }
+                                isMelee={ this.props.currentGame.isMelee }
                                 onCardClick={ this.onCardClick }
                                 onMouseOver={ this.onMouseOver }
                                 onMouseOut={ this.onMouseOut }
@@ -503,6 +506,7 @@ export class InnerGameBoard extends React.Component {
                                 discardPile={ thisPlayer.cardPiles.discardPile }
                                 deadPile={ thisPlayer.cardPiles.deadPile }
                                 spectating={ this.state.spectating }
+                                title={ thisPlayer.title }
                                 onMenuItemClick={ this.onMenuItemClick } />
                         </div>
                     </div>

--- a/client/GameComponents/PlayerRow.jsx
+++ b/client/GameComponents/PlayerRow.jsx
@@ -112,6 +112,22 @@ class PlayerRow extends React.Component {
         );
     }
 
+    getTitleCard() {
+        if(!this.props.isMelee) {
+            return;
+        }
+
+        return (
+            <CardPile className='title'
+                cards={ [] }
+                disablePopup
+                onMouseOut={ this.props.onMouseOut }
+                onMouseOver={ this.props.onMouseOver }
+                source='title'
+                topCard={ this.props.title } />
+        );
+    }
+
     onFactionCardClick() {
         if(this.props.onFactionCardClick) {
             this.props.onFactionCardClick();
@@ -134,6 +150,7 @@ class PlayerRow extends React.Component {
                     onMouseOver={ this.onMouseOver } onMouseOut={ this.onMouseOut } disablePopup
                     onCardClick={ this.props.isMe && !this.props.spectating ? this.onFactionCardClick.bind(this) : null } />
                 { this.getAgenda() }
+                { this.getTitleCard() }
                 <PlayerHand
                     cards={ this.props.hand }
                     isMe={ this.props.isMe }
@@ -168,6 +185,7 @@ PlayerRow.propTypes = {
     faction: React.PropTypes.object,
     hand: React.PropTypes.array,
     isMe: React.PropTypes.bool,
+    isMelee: React.PropTypes.bool,
     numDrawCards: React.PropTypes.number,
     onCardClick: React.PropTypes.func,
     onDragDrop: React.PropTypes.func,
@@ -181,7 +199,8 @@ PlayerRow.propTypes = {
     plotDeck: React.PropTypes.array,
     power: React.PropTypes.number,
     showDrawDeck: React.PropTypes.bool,
-    spectating: React.PropTypes.bool
+    spectating: React.PropTypes.bool,
+    title: React.PropTypes.object
 };
 
 export default PlayerRow;

--- a/client/NewGame.jsx
+++ b/client/NewGame.jsx
@@ -15,6 +15,7 @@ class InnerNewGame extends React.Component {
 
         this.state = {
             spectators: true,
+            selectedGameFormat: 'joust',
             selectedGameType: 'casual',
             password: ''
         };
@@ -49,6 +50,7 @@ class InnerNewGame extends React.Component {
             name: this.state.gameName,
             spectators: this.state.spectators,
             gameType: this.state.selectedGameType,
+            isMelee: this.state.selectedGameFormat === 'melee',
             password: this.state.password
         });
     }
@@ -57,8 +59,36 @@ class InnerNewGame extends React.Component {
         this.setState({ selectedGameType: gameType });
     }
 
+    onGameFormatChange(format) {
+        this.setState({ selectedGameFormat: format });
+    }
+
     isGameTypeSelected(gameType) {
         return this.state.selectedGameType === gameType;
+    }
+
+    getMeleeOptions() {
+        if(!this.props.allowMelee) {
+            return;
+        }
+
+        return (
+            <div className='row'>
+                <div className='col-sm-12'>
+                    <b>Game Format</b>
+                </div>
+                <div className='col-sm-10'>
+                    <label className='radio-inline'>
+                        <input type='radio' onChange={ this.onGameFormatChange.bind(this, 'joust') } checked={ this.state.selectedGameFormat === 'joust' } />
+                        Joust
+                    </label>
+                    <label className='radio-inline'>
+                        <input type='radio' onChange={ this.onGameFormatChange.bind(this, 'melee') } checked={ this.state.selectedGameFormat === 'melee' } />
+                        Melee
+                    </label>
+                </div>
+            </div>
+        );
     }
 
     render() {
@@ -85,6 +115,7 @@ class InnerNewGame extends React.Component {
                                 </label>
                             </div>
                         </div>
+                        { this.getMeleeOptions() }
                         <div className='row'>
                             <div className='col-sm-12'>
                                 <b>Game Type</b>
@@ -126,6 +157,7 @@ class InnerNewGame extends React.Component {
 
 InnerNewGame.displayName = 'NewGame';
 InnerNewGame.propTypes = {
+    allowMelee: React.PropTypes.bool,
     cancelNewGame: React.PropTypes.func,
     defaultGameName: React.PropTypes.string,
     socket: React.PropTypes.object
@@ -133,6 +165,7 @@ InnerNewGame.propTypes = {
 
 function mapStateToProps(state) {
     return {
+        allowMelee: state.auth.user.permissions.allowMelee,
         socket: state.socket.socket
     };
 }

--- a/server/game/TitleCard.js
+++ b/server/game/TitleCard.js
@@ -1,0 +1,7 @@
+const BaseCard = require('./basecard.js');
+
+class TitleCard extends BaseCard {
+
+}
+
+module.exports = TitleCard;

--- a/server/game/TitleCard.js
+++ b/server/game/TitleCard.js
@@ -7,6 +7,30 @@ class TitleCard extends BaseCard {
         this.dominanceStrengthModifier = 0;
     }
 
+    supports(...values) {
+        this.supporterNames = values;
+    }
+
+    rivals(...values) {
+        this.rivalNames = values;
+    }
+
+    isRival(card) {
+        if(!card || card.getType() !== 'title') {
+            return false;
+        }
+
+        return this.rivalNames.includes(card.name);
+    }
+
+    isSupporter(card) {
+        if(!card || card.getType() !== 'title') {
+            return false;
+        }
+
+        return this.supporterNames.includes(card.name);
+    }
+
     modifyDominanceStrength(value) {
         this.dominanceStrengthModifier += value;
     }

--- a/server/game/TitleCard.js
+++ b/server/game/TitleCard.js
@@ -1,7 +1,19 @@
 const BaseCard = require('./basecard.js');
 
 class TitleCard extends BaseCard {
+    constructor(owner, cardData) {
+        super(owner, cardData);
 
+        this.dominanceStrengthModifier = 0;
+    }
+
+    modifyDominanceStrength(value) {
+        this.dominanceStrengthModifier += value;
+    }
+
+    getDominanceStrength() {
+        return this.dominanceStrengthModifier;
+    }
 }
 
 module.exports = TitleCard;

--- a/server/game/TitlePool.js
+++ b/server/game/TitlePool.js
@@ -19,7 +19,7 @@ class TitlePool {
         });
     }
 
-    getRandomCards() {
+    getCardsForSelection() {
         let amount = this.amountToSetAside();
         let shuffledPool = _.shuffle(this.cards);
 

--- a/server/game/TitlePool.js
+++ b/server/game/TitlePool.js
@@ -1,0 +1,63 @@
+const _ = require('underscore');
+
+const titles = [
+    require('./cards/titles/CrownRegent.js'),
+    require('./cards/titles/HandOfTheKing.js'),
+    require('./cards/titles/MasterOfCoin.js'),
+    require('./cards/titles/MasterOfLaws.js'),
+    require('./cards/titles/MasterOfShips.js'),
+    require('./cards/titles/MasterOfWhispers.js')
+];
+
+class TitlePool {
+    constructor(game, cardData) {
+        this.game = game;
+        this.cards = titles.map(titleClass => {
+            let title = new titleClass({ game: game }, cardData[titleClass.code] || {});
+            title.moveTo('title pool');
+            return title;
+        });
+    }
+
+    getRandomCards() {
+        let amount = this.amountToSetAside();
+        let shuffledPool = _.shuffle(this.cards);
+
+        return _.first(shuffledPool, this.cards.length - amount);
+    }
+
+    amountToSetAside() {
+        let players = this.game.getPlayers();
+
+        if(players.length >= 6) {
+            return 0;
+        } else if(players.length >= 4) {
+            return 1;
+        }
+
+        return 2;
+    }
+
+    chooseFromPool(player, card) {
+        if(!this.cards.includes(card)) {
+            return;
+        }
+
+        card.controller = player;
+        card.moveTo('title');
+        card.applyPersistentEffects();
+        player.title = card;
+    }
+
+    returnToPool(player, card) {
+        if(!card || card.getType() !== 'title') {
+            return;
+        }
+
+        card.controller = null;
+        card.moveTo('title pool');
+        player.title = null;
+    }
+}
+
+module.exports = TitlePool;

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -32,7 +32,7 @@ const ValidFactions = [
     'greyjoy'
 ];
 
-const LocationsWithEventHandling = ['play area', 'active plot', 'faction', 'agenda'];
+const LocationsWithEventHandling = ['play area', 'active plot', 'faction', 'agenda', 'title'];
 
 class BaseCard {
     constructor(owner, cardData) {

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -554,7 +554,7 @@ class BaseCard {
         let selectionState = activePlayer.getCardSelectionState(this);
         let state = {
             code: this.cardData.code,
-            controlled: this.owner !== this.controller,
+            controlled: this.owner !== this.controller && this.getType() !== 'title',
             facedown: this.facedown,
             menu: this.getMenu(),
             name: this.cardData.label,

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -197,10 +197,11 @@ class BaseCard {
      * is both in play and not blank.
      */
     persistentEffect(properties) {
-        const allowedLocations = ['active plot', 'agenda', 'any', 'play area'];
+        const allowedLocations = ['active plot', 'agenda', 'any', 'play area', 'title'];
         const defaultLocationForType = {
             agenda: 'agenda',
-            plot: 'active plot'
+            plot: 'active plot',
+            title: 'title'
         };
 
         let location = properties.location || defaultLocationForType[this.getType()] || 'play area';

--- a/server/game/cards/titles/CrownRegent.js
+++ b/server/game/cards/titles/CrownRegent.js
@@ -1,0 +1,15 @@
+const TitleCard = require('../../TitleCard.js');
+
+class CrownRegent extends TitleCard {
+    setupCardAbilities(ability) {
+        // TODO: Redirect ability
+        this.persistentEffect({
+            match: this,
+            effect: ability.effects.modifyDominanceStrength(2)
+        });
+    }
+}
+
+CrownRegent.code = '01211';
+
+module.exports = CrownRegent;

--- a/server/game/cards/titles/HandOfTheKing.js
+++ b/server/game/cards/titles/HandOfTheKing.js
@@ -2,7 +2,8 @@ const TitleCard = require('../../TitleCard.js');
 
 class HandOfTheKing extends TitleCard {
     setupCardAbilities(ability) {
-        // TODO: Rivals + Supports
+        this.supports('Master of Laws');
+        this.rivals('Master of Coin', 'Master of Ships');
         // TODO: Additional power challenge against different opponent
         this.persistentEffect({
             condition: () => (

--- a/server/game/cards/titles/HandOfTheKing.js
+++ b/server/game/cards/titles/HandOfTheKing.js
@@ -1,0 +1,22 @@
+const TitleCard = require('../../TitleCard.js');
+
+class HandOfTheKing extends TitleCard {
+    setupCardAbilities(ability) {
+        // TODO: Rivals + Supports
+        // TODO: Additional power challenge against different opponent
+        this.persistentEffect({
+            condition: () => (
+                this.game.currentChallenge &&
+                this.game.currentChallenge.challengeType === 'power' &&
+                this.game.currentChallenge.anyParticipants(card => card.controller === this.controller)
+            ),
+            targetType: 'player',
+            targetController: 'current',
+            effect: ability.effects.contributeChallengeStrength(1)
+        });
+    }
+}
+
+HandOfTheKing.code = '01208';
+
+module.exports = HandOfTheKing;

--- a/server/game/cards/titles/MasterOfCoin.js
+++ b/server/game/cards/titles/MasterOfCoin.js
@@ -2,7 +2,8 @@ const TitleCard = require('../../TitleCard.js');
 
 class MasterOfCoin extends TitleCard {
     setupCardAbilities() {
-        // TODO: Rivals + Supports
+        this.supports('Master of Ships');
+        this.rivals('Hand of the King', 'Master of Whispers');
         this.plotModifiers({
             gold: 2
         });

--- a/server/game/cards/titles/MasterOfCoin.js
+++ b/server/game/cards/titles/MasterOfCoin.js
@@ -1,0 +1,14 @@
+const TitleCard = require('../../TitleCard.js');
+
+class MasterOfCoin extends TitleCard {
+    setupCardAbilities() {
+        // TODO: Rivals + Supports
+        this.plotModifiers({
+            gold: 2
+        });
+    }
+}
+
+MasterOfCoin.code = '01209';
+
+module.exports = MasterOfCoin;

--- a/server/game/cards/titles/MasterOfLaws.js
+++ b/server/game/cards/titles/MasterOfLaws.js
@@ -1,0 +1,20 @@
+const TitleCard = require('../../TitleCard.js');
+
+class MasterOfLaws extends TitleCard {
+    setupCardAbilities(ability) {
+        // TODO: Rivals + Supports
+        this.persistentEffect({
+            condition: () => this.game.currentPhase === 'draw',
+            targetType: 'player',
+            targetController: 'current',
+            effect: ability.effects.modifyDrawPhaseCards(1)
+        });
+        this.plotModifiers({
+            reserve: 1
+        });
+    }
+}
+
+MasterOfLaws.code = '01210';
+
+module.exports = MasterOfLaws;

--- a/server/game/cards/titles/MasterOfLaws.js
+++ b/server/game/cards/titles/MasterOfLaws.js
@@ -2,7 +2,8 @@ const TitleCard = require('../../TitleCard.js');
 
 class MasterOfLaws extends TitleCard {
     setupCardAbilities(ability) {
-        // TODO: Rivals + Supports
+        this.supports('Master of Coin');
+        this.rivals('Master of Whispers', 'Master of Ships');
         this.persistentEffect({
             condition: () => this.game.currentPhase === 'draw',
             targetType: 'player',

--- a/server/game/cards/titles/MasterOfShips.js
+++ b/server/game/cards/titles/MasterOfShips.js
@@ -1,0 +1,22 @@
+const TitleCard = require('../../TitleCard.js');
+
+class MasterOfShips extends TitleCard {
+    setupCardAbilities(ability) {
+        // TODO: Rivals + Supports
+        // TODO: Raise claim for military when attacking a rival
+        this.persistentEffect({
+            condition: () => (
+                this.game.currentChallenge &&
+                this.game.currentChallenge.challengeType === 'military' &&
+                this.game.currentChallenge.anyParticipants(card => card.controller === this.controller)
+            ),
+            targetType: 'player',
+            targetController: 'current',
+            effect: ability.effects.contributeChallengeStrength(1)
+        });
+    }
+}
+
+MasterOfShips.code = '01207';
+
+module.exports = MasterOfShips;

--- a/server/game/cards/titles/MasterOfShips.js
+++ b/server/game/cards/titles/MasterOfShips.js
@@ -2,7 +2,8 @@ const TitleCard = require('../../TitleCard.js');
 
 class MasterOfShips extends TitleCard {
     setupCardAbilities(ability) {
-        // TODO: Rivals + Supports
+        this.supports('Master of Whispers');
+        this.rivals('Master of Laws', 'Hand of the King');
         // TODO: Raise claim for military when attacking a rival
         this.persistentEffect({
             condition: () => (

--- a/server/game/cards/titles/MasterOfShips.js
+++ b/server/game/cards/titles/MasterOfShips.js
@@ -4,7 +4,16 @@ class MasterOfShips extends TitleCard {
     setupCardAbilities(ability) {
         this.supports('Master of Whispers');
         this.rivals('Master of Laws', 'Hand of the King');
-        // TODO: Raise claim for military when attacking a rival
+        this.persistentEffect({
+            condition: () => (
+                this.game.currentChallenge &&
+                this.game.currentChallenge.challengeType === 'military' &&
+                this.game.currentChallenge.attackingPlayer === this.controller &&
+                this.controller.isRival(this.game.currentChallenge.defendingPlayer)
+            ),
+            match: card => card === this.controller.activePlot,
+            effect: ability.effects.modifyClaim(1)
+        });
         this.persistentEffect({
             condition: () => (
                 this.game.currentChallenge &&

--- a/server/game/cards/titles/MasterOfWhispers.js
+++ b/server/game/cards/titles/MasterOfWhispers.js
@@ -1,0 +1,22 @@
+const TitleCard = require('../../TitleCard.js');
+
+class MasterOfWhispers extends TitleCard {
+    setupCardAbilities(ability) {
+        // TODO: Rivals + Supports
+        // TODO: Resolve intrigue claim against any number of opponents
+        this.persistentEffect({
+            condition: () => (
+                this.game.currentChallenge &&
+                this.game.currentChallenge.challengeType === 'intrigue' &&
+                this.game.currentChallenge.anyParticipants(card => card.controller === this.controller)
+            ),
+            targetType: 'player',
+            targetController: 'current',
+            effect: ability.effects.contributeChallengeStrength(1)
+        });
+    }
+}
+
+MasterOfWhispers.code = '01206';
+
+module.exports = MasterOfWhispers;

--- a/server/game/cards/titles/MasterOfWhispers.js
+++ b/server/game/cards/titles/MasterOfWhispers.js
@@ -2,7 +2,8 @@ const TitleCard = require('../../TitleCard.js');
 
 class MasterOfWhispers extends TitleCard {
     setupCardAbilities(ability) {
-        // TODO: Rivals + Supports
+        this.supports('Hand of the King');
+        this.rivals('Master of Laws', 'Master of Coin');
         // TODO: Resolve intrigue claim against any number of opponents
         this.persistentEffect({
             condition: () => (

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -59,7 +59,7 @@ class Game extends EventEmitter {
             isApplying: false,
             type: undefined
         };
-        this.isMelee = details.isMelee || false;
+        this.isMelee = !!details.isMelee;
         this.titlePool = new TitlePool(this, options.titleCardData || []);
 
         _.each(details.players, player => {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -908,6 +908,7 @@ class Game extends EventEmitter {
 
             return {
                 id: this.id,
+                isMelee: this.isMelee,
                 name: this.name,
                 owner: this.owner,
                 players: playerState,
@@ -962,6 +963,7 @@ class Game extends EventEmitter {
             createdAt: this.createdAt,
             gameType: this.gameType,
             id: this.id,
+            isMelee: this.isMelee,
             messages: this.gameChat.messages,
             name: this.name,
             owner: this.owner,

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -29,6 +29,7 @@ const AbilityResolver = require('./gamesteps/abilityresolver.js');
 const ForcedTriggeredAbilityWindow = require('./gamesteps/forcedtriggeredabilitywindow.js');
 const TriggeredAbilityWindow = require('./gamesteps/triggeredabilitywindow.js');
 const KillCharacters = require('./gamesteps/killcharacters.js');
+const TitlePool = require('./TitlePool.js');
 
 class Game extends EventEmitter {
     constructor(details, options = {}) {
@@ -58,6 +59,8 @@ class Game extends EventEmitter {
             isApplying: false,
             type: undefined
         };
+        this.isMelee = details.isMelee || false;
+        this.titlePool = new TitlePool(this, options.titleCardData || []);
 
         _.each(details.players, player => {
             this.playersAndSpectators[player.user.username] = new Player(player.id, player.user, this.owner === player.user.username, this);
@@ -576,9 +579,7 @@ class Game extends EventEmitter {
             player.initialise();
         });
 
-        this.allCards = _(_.reduce(this.getPlayers(), (cards, player) => {
-            return cards.concat(player.allCards.toArray());
-        }, []));
+        this.allCards = _(this.gatherAllCards());
 
         this.pipeline.initialise([
             new SetupPhase(this),
@@ -589,6 +590,18 @@ class Game extends EventEmitter {
         this.startedAt = new Date();
 
         this.continue();
+    }
+
+    gatherAllCards() {
+        let playerCards = _.reduce(this.getPlayers(), (cards, player) => {
+            return cards.concat(player.allCards.toArray());
+        }, []);
+
+        if(this.isMelee) {
+            return this.titlePool.cards.concat(playerCards);
+        }
+
+        return playerCards;
     }
 
     beginRound() {

--- a/server/game/gamesteps/plot/ChooseTitlePrompt.js
+++ b/server/game/gamesteps/plot/ChooseTitlePrompt.js
@@ -1,0 +1,62 @@
+const _ = require('underscore');
+
+const BaseStep = require('../basestep.js');
+
+class ChooseTitlePrompt extends BaseStep {
+    constructor(game, titlePool) {
+        super(game);
+
+        this.titlePool = titlePool;
+        this.remainingPlayers = game.getPlayersInFirstPlayerOrder();
+        this.selections = [];
+    }
+
+    continue() {
+        if(!this.game.isMelee) {
+            return true;
+        }
+
+        if(this.selections.length === 0) {
+            this.remainingTitles = this.titlePool.getCardsForSelection();
+        }
+
+        if(this.remainingPlayers.length !== 0) {
+            let currentPlayer = this.remainingPlayers.shift();
+            this.promptForTitle(currentPlayer);
+            return false;
+        }
+
+        _.each(this.selections, selection => {
+            this.titlePool.chooseFromPool(selection.player, selection.title);
+            this.game.addMessage('{0} selects {1}', selection.player, selection.title);
+        });
+    }
+
+    promptForTitle(player) {
+        let buttons = _.map(this.remainingTitles, title => {
+            return { method: 'chooseTitle', card: title };
+        });
+        this.game.promptWithMenu(player, this, {
+            activePrompt: {
+                menuTitle: 'Select a title',
+                buttons: buttons
+            },
+            waitingPromptTitle: 'Waiting for ' + player.name + ' to select a title'
+        });
+    }
+
+    chooseTitle(player, titleId) {
+        let title = this.remainingTitles.find(title => title.uuid === titleId);
+
+        if(!title) {
+            return false;
+        }
+
+        this.remainingTitles = _.reject(this.remainingTitles, t => t === title);
+        this.selections.push({ player: player, title: title });
+
+        return true;
+    }
+}
+
+module.exports = ChooseTitlePrompt;

--- a/server/game/gamesteps/plotphase.js
+++ b/server/game/gamesteps/plotphase.js
@@ -3,6 +3,7 @@ const Phase = require('./phase.js');
 const SimpleStep = require('./simplestep.js');
 const SelectPlotPrompt = require('./plot/selectplotprompt.js');
 const RevealPlots = require('./revealplots.js');
+const ChooseTitlePrompt = require('./plot/ChooseTitlePrompt.js');
 const ActionWindow = require('./actionwindow.js');
 
 class PlotPhase extends Phase {
@@ -14,6 +15,7 @@ class PlotPhase extends Phase {
             new SimpleStep(game, () => this.removeActivePlots()),
             new SimpleStep(game, () => this.flipPlotsFaceup()),
             () => new RevealPlots(game, _.map(this.game.getPlayers(), player => player.activePlot)),
+            () => new ChooseTitlePrompt(game, game.titlePool),
             new ActionWindow(this.game, 'After plots revealed', 'plot'),
             new SimpleStep(game, () => this.recyclePlots())
         ]);

--- a/server/game/gamesteps/taxationphase.js
+++ b/server/game/gamesteps/taxationphase.js
@@ -10,6 +10,7 @@ class TaxationPhase extends Phase {
         this.initialise([
             new SimpleStep(game, () => this.returnGold()),
             new DiscardToReservePrompt(game),
+            new SimpleStep(game, () => this.returnTitleCards()),
             new ActionWindow(game, 'After reserve check', 'taxation'),
             new SimpleStep(game, () => this.roundEnded())
         ]);
@@ -20,6 +21,16 @@ class TaxationPhase extends Phase {
             if(!player.doesNotReturnUnspentGold) {
                 player.taxation();
             }
+        });
+    }
+
+    returnTitleCards() {
+        if(!this.game.isMelee) {
+            return;
+        }
+
+        _.each(this.game.getPlayers(), player => {
+            this.game.titlePool.returnToPool(player, player.title);
         });
     }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -932,6 +932,10 @@ class Player extends Spectator {
             return memo + card.getDominanceStrength();
         }, 0);
 
+        if(this.title) {
+            cardStrength += this.title.getDominanceStrength();
+        }
+
         return cardStrength + this.gold;
     }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -1231,6 +1231,7 @@ class Player extends Spectator {
             promptedActionWindows: this.promptedActionWindows,
             stats: this.getStats(isActivePlayer),
             timerSettings: this.timerSettings,
+            title: this.title ? this.title.getSummary(activePlayer) : undefined,
             user: _.omit(this.user, ['password', 'email'])
         };
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -1152,6 +1152,22 @@ class Player extends Spectator {
         return this.hand.size() <= this.getTotalReserve();
     }
 
+    isRival(opponent) {
+        if(!this.title) {
+            return false;
+        }
+
+        return this.title.isRival(opponent.title);
+    }
+
+    isSupporter(opponent) {
+        if(!this.title) {
+            return false;
+        }
+
+        return this.title.isSupporter(opponent.title);
+    }
+
     setSelectedCards(cards) {
         this.promptState.setSelectedCards(cards);
     }

--- a/server/gamenode/gameserver.js
+++ b/server/gamenode/gameserver.js
@@ -5,12 +5,14 @@ const Raven = require('raven');
 const http = require('http');
 const https = require('https');
 const fs = require('fs');
+const monk = require('monk');
 
 const config = require('./nodeconfig.js');
 const logger = require('../log.js');
 const ZmqSocket = require('./zmqsocket.js');
 const Game = require('../game/game.js');
 const Socket = require('../socket.js');
+const CardService = require('../services/CardService.js');
 const version = require('../../version.js');
 
 if(config.sentryDsn) {
@@ -66,6 +68,22 @@ class GameServer {
         }
 
         this.io.on('connection', this.onConnection.bind(this));
+
+        this.titleCardData = [];
+        this.loadTitleCardData();
+    }
+
+    loadTitleCardData() {
+        let db = monk(config.dbPath);
+        let cardService = new CardService(db);
+        cardService.getTitleCards()
+            .then(cards => {
+                this.titleCardData = cards;
+                db.close();
+            })
+            .catch(() => {
+                db.close();
+            });
     }
 
     debugDump() {
@@ -169,7 +187,7 @@ class GameServer {
     }
 
     onStartGame(pendingGame) {
-        var game = new Game(pendingGame, { router: this });
+        var game = new Game(pendingGame, { router: this, titleCardData: this.titleCardData });
         this.games[pendingGame.id] = game;
 
         game.started = true;

--- a/server/pendinggame.js
+++ b/server/pendinggame.js
@@ -14,6 +14,7 @@ class PendingGame {
         this.name = details.name;
         this.allowSpectators = details.spectators;
         this.gameType = details.gameType;
+        this.isMelee = details.isMelee;
         this.createdAt = new Date();
         this.gameChat = new GameChat();
     }

--- a/server/services/CardService.js
+++ b/server/services/CardService.js
@@ -37,6 +37,16 @@ class CardService {
             });
     }
 
+    getTitleCards() {
+        return this.cards.find({ type_code: 'title' })
+            .then(cards => {
+                return cards.reduce((memo, card) => {
+                    memo[card.code] = card;
+                    return memo;
+                }, {});
+            });
+    }
+
     getAllPacks() {
         return this.packs.find({}).catch(err => {
             logger.info(err);


### PR DESCRIPTION
* Melee can be accessed by giving the user that creates the game an `allowMelee` permission.
* Implements the persistent effects for each title card in Melee games.
* Players select their title during the plot phase, return it during the taxation phase.
* Joust games remain unaffected.

![screen shot 2017-09-11 at 11 23 43 am](https://user-images.githubusercontent.com/145077/30290245-8861c77c-96e3-11e7-92ea-ff7ca8f378fc.png)
![screen shot 2017-09-11 at 11 23 52 am](https://user-images.githubusercontent.com/145077/30290250-8a4d0024-96e3-11e7-9cc7-41fac28f0558.png)

Not currently implemented:
* Challenge restrictions for titles that support another title
* Challenge bonuses for titles that rival another title
* Challenge redirect ability for Crown Regent
* Hand of the King allowing an additional power challenge against a different opponent (need to track which opponents they've initiated against)
* Master of Whispers applying intrigue claim to players of their choice (this is just going to be super weird so probably should be done separately)

Progress toward #1237 