### PR TITLE
Track challenges directly for Melee

### DIFF
--- a/server/game/cards/05-LoCR/ALannisterAlwaysPaysHisDebts.js
+++ b/server/game/cards/05-LoCR/ALannisterAlwaysPaysHisDebts.js
@@ -5,10 +5,7 @@ class ALannisterAlwaysPaysHisDebts extends DrawCard {
         this.action({
             max: ability.limit.perPhase(1),
             title: 'Raise challenge limit',
-            // TODO: This condition and opponent choice should be limited to
-            // players who won a challenge against the current player for Melee.
-            condition: () => this.hasLostChallenge(),
-            chooseOpponent: true,
+            chooseOpponent: opponent => this.hasLostChallengeAgainst(opponent),
             phase: 'challenge',
             handler: () => {
                 this.untilEndOfPhase(ability => ({
@@ -26,10 +23,9 @@ class ALannisterAlwaysPaysHisDebts extends DrawCard {
         });
     }
 
-    hasLostChallenge() {
-        return (this.controller.getNumberOfChallengesLost('military') +
-               this.controller.getNumberOfChallengesLost('intrigue') +
-               this.controller.getNumberOfChallengesLost('power')) > 0;
+    hasLostChallengeAgainst(opponent) {
+        let challenges = this.controller.getParticipatedChallenges();
+        return challenges.some(challenge => challenge.winner === opponent);
     }
 }
 

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -180,8 +180,6 @@ class Challenge {
             this.winnerStrength = this.defenderStrength;
         }
 
-        this.winner.winChallenge(this.challengeType, this.attackingPlayer === this.winner);
-        this.loser.loseChallenge(this.challengeType, this.attackingPlayer === this.loser);
         this.strengthDifference = this.winnerStrength - this.loserStrength;
     }
 

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -35,7 +35,6 @@ class Challenge {
     }
 
     initiateChallenge() {
-        this.attackingPlayer.initiateChallenge(this.challengeType);
         this.attackingPlayer.trackChallenge(this);
         this.defendingPlayer.trackChallenge(this);
     }

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -36,6 +36,8 @@ class Challenge {
 
     initiateChallenge() {
         this.attackingPlayer.initiateChallenge(this.challengeType);
+        this.attackingPlayer.trackChallenge(this);
+        this.defendingPlayer.trackChallenge(this);
     }
 
     addAttackers(attackers) {

--- a/server/game/challengetracker.js
+++ b/server/game/challengetracker.js
@@ -5,27 +5,13 @@ class ChallengeTracker {
         this.player = player;
         this.challengeTypes = {
             military: {
-                max: 1,
-                won: 0,
-                lost: 0
+                max: 1
             },
             intrigue: {
-                max: 1,
-                won: 0,
-                lost: 0
+                max: 1
             },
             power: {
-                max: 1,
-                won: 0,
-                lost: 0
-            },
-            defender: {
-                won: 0,
-                lost: 0
-            },
-            attacker: {
-                won: 0,
-                lost: 0
+                max: 1
             }
         };
         this.challenges = [];
@@ -46,8 +32,6 @@ class ChallengeTracker {
     }
 
     resetForType(challengeType) {
-        this.challengeTypes[challengeType].won = 0;
-        this.challengeTypes[challengeType].lost = 0;
     }
 
     canInitiate(challengeType, opponent) {
@@ -108,16 +92,6 @@ class ChallengeTracker {
 
     removeRestriction(restriction) {
         this.restrictions = this.restrictions.filter(r => r !== restriction);
-    }
-
-    won(challengeType, wasAttacker) {
-        this.challengeTypes[challengeType].won++;
-        this.challengeTypes[wasAttacker ? 'attacker' : 'defender'].won++;
-    }
-
-    lost(challengeType, wasAttacker) {
-        this.challengeTypes[challengeType].lost++;
-        this.challengeTypes[wasAttacker ? 'attacker' : 'defender'].lost++;
     }
 
     modifyMaxForType(challengeType, number) {

--- a/server/game/challengetracker.js
+++ b/server/game/challengetracker.js
@@ -24,14 +24,6 @@ class ChallengeTracker {
 
     reset() {
         this.challenges = [];
-        this.resetForType('military');
-        this.resetForType('intrigue');
-        this.resetForType('power');
-        this.resetForType('defender');
-        this.resetForType('attacker');
-    }
-
-    resetForType(challengeType) {
     }
 
     canInitiate(challengeType, opponent) {

--- a/server/game/challengetracker.js
+++ b/server/game/challengetracker.js
@@ -33,11 +33,17 @@ class ChallengeTracker {
                 lost: 0
             }
         };
+        this.challenges = [];
         this.restrictions = [];
+    }
+
+    track(challenge) {
+        this.challenges.push(challenge);
     }
 
     reset() {
         this.complete = 0;
+        this.challenges = [];
         this.resetForType('military');
         this.resetForType('intrigue');
         this.resetForType('power');

--- a/server/game/challengetracker.js
+++ b/server/game/challengetracker.js
@@ -26,6 +26,10 @@ class ChallengeTracker {
         this.challenges = [];
     }
 
+    getChallenges() {
+        return this.challenges;
+    }
+
     canInitiate(challengeType, opponent) {
         if(!_.isUndefined(this.maxTotal) && this.getPerformed() >= this.maxTotal) {
             return false;

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -850,14 +850,6 @@ class Player extends Spectator {
         this.challenges.track(challenge);
     }
 
-    winChallenge(challengeType, wasAttacker) {
-        this.challenges.won(challengeType, wasAttacker);
-    }
-
-    loseChallenge(challengeType, wasAttacker) {
-        this.challenges.lost(challengeType, wasAttacker);
-    }
-
     resetForChallenge() {
         this.cardsInPlay.each(card => {
             card.resetForChallenge();

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -846,6 +846,10 @@ class Player extends Spectator {
         });
     }
 
+    trackChallenge(challenge) {
+        this.challenges.track(challenge);
+    }
+
     initiateChallenge(challengeType) {
         this.challenges.perform(challengeType);
     }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -39,7 +39,7 @@ class Player extends Spectator {
         this.setupGold = 8;
         this.cardsInPlayBeforeSetup = [];
         this.deck = {};
-        this.challenges = new ChallengeTracker();
+        this.challenges = new ChallengeTracker(this);
         this.minReserve = 0;
         this.costReducers = [];
         this.playableLocations = _.map(['marshal', 'play', 'ambush'], playingType => new PlayableLocation(playingType, this, 'hand'));
@@ -183,7 +183,7 @@ class Player extends Spectator {
     }
 
     getNumberOfChallengesInitiated() {
-        return this.challenges.complete;
+        return this.challenges.getPerformed();
     }
 
     getNumberOfUsedPlots() {
@@ -848,10 +848,6 @@ class Player extends Spectator {
 
     trackChallenge(challenge) {
         this.challenges.track(challenge);
-    }
-
-    initiateChallenge(challengeType) {
-        this.challenges.perform(challengeType);
     }
 
     winChallenge(challengeType, wasAttacker) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -850,6 +850,10 @@ class Player extends Spectator {
         this.challenges.track(challenge);
     }
 
+    getParticipatedChallenges() {
+        return this.challenges.getChallenges();
+    }
+
     resetForChallenge() {
         this.cardsInPlay.each(card => {
             card.resetForChallenge();

--- a/test/server/challenge/determinewinner.spec.js
+++ b/test/server/challenge/determinewinner.spec.js
@@ -10,11 +10,7 @@ describe('Challenge', function() {
         });
 
         this.attackingPlayer = new Player('1', { username: 'Player 1', settings: {} }, true, this.gameSpy);
-        spyOn(this.attackingPlayer, 'winChallenge');
-        spyOn(this.attackingPlayer, 'loseChallenge');
         this.defendingPlayer = new Player('2', { username: 'Player 2', settings: {} }, true, this.gameSpy);
-        spyOn(this.defendingPlayer, 'winChallenge');
-        spyOn(this.defendingPlayer, 'loseChallenge');
 
         this.attackerCard = new DrawCard(this.attackingPlayer, {});
         this.defenderCard = new DrawCard(this.defendingPlayer, {});
@@ -36,16 +32,8 @@ describe('Challenge', function() {
                 expect(this.challenge.winner).toBe(this.attackingPlayer);
             });
 
-            it('should mark the win for the attacking player', function() {
-                expect(this.attackingPlayer.winChallenge).toHaveBeenCalledWith('military', true);
-            });
-
             it('should have the defending player be the loser', function() {
                 expect(this.challenge.loser).toBe(this.defendingPlayer);
-            });
-
-            it('should mark the loss for the defending player', function() {
-                expect(this.defendingPlayer.loseChallenge).toHaveBeenCalledWith('military', false);
             });
         });
 
@@ -63,16 +51,8 @@ describe('Challenge', function() {
                 expect(this.challenge.winner).toBe(this.attackingPlayer);
             });
 
-            it('should mark the win for the attacking player', function() {
-                expect(this.attackingPlayer.winChallenge).toHaveBeenCalledWith('military', true);
-            });
-
             it('should have the defending player be the loser', function() {
                 expect(this.challenge.loser).toBe(this.defendingPlayer);
-            });
-
-            it('should mark the loss for the defending player', function() {
-                expect(this.defendingPlayer.loseChallenge).toHaveBeenCalledWith('military', false);
             });
         });
 
@@ -89,16 +69,8 @@ describe('Challenge', function() {
                 expect(this.challenge.winner).toBe(this.defendingPlayer);
             });
 
-            it('should mark the win for the defending player', function() {
-                expect(this.defendingPlayer.winChallenge).toHaveBeenCalledWith('military', false);
-            });
-
             it('should have the attacking player be the loser', function() {
                 expect(this.challenge.loser).toBe(this.attackingPlayer);
-            });
-
-            it('should mark the loss for the attacking player', function() {
-                expect(this.attackingPlayer.loseChallenge).toHaveBeenCalledWith('military', true);
             });
         });
     });

--- a/test/server/challenge/removefromchallenge.spec.js
+++ b/test/server/challenge/removefromchallenge.spec.js
@@ -10,9 +10,7 @@ describe('Challenge', function() {
         });
 
         this.attackingPlayer = new Player('1', { username: 'Player 1', settings: {} }, true, this.gameSpy);
-        spyOn(this.attackingPlayer, 'winChallenge');
         this.defendingPlayer = new Player('2', { username: 'Player 2', settings: {} }, true, this.gameSpy);
-        spyOn(this.defendingPlayer, 'winChallenge');
 
         this.attackerCard = new DrawCard(this.attackingPlayer, {});
         spyOn(this.attackerCard, 'getStrength').and.returnValue(5);


### PR DESCRIPTION
Updates the challenge tracker to simply keep records of challenges that the player has participated in.  The performed / won / lost stats are then calculated based on the list of challenges.

This allows proper implementations for WotW Aemon and A Lannister Always Pays Their Debts that will work in Melee, as well as provides some infrastructure necessary to implement the Hand of the King title additional power challenge ability (not implemented here).

Progress toward #1237 