### PR TITLE
Implement proper behavior for replacement effects

### DIFF
--- a/docs/implementing-cards.md
+++ b/docs/implementing-cards.md
@@ -539,7 +539,7 @@ this.interrupt({
 });
 ```
 
-In other cases, abilities contain the word 'instead' to indicate that the event will not be cancelled, but the normal effect will be replaced. In these case, `context.skipHandler()` can be called to replace the effect.
+In other cases, abilities contain the word 'instead' to indicate that the event will not be cancelled, but the normal effect will be replaced. In these cases, the `context.replaceHandler` method can be used to replace the effect. It must be passed a function that will execute instead of the normal handler.
 
 ```javascript
 this.interrupt({
@@ -547,8 +547,9 @@ this.interrupt({
         // claim is applied and Mirri is attacking alone
     },
     handler: context => {
-        context.skipHandler();
-        // prompt the player to select a character to kill
+        context.replaceHandler(() => {
+            // kill the chosen character
+        });
     }
 });
 ```

--- a/server/game/cards/01-Core/BenjenStark.js
+++ b/server/game/cards/01-Core/BenjenStark.js
@@ -11,12 +11,13 @@ class BenjenStark extends DrawCard {
                 onCharacterKilled: event => event.card === this
             },
             handler: (context) => {
-                context.skipHandler();
                 this.game.addMessage('{0} uses {1} to gain 2 power for their faction and shuffles {1} back into their deck instead of placing it in their dead pile', this.controller, this);
 
                 this.game.addPower(this.controller, 2);
-                this.controller.moveCard(this, 'draw deck', {}, () => {
-                    this.controller.shuffleDrawDeck();
+                context.replaceHandler(() => {
+                    this.controller.moveCard(this, 'draw deck', {}, () => {
+                        this.controller.shuffleDrawDeck();
+                    });
                 });
             }
         });

--- a/server/game/cards/01-Core/SerDavosSeaworth.js
+++ b/server/game/cards/01-Core/SerDavosSeaworth.js
@@ -6,10 +6,11 @@ class SerDavosSeaworth extends DrawCard {
             when: {
                 onCharacterKilled: event => event.card === this
             },
-            handler: (context) => {
-                context.skipHandler();
+            handler: context => {
                 this.game.addMessage('{0} uses {1} to return {1} to their hand instead of their dead pile', this.controller, this, this);
-                this.controller.moveCard(this, 'hand');
+                context.replaceHandler(() => {
+                    this.controller.moveCard(this, 'hand');
+                });
             }
         });
     }

--- a/server/game/cards/02.1-TtB/TheSeastoneChair.js
+++ b/server/game/cards/02.1-TtB/TheSeastoneChair.js
@@ -17,10 +17,11 @@ class TheSeastoneChair extends DrawCard {
                 gameAction: 'kill'
             },
             handler: context => {
-                context.skipHandler();
                 this.game.addMessage('{0} uses {1} and kneels their faction card to kill {2} instead of normal claim effects',
                     this.controller, this, context.target);
-                context.target.controller.killCharacter(context.target);
+                context.replaceHandler(() => {
+                    context.target.controller.killCharacter(context.target);
+                });
             }
         });
     }

--- a/server/game/cards/02.5-COW/MirriMazDuur.js
+++ b/server/game/cards/02.5-COW/MirriMazDuur.js
@@ -10,25 +10,18 @@ class MirriMazDuur extends DrawCard {
                     event.challenge.attackers.length === 1
                 )
             },
+            target: {
+                cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.controller !== this.controller,
+                gameAction: 'kill'
+            },
             handler: context => {
-                context.skipHandler();
-                this.game.promptForSelect(this.controller, {
-                    activePromptTitle: 'Select a character',
-                    source: this,
-                    cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.controller !== this.controller,
-                    gameAction: 'kill',
-                    onSelect: (p, card) => this.onCardSelected(p, card)
+                this.game.addMessage('{0} uses {1} to kill {2} instead of normal claim effects', context.player, this, context.target);
+
+                context.replaceHandler(() => {
+                    this.game.killCharacter(context.target);
                 });
             }
         });
-    }
-
-    onCardSelected(player, card) {
-        this.game.addMessage('{0} uses {1} to kill {2} instead of normal claim effects', player, this, card);
-
-        card.controller.killCharacter(card);
-
-        return true;
     }
 }
 

--- a/server/game/cards/02.5-COW/TrialByCombat.js
+++ b/server/game/cards/02.5-COW/TrialByCombat.js
@@ -12,20 +12,20 @@ class TrialByCombat extends DrawCard {
                 )
             },
             handler: context => {
-                let opponent = this.game.getOtherPlayer(this.controller);
-
-                context.skipHandler();
+                let opponent = context.event.challenge.defendingPlayer;
 
                 this.game.addMessage('{0} uses {1} to have {2} apply {3} claim instead of {4} claim', this.controller, this, opponent, 'military', 'intrigue');
 
-                let replacementChallenge = {
-                    challengeType: 'military',
-                    claim: this.controller.getClaim(),
-                    loser: opponent,
-                    winner: this.controller
-                };
+                context.replaceHandler(() => {
+                    let replacementChallenge = {
+                        challengeType: 'military',
+                        claim: this.controller.getClaim(),
+                        loser: opponent,
+                        winner: this.controller
+                    };
 
-                this.game.queueStep(new ApplyClaim(this.game, replacementChallenge));
+                    this.game.queueStep(new ApplyClaim(this.game, replacementChallenge));
+                });
             }
         });
     }

--- a/server/game/cards/02.5-COW/VengeanceForElia.js
+++ b/server/game/cards/02.5-COW/VengeanceForElia.js
@@ -11,18 +11,18 @@ class VengeanceForElia extends DrawCard {
             handler: context => {
                 let opponent = context.opponent;
 
-                context.skipHandler();
-
                 this.game.addMessage('{0} uses {1} to apply claim to {2} instead', context.player, this, opponent);
 
-                let replacementChallenge = {
-                    challengeType: this.game.currentChallenge.challengeType,
-                    claim: this.game.currentChallenge.claim,
-                    loser: opponent,
-                    winner: this.game.currentChallenge.winner
-                };
+                context.replaceHandler(() => {
+                    let replacementChallenge = {
+                        challengeType: this.game.currentChallenge.challengeType,
+                        claim: this.game.currentChallenge.claim,
+                        loser: opponent,
+                        winner: this.game.currentChallenge.winner
+                    };
 
-                this.game.queueStep(new ApplyClaim(this.game, replacementChallenge));
+                    this.game.queueStep(new ApplyClaim(this.game, replacementChallenge));
+                });
             }
         });
     }

--- a/server/game/cards/02.6-TS/DagmerCleftjaw.js
+++ b/server/game/cards/02.6-TS/DagmerCleftjaw.js
@@ -9,28 +9,23 @@ class DagmerCleftjaw extends DrawCard {
                     event.challenge.isAttacking(this) &&
                     event.challenge.attackers.length === 1)
             },
+            target: {
+                activePromptTitle: 'Select a location',
+                source: this,
+                cardCondition: card => (
+                    card.location === 'play area' &&
+                    card.getType() === 'location' &&
+                    card.getCost() <= 3 &&
+                    !card.isLimited() &&
+                    card.controller !== this.controller)
+            },
             handler: context => {
-                context.skipHandler();
-                this.game.promptForSelect(this.controller, {
-                    activePromptTitle: 'Select a location',
-                    source: this,
-                    cardCondition: card => (
-                        card.location === 'play area' &&
-                        card.getType() === 'location' &&
-                        card.getCost() <= 3 &&
-                        !card.isLimited() &&
-                        card.controller !== this.controller),
-                    onSelect: (p, card) => this.onCardSelected(p, card)
+                this.game.addMessage('{0} uses {1} to take control of {2} instead of normal claim effects', context.player, this, context.target);
+                context.replaceHandler(() => {
+                    this.game.takeControl(context.player, context.target);
                 });
             }
         });
-    }
-
-    onCardSelected(player, card) {
-        this.game.takeControl(player, card);
-        this.game.addMessage('{0} uses {1} to take control of {2} instead of normal claim effects', player, this, card);
-
-        return true;
     }
 }
 

--- a/server/game/cards/03-WotN/Needle.js
+++ b/server/game/cards/03-WotN/Needle.js
@@ -12,9 +12,10 @@ class Needle extends DrawCard {
             },
             cost: ability.costs.sacrificeSelf(),
             handler: context => {
-                context.skipHandler();
                 this.game.addMessage('{0} sacrifices {1} to return {2} to their hand', this.controller, this, context.event.card);
-                this.controller.returnCardToHand(context.event.card, false);
+                context.replaceHandler(() => {
+                    this.controller.returnCardToHand(context.event.card, false);
+                });
             }
         });
     }

--- a/server/game/cards/04.5-GoH/Craster.js
+++ b/server/game/cards/04.5-GoH/Craster.js
@@ -18,7 +18,7 @@ class Craster extends DrawCard {
             cost: ability.costs.sacrificeSelf(),
             condition: () => this.tracker.anyKilled(),
             handler: () => {
-                let characters = this.tracker.killedThisPhase;
+                let characters = this.tracker.killedThisPhase.filter(card => card.location === 'dead pile');
                 _.each(characters, character => {
                     character.owner.putIntoPlay(character);
                 });

--- a/server/game/cards/06.3-TFoA/SpearsOfTheMerlingKing.js
+++ b/server/game/cards/06.3-TFoA/SpearsOfTheMerlingKing.js
@@ -7,11 +7,12 @@ class SpearsOfTheMerlingKing extends DrawCard {
                 onCharacterKilled: event => event.card.controller === this.controller
             },
             cost: ability.costs.sacrificeSelf(),
-            handler: (context) => {
-                context.skipHandler();
-                this.controller.moveCard(context.event.card, 'hand');
+            handler: context => {
                 this.game.addMessage('{0} sacrifices {1} to return {2} to their hand',
                     this.controller, this, context.event.card);
+                context.replaceHandler(() => {
+                    this.controller.moveCard(context.event.card, 'hand');
+                });
             }
         });
     }

--- a/server/game/event.js
+++ b/server/game/event.js
@@ -4,7 +4,7 @@ class Event {
     constructor(name, params, merge = false) {
         this.name = name;
         this.cancelled = false;
-        this.shouldSkipHandler = false;
+        this.replacementHandler = null;
 
         if(merge) {
             _.extend(this, params);
@@ -22,8 +22,16 @@ class Event {
         this.cancelled = true;
     }
 
-    skipHandler() {
-        this.shouldSkipHandler = true;
+    replaceHandler(handler) {
+        this.replacementHandler = handler;
+    }
+
+    executeHandler(handler) {
+        if(this.replacementHandler) {
+            this.replacementHandler(...this.params);
+        } else {
+            handler(...this.params);
+        }
     }
 
     saveCard(card) {

--- a/server/game/gamesteps/atomiceventwindow.js
+++ b/server/game/gamesteps/atomiceventwindow.js
@@ -71,9 +71,8 @@ class AtomicEventWindow extends BaseStep {
             return;
         }
 
-        if(_.all(this.events, event => !event.shouldSkipHandler)) {
-            this.handler();
-        }
+        let primaryEvent = this.events[0];
+        primaryEvent.executeHandler(this.handler);
 
         _.each(this.events, event => {
             this.game.emit(event.name, ...event.params);

--- a/server/game/gamesteps/eventwindow.js
+++ b/server/game/gamesteps/eventwindow.js
@@ -91,14 +91,12 @@ class EventWindow extends BaseStep {
             return;
         }
 
-        if(!this.event.shouldSkipHandler) {
-            this.handler(...this.event.params);
+        this.event.executeHandler(this.handler);
 
-            if(this.event.cancelled) {
-                return;
-            }
+        if(this.event.cancelled) {
+            return;
         }
-        
+
         this.game.emit(this.eventName, ...this.event.params);
         if(this.eventName === 'onPlotsWhenRevealed') {
             this.game.openAbilityWindow({

--- a/server/game/gamesteps/simultaneouseventwindow.js
+++ b/server/game/gamesteps/simultaneouseventwindow.js
@@ -10,6 +10,7 @@ class SimultaneousEventWindow extends BaseStep {
         super(game);
 
         this.handler = properties.handler || (() => true);
+        this.postHandler = properties.postHandler || (() => true);
 
         this.event = new Event(properties.eventName, _.extend({ cards: cards }, properties.params), true);
         this.perCardEventMap = this.buildPerCardEvents(cards, properties);
@@ -25,6 +26,7 @@ class SimultaneousEventWindow extends BaseStep {
             new SimpleStep(game, () => this.perCardWindow('interrupt')),
             new SimpleStep(game, () => this.executeHandler()),
             new SimpleStep(game, () => this.executePerCardHandlers()),
+            new SimpleStep(game, () => this.executePostHandler()),
             new SimpleStep(game, () => this.openWindow('forcedreaction')),
             new SimpleStep(game, () => this.perCardWindow('forcedreaction')),
             new SimpleStep(game, () => this.openWindow('reaction')),
@@ -139,6 +141,14 @@ class SimultaneousEventWindow extends BaseStep {
                 this.executeEventHandler(event, this.perCardHandler);
             });
         });
+    }
+
+    executePostHandler() {
+        if(this.event.cancelled) {
+            return;
+        }
+
+        this.executeEventHandler(this.event, this.postHandler);
     }
 
     executeEventHandler(event, handler) {

--- a/server/game/gamesteps/simultaneouseventwindow.js
+++ b/server/game/gamesteps/simultaneouseventwindow.js
@@ -152,13 +152,12 @@ class SimultaneousEventWindow extends BaseStep {
     }
 
     executeEventHandler(event, handler) {
-        if(!event.shouldSkipHandler) {
-            handler(...event.params);
+        event.executeHandler(handler);
 
-            if(event.cancelled) {
-                return;
-            }
+        if(event.cancelled) {
+            return;
         }
+
         this.game.emit(event.name, ...event.params);
     }
 }

--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -16,8 +16,8 @@ class TriggeredAbilityContext {
         this.event.cancel();
     }
 
-    skipHandler() {
-        this.event.skipHandler();
+    replaceHandler(handler) {
+        this.event.replaceHandler(handler);
     }
 }
 

--- a/test/server/gamesteps/eventwindow.spec.js
+++ b/test/server/gamesteps/eventwindow.spec.js
@@ -61,9 +61,10 @@ describe('EventWindow', function() {
             });
         });
 
-        describe('when an event has its handler skipped', function() {
+        describe('when an event has its handler replaced', function() {
             beforeEach(function() {
-                this.eventWindow.event.skipHandler();
+                this.replacementHandler = jasmine.createSpy('replacementHandler');
+                this.eventWindow.event.replaceHandler(this.replacementHandler);
                 this.eventWindow.continue();
             });
 
@@ -78,6 +79,10 @@ describe('EventWindow', function() {
 
             it('should not call the handler', function() {
                 expect(this.handler).not.toHaveBeenCalled();
+            });
+
+            it('should call the replacement handler', function() {
+                expect(this.replacementHandler).toHaveBeenCalled();
             });
         });
 

--- a/test/server/gamesteps/simultaneouseventwindow.spec.js
+++ b/test/server/gamesteps/simultaneouseventwindow.spec.js
@@ -122,7 +122,8 @@ describe('SimultaneousEventWindow', function() {
 
         describe('when an event has its handler skipped', function() {
             beforeEach(function() {
-                this.eventWindow.event.skipHandler();
+                this.replacementHandler = jasmine.createSpy('replacementHandler');
+                this.eventWindow.event.replaceHandler(this.replacementHandler);
                 this.eventWindow.continue();
             });
 
@@ -137,6 +138,10 @@ describe('SimultaneousEventWindow', function() {
 
             it('should not call the handler', function() {
                 expect(this.handler).not.toHaveBeenCalled();
+            });
+
+            it('should call the replacement handler', function() {
+                expect(this.replacementHandler).toHaveBeenCalled();
             });
         });
 

--- a/test/server/integration/ReplacementEffects.spec.js
+++ b/test/server/integration/ReplacementEffects.spec.js
@@ -1,0 +1,110 @@
+describe('replacement effects', function() {
+    integration(function() {
+        describe('when a replacement effect is applied', function() {
+            beforeEach(function() {
+                const deck1 = this.buildDeck('thenightswatch', [
+                    'A Noble Cause',
+                    'Benjen Stark'
+                ]);
+                const deck2 = this.buildDeck('lannister', [
+                    'A Noble Cause',
+                    'Chella Daughter of Cheyk'
+                ]);
+                this.player1.selectDeck(deck1);
+                this.player2.selectDeck(deck2);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.benjen = this.player1.findCardByName('Benjen Stark', 'hand');
+                this.chella = this.player2.findCardByName('Chella Daughter of Cheyk', 'hand');
+
+                this.player1.clickCard(this.benjen);
+                this.player2.clickCard(this.chella);
+
+                this.completeSetup();
+
+                this.player1.selectPlot('A Noble Cause');
+                this.player2.selectPlot('A Noble Cause');
+                this.selectFirstPlayer(this.player2);
+
+                this.completeMarshalPhase();
+
+                this.unopposedChallenge(this.player2, 'military', this.chella);
+                this.player2.clickPrompt('Apply Claim');
+
+                // Choose Benjen for claim
+                this.player1.clickCard(this.benjen);
+                this.player1.clickPrompt('Benjen Stark');
+            });
+
+            it('should replace the effect', function() {
+                expect(this.benjen.location).toBe('draw deck');
+            });
+
+            it('should still be considered to have happened', function() {
+                // Chella should gain an ear token from Benjen dying
+                this.player2.clickPrompt('Chella Daughter of Cheyk');
+
+                expect(this.chella.tokens.ear).toBe(1);
+            });
+        });
+
+        describe('when a multiple replacement effects are applied', function() {
+            beforeEach(function() {
+                const deck1 = this.buildDeck('thenightswatch', [
+                    'A Noble Cause',
+                    'Mirri Maz Duur', 'Hedge Knight'
+                ]);
+                const deck2 = this.buildDeck('lannister', [
+                    'A Noble Cause',
+                    'Vengeance for Elia', 'Hedge Knight', 'Hedge Knight'
+                ]);
+                this.player1.selectDeck(deck1);
+                this.player2.selectDeck(deck2);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.mirri = this.player1.findCardByName('Mirri Maz Duur', 'hand');
+                this.character = this.player2.findCardByName('Hedge Knight', 'hand');
+
+                this.player1.clickCard(this.mirri);
+                this.player2.clickCard(this.character);
+
+                this.completeSetup();
+
+                this.player1.selectPlot('A Noble Cause');
+                this.player2.selectPlot('A Noble Cause');
+                this.selectFirstPlayer(this.player1);
+
+                this.completeMarshalPhase();
+
+                this.unopposedChallenge(this.player1, 'intrigue', this.mirri);
+                this.player1.clickPrompt('Apply Claim');
+
+                // Player 1 attempts to trigger Mirri to kill the character
+                this.player1.clickPrompt('Mirri Maz Duur');
+                this.player1.clickCard(this.character);
+
+                // Player 2 applies the claim back to the attacker
+                this.player2.clickPrompt('Vengeance for Elia');
+            });
+
+            it('should replace the original effect', function() {
+                // Vengeance for Elia is in discard but no other card is discarded
+                expect(this.player2Object.hand.size()).toBe(1);
+                expect(this.player2Object.discardPile.size()).toBe(1);
+            });
+
+            it('should not use the first replacement', function() {
+                // The character chosen by Mirri is not killed
+                expect(this.character.location).toBe('play area');
+            });
+
+            it('should use the final replacement', function() {
+                // Vengeance for Elia discards 1 card from player 1.
+                expect(this.player1Object.hand.size()).toBe(0);
+                expect(this.player1Object.discardPile.size()).toBe(1);
+            });
+        });
+    });
+});


### PR DESCRIPTION
* Replacement effects now execute when the thing they're supposed to replace would execute instead of immediately after triggering.
* Because replacement effects no longer trigger immediately, when multiple replacements are triggered only the last will actually be applied, as per the rules.
* Fixing the timing revealed a bug w/ Craster where he could return Benjen Stark from the draw deck into play.
* Fixing the timing revealed a bug where dead pile order was being asked before it was determined which cards may be placed somewhere other than the dead pile (e.g. Benjen, Davos)
* Fixing the timing revealed a bug where if a replacement effect occurred, reactions to that event would not fire (e.g. Benjen dying vs Chella gaining ears). (Not sure why this bug was happening, but this PR fixes it apparently ????)