### PR TITLE
Display targets on cancel prompts

### DIFF
--- a/client/GameBoard.jsx
+++ b/client/GameBoard.jsx
@@ -465,6 +465,7 @@ export class InnerGameBoard extends React.Component {
                                 <div className='inset-pane'>
                                     <ActivePlayerPrompt title={ thisPlayer.menuTitle }
                                         buttons={ thisPlayer.buttons }
+                                        controls={ thisPlayer.controls }
                                         promptTitle={ thisPlayer.promptTitle }
                                         onButtonClick={ this.onCommand }
                                         onMouseOver={ this.onMouseOver }

--- a/client/GameComponents/AbilityTargeting.jsx
+++ b/client/GameComponents/AbilityTargeting.jsx
@@ -20,6 +20,7 @@ class AbilityTargeting extends React.Component {
                 onMouseOut={ event => this.onMouseOut(event, card) }
                 onMouseOver={ event => this.onMouseOver(event, card) }>
                 <img className='target-card-image vertical'
+                    alt={ card.name }
                     src={ '/img/cards/' + (!card.facedown ? (card.code + '.png') : 'cardback.jpg') } />
             </div>);
     }

--- a/client/GameComponents/AbilityTargeting.jsx
+++ b/client/GameComponents/AbilityTargeting.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import _ from 'underscore';
+
+class AbilityTargeting extends React.Component {
+    onMouseOver(event, card) {
+        if(card && this.props.onMouseOver) {
+            this.props.onMouseOver(card);
+        }
+    }
+
+    onMouseOut(event, card) {
+        if(card && this.props.onMouseOut) {
+            this.props.onMouseOut(card);
+        }
+    }
+
+    renderSimpleCard(card) {
+        return (
+            <div className='target-card vertical'
+                onMouseOut={ event => this.onMouseOut(event, card) }
+                onMouseOver={ event => this.onMouseOver(event, card) }>
+                <img className='target-card-image vertical'
+                    src={ '/img/cards/' + (!card.facedown ? (card.code + '.png') : 'cardback.jpg') } />
+            </div>);
+    }
+
+    render() {
+        let targetCards = _.map(this.props.targets, target => this.renderSimpleCard(target));
+        return (
+            <div className='prompt-control-targeting'>
+                { this.renderSimpleCard(this.props.source) }
+                <span className='glyphicon glyphicon-arrow-right targeting-arrow' />
+                { targetCards }
+            </div>);
+    }
+}
+
+AbilityTargeting.displayName = 'AbilityTargeting';
+AbilityTargeting.propTypes = {
+    onMouseOut: React.PropTypes.func,
+    onMouseOver: React.PropTypes.func,
+    source: React.PropTypes.object,
+    targets: React.PropTypes.array
+};
+
+export default AbilityTargeting;

--- a/client/GameComponents/ActivePlayerPrompt.jsx
+++ b/client/GameComponents/ActivePlayerPrompt.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import _ from 'underscore';
 
+import AbilityTargeting from './AbilityTargeting.jsx';
+
+
 class ActivePlayerPrompt extends React.Component {
     constructor() {
         super();
@@ -150,6 +153,20 @@ class ActivePlayerPrompt extends React.Component {
         return buttons;
     }
 
+    getControls() {
+        return _.map(this.props.controls, control => {
+            switch(control.type) {
+                case 'targeting':
+                    return (
+                        <AbilityTargeting
+                            onMouseOut={ this.props.onMouseOut }
+                            onMouseOver={ this.props.onMouseOver }
+                            source={ control.source }
+                            targets={ control.targets } />);
+            }
+        });
+    }
+
     render() {
         let promptTitle;
 
@@ -178,6 +195,7 @@ class ActivePlayerPrompt extends React.Component {
             <div className='menu-pane'>
                 <div className='panel'>
                     <h4>{ this.props.title }</h4>
+                    { this.getControls() }
                     { this.getButtons() }
                 </div>
             </div>

--- a/client/GameComponents/ActivePlayerPrompt.jsx
+++ b/client/GameComponents/ActivePlayerPrompt.jsx
@@ -188,6 +188,7 @@ class ActivePlayerPrompt extends React.Component {
 ActivePlayerPrompt.displayName = 'ActivePlayerPrompt';
 ActivePlayerPrompt.propTypes = {
     buttons: React.PropTypes.array,
+    controls: React.PropTypes.array,
     onButtonClick: React.PropTypes.func,
     onMouseOut: React.PropTypes.func,
     onMouseOver: React.PropTypes.func,

--- a/client/GameComponents/ActivePlayerPrompt.jsx
+++ b/client/GameComponents/ActivePlayerPrompt.jsx
@@ -13,7 +13,7 @@ class ActivePlayerPrompt extends React.Component {
 
     shouldComponentUpdate(newProps, newState) {
         return newProps.phase !== this.props.phase || newProps.promptTitle !== this.props.promptTitle ||
-            newProps.title !== this.props.title || newProps.arrowDirection !== this.props.arrowDirection ||
+            newProps.title !== this.props.title ||
             !this.buttonsAreEqual(this.props.buttons, newProps.buttons) ||
             newState.showTimer !== this.state.showTimer ||
             newState.timeLeft !== this.state.timeLeft || newState.timerClass !== this.state.timerClass;
@@ -187,11 +187,6 @@ class ActivePlayerPrompt extends React.Component {
 
 ActivePlayerPrompt.displayName = 'ActivePlayerPrompt';
 ActivePlayerPrompt.propTypes = {
-    arrowDirection: React.PropTypes.oneOf([
-        'up',
-        'down',
-        'none'
-    ]),
     buttons: React.PropTypes.array,
     onButtonClick: React.PropTypes.func,
     onMouseOut: React.PropTypes.func,

--- a/less/gameboard.less
+++ b/less/gameboard.less
@@ -465,6 +465,32 @@
   white-space: normal;
 }
 
+.prompt-control-targeting {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.targeting-arrow {
+  margin: 5px;
+}
+
+.target-card {
+  border-radius: 6.25%;
+  flex-shrink: 1;
+  margin: 0 2px;
+  max-height: @card-height;
+  max-width: @card-width;
+}
+
+.target-card-image {
+  max-height: @card-height;
+  object-fit: contain;
+  width: 100%;
+}
+
 .phase-indicator {
   margin: 5px;
   margin-bottom: 0;

--- a/server/game/gamesteps/abilityresolver.js
+++ b/server/game/gamesteps/abilityresolver.js
@@ -146,7 +146,8 @@ class AbilityResolver extends BaseStep {
         // instance, marshaling does not count as initiating a card ability and
         // thus is not subject to cancels such as Treachery.
         if(this.ability.isCardAbility()) {
-            this.game.raiseEvent('onCardAbilityInitiated', { player: this.context.player, source: this.context.source }, () => {
+            let targets = _.flatten(_.values(this.context.targets));
+            this.game.raiseEvent('onCardAbilityInitiated', { player: this.context.player, source: this.context.source, targets: targets }, () => {
                 this.ability.executeHandler(this.context);
             });
         } else {

--- a/server/game/gamesteps/triggeredabilitywindow.js
+++ b/server/game/gamesteps/triggeredabilitywindow.js
@@ -109,12 +109,28 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
         this.game.promptWithMenu(player, this, {
             activePrompt: {
                 menuTitle: TriggeredAbilityWindowTitles.getTitle(this.abilityType, this.events[0]),
-                buttons: buttons
+                buttons: buttons,
+                controls: this.getAdditionalPromptControls()
             },
             waitingPromptTitle: 'Waiting for opponents'
         });
 
         this.forceWindowPerPlayer[player.name] = false;
+    }
+
+    getAdditionalPromptControls() {
+        let controls = [];
+        for(let event of this.events) {
+            if(event.name === 'onCardAbilityInitiated' && event.targets.length > 0) {
+                controls.push({
+                    type: 'targeting',
+                    source: event.source.getShortSummary(),
+                    targets: event.targets.map(target => target.getShortSummary())
+                });
+            }
+        }
+
+        return controls;
     }
 
     getChoicesForPlayer(player) {

--- a/server/game/playerpromptstate.js
+++ b/server/game/playerpromptstate.js
@@ -7,6 +7,7 @@ class PlayerPromptState {
         this.menuTitle = '';
         this.promptTitle = '';
         this.buttons = [];
+        this.controls = [];
 
         this.selectableCards = [];
         this.selectedCards = [];
@@ -42,12 +43,14 @@ class PlayerPromptState {
 
             return button;
         });
+        this.controls = prompt.controls || [];
     }
 
     cancelPrompt() {
         this.selectCard = false;
         this.menuTitle = '';
         this.buttons = [];
+        this.controls = [];
     }
 
     getCardSelectionState(card) {
@@ -74,7 +77,8 @@ class PlayerPromptState {
             selectOrder: this.selectOrder,
             menuTitle: this.menuTitle,
             promptTitle: this.promptTitle,
-            buttons: this.buttons
+            buttons: this.buttons,
+            controls: this.controls
         };
     }
 }

--- a/test/server/gamesteps/abilityresolver.spec.js
+++ b/test/server/gamesteps/abilityresolver.spec.js
@@ -56,7 +56,7 @@ describe('AbilityResolver', function() {
             });
 
             it('should raise the onCardAbilityInitiated event', function() {
-                expect(this.game.raiseEvent).toHaveBeenCalledWith('onCardAbilityInitiated', { player: this.player, source: this.source }, jasmine.any(Function));
+                expect(this.game.raiseEvent).toHaveBeenCalledWith('onCardAbilityInitiated', { player: this.player, source: this.source, targets: [] }, jasmine.any(Function));
             });
         });
 
@@ -194,6 +194,10 @@ describe('AbilityResolver', function() {
 
                         it('should execute the handler', function() {
                             expect(this.ability.executeHandler).toHaveBeenCalledWith(this.context);
+                        });
+
+                        it('should raise the onCardAbilityInitiated event with appropriate targets', function() {
+                            expect(this.game.raiseEvent).toHaveBeenCalledWith('onCardAbilityInitiated', { player: this.player, source: this.source, targets: [this.target] }, jasmine.any(Function));
                         });
                     });
 

--- a/test/server/gamesteps/triggeredabilitywindow.spec.js
+++ b/test/server/gamesteps/triggeredabilitywindow.spec.js
@@ -137,7 +137,7 @@ describe('TriggeredAbilityWindow', function() {
 
                 it('should prompt the first player', function() {
                     expect(this.gameSpy.promptWithMenu).toHaveBeenCalledWith(this.player1Spy, this.window, jasmine.objectContaining({
-                        activePrompt: {
+                        activePrompt: jasmine.objectContaining({
                             menuTitle: jasmine.any(String),
                             buttons: [
                                 jasmine.objectContaining({ text: 'The Card - My Choice 1', arg: '1', method: 'chooseAbility' }),
@@ -145,7 +145,7 @@ describe('TriggeredAbilityWindow', function() {
                                 jasmine.objectContaining({ text: 'The Card 2', arg: '3', method: 'chooseAbility' }),
                                 jasmine.objectContaining({ text: 'Pass', method: 'pass' })
                             ]
-                        }
+                        })
                     }));
                 });
 
@@ -169,14 +169,14 @@ describe('TriggeredAbilityWindow', function() {
                     it('should display buttons as normal', function() {
                         this.window.continue();
                         expect(this.gameSpy.promptWithMenu).toHaveBeenCalledWith(this.player1Spy, this.window, jasmine.objectContaining({
-                            activePrompt: {
+                            activePrompt: jasmine.objectContaining({
                                 menuTitle: jasmine.any(String),
                                 buttons: [
                                     jasmine.objectContaining({ text: 'The Card', arg: '1', method: 'chooseAbility' }),
                                     jasmine.objectContaining({ text: 'The Card 2', arg: '2', method: 'chooseAbility' }),
                                     jasmine.objectContaining({ text: 'Pass', method: 'pass' })
                                 ]
-                            }
+                            })
                         }));
                     });
                 });
@@ -189,13 +189,13 @@ describe('TriggeredAbilityWindow', function() {
 
                     it('should only display the first copy', function() {
                         expect(this.gameSpy.promptWithMenu).toHaveBeenCalledWith(this.player1Spy, this.window, jasmine.objectContaining({
-                            activePrompt: {
+                            activePrompt: jasmine.objectContaining({
                                 menuTitle: jasmine.any(String),
                                 buttons: [
                                     jasmine.objectContaining({ text: 'The Card', arg: '1', method: 'chooseAbility' }),
                                     jasmine.objectContaining({ text: 'Pass', method: 'pass' })
                                 ]
-                            }
+                            })
                         }));
                     });
                 });
@@ -209,13 +209,13 @@ describe('TriggeredAbilityWindow', function() {
 
                 it('should filter out choices for that ability', function() {
                     expect(this.gameSpy.promptWithMenu).toHaveBeenCalledWith(this.player1Spy, this.window, jasmine.objectContaining({
-                        activePrompt: {
+                        activePrompt: jasmine.objectContaining({
                             menuTitle: jasmine.any(String),
                             buttons: [
                                 jasmine.objectContaining({ text: 'The Card 2', arg: '3', method: 'chooseAbility' }),
                                 jasmine.objectContaining({ text: 'Pass', method: 'pass' })
                             ]
-                        }
+                        })
                     }));
                 });
             });
@@ -229,13 +229,13 @@ describe('TriggeredAbilityWindow', function() {
 
                 it('should prompt the next player', function() {
                     expect(this.gameSpy.promptWithMenu).toHaveBeenCalledWith(this.player2Spy, this.window, jasmine.objectContaining({
-                        activePrompt: {
+                        activePrompt: jasmine.objectContaining({
                             menuTitle: jasmine.any(String),
                             buttons: [
                                 jasmine.objectContaining({ text: 'Their Card', arg: '4', method: 'chooseAbility' }),
                                 jasmine.objectContaining({ text: 'Pass', method: 'pass' })
                             ]
-                        }
+                        })
                     }));
                 });
             });


### PR DESCRIPTION
* Adds a `controls` property to prompts to add on additional display / form elements.
* When a user is prompted for an ability / event cancel and the ability has at least one target, it will display the card that generated the ability as well as all of the targets chosen for the ability. If there are multiple targets, the cards shrink to fit on a single line. Hovering over these cards displays a card preview as normal:
![screen shot 2017-09-14 at 5 36 49 pm](https://user-images.githubusercontent.com/145077/30468283-28e1f01a-999f-11e7-8a57-bf3f64451ec8.png) ![screen shot 2017-09-14 at 5 40 31 pm](https://user-images.githubusercontent.com/145077/30468282-28cfec80-999f-11e7-8a03-7163d72290f8.png) ![screen shot 2017-09-14 at 5 41 28 pm](https://user-images.githubusercontent.com/145077/30468284-28e48e74-999f-11e7-8342-9527af6978db.png)

Major progress toward #1249 but the targeting improvements from #1389 needed to fully resolve it.