### PR TITLE
Convert old cards to target API

### DIFF
--- a/server/game/cards/01-Core/AreoHotah.js
+++ b/server/game/cards/01-Core/AreoHotah.js
@@ -10,27 +10,15 @@ class AreoHotah extends DrawCard {
                     this.game.currentPhase === 'challenge'
                 )
             },
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    cardCondition: card => this.cardCondition(card),
-                    activePromptTitle: 'Select character',
-                    source: this,
-                    onSelect: (player, card) => this.onCardSelected(player, card)
-                });
+            target: {
+                cardCondition: card => card.getType() === 'character' && this.game.currentChallenge.isParticipating(card)
+            },
+            handler: context => {
+                this.game.currentChallenge.removeFromChallenge(context.target);
+
+                this.game.addMessage('{0} uses {1} to remove {2} from the challenge', context.player, this, context.target);
             }
         });
-    }
-
-    cardCondition(card) {
-        return card.getType() === 'character' && this.game.currentChallenge.isParticipating(card);
-    }
-
-    onCardSelected(player, card) {
-        this.game.currentChallenge.removeFromChallenge(card);
-
-        this.game.addMessage('{0} uses {1} to remove {2} from the challenge', player, this, card);
-
-        return true;
     }
 }
 

--- a/server/game/cards/01-Core/FilthyAccusations.js
+++ b/server/game/cards/01-Core/FilthyAccusations.js
@@ -4,7 +4,7 @@ class FilthyAccusations extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
             target: {
-                cardCondition: card => card.getType() === 'character' && !card.kneeled,
+                cardCondition: card => card.location === 'play area' && card.getType() === 'character' && !card.kneeled,
                 gameAction: 'kneel'
             },
             handler: context => {

--- a/server/game/cards/01-Core/FilthyAccusations.js
+++ b/server/game/cards/01-Core/FilthyAccusations.js
@@ -3,28 +3,16 @@ const PlotCard = require('../../plotcard.js');
 class FilthyAccusations extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    cardCondition: card => this.cardCondition(card),
-                    activePromptTitle: 'Select character to kneel',
-                    source: this,
-                    gameAction: 'kneel',
-                    onSelect: (player, card) => this.onCardSelected(player, card)
-                });
+            target: {
+                cardCondition: card => card.getType() === 'character' && !card.kneeled,
+                gameAction: 'kneel'
+            },
+            handler: context => {
+                this.controller.kneelCard(context.target);
+
+                this.game.addMessage('{0} uses {1} to kneel {2}', this.controller, this, context.target);
             }
         });
-    }
-
-    cardCondition(card) {
-        return card.getType() === 'character' && !card.kneeled;
-    }
-
-    onCardSelected(player, card) {
-        player.kneelCard(card);
-
-        this.game.addMessage('{0} uses {1} to kneel {2}', player, this, card);
-
-        return true;
     }
 }
 

--- a/server/game/cards/01-Core/Melisandre.js
+++ b/server/game/cards/01-Core/Melisandre.js
@@ -10,7 +10,7 @@ class Melisandre extends DrawCard {
             },
             limit: ability.limit.perRound(1),
             target: {
-                cardCondition: card => card.getType() === 'character' && !card.kneeled,
+                cardCondition: card => card.location === 'play area' && card.getType() === 'character' && !card.kneeled,
                 gameAction: 'kneel'
             },
             handler: context => {

--- a/server/game/cards/01-Core/Melisandre.js
+++ b/server/game/cards/01-Core/Melisandre.js
@@ -9,28 +9,16 @@ class Melisandre extends DrawCard {
                 onCardPlayed: event => event.card.controller === this.controller && event.card.hasTrait('R\'hllor')
             },
             limit: ability.limit.perRound(1),
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    cardCondition: card => this.cardCondition(card),
-                    activePromptTitle: 'Select a character',
-                    source: this,
-                    gameAction: 'kneel',
-                    onSelect: (player, card) => this.onCardSelected(player, card)
-                });
+            target: {
+                cardCondition: card => card.getType() === 'character' && !card.kneeled,
+                gameAction: 'kneel'
+            },
+            handler: context => {
+                this.controller.kneelCard(context.target);
+
+                this.game.addMessage('{0} uses {1} to kneel {2}', this.controller, this, context.target);
             }
         });
-    }
-
-    cardCondition(card) {
-        return card.getType() === 'character' && !card.kneeled;
-    }
-
-    onCardSelected(player, card) {
-        player.kneelCard(card);
-
-        this.game.addMessage('{0} uses {1} to kneel {2}', player, this, card);
-
-        return true;
     }
 }
 

--- a/server/game/cards/01-Core/OldBearMormont.js
+++ b/server/game/cards/01-Core/OldBearMormont.js
@@ -12,6 +12,7 @@ class OldBearMormont extends DrawCard {
                 onPhaseEnded: event => event.phase === 'challenge' && this.controller.getNumberOfChallengesLost('defender') === 0
             },
             target: {
+                activePromptTitle: 'Select a card',
                 cardCondition: card => card.location === 'hand' && card.controller === this.controller && card.isFaction('thenightswatch')
             },
             handler: context => {

--- a/server/game/cards/01-Core/OldBearMormont.js
+++ b/server/game/cards/01-Core/OldBearMormont.js
@@ -11,23 +11,15 @@ class OldBearMormont extends DrawCard {
             when: {
                 onPhaseEnded: event => event.phase === 'challenge' && this.controller.getNumberOfChallengesLost('defender') === 0
             },
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    cardCondition: card => card.location === 'hand' && card.controller === this.controller && card.isFaction('thenightswatch'),
-                    activePromptTitle: 'Select character',
-                    source: this,
-                    onSelect: (player, card) => this.onCardSelected(player, card)
-                });
+            target: {
+                cardCondition: card => card.location === 'hand' && card.controller === this.controller && card.isFaction('thenightswatch')
+            },
+            handler: context => {
+                this.controller.putIntoPlay(context.target);
+
+                this.game.addMessage('{0} uses {1} to put {2} into play from their hand', this.controller, this, context.target);
             }
         });
-    }
-
-    onCardSelected(player, card) {
-        player.putIntoPlay(card);
-
-        this.game.addMessage('{0} uses {1} to put {2} into play from their hand', player, this, card);
-
-        return true;
     }
 }
 

--- a/server/game/cards/01-Core/RattleshirtsRaiders.js
+++ b/server/game/cards/01-Core/RattleshirtsRaiders.js
@@ -4,29 +4,22 @@ class RattleshirtsRaiders extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.attackingPlayer === this.controller &&
-                    challenge.winner === this.controller &&
-                    challenge.isAttacking(this)
+                afterChallenge: event => (
+                    event.challenge.attackingPlayer === this.controller &&
+                    event.challenge.winner === this.controller &&
+                    event.challenge.isAttacking(this)
                 )
             },
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    activePromptTitle: 'Select an attachment',
-                    source: this,
-                    cardCondition: card => card.location === 'play area' && card.controller === this.game.currentChallenge.loser && card.getType() === 'attachment',
-                    onSelect: (p, card) => this.onCardSelected(p, card)
-                });
+            target: {
+                activePromptTitle: 'Select an attachment',
+                cardCondition: card => card.location === 'play area' && card.controller === this.game.currentChallenge.loser && card.getType() === 'attachment'
+            },
+            handler: context => {
+                context.target.owner.discardCard(context.target);
+
+                this.game.addMessage('{0} uses {1} to discard {2}', this.controller, this, context.target);
             }
         });
-    }
-
-    onCardSelected(player, card) {
-        card.owner.discardCard(card);
-
-        this.game.addMessage('{0} uses {1} to discard {2}', player, this, card);
-
-        return true;
     }
 }
 

--- a/server/game/cards/01-Core/Rebuilding.js
+++ b/server/game/cards/01-Core/Rebuilding.js
@@ -1,38 +1,23 @@
-const _ = require('underscore');
-
 const PlotCard = require('../../plotcard.js');
 
 class Rebuilding extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    numCards: 3,
-                    activePromptTitle: 'Select up to 3 cards from discard',
-                    source: this,
-                    cardCondition: card => this.cardCondition(card),
-                    onSelect: (player, cards) => this.doneSelect(player, cards)
-                });
+            target: {
+                numCards: 3,
+                activePromptTitle: 'Select up to 3 cards',
+                cardCondition: card => this.controller === card.controller && card.location === 'discard pile'
+            },
+            handler: context => {
+                for(let card of context.target) {
+                    this.controller.moveCard(card, 'draw deck');
+
+                }
+
+                this.controller.shuffleDrawDeck();
+                this.game.addMessage('{0} uses {1} to shuffle {2} into their deck', this.controller, this, context.target);
             }
         });
-    }
-
-    cardCondition(card) {
-        var player = card.controller;
-        return this.controller === player && player.findCardByUuid(player.discardPile, card.uuid);
-    }
-
-    doneSelect(player, cards) {
-        _.each(cards, card => {
-            player.moveCard(card, 'draw deck');
-            player.shuffleDrawDeck();
-        });
-
-        if(!_.isEmpty(cards)) {
-            this.game.addMessage('{0} uses {1} to shuffle {2} into their deck', player, this, cards);
-        }
-
-        return true;
     }
 }
 

--- a/server/game/cards/01-Core/Reinforcement.js
+++ b/server/game/cards/01-Core/Reinforcement.js
@@ -3,33 +3,19 @@ const PlotCard = require('../../plotcard.js');
 class Reinforcements extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    activePromptTitle: 'Select a character',
-                    source: this,
-                    cardCondition: card => this.cardCondition(card),
-                    onSelect: (player, card) => this.onCardClicked(player, card)
-                });
+            target: {
+                cardCondition: card => (
+                    this.controller === card.controller &&
+                    card.getCost() <= 5 &&
+                    card.getType() === 'character' &&
+                    ['hand', 'discard pile'].includes(card.location)
+                )
+            },
+            handler: context => {
+                this.game.addMessage('{0} uses {1} to put {2} into play from their {3}', this.controller, this, context.target, context.target.location);
+                this.controller.putIntoPlay(context.target);
             }
         });
-    }
-
-    cardCondition(card) {
-        var player = card.controller;
-        return this.controller === player &&
-            card.getCost() <= 5 &&
-            card.getType() === 'character' &&
-            (player.findCardByUuid(player.discardPile, card.uuid) || player.findCardByUuid(player.hand, card.uuid));
-    }
-
-    onCardClicked(player, card) {
-        var hand = !!player.findCardByUuid(player.hand, card.uuid);
-
-        this.game.addMessage('{0} uses {1} to put {2} into play from their {3}', player, this, card, hand ? 'hand' : 'discard pile');
-
-        player.putIntoPlay(card);
-
-        return true;
     }
 }
 

--- a/server/game/cards/01-Core/Rhaegal.js
+++ b/server/game/cards/01-Core/Rhaegal.js
@@ -12,22 +12,14 @@ class Rhaegal extends DrawCard {
                 )
             },
             limit: ability.limit.perPhase(1),
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    activePromptTitle: 'Select character to stand',
-                    source: this,
-                    cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.hasTrait('Stormborn'),
-                    onSelect: (p, card) => this.onCardSelected(p, card)
-                });
+            target: {
+                cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.hasTrait('Stormborn')
+            },
+            handler: context => {
+                this.controller.standCard(context.target);
+                this.game.addMessage('{0} uses {1} to stand {2}', this.controller, this, context.target);
             }
         });
-    }
-
-    onCardSelected(player, card) {
-        player.standCard(card);
-        this.game.addMessage('{0} uses {1} to stand {2}', player, this, card);
-
-        return true;
     }
 }
 

--- a/server/game/cards/01-Core/Rhaegal.js
+++ b/server/game/cards/01-Core/Rhaegal.js
@@ -13,7 +13,7 @@ class Rhaegal extends DrawCard {
             },
             limit: ability.limit.perPhase(1),
             target: {
-                cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.hasTrait('Stormborn')
+                cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.hasTrait('Stormborn') && card.kneeled
             },
             handler: context => {
                 this.controller.standCard(context.target);

--- a/server/game/cards/01-Core/ShireenBaratheon.js
+++ b/server/game/cards/01-Core/ShireenBaratheon.js
@@ -7,7 +7,7 @@ class ShireenBaratheon extends DrawCard {
                 onCharacterKilled: event => event.card === this
             },
             target: {
-                cardCondition: card => card.getType() === 'character' && !card.kneeled,
+                cardCondition: card => card.location === 'play area' && card.getType() === 'character' && !card.kneeled,
                 gameAction: 'kneel'
             },
             handler: context => {

--- a/server/game/cards/01-Core/ShireenBaratheon.js
+++ b/server/game/cards/01-Core/ShireenBaratheon.js
@@ -6,28 +6,16 @@ class ShireenBaratheon extends DrawCard {
             when: {
                 onCharacterKilled: event => event.card === this
             },
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    cardCondition: card => this.cardCondition(card),
-                    activePromptTitle: 'Select a character to kneel',
-                    source: this,
-                    gameAction: 'kneel',
-                    onSelect: (player, card) => this.onCardSelected(player, card)
-                });
+            target: {
+                cardCondition: card => card.getType() === 'character' && !card.kneeled,
+                gameAction: 'kneel'
+            },
+            handler: context => {
+                this.controller.kneelCard(context.target);
+
+                this.game.addMessage('{0} uses {1} to kneel {2}', this.controller, this, context.target);
             }
         });
-    }
-
-    cardCondition(card) {
-        return card.getType() === 'character' && !card.kneeled;
-    }
-
-    onCardSelected(player, card) {
-        player.kneelCard(card);
-
-        this.game.addMessage('{0} uses {1} to kneel {2}', player, this, card);
-
-        return true;
     }
 }
 

--- a/server/game/cards/01-Core/Summer.js
+++ b/server/game/cards/01-Core/Summer.js
@@ -11,13 +11,14 @@ class Summer extends DrawCard {
             when: {
                 onCardEntersPlay: event => event.card === this
             },
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    activePromptTitle: 'Select a character',
-                    source: this,
-                    cardCondition: (card) => this.cardCondition(card),
-                    onSelect: (p, card) => this.onCardSelected(p, card)
-                });
+            target: {
+                cardCondition: (card) => this.cardCondition(card)
+            },
+            handler: context => {
+                let oldLocation = context.target.location;
+
+                this.controller.moveCard(context.target, 'hand');
+                this.game.addMessage('{0} uses {1} to move {2} from their {3} to their hand', this.controller, this, context.target, oldLocation);
             }
         });
     }
@@ -25,16 +26,6 @@ class Summer extends DrawCard {
     cardCondition(card) {
         return (card.location === 'dead pile' || card.location === 'discard pile') && card.controller === this.controller && card.getType() === 'character' &&
             card.isFaction('stark') && card.getPrintedStrength() <= 2;
-    }
-
-    onCardSelected(player, card) {
-        var oldLocation = card.location;
-
-        player.moveCard(card, 'hand');
-
-        this.game.addMessage('{0} uses {1} to move {2} from their {3} to their hand', player, this, card, oldLocation);
-
-        return true;
     }
 }
 

--- a/server/game/cards/01-Core/WildlingHorde.js
+++ b/server/game/cards/01-Core/WildlingHorde.js
@@ -7,38 +7,22 @@ class WildlingHorde extends DrawCard {
             phase: 'challenge',
             condition: () => this.game.currentChallenge,
             cost: ability.costs.kneelFactionCard(),
-            handler: (context) => {
-                this.game.promptForSelect(context.player, {
-                    activePromptTitle: 'Select a character',
-                    source: this,
-                    cardCondition: card => this.cardCondition(context.player, card),
-                    onSelect: (p, card) => this.onCardSelected(p, card)
-                });
+            target: {
+                cardCondition: card => (
+                    card.location === 'play area' &&
+                    card.controller === this.controller &&
+                    card.hasTrait('Wildling') &&
+                    this.game.currentChallenge.isParticipating(card)
+                )
+            },
+            handler: context => {
+                this.game.addMessage('{0} uses {1} to kneel their faction card and increase the strength of {2} by 2 until the end of the challenge', this.controller, this, context.target);
+                this.untilEndOfChallenge(ability => ({
+                    match: context.target,
+                    effect: ability.effects.modifyStrength(2)
+                }));
             }
         });
-    }
-
-    cardCondition(player, card) {
-        var currentChallenge = this.game.currentChallenge;
-        if(!currentChallenge) {
-            return false;
-        }
-
-        return card.location === 'play area' && card.controller === player && card.hasTrait('Wildling') && currentChallenge.isParticipating(card);
-    }
-
-    onCardSelected(player, card) {
-        if(this.controller !== player) {
-            return false;
-        }
-
-        this.game.addMessage('{0} uses {1} to kneel their faction card and increase the strength of {2} by 2 until the end of the challenge', player, this, card);
-        this.untilEndOfChallenge(ability => ({
-            match: card,
-            effect: ability.effects.modifyStrength(2)
-        }));
-
-        return true;
     }
 }
 

--- a/server/game/cards/01-Core/Yoren.js
+++ b/server/game/cards/01-Core/Yoren.js
@@ -6,22 +6,14 @@ class Yoren extends DrawCard {
             when: {
                 onCardEntersPlay: event => event.card === this && event.playingType === 'marshal'
             },
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    cardCondition: card => card.location === 'discard pile' && card.getType() === 'character' && card.owner !== this.controller && card.getCost() <= 3,
-                    activePromptTitle: 'Select a character',
-                    source: this,
-                    onSelect: (player, card) => this.onCardSelected(player, card)
-                });
+            target: {
+                cardCondition: card => card.location === 'discard pile' && card.getType() === 'character' && card.owner !== this.controller && card.getCost() <= 3
+            },
+            handler: context => {
+                this.controller.putIntoPlay(context.target);
+                this.game.addMessage('{0} uses {1} to put {2} into play from {3}\'s discard pile under their control', this.controller, this, context.target, context.target.owner);
             }
         });
-    }
-
-    onCardSelected(player, card) {
-        player.putIntoPlay(card);
-        this.game.addMessage('{0} uses {1} to put {2} into play from {3}\'s discard pile under their control', player, this, card, card.owner);
-
-        return true;
     }
 }
 

--- a/server/game/cards/02.1-TtB/Will.js
+++ b/server/game/cards/02.1-TtB/Will.js
@@ -6,23 +6,15 @@ class Will extends DrawCard {
             when: {
                 afterChallenge: ({challenge}) => this.controller === challenge.loser && challenge.isUnopposed()
             },
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    activePromptTitle: 'Select a character',
-                    source: this,
-                    cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.hasTrait('Ranger') && card.controller === this.controller,
-                    onSelect: (p, card) => this.onCardSelected(p, card)
-                });
+            target: {
+                cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.hasTrait('Ranger') && card.controller === this.controller
+            },
+            handler: context => {
+                this.controller.sacrificeCard(context.target);
+
+                this.game.addMessage('{0} is forced to use {1} to sacrifice {2}', this.controller, this, context.target);
             }
         });
-    }
-
-    onCardSelected(player, card) {
-        player.sacrificeCard(card);
-
-        this.game.addMessage('{0} is forced to use {1} to sacrifice {2}', player, this, card);
-
-        return true;
     }
 }
 

--- a/server/game/cards/02.2-TRtW/LadyInWaiting.js
+++ b/server/game/cards/02.2-TRtW/LadyInWaiting.js
@@ -5,13 +5,12 @@ class LadyInWaiting extends DrawCard {
         this.playAction({
             title: 'Marshal as dupe',
             condition: () => this.canMarshalAsDupe(),
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    activePromptTitle: 'Select a character',
-                    cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.hasTrait('Lady') &&
-                                           card.controller === this.controller && card.owner === this.controller,
-                    onSelect: (player, card) => this.marshalAsDupe(card)
-                });
+            target: {
+                cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.hasTrait('Lady') &&
+                card.controller === this.controller && card.owner === this.controller
+            },
+            handler: context => {
+                this.marshalAsDupe(context.target);
             }
         });
     }

--- a/server/game/cards/02.4-NMG/Halder.js
+++ b/server/game/cards/02.4-NMG/Halder.js
@@ -8,26 +8,18 @@ class Halder extends DrawCard {
                 card.isFaction('thenightswatch') &&
                 (card.getType() === 'attachment' || card.getType() === 'location')
             )),
+            target: {
+                cardCondition: card => card.isFaction('thenightswatch') && card.getType() === 'character'
+            },
             handler: (context) => {
-                this.game.promptForSelect(context.player, {
-                    cardCondition: card => card.isFaction('thenightswatch') && card.getType() === 'character',
-                    activePromptTitle: 'Select character',
-                    source: this,
-                    onSelect: (player, card) => this.onStrCardSelected(player, card, context.kneelingCostCard)
-                });
+                this.game.addMessage('{0} uses {1} to kneels {2} to give {3} +1 STR until the end of the phase', this.controller, this, context.kneelingCostCard, context.target);
+
+                this.untilEndOfPhase(ability => ({
+                    match: context.target,
+                    effect: ability.effects.modifyStrength(1)
+                }));
             }
         });
-    }
-
-    onStrCardSelected(player, card, kneelingCard) {
-        this.game.addMessage('{0} uses {1} to kneels {2} to give {3} +1 STR until the end of the phase', player, this, kneelingCard, card);
-
-        this.untilEndOfPhase(ability => ({
-            match: card,
-            effect: ability.effects.modifyStrength(1)
-        }));
-
-        return true;
     }
 }
 

--- a/server/game/cards/02.4-NMG/Halder.js
+++ b/server/game/cards/02.4-NMG/Halder.js
@@ -12,7 +12,7 @@ class Halder extends DrawCard {
                 cardCondition: card => card.isFaction('thenightswatch') && card.getType() === 'character'
             },
             handler: (context) => {
-                this.game.addMessage('{0} uses {1} to kneels {2} to give {3} +1 STR until the end of the phase', this.controller, this, context.kneelingCostCard, context.target);
+                this.game.addMessage('{0} uses {1} and kneels {2} to give {3} +1 STR until the end of the phase', this.controller, this, context.kneelingCostCard, context.target);
 
                 this.untilEndOfPhase(ability => ({
                     match: context.target,

--- a/server/game/cards/02.4-NMG/MaesterOfStarfall.js
+++ b/server/game/cards/02.4-NMG/MaesterOfStarfall.js
@@ -5,38 +5,30 @@ const DrawCard = require('../../drawcard.js');
 class MaesterOfStarfall extends DrawCard {
     setupCardAbilities(ability) {
         this.action({
-            title: 'Kneel this card to remove keyword',
+            title: 'Remove a keyword',
             phase: 'challenge',
             cost: ability.costs.kneelSelf(),
+            target: {
+                cardCondition: card => card.location === 'play area' && card.getType() === 'character'
+            },
             handler: context => {
-                this.game.promptForSelect(context.player, {
-                    cardCondition: card => card.location === 'play area' && card.getType() === 'character',
-                    activePromptTitle: 'Select a character',
-                    source: this,
-                    onSelect: (player, card) => this.onCardSelected(player, card)
+                let keywords = ['Insight', 'Intimidate', 'Pillage', 'Renown'];
+
+                this.selectedCard = context.target;
+
+                var buttons = _.map(keywords, keyword => {
+                    return { text: keyword, method: 'keywordSelected', arg: keyword.toLowerCase() };
+                });
+
+                this.game.promptWithMenu(this.controller, this, {
+                    activePrompt: {
+                        menuTitle: 'Select a keyword',
+                        buttons: buttons
+                    },
+                    source: this
                 });
             }
         });
-    }
-
-    onCardSelected(player, card) {
-        var keywords = ['Insight', 'Intimidate', 'Pillage', 'Renown'];
-
-        this.selectedCard = card;
-
-        var buttons = _.map(keywords, keyword => {
-            return { text: keyword, method: 'keywordSelected', arg: keyword.toLowerCase() };
-        });
-
-        this.game.promptWithMenu(this.controller, this, {
-            activePrompt: {
-                menuTitle: 'Select a keyword',
-                buttons: buttons
-            },
-            source: this
-        });
-
-        return true;
     }
 
     keywordSelected(player, keyword) {

--- a/server/game/cards/02.5-COW/Chett.js
+++ b/server/game/cards/02.5-COW/Chett.js
@@ -3,21 +3,22 @@ const DrawCard = require('../../drawcard.js');
 class Chett extends DrawCard {
     setupCardAbilities(ability) {
         this.action({
-            title: 'Kneel a steward to return a direwolf or raven',
+            title: 'Return a card to hand',
             cost: ability.costs.kneel(card => card.hasTrait('Steward') && card.getType() === 'character'),
             phase: 'dominance',
             limit: ability.limit.perPhase(1),
+            target: {
+                activePromptTitle: 'Select a card',
+                cardCondition: card => (
+                    card.location === 'discard pile' &&
+                    card.controller === this.controller &&
+                    (card.hasTrait('Direwolf') || card.hasTrait('Raven'))
+                )
+            },
             handler: context => {
-                this.game.promptForSelect(context.player, {
-                    cardCondition: card => card.location === 'discard pile' && (card.hasTrait('Direwolf') || card.hasTrait('Raven')),
-                    activePromptTitle: 'Select Direwolf or Raven card',
-                    source: this,
-                    onSelect: (player, card) => {
-                        player.moveCard(card, 'hand');
-                        this.game.addMessage('{0} uses {1} to kneel {2} to return {3} to their hand',
-                            context.player, this, context.kneelingCostCard, card);
-                    }
-                });
+                this.controller.moveCard(context.target, 'hand');
+                this.game.addMessage('{0} uses {1} to kneel {2} to return {3} to their hand',
+                    context.player, this, context.kneelingCostCard, context.target);
             }
         });
     }

--- a/server/game/cards/03-WotN/AryaStark.js
+++ b/server/game/cards/03-WotN/AryaStark.js
@@ -9,26 +9,18 @@ class AryaStark extends DrawCard {
                     event.cardStateWhenKilled.isFaction('stark'))
             },
             cost: ability.costs.sacrificeSelf(),
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    cardCondition: card => (
-                        card.location === 'play area' &&
-                        card.getType() === 'character' &&
-                        card.getStrength() <= 3),
-                    activePromptTitle: 'Select a character',
-                    source: this,
-                    gameAction: 'kill',
-                    onSelect: (player, card) => this.onCardSelected(player, card)
-                });
+            target: {
+                cardCondition: card => (
+                    card.location === 'play area' &&
+                    card.getType() === 'character' &&
+                    card.getStrength() <= 3),
+                gameAction: 'kill'
+            },
+            handler: context => {
+                this.game.killCharacter(context.target);
+                this.game.addMessage('{0} sacrifices {1} to kill {2}', context.player, this, context.target);
             }
         });
-    }
-
-    onCardSelected(player, card) {
-        card.controller.killCharacter(card);
-        this.game.addMessage('{0} sacrifices {1} to kill {2}', player, this, card);
-
-        return true;
     }
 }
 

--- a/server/game/cards/03-WotN/QuentynMartell.js
+++ b/server/game/cards/03-WotN/QuentynMartell.js
@@ -15,7 +15,7 @@ class QuentynMartell extends DrawCard {
                 onCharacterKilled: event => event.card === this
             },
             target: {
-                cardCondition: card => card.getType() === 'character' && card.getStrength() < this.getStrength(),
+                cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.getStrength() < this.getStrength(),
                 gameAction: 'kill'
             },
             handler: context => {

--- a/server/game/cards/03-WotN/QuentynMartell.js
+++ b/server/game/cards/03-WotN/QuentynMartell.js
@@ -14,28 +14,15 @@ class QuentynMartell extends DrawCard {
             when: {
                 onCharacterKilled: event => event.card === this
             },
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    cardCondition: card => this.cardCondition(card),
-                    activePromptTitle: 'Select a character',
-                    source: this,
-                    gameAction: 'kill',
-                    onSelect: (player, card) => this.onCardSelected(player, card)
-                });
+            target: {
+                cardCondition: card => card.getType() === 'character' && card.getStrength() < this.getStrength(),
+                gameAction: 'kill'
+            },
+            handler: context => {
+                this.game.killCharacter(context.target);
+                this.game.addMessage('{0} uses {1} to kill {2}', this.controller, this, context.target);
             }
         });
-    }
-
-    cardCondition(card) {
-        return card.getType() === 'character' && card.getStrength() < this.getStrength();
-    }
-
-    onCardSelected(player, card) {
-        card.controller.killCharacter(card);
-
-        this.game.addMessage('{0} uses {1} to kill {2}', player, this, card);
-
-        return true;
     }
 }
 

--- a/server/game/cards/03-WotN/RiverrunMinstrel.js
+++ b/server/game/cards/03-WotN/RiverrunMinstrel.js
@@ -7,7 +7,7 @@ class RiverrunMinstrel extends DrawCard {
                 onCardEntersPlay: event => event.card === this
             },
             target: {
-                cardCondition: card => card.hasTrait('House Tully') && card.getType() === 'character'
+                cardCondition: card => card.location === 'play area' && card.hasTrait('House Tully') && card.getType() === 'character'
             },
             handler: context => {
                 context.target.modifyPower(1);

--- a/server/game/cards/03-WotN/RiverrunMinstrel.js
+++ b/server/game/cards/03-WotN/RiverrunMinstrel.js
@@ -6,18 +6,12 @@ class RiverrunMinstrel extends DrawCard {
             when: {
                 onCardEntersPlay: event => event.card === this
             },
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    cardCondition: card => card.hasTrait('House Tully') && card.getType() === 'character',
-                    activePromptTitle: 'Select a character',
-                    source: this,
-                    onSelect: (player, card) => {
-                        card.modifyPower(1);
-                        this.game.addMessage('{0} uses {1} to have {2} gain a power', this.controller, this, card);
-
-                        return true;
-                    }
-                });
+            target: {
+                cardCondition: card => card.hasTrait('House Tully') && card.getType() === 'character'
+            },
+            handler: context => {
+                context.target.modifyPower(1);
+                this.game.addMessage('{0} uses {1} to have {2} gain a power', this.controller, this, context.target);
             }
         });
     }

--- a/server/game/cards/04.1-AtSK/Pyromancers.js
+++ b/server/game/cards/04.1-AtSK/Pyromancers.js
@@ -3,24 +3,19 @@ const DrawCard = require('../../drawcard.js');
 class Pyromancers extends DrawCard {
     setupCardAbilities(ability) {
         this.action({
-            title: 'Kneel Pyromancers to discard location',
+            title: 'Discard a location',
             phase: 'dominance',
             cost: [
                 ability.costs.kneelSelf(),
                 ability.costs.discardFactionPower(1)
             ],
+            target: {
+                activePromptTitle: 'Select a location',
+                cardCondition: card => card.location === 'play area' && !card.isLimited() && card.getType() === 'location'
+            },
             handler: context => {
-                this.game.promptForSelect(context.player, {
-                    activePromptTitle: 'Select a location',
-                    source: this,
-                    cardCondition: card => card.location === 'play area' && !card.isLimited() && card.getType() === 'location',
-                    onSelect: (p, card) => {
-                        card.controller.discardCard(card);
-                        this.game.addMessage('{0} kneels {1} and discards a power from their faction to discard {2} from play', this.controller, this, card);
-
-                        return true;
-                    }
-                });
+                context.target.controller.discardCard(context.target);
+                this.game.addMessage('{0} kneels {1} and discards a power from their faction to discard {2} from play', this.controller, this, context.target);
             }
         });
     }

--- a/server/game/cards/04.1-AtSK/RobbStark.js
+++ b/server/game/cards/04.1-AtSK/RobbStark.js
@@ -15,13 +15,14 @@ class RobbStark extends DrawCard {
             title: 'Stand and remove a character from the challenge',
             limit: ability.limit.perChallenge(1),
             condition: () => this.isParticipatingInMilitaryChallenge(),
+            target: {
+                cardCondition: card => this.isParticipatingNonKing(card)
+            },
             handler: context => {
-                this.game.promptForSelect(context.player, {
-                    cardCondition: card => this.isParticipatingNonKing(card),
-                    activePromptTitle: 'Select character to stand and remove',
-                    source: this,
-                    onSelect: (player, card) => this.onCardSelected(player, card)
-                });
+                context.target.controller.standCard(context.target);
+                this.game.currentChallenge.removeFromChallenge(context.target);
+
+                this.game.addMessage('{0} uses {1} to stand {2} and remove them from the challenge', this.controller, this, context.target);
             }
         });
     }
@@ -41,15 +42,6 @@ class RobbStark extends DrawCard {
             !card.hasTrait('King') &&
             this.game.currentChallenge.isParticipating(card)
         );
-    }
-
-    onCardSelected(player, card) {
-        card.controller.standCard(card);
-        this.game.currentChallenge.removeFromChallenge(card);
-
-        this.game.addMessage('{0} uses {1} to stand {2} and remove them from the challenge', player, this, card);
-
-        return true;
     }
 
     numberOfLoyalChars () {

--- a/server/game/cards/04.3-FFH/AsshaiPriestess.js
+++ b/server/game/cards/04.3-FFH/AsshaiPriestess.js
@@ -7,7 +7,7 @@ class AsshaiPriestess extends DrawCard {
                 onCardEntersPlay: event => event.card === this && event.playingType === 'marshal'
             },
             target: {
-                cardCondition: card => card.getType() === 'character' && card.getStrength() <= 2 && !card.kneeled,
+                cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.getStrength() <= 2 && !card.kneeled,
                 gameAction: 'kneel'
             },
             handler: context => {

--- a/server/game/cards/04.3-FFH/AsshaiPriestess.js
+++ b/server/game/cards/04.3-FFH/AsshaiPriestess.js
@@ -6,28 +6,15 @@ class AsshaiPriestess extends DrawCard {
             when: {
                 onCardEntersPlay: event => event.card === this && event.playingType === 'marshal'
             },
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    cardCondition: card => this.cardCondition(card),
-                    activePromptTitle: 'Select a character',
-                    source: this,
-                    gameAction: 'kneel',
-                    onSelect: (player, card) => this.onCardSelected(player, card)
-                });
+            target: {
+                cardCondition: card => card.getType() === 'character' && card.getStrength() <= 2 && !card.kneeled,
+                gameAction: 'kneel'
+            },
+            handler: context => {
+                this.controller.kneelCard(context.target);
+                this.game.addMessage('{0} uses {1} to kneel {2}', this.controller, this, context.target);
             }
         });
-    }
-
-    cardCondition(card) {
-        return card.getType() === 'character' && card.getStrength() <= 2 && !card.kneeled;
-    }
-
-    onCardSelected(player, card) {
-        player.kneelCard(card);
-
-        this.game.addMessage('{0} uses {1} to kneel {2}', player, this, card);
-
-        return true;
     }
 }
 

--- a/server/game/cards/04.6-TC/SalladhorSaan.js
+++ b/server/game/cards/04.6-TC/SalladhorSaan.js
@@ -8,22 +8,17 @@ class SalladhorSaan extends DrawCard {
                     challenge.winner === this.controller &&
                     challenge.isParticipating(this))
             },
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    activePromptTitle: 'Select a card',
-                    source: this,
-                    cardCondition: card => (
-                        card.location === 'hand' &&
-                        card.controller === this.controller &&
-                        ((card.hasTrait('Warship') && card.getType() === 'location') ||
-                        (card.hasTrait('Weapon') && card.getType() === 'attachment'))),
-                    onSelect: (player, card) => {
-                        player.putIntoPlay(card);
-                        this.game.addMessage('{0} uses {1} to put {2} into play', this.controller, this, card);
-
-                        return true;
-                    }
-                });
+            target: {
+                activePromptTitle: 'Select a card',
+                cardCondition: card => (
+                    card.location === 'hand' &&
+                    card.controller === this.controller &&
+                    ((card.hasTrait('Warship') && card.getType() === 'location') ||
+                    (card.hasTrait('Weapon') && card.getType() === 'attachment')))
+            },
+            handler: context => {
+                this.controller.putIntoPlay(context.target);
+                this.game.addMessage('{0} uses {1} to put {2} into play', this.controller, this, context.target);
             }
         });
     }

--- a/server/game/cards/05-LoCR/EdricStorm.js
+++ b/server/game/cards/05-LoCR/EdricStorm.js
@@ -7,30 +7,20 @@ class EdricStorm extends DrawCard {
             when: {
                 onPhaseStarted: event => event.phase === 'dominance'
             },
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    activePromptTitle: 'Select a character',
-                    source: this,
-                    cardCondition: card =>
-                        card.location === 'play area' && card.getType() === 'character',
-                    onSelect: (player, card) => this.onSelect(player, card)
-                });
+            target: {
+                cardCondition: card => card.location === 'play area' && card.getType() === 'character'
+            },
+            handler: context => {
+                this.untilEndOfPhase(ability => ({
+                    match: context.target,
+                    effect: ability.effects.doesNotContributeToDominance()
+                }));
+
+                this.game.addMessage('{0} uses {1} to exclude {2}\'s strength from dominance this phase',
+                    this.controller, this, context.target);
             }
         });
     }
-
-    onSelect(player, card) {
-        this.untilEndOfPhase(ability => ({
-            match: card,
-            effect: ability.effects.doesNotContributeToDominance()
-        }));
-
-        this.game.addMessage('{0} uses {1} to exclude {2}\'s strength from dominance this phase',
-            this.controller, this, card);
-
-        return true;
-    }
-
 }
 
 EdricStorm.code = '05025';

--- a/server/game/cards/05-LoCR/RedKeepSpy.js
+++ b/server/game/cards/05-LoCR/RedKeepSpy.js
@@ -10,22 +10,16 @@ class RedKeepSpy extends DrawCard {
                     this.hasMoreCardsInHand()
                 )
             },
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    activePromptTitle: 'Select a character',
-                    source: this,
-                    cardCondition: card => (
-                        card.location === 'play area' &&
-                        card.controller !== this.controller &&
-                        card.getType() === 'character' &&
-                        card.getCost() <= 3),
-                    onSelect: (player, card) => {
-                        card.owner.returnCardToHand(card);
-                        this.game.addMessage('{0} uses {1} to return {2} to {3}\'s hand', player, this, card, card.controller);
-
-                        return true;
-                    }
-                });
+            target: {
+                cardCondition: card => (
+                    card.location === 'play area' &&
+                    card.controller !== this.controller &&
+                    card.getType() === 'character' &&
+                    card.getCost() <= 3)
+            },
+            handler: context => {
+                context.target.owner.returnCardToHand(context.target);
+                this.game.addMessage('{0} uses {1} to return {2} to {3}\'s hand', this.controller, this, context.target, context.target.controller);
             }
         });
     }

--- a/server/game/cards/05-LoCR/SerKevanLannister.js
+++ b/server/game/cards/05-LoCR/SerKevanLannister.js
@@ -6,22 +6,17 @@ class SerKevanLannister extends DrawCard {
             when: {
                 onCardEntersPlay: event => event.card === this && event.playingType === 'marshal'
             },
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    activePromptTitle: 'Select location or attachment',
-                    source: this,
-                    cardCondition: card => (
-                        card.location === 'discard pile' &&
-                        card.controller === this.controller &&
-                        (card.isFaction('lannister') || card.isFaction('neutral')) &&
-                        (card.getType() === 'location' || card.getType() === 'attachment')),
-                    onSelect: (player, card) => {
-                        player.putIntoPlay(card);
-                        this.game.addMessage('{0} uses {1} to put {2} into play', this.controller, this, card);
-
-                        return true;
-                    }
-                });
+            target: {
+                activePromptTitle: 'Select a location or attachment',
+                cardCondition: card => (
+                    card.location === 'discard pile' &&
+                    card.controller === this.controller &&
+                    (card.isFaction('lannister') || card.isFaction('neutral')) &&
+                    (card.getType() === 'location' || card.getType() === 'attachment'))
+            },
+            handler: context => {
+                this.controller.putIntoPlay(context.target);
+                this.game.addMessage('{0} uses {1} to put {2} into play', this.controller, this, context.target);
             }
         });
     }

--- a/server/game/cards/05-LoCR/TrystaneMartell.js
+++ b/server/game/cards/05-LoCR/TrystaneMartell.js
@@ -6,24 +6,18 @@ class TrystaneMartell extends DrawCard {
             when: {
                 afterChallenge: ({challenge}) => this.controller === challenge.loser && challenge.isParticipating(this)
             },
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    activePromptTitle: 'Select character',
-                    waitingPromptTitle: 'Waiting for opponent to use ' + this.name,
-                    cardCondition: card => (
-                        card.location === 'play area' &&
-                        card.getType() === 'character' &&
-                        card.getStrength() < this.getStrength()),
-                    onSelect: (player, card) => {
-                        this.game.addMessage('{0} uses {1} to make {2} unable to be declared as a defender', player, this, card);
-                        this.untilEndOfPhase(ability => ({
-                            match: card,
-                            effect: ability.effects.cannotBeDeclaredAsDefender()
-                        }));
-
-                        return true;
-                    }
-                });
+            target: {
+                cardCondition: card => (
+                    card.location === 'play area' &&
+                    card.getType() === 'character' &&
+                    card.getStrength() < this.getStrength())
+            },
+            handler: context => {
+                this.game.addMessage('{0} uses {1} to make {2} unable to be declared as a defender', this.controller, this, context.target);
+                this.untilEndOfPhase(ability => ({
+                    match: context.target,
+                    effect: ability.effects.cannotBeDeclaredAsDefender()
+                }));
             }
         });
     }

--- a/server/game/cards/06.1-AMAF/GhiscariElite.js
+++ b/server/game/cards/06.1-AMAF/GhiscariElite.js
@@ -9,13 +9,13 @@ class GhiscariElite extends DrawCard {
                     this.controller.discardPile.any(c => this.eventOrAttachmentInDiscard(c))
                 )
             },
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    source: this,
-                    cardCondition: card => this.eventOrAttachmentInDiscard(card),
-                    activePromptTitle: 'Select attachment or event',
-                    onSelect: (player, card) => this.moveToBottomOfDeck(card)
-                });
+            target: {
+                activePromptTitle: 'Select attachment or event',
+                cardCondition: card => this.eventOrAttachmentInDiscard(card)
+            },
+            handler: context => {
+                this.game.addMessage('{0} uses {1} to move {2} to the bottom of their deck', this.controller, this, context.target);
+                this.controller.moveCard(context.target, 'draw deck', { bottom: true });
             }
         });
     }
@@ -26,12 +26,6 @@ class GhiscariElite extends DrawCard {
             card.location === 'discard pile' &&
             ['event', 'attachment'].includes(card.getType())
         );
-    }
-
-    moveToBottomOfDeck(card) {
-        this.game.addMessage('{0} uses {1} to move {2} to the bottom of their deck', this.controller, this, card);
-        this.controller.moveCard(card, 'draw deck', { bottom: true });
-        return true;
     }
 }
 

--- a/server/game/cards/06.2-GtR/BearIslandHost.js
+++ b/server/game/cards/06.2-GtR/BearIslandHost.js
@@ -5,30 +5,22 @@ class BearIslandHost extends DrawCard {
         this.action({
             title: 'Discard 1 gold from ' + this.name,
             cost: ability.costs.discardGold(),
+            target: {
+                cardCondition: card => card.location === 'play area' && card.hasTrait('House Mormont') && card.getType() === 'character'
+            },
             handler: context => {
-                this.game.promptForSelect(context.player, {
-                    activePromptTitle: 'Select a character',
-                    source: this,
-                    cardCondition: card => card.location === 'play area' && card.hasTrait('House Mormont') && card.getType() === 'character',
-                    onSelect: (player, card) => this.onCardSelected(player, card)
-                });
+                this.untilEndOfPhase(ability => ({
+                    condition: () => (
+                        this.game.currentChallenge &&
+                        this.game.currentChallenge.challengeType === 'military'),
+                    match: context.target,
+                    effect: ability.effects.doesNotKneelAsAttacker()
+                }));
+
+                this.game.addMessage('{0} discards a gold from {1} to make {2} not kneel as an attacker in a military challenge',
+                    this.controller, this, context.target);
             }
         });
-    }
-
-    onCardSelected(player, card) {
-        this.untilEndOfPhase(ability => ({
-            condition: () => (
-                this.game.currentChallenge &&
-                this.game.currentChallenge.challengeType === 'military'),
-            match: card,
-            effect: ability.effects.doesNotKneelAsAttacker()
-        }));
-
-        this.game.addMessage('{0} discards a gold from {1} to make {2} not kneel as an attacker in a military challenge',
-            player, this, card);
-
-        return true;
     }
 }
 

--- a/server/game/cards/07-WotW/OldBearMormont.js
+++ b/server/game/cards/07-WotW/OldBearMormont.js
@@ -6,29 +6,21 @@ class OldBearMormont extends DrawCard {
             when: {
                 afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isParticipating(this)
             },
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    cardCondition: card => (
-                        !card.isUnique() &&
-                        card.getType() === 'character' &&
-                        card.controller !== this.controller &&
-                        card.location === 'discard pile'),
-                    activePromptTitle: 'Select character',
-                    source: this,
-                    onSelect: (player, card) => this.onCardSelected(player, card)
-                });
+            target: {
+                cardCondition: card => (
+                    !card.isUnique() &&
+                    card.getType() === 'character' &&
+                    card.controller !== this.controller &&
+                    card.location === 'discard pile')
+            },
+            handler: context => {
+                let originalPlayer = context.target.controller;
+                this.controller.putIntoPlay(context.target);
+
+                this.game.addMessage('{0} uses {1} to put {2} into play under their control from {3}\'s discard pile',
+                    this.controller, this, context.target, originalPlayer);
             }
         });
-    }
-
-    onCardSelected(player, card) {
-        player.putIntoPlay(card);
-
-        var otherPlayer = this.game.getOtherPlayer(this.controller);
-        this.game.addMessage('{0} uses {1} to put {2} into play under their control from {3}\'s discard pile',
-            player, this, card, otherPlayer);
-
-        return true;
     }
 }
 


### PR DESCRIPTION
Converts everything that must AND **can** be converted to the target API for the purposes of cancels.

Things remaining that haven't been converted and need target API support:
* Cards that don't use the word 'choose' but could benefit from the target API shorthand (e.g. Tyene, Close Call)
* "each player" chooses (e.g. Wildfire)
* Opponent chooses (e.g. Queen's Assassin, Stone Crows, Duel)
* Choices based on dynamic conditions (e.g. Frey Hospitality's 1 vs 3 cards chosen)

Progress toward #1389 