### PR TITLE
Record card snapshots in replacement handlers

### DIFF
--- a/server/game/cards/01-Core/BenjenStark.js
+++ b/server/game/cards/01-Core/BenjenStark.js
@@ -15,6 +15,7 @@ class BenjenStark extends DrawCard {
 
                 this.game.addPower(this.controller, 2);
                 context.replaceHandler(() => {
+                    context.event.cardStateWhenKilled = this.createSnapshot();
                     this.controller.moveCard(this, 'draw deck', {}, () => {
                         this.controller.shuffleDrawDeck();
                     });

--- a/server/game/cards/01-Core/SerDavosSeaworth.js
+++ b/server/game/cards/01-Core/SerDavosSeaworth.js
@@ -9,6 +9,7 @@ class SerDavosSeaworth extends DrawCard {
             handler: context => {
                 this.game.addMessage('{0} uses {1} to return {1} to their hand instead of their dead pile', this.controller, this, this);
                 context.replaceHandler(() => {
+                    context.event.cardStateWhenKilled = this.createSnapshot();
                     this.controller.moveCard(this, 'hand');
                 });
             }

--- a/server/game/cards/03-WotN/Needle.js
+++ b/server/game/cards/03-WotN/Needle.js
@@ -14,6 +14,7 @@ class Needle extends DrawCard {
             handler: context => {
                 this.game.addMessage('{0} sacrifices {1} to return {2} to their hand', this.controller, this, context.event.card);
                 context.replaceHandler(() => {
+                    context.event.cardStateWhenSacrificed = context.event.card.createSnapshot();
                     this.controller.returnCardToHand(context.event.card, false);
                 });
             }

--- a/server/game/cards/06.3-TFoA/SpearsOfTheMerlingKing.js
+++ b/server/game/cards/06.3-TFoA/SpearsOfTheMerlingKing.js
@@ -11,6 +11,7 @@ class SpearsOfTheMerlingKing extends DrawCard {
                 this.game.addMessage('{0} sacrifices {1} to return {2} to their hand',
                     this.controller, this, context.event.card);
                 context.replaceHandler(() => {
+                    context.event.cardStateWhenKilled = context.event.card.createSnapshot();
                     this.controller.moveCard(context.event.card, 'hand');
                 });
             }


### PR DESCRIPTION
Because card snapshots for kill / sacrifice events are done within the
normal handler, any replacement effects like Benjen Stark must
explicitly also create a snapshot. Otherwise, cards that react to other
cards being killed (Starks, Funeral Pyre, etc) will encounter an
undefined object when looking for card state.

Fixes THRONETEKI-1E5
Fixes THRONETEKI-1EF
Fixes THRONETEKI-1EA
Fixes THRONETEKI-1EK
Fixes THRONETEKI-1E0
Fixes THRONETEKI-1E7
Fixes THRONETEKI-1EE