### PR TITLE
Remove `getOtherPlayer` from cards to allow Melee

### DIFF
--- a/server/game/cards/00-VDS/HoldingTheTrident.js
+++ b/server/game/cards/00-VDS/HoldingTheTrident.js
@@ -11,15 +11,13 @@ class HoldingTheTrident extends PlotCard {
 
     controlsFewerCharactersThanOpponent() {
         let numOwnChars = this.controller.getNumberOfCardsInPlay(card => card.getType() === 'character');
-        let opponent = this.game.getOtherPlayer(this.controller);
+        let opponents = this.game.getOpponents(this.controller);
 
-        if(!opponent) {
-            return false;
-        }
+        return opponents.every(opponent => {
+            let numOpponentChars = opponent.getNumberOfCardsInPlay(card => card.getType() === 'character');
 
-        let numOpponentChars = opponent.getNumberOfCardsInPlay(card => card.getType() === 'character');
-
-        return numOwnChars < numOpponentChars;
+            return numOwnChars < numOpponentChars;
+        });
     }
 }
 

--- a/server/game/cards/01-Core/KingsHuntingParty.js
+++ b/server/game/cards/01-Core/KingsHuntingParty.js
@@ -3,25 +3,18 @@ const DrawCard = require('../../drawcard.js');
 class KingsHuntingParty extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            condition: this.effectCondition.bind(this),
+            condition: () => this.anyOpponentHasKing(),
             match: this,
             effect: ability.effects.addIcon('intrigue')
         });
     }
 
-    effectCondition() {
-        var otherPlayer = this.game.getOtherPlayer(this.controller);
-        if(!otherPlayer || this.controller.phase === 'setup') {
-            return false;
-        }
-
-        if(otherPlayer.anyCardsInPlay(card => {
-            return card.getType() === 'character' && card.hasTrait('King');
-        })) {
-            return true;
-        }
-
-        return false;
+    anyOpponentHasKing() {
+        return this.game.anyCardsInPlay(card => (
+            card.controller !== this.controller &&
+            card.getType() === 'character' &&
+            card.hasTrait('King')
+        ));
     }
 }
 

--- a/server/game/cards/01-Core/SerWaymarRoyce.js
+++ b/server/game/cards/01-Core/SerWaymarRoyce.js
@@ -7,13 +7,10 @@ class SerWaymarRoyce extends DrawCard {
                 onCharacterKilled: event => event.card === this
             },
             handler: () => {
-                var otherPlayer = this.game.getOtherPlayer(this.controller);
-                if(!otherPlayer) {
-                    return;
+                this.game.addMessage('{0} uses {1} to 1 card at random from each opponent\'s hand', this.controller, this);
+                for(let opponent of this.game.getOpponents(this.controller)) {
+                    opponent.discardAtRandom(1);
                 }
-
-                this.game.addMessage('{0} uses {1} to 1 card at random from {2}\'s hand', this.controller, this, otherPlayer);
-                otherPlayer.discardAtRandom(1);
             }
         });
     }

--- a/server/game/cards/01-Core/TheSwordInTheDarkness.js
+++ b/server/game/cards/01-Core/TheSwordInTheDarkness.js
@@ -9,18 +9,14 @@ class TheSwordInTheDarkness extends DrawCard {
                 afterChallenge: event => event.challenge.winner === this.controller && event.challenge.defendingPlayer === this.controller &&
                                          event.challenge.strengthDifference >= 5 && this.hasNightsWatchParticipant()
             },
-            handler: () => {
-                let opponent = this.game.getOtherPlayer(this.controller);
-
-                if(!opponent) {
-                    return;
-                }
+            handler: context => {
+                let opponent = context.challenge.loser;
 
                 this.game.addMessage('{0} plays {1} to prevent {2} from initiating any more challenges this round', this.controller, this, opponent);
 
                 this.untilEndOfRound(ability => ({
                     targetType: 'player',
-                    targetController: 'opponent',
+                    targetController: opponent,
                     effect: ability.effects.cannotInitiateChallengeAgainst(this.controller)
                 }));
             }

--- a/server/game/cards/01-Core/TheThingsIDoForLove.js
+++ b/server/game/cards/01-Core/TheThingsIDoForLove.js
@@ -25,13 +25,8 @@ class TheThingsIDoForLove extends DrawCard {
     }
 
     getMinimumCharCost() {
-        let opponent = this.game.getOtherPlayer(this.controller);
-
-        if(!opponent) {
-            return 0;
-        }
-
-        let opponentCharacters = opponent.filterCardsInPlay(card => card.getType() === 'character');
+        let opponents = this.game.getOpponents(this.controller);
+        let opponentCharacters = _.flatten(opponents.map(opponent => opponent.filterCardsInPlay(card => card.getType() === 'character')));
         let charCosts = _.map(opponentCharacters, card => card.getCost());
 
         return _.min(charCosts);

--- a/server/game/cards/01-Core/UnbowedUnbentUnbroken.js
+++ b/server/game/cards/01-Core/UnbowedUnbentUnbroken.js
@@ -8,7 +8,8 @@ class UnbowedUnbentUnbroken extends DrawCard {
                 afterChallenge: event => !this.controller.firstPlayer && event.challenge.defendingPlayer === this.controller &&
                                          event.challenge.loser === this.controller
             },
-            handler: () => {
+            handler: context => {
+                this.challengeWinner = context.event.challenge.winner;
                 this.game.promptWithMenu(this.controller, this, {
                     activePrompt: {
                         menuTitle: 'Select a challenge type',
@@ -26,19 +27,13 @@ class UnbowedUnbentUnbroken extends DrawCard {
     }
 
     trigger(player, challengeType) {
-        let otherPlayer = this.game.getOtherPlayer(player);
-
-        if(!otherPlayer) {
-            return true;
-        }
-
         this.untilEndOfPhase(ability => ({
             targetType: 'player',
-            targetController: 'opponent',
+            targetController: this.challengeWinner,
             effect: ability.effects.cannotInitiateChallengeType(challengeType)
         }));
 
-        this.game.addMessage('{0} plays {1} to make {2} unable to initiate {3} challenges until the end of the phase', player, this, otherPlayer, challengeType);
+        this.game.addMessage('{0} plays {1} to make {2} unable to initiate {3} challenges until the end of the phase', player, this, this.challengeWinner, challengeType);
 
         return true;
     }

--- a/server/game/cards/02.1-TtB/BastardDaughter.js
+++ b/server/game/cards/02.1-TtB/BastardDaughter.js
@@ -10,15 +10,11 @@ class BastardDaughter extends DrawCard {
                 )
             },
             handler: () => {
-                var otherPlayer = this.game.getOtherPlayer(this.controller);
+                this.game.addMessage('{0} uses {1} to discard 1 card at random from each opponent\'s hand', this.controller, this);
 
-                if(!otherPlayer) {
-                    return true;
+                for(let opponent of this.game.getOpponents(this.controller)) {
+                    opponent.discardAtRandom(1);
                 }
-
-                this.game.addMessage('{0} uses {1} to discard 1 card at random from {2}\'s hand', this.controller, this, otherPlayer);
-
-                otherPlayer.discardAtRandom(1);
             }
         });
     }

--- a/server/game/cards/02.2-TRtW/BrothelMadame.js
+++ b/server/game/cards/02.2-TRtW/BrothelMadame.js
@@ -13,23 +13,20 @@ class BrothelMadame extends DrawCard {
             when: {
                 onPhaseStarted: event => event.phase === 'challenge'
             },
-            handler: () => {
-                let otherPlayer = this.game.getOtherPlayer(this.controller);
-                if(!otherPlayer) {
-                    return false;
-                }
-
+            chooseOpponent: true,
+            handler: context => {
+                this.chosenOpponent = context.opponent;
                 this.hasPaidGoldThisPhase = false;
 
                 this.untilEndOfPhase(ability => ({
                     targetType: 'player',
-                    targetController: 'opponent',
+                    targetController: context.opponent,
                     condition: () => !this.hasPaidGoldThisPhase,
                     effect: ability.effects.cannotInitiateChallengeType('military', opponent => opponent === this.controller)
                 }));
 
-                if(otherPlayer.gold >= 1) {
-                    this.game.promptWithMenu(otherPlayer, this, {
+                if(context.opponent.gold >= 1) {
+                    this.game.promptWithMenu(context.opponent, this, {
                         activePrompt: {
                             menuTitle: 'Pay 1 gold to initiate military challenges this phase?',
                             buttons: [
@@ -40,14 +37,14 @@ class BrothelMadame extends DrawCard {
                         source: this
                     });
                 } else {
-                    this.doNotPay(otherPlayer);
+                    this.doNotPay(context.opponent);
                 }
             }
         });
     }
 
     onGoldTransferred(event) {
-        if(event.target !== this.controller || event.amount <= 0) {
+        if(event.target !== this.controller || event.source !== this.chosenOpponent || event.amount <= 0) {
             return false;
         }
 

--- a/server/game/cards/02.2-TRtW/TheReader.js
+++ b/server/game/cards/02.2-TRtW/TheReader.js
@@ -19,15 +19,10 @@ class TheReader extends DrawCard {
                     this.game.addMessage('{0} uses {1} to draw 1 card', this.controller, this);
                 },
                 'Discard 3 cards': () => {
-                    var otherPlayer = this.game.getOtherPlayer(this.controller);
-
-                    if(!otherPlayer) {
-                        return true;
+                    this.game.addMessage('{0} uses {1} to discard the top 3 cards from each opponent\'s deck', this.controller, this);
+                    for(let opponent of this.game.getOpponents(this.controller)) {
+                        opponent.discardFromDraw(3);
                     }
-
-                    otherPlayer.discardFromDraw(3);
-
-                    this.game.addMessage('{0} uses {1} to discard the top 3 cards from {2}\'s deck', this.controller, this, otherPlayer);
                 }
             }
         });

--- a/server/game/cards/02.2-TRtW/TradingWithThePentoshi.js
+++ b/server/game/cards/02.2-TRtW/TradingWithThePentoshi.js
@@ -4,11 +4,9 @@ class TradingWithThePentoshi extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
             handler: () => {
-                var otherPlayer = this.game.getOtherPlayer(this.controller);
-
-                if(otherPlayer) {
-                    this.game.addGold(otherPlayer, 3);
-                    this.game.addMessage('{0} gains 3 gold from {1}\'s {2}', otherPlayer, this.controller, this);
+                this.game.addMessage('Each opponent gains 3 gold from {0}\'s {1}', this.controller, this);
+                for(let opponent of this.game.getOpponents(this.controller)) {
+                    this.game.addGold(opponent, 3);
                 }
             }
         });

--- a/server/game/cards/02.3-TKP/CroneOfVaesDothrak.js
+++ b/server/game/cards/02.3-TKP/CroneOfVaesDothrak.js
@@ -8,22 +8,17 @@ class CroneOfVaesDothrak extends DrawCard {
                 onCardDiscarded: event =>
                     ((event.originalLocation === 'hand' || event.originalLocation === 'draw deck')
                      && event.card.getType() === 'character'
-                     && event.player !== this.controller)
+                     && event.card.controller !== this.controller)
             },
             cost: ability.costs.kneel(card => (
                 card.getType() === 'character' && card.hasTrait('Dothraki')
             )),
             handler: (context) => {
-                var discardedCard = context.event.card;
-                var otherPlayer = this.game.getOtherPlayer(this.controller);
-                if(!otherPlayer) {
-                    return true;
-                }
-
-                otherPlayer.moveCard(discardedCard, 'dead pile');
+                let discardedCard = context.event.card;
+                discardedCard.owner.moveCard(discardedCard, 'dead pile');
 
                 this.game.addMessage('{0} uses {1} to place {2} in the dead pile',
-                    this.controler, this, discardedCard);
+                    this.controller, this, discardedCard);
             }
         });
     }

--- a/server/game/cards/02.6-TS/CityWatch.js
+++ b/server/game/cards/02.6-TS/CityWatch.js
@@ -5,13 +5,16 @@ class CityWatch extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             location: 'any',
-            condition: () =>
-                this.game.getOtherPlayer(this.controller)
-                && this.controller.faction.power > this.game.getOtherPlayer(this.controller).faction.power,
+            condition: () => this.hasMorePowerThanAnOpponent(),
             targetType: 'player',
             targetController: 'current',
             effect: ability.effects.reduceSelfCost('ambush', 2)
         });
+    }
+
+    hasMorePowerThanAnOpponent() {
+        let opponents = this.game.getOpponents(this.controller);
+        return opponents.some(opponent => this.controller.faction.power > opponent.faction.power);
     }
 
 }

--- a/server/game/cards/02.6-TS/CloseCall.js
+++ b/server/game/cards/02.6-TS/CloseCall.js
@@ -23,8 +23,7 @@ class CloseCall extends PlotCard {
 
         this.game.addMessage('{0} uses {1} to move {2} to their discard pile', player, this, card);
 
-        let otherPlayer = this.game.getOtherPlayer(player);
-        if(!otherPlayer || !otherPlayer.activePlot.hasTrait('Winter')) {
+        if(!this.game.anyPlotHasTrait('Winter')) {
             player.drawCardsToHand(1);
             this.game.addMessage('{0} uses {1} to draw 1 card', player, this);
         }

--- a/server/game/cards/03-WotN/HisViperEyes.js
+++ b/server/game/cards/03-WotN/HisViperEyes.js
@@ -12,9 +12,9 @@ class HisViperEyes extends DrawCard {
                 )
             },
             handler: () => {
-                let otherPlayer = this.game.currentChallenge.winner;
+                this.challengeWinner = this.game.currentChallenge.winner;
 
-                let buttons = otherPlayer.hand.map(card => {
+                let buttons = this.challengeWinner.hand.map(card => {
                     return { method: 'cardSelected', card: card };
                 });
 
@@ -30,10 +30,7 @@ class HisViperEyes extends DrawCard {
     }
 
     cardSelected(player, cardId) {
-        var otherPlayer = this.game.getOtherPlayer(player);
-        if(!otherPlayer) {
-            return false;
-        }
+        var otherPlayer = this.challengeWinner;
 
         var card = otherPlayer.findCardByUuid(otherPlayer.hand, cardId);
         if(!card) {

--- a/server/game/cards/03-WotN/YoungSpearwife.js
+++ b/server/game/cards/03-WotN/YoungSpearwife.js
@@ -10,11 +10,8 @@ class YoungSpearwife extends DrawCard {
     }
 
     hasLessFactionPower() {
-        var otherPlayer = this.game.getOtherPlayer(this.controller);
-        if(!otherPlayer) {
-            return false;
-        }
-        return this.controller.faction.power < otherPlayer.faction.power;
+        let opponents = this.game.getOpponents(this.controller);
+        return opponents.some(opponent => this.controller.faction.power < opponent.faction.power);
     }
 }
 

--- a/server/game/cards/04.1-AtSK/LeviesAtTheRock.js
+++ b/server/game/cards/04.1-AtSK/LeviesAtTheRock.js
@@ -4,22 +4,21 @@ class LeviesAtTheRock extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onChallengeInitiated: event => event.challenge.defendingPlayer === this.controller && this.opponentHasGold()
+                onChallengeInitiated: event => (
+                    event.challenge.defendingPlayer === this.controller &&
+                    event.challenge.attackingPlayer.gold >= 1
+                )
             },
-            handler: () => {
-                let opponent = this.game.getOtherPlayer(this.controller);
-                let gold = Math.min(opponent.gold, this.game.currentChallenge.attackers.length);
+            handler: context => {
+                let challenge = context.event.challenge;
+                let opponent = challenge.attackingPlayer;
+                let gold = Math.min(opponent.gold, challenge.attackers.length);
                 this.game.addGold(opponent, -gold);
                 this.game.addGold(this.controller, gold);
                 this.game.addMessage('{0} plays {1} to move {2} gold from {3}\'s gold pool to their own',
                     this.controller, this, gold, opponent);
             }
         });
-    }
-
-    opponentHasGold() {
-        let opponent = this.game.getOtherPlayer(this.controller);
-        return opponent && opponent.gold >= 1;
     }
 }
 

--- a/server/game/cards/04.1-AtSK/ViserysTargaryen.js
+++ b/server/game/cards/04.1-AtSK/ViserysTargaryen.js
@@ -21,8 +21,8 @@ class ViserysTargaryen extends DrawCard {
     }
 
     opponentHasNoKing() {
-        let opponent = this.game.getOtherPlayer(this.controller);
-        return opponent && !opponent.anyCardsInPlay(card => card.hasTrait('King'));
+        let opponents = this.game.getOpponents(this.controller);
+        return opponents.every(opponent => !opponent.anyCardsInPlay(card => card.hasTrait('King')));
     }
 }
 

--- a/server/game/cards/04.2-CtA/BalonGreyjoy.js
+++ b/server/game/cards/04.2-CtA/BalonGreyjoy.js
@@ -4,12 +4,9 @@ class BalonGreyjoy extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             condition: () => {
-                var otherPlayer = this.game.getOtherPlayer(this.controller);
-
-                return !otherPlayer ||
-                    (this.game.currentChallenge &&
+                return (this.game.currentChallenge &&
                     this.game.currentChallenge.challengeType === 'military' &&
-                    !otherPlayer.anyCardsInPlay(card => card.hasTrait('King')));
+                    !this.game.currentChallenge.defendingPlayer.anyCardsInPlay(card => card.hasTrait('King')));
             },
             match: this,
             effect: [

--- a/server/game/cards/04.2-CtA/BeggarKing.js
+++ b/server/game/cards/04.2-CtA/BeggarKing.js
@@ -7,29 +7,26 @@ class BeggarKing extends DrawCard {
         });
         this.reaction({
             when: {
-                onPlotsRevealed: event => {
-                    let opponent = this.game.getOtherPlayer(this.controller);
-
-                    if(!opponent || !event.plots.includes(opponent.activePlot)) {
-                        return false;
-                    }
-
-                    return this.controller.activePlot.getIncome(true) < opponent.activePlot.getIncome(true);
-                }
+                onPlotsRevealed: event => this.opponentRevealedLowerIncome(event.plots)
             },
             cost: ability.costs.kneelSelf(),
             handler: () => {
-                let gold = 1;
-
-                let opponent = this.game.getOtherPlayer(this.controller);
-                if(!opponent || !opponent.anyCardsInPlay(card => card.hasTrait('King'))) {
-                    gold = 2;
-                }
+                let gold = !this.opponentHasKing() ? 2 : 1;
 
                 this.game.addGold(this.controller, gold);
                 this.game.addMessage('{0} kneels {1} to gain {2} gold', this.controller, this, gold);
             }
         });
+    }
+
+    opponentRevealedLowerIncome(plots) {
+        let opponentPlots = plots.filter(plot => plot.controller !== this.controller);
+
+        return opponentPlots.some(opponentPlot => this.controller.activePlot.getPrintedIncome() < opponentPlot.getPrintedIncome());
+    }
+
+    opponentHasKing() {
+        return this.game.anyCardsInPlay(card => card.controller !== this.controller && card.getType() === 'character' && card.hasTrait('King'));
     }
 
     canAttach(player, card) {

--- a/server/game/cards/04.2-CtA/SummerHarvest.js
+++ b/server/game/cards/04.2-CtA/SummerHarvest.js
@@ -5,7 +5,7 @@ class SummerHarvest extends PlotCard {
         this.whenRevealed({
             chooseOpponent: true,
             handler: context => {
-                this.baseIncome = context.opponent.activePlot.getIncome(true) + 2;
+                this.baseIncome = context.opponent.activePlot.getPrintedIncome() + 2;
             }
         });
     }

--- a/server/game/cards/04.3-FFH/SerAmoryLorch.js
+++ b/server/game/cards/04.3-FFH/SerAmoryLorch.js
@@ -10,13 +10,10 @@ class SerAmoryLorch extends DrawCard {
     }
 
     opponentHasThreeOrFewerChars() {
-        var otherPlayer = this.game.getOtherPlayer(this.controller);
-
-        if(!otherPlayer) {
-            return true;
-        }
-
-        return otherPlayer.getNumberOfCardsInPlay(card => card.getType() === 'character') <= 3;
+        let opponents = this.game.getOpponents(this.controller);
+        return opponents.some(opponent => {
+            return opponent.getNumberOfCardsInPlay(card => card.getType() === 'character') <= 3;
+        });
     }
 }
 

--- a/server/game/cards/04.4-TIMC/BurningOnTheSand.js
+++ b/server/game/cards/04.4-TIMC/BurningOnTheSand.js
@@ -4,16 +4,16 @@ class BurningOnTheSand extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.loser === this.controller && challenge.isUnopposed()
+                afterChallenge: event => event.challenge.loser === this.controller && event.challenge.isUnopposed()
             },
-            handler: () => {
+            handler: context => {
+                let opponent = context.event.winner;
                 this.untilEndOfChallenge(ability => ({
                     match: card => card === card.controller.activePlot,
-                    targetController: 'opponent',
+                    targetController: opponent,
                     effect: ability.effects.setClaim(0)
                 }));
 
-                let opponent = this.game.getOtherPlayer(this.controller);
                 this.game.addMessage('{0} plays {1} to set the claim value on {2}\'s revealed plot card to 0 until the end of the challenge',
                     this.controller, this, opponent);
             }

--- a/server/game/cards/04.4-TIMC/KingBeyondTheWall.js
+++ b/server/game/cards/04.4-TIMC/KingBeyondTheWall.js
@@ -7,7 +7,7 @@ class KingBeyondTheWall extends DrawCard {
         });
 
         this.persistentEffect({
-            condition: () => this.game.currentChallenge && this.game.currentChallenge.isAttacking(this.parent) && this.hasLessTotalPower(),
+            condition: () => this.game.currentChallenge && this.game.currentChallenge.isAttacking(this.parent) && this.hasLessTotalPower(this.game.currentChallenge.defendingPlayer),
             match: (card) => card === this.controller.activePlot,
             effect: ability.effects.modifyClaim(1)
         });
@@ -21,12 +21,8 @@ class KingBeyondTheWall extends DrawCard {
         return super.canAttach(player, card);
     }
 
-    hasLessTotalPower() {
-        let otherPlayer = this.game.getOtherPlayer(this.controller);
-        if(!otherPlayer) {
-            return false;
-        }
-        return this.controller.getTotalPower() < otherPlayer.getTotalPower();
+    hasLessTotalPower(opponent) {
+        return this.controller.getTotalPower() < opponent.getTotalPower();
     }
 }
 

--- a/server/game/cards/04.4-TIMC/WithoutHisBeard.js
+++ b/server/game/cards/04.4-TIMC/WithoutHisBeard.js
@@ -6,18 +6,13 @@ class WithoutHisBeard extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.winner === this.controller &&
-                    challenge.challengeType === 'intrigue' &&
-                    this.opponentHasCardsInHand())
+                afterChallenge: event => (
+                    event.challenge.winner === this.controller &&
+                    event.challenge.challengeType === 'intrigue' &&
+                    this.opponentHasCardsInHand(event.challenge.loser))
             },
-            handler: () => {
-                let opponent = this.game.getOtherPlayer(this.controller);
-
-                if(!opponent) {
-                    return false;
-                }
-
+            handler: context => {
+                this.losingOpponent = context.event.challenge.loser;
                 let nums = ['1', '2', '3'];
 
                 let buttons = _.map(nums, num => {
@@ -36,7 +31,7 @@ class WithoutHisBeard extends DrawCard {
     }
 
     numSelected(player, num) {
-        let opponent = this.game.getOtherPlayer(this.controller);
+        let opponent = this.losingOpponent;
         opponent.discardAtRandom(num);
         opponent.drawCardsToHand(2);
         this.game.addMessage('{0} plays {1} to have {2} discard {3} cards at random, then draw 2 cards',
@@ -45,14 +40,8 @@ class WithoutHisBeard extends DrawCard {
         return true;
     }
 
-    opponentHasCardsInHand() {
-        let otherPlayer = this.game.getOtherPlayer(this.controller);
-
-        if(!otherPlayer) {
-            return false;
-        }
-
-        return otherPlayer.hand.size() >= 1;
+    opponentHasCardsInHand(opponent) {
+        return opponent.hand.size() >= 1;
     }
 }
 

--- a/server/game/cards/04.6-TC/FistOfTheFirstMen.js
+++ b/server/game/cards/04.6-TC/FistOfTheFirstMen.js
@@ -13,8 +13,8 @@ class FistOfTheFirstMen extends DrawCard {
     }
 
     hasHigherReserveThanOpponent() {
-        let opponent = this.game.getOtherPlayer(this.controller);
-        return opponent && this.controller.getTotalReserve() > opponent.getTotalReserve();
+        let opponents = this.game.getOpponents(this.controller);
+        return opponents.some(opponent => this.controller.getTotalReserve() > opponent.getTotalReserve());
     }
 }
 

--- a/server/game/cards/04.6-TC/TarredHeads.js
+++ b/server/game/cards/04.6-TC/TarredHeads.js
@@ -4,13 +4,13 @@ class TarredHeads extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.challengeType === 'power' &&
-                    challenge.winner === this.controller &&
-                    this.opponentHasCards())
+                afterChallenge: event => (
+                    event.challenge.challengeType === 'power' &&
+                    event.challenge.winner === this.controller &&
+                    event.challenge.loser.hand.size() >= 1)
             },
-            handler: () => {
-                let opponent = this.game.getOtherPlayer(this.controller);
+            handler: context => {
+                let opponent = context.event.challenge.loser;
 
                 opponent.discardAtRandom(1, cards => {
                     let card = cards[0];
@@ -26,11 +26,6 @@ class TarredHeads extends DrawCard {
                 });
             }
         });
-    }
-
-    opponentHasCards() {
-        let opponent = this.game.getOtherPlayer(this.controller);
-        return opponent && opponent.hand.size() >= 1;
     }
 }
 

--- a/server/game/cards/05-LoCR/Alayaya.js
+++ b/server/game/cards/05-LoCR/Alayaya.js
@@ -4,29 +4,19 @@ class Alayaya extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.winner === this.controller &&
-                    challenge.isParticipating(this) &&
-                    this.opponentHasGold())
+                afterChallenge: event => (
+                    event.challenge.winner === this.controller &&
+                    event.challenge.isParticipating(this) &&
+                    event.challenge.loser.gold >= 1)
             },
-            handler: () => {
-                var otherPlayer = this.game.getOtherPlayer(this.controller);
+            handler: context => {
+                let otherPlayer = context.event.challenge.loser;
 
                 this.game.addGold(otherPlayer, -1);
                 this.game.addGold(this.controller, 1);
                 this.game.addMessage('{0} uses {1} to move 1 gold from {2}\'s gold pool to their own', this.controller, this, otherPlayer);
             }
         });
-    }
-
-    opponentHasGold() {
-        var otherPlayer = this.game.getOtherPlayer(this.controller);
-
-        if(!otherPlayer) {
-            return false;
-        }
-
-        return otherPlayer.gold >= 1;
     }
 }
 

--- a/server/game/cards/05-LoCR/DisputedClaim.js
+++ b/server/game/cards/05-LoCR/DisputedClaim.js
@@ -3,13 +3,7 @@ const DrawCard = require('../../drawcard.js');
 class DisputedClaim extends DrawCard {
     setupCardAbilities(ability) {
         this.whileAttached({
-            condition: () => {
-                let otherPlayer = this.game.getOtherPlayer(this.controller);
-                if(!otherPlayer || this.controller.faction.power > otherPlayer.faction.power) {
-                    return true;
-                }
-                return false;
-            },
+            condition: () => this.hasMostFactionPower(),
             effect: [
                 ability.effects.modifyStrength(2),
                 ability.effects.addKeyword('Renown')
@@ -22,6 +16,11 @@ class DisputedClaim extends DrawCard {
             return false;
         }
         return super.canAttach(player, card);
+    }
+
+    hasMostFactionPower() {
+        let opponents = this.game.getOpponents(this.controller);
+        return opponents.every(opponent => this.controller.faction.power > opponent.faction.power);
     }
 }
 

--- a/server/game/cards/05-LoCR/GoldenTooth.js
+++ b/server/game/cards/05-LoCR/GoldenTooth.js
@@ -6,12 +6,16 @@ class GoldenTooth extends DrawCard {
             title: 'Gain gold',
             cost: ability.costs.kneelSelf(),
             handler: () => {
-                let opponent = this.game.getOtherPlayer(this.controller);
-                let gold = opponent && opponent.hand.size() === 0 ? 3 : 1;
+                let gold = this.opponentHasEmptyHand() ? 3 : 1;
                 this.game.addMessage('{0} kneels {1} to gain {2} gold', this.controller, this, gold);
                 this.game.addGold(this.controller, gold);
             }
         });
+    }
+
+    opponentHasEmptyHand() {
+        let opponents = this.game.getOpponents(this.controller);
+        return opponents.some(opponent => opponent.hand.size() === 0);
     }
 }
 

--- a/server/game/cards/05-LoCR/InsidiousScheme.js
+++ b/server/game/cards/05-LoCR/InsidiousScheme.js
@@ -9,9 +9,9 @@ class InsidiousScheme extends DrawCard {
                     event.challenge.winner === this.controller &&
                     event.challenge.strengthDifference >= 5)
             },
-            handler: () => {
-                let opponent = this.game.getOtherPlayer(this.controller);
-                let cards = opponent && opponent.hand.size() === 0 ? 4 : 2;
+            handler: context => {
+                let opponent = context.event.challenge.loser;
+                let cards = opponent.hand.size() === 0 ? 4 : 2;
                 this.controller.drawCardsToHand(cards);
                 this.game.addMessage('{0} plays {1} to draw {2} cards', this.controller, this, cards);
             }

--- a/server/game/cards/05-LoCR/RedKeepSpy.js
+++ b/server/game/cards/05-LoCR/RedKeepSpy.js
@@ -4,16 +4,13 @@ class RedKeepSpy extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onCardEntersPlay: event => (
-                    event.playingType === 'ambush' &&
-                    this === event.card &&
-                    this.hasMoreCardsInHand()
-                )
+                onCardEntersPlay: event => event.playingType === 'ambush' && this === event.card
             },
             target: {
                 cardCondition: card => (
                     card.location === 'play area' &&
                     card.controller !== this.controller &&
+                    card.controller.hand.size() < this.controller.hand.size() &&
                     card.getType() === 'character' &&
                     card.getCost() <= 3)
             },
@@ -22,16 +19,6 @@ class RedKeepSpy extends DrawCard {
                 this.game.addMessage('{0} uses {1} to return {2} to {3}\'s hand', this.controller, this, context.target, context.target.controller);
             }
         });
-    }
-
-    hasMoreCardsInHand() {
-        var otherPlayer = this.game.getOtherPlayer(this.controller);
-
-        if(!otherPlayer) {
-            return false;
-        }
-
-        return this.controller.hand.size() > otherPlayer.hand.size();
     }
 }
 

--- a/server/game/cards/05-LoCR/SerBarristanSelmy.js
+++ b/server/game/cards/05-LoCR/SerBarristanSelmy.js
@@ -4,11 +4,10 @@ class SerBarristanSelmy extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) =>
-                    challenge.winner === this.controller
-                    && challenge.isParticipating(this)
-                    && this.game.getOtherPlayer(this.controller)
-                    && this.controller.hand.size() < this.game.getOtherPlayer(this.controller).hand.size()
+                afterChallenge: event =>
+                    event.challenge.winner === this.controller
+                    && event.challenge.isParticipating(this)
+                    && this.controller.hand.size() < event.challenge.loser.hand.size()
             },
             handler: () => {
                 this.controller.standCard(this);

--- a/server/game/cards/05-LoCR/TheCouncilConsents.js
+++ b/server/game/cards/05-LoCR/TheCouncilConsents.js
@@ -1,5 +1,3 @@
-const _ = require('underscore');
-
 const DrawCard = require('../../drawcard.js');
 
 class TheCouncilConsents extends DrawCard {
@@ -12,27 +10,20 @@ class TheCouncilConsents extends DrawCard {
                     this.anySmallCouncilCharacterInPlay())
             },
             handler: () => {
-                let ownSmallCouncilChars = this.controller.filterCardsInPlay(card => card.hasTrait('Small Council') && card.getType() === 'character');
+                let smallCouncilChars = this.game.filterCardsInPlay(card => card.hasTrait('Small Council') && card.getType() === 'character');
 
-                let opponent = this.game.getOtherPlayer(this.controller);
-                let opponentSmallCouncilChars = opponent.filterCardsInPlay(card => card.hasTrait('Small Council') && card.getType() === 'character');
-
-                let allSmallCouncilChars = ownSmallCouncilChars.concat(opponentSmallCouncilChars);
-
-                _.each(allSmallCouncilChars, card => {
+                for(let card of smallCouncilChars) {
                     card.controller.standCard(card);
-                });
+                }
 
                 this.game.addMessage('{0} plays {1} to stand {2}',
-                    this.controller, this, allSmallCouncilChars);
+                    this.controller, this, smallCouncilChars);
             }
         });
     }
 
     anySmallCouncilCharacterInPlay() {
-        let opponent = this.game.getOtherPlayer(this.controller);
-        return this.controller.anyCardsInPlay(card => card.hasTrait('Small Council') && card.getType() === 'character') ||
-               (opponent && opponent.anyCardsInPlay(card => card.hasTrait('Small Council') && card.getType() === 'character'));
+        return this.game.anyCardsInPlay(card => card.hasTrait('Small Council') && card.getType() === 'character');
     }
 }
 

--- a/server/game/cards/05-LoCR/TommenBaratheon.js
+++ b/server/game/cards/05-LoCR/TommenBaratheon.js
@@ -3,27 +3,11 @@ const DrawCard = require('../../drawcard.js');
 class TommenBaratheon extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            condition: () => this.controller.hand.size() === 0,
             targetType: 'player',
+            targetController: 'any',
+            match: player => player.hand.size() === 0,
             effect: ability.effects.cannotGainChallengeBonus()
         });
-
-        this.persistentEffect({
-            condition: () => this.opponentHasNoCardsInHand(),
-            targetType: 'player',
-            targetController: 'opponent',
-            effect: ability.effects.cannotGainChallengeBonus()
-        });
-    }
-
-    opponentHasNoCardsInHand() {
-        var opponent = this.game.getOtherPlayer(this.controller);
-
-        if(!opponent) {
-            return true;
-        }
-
-        return opponent.hand.size() === 0;
     }
 }
 

--- a/server/game/cards/05-LoCR/WildlingBandit.js
+++ b/server/game/cards/05-LoCR/WildlingBandit.js
@@ -6,18 +6,10 @@ class WildlingBandit extends DrawCard {
             condition: () => (
                 this.game.currentChallenge &&
                 this.game.currentChallenge.isAttacking(this) &&
-                this.hasLessGold()),
+                this.game.currentChallenge.defendingPlayer.gold > this.controller.gold),
             match: this,
             effect: ability.effects.modifyStrength(2)
         });
-    }
-
-    hasLessGold() {
-        var otherPlayer = this.game.getOtherPlayer(this.controller);
-        if(!otherPlayer) {
-            return false;
-        }
-        return this.controller.gold < otherPlayer.gold;
     }
 }
 

--- a/server/game/cards/06.1-AMAF/EastwatchByTheSea.js
+++ b/server/game/cards/06.1-AMAF/EastwatchByTheSea.js
@@ -18,8 +18,8 @@ class EastwatchByTheSea extends DrawCard {
     }
 
     hasHigherReserveThanOpponent() {
-        let opponent = this.game.getOtherPlayer(this.controller);
-        return opponent && this.controller.getTotalReserve() > opponent.getTotalReserve();
+        let opponents = this.game.getOpponents(this.controller);
+        return opponents.some(opponent => this.controller.getTotalReserve() > opponent.getTotalReserve());
     }
 }
 

--- a/server/game/cards/06.1-AMAF/FickleBannerman.js
+++ b/server/game/cards/06.1-AMAF/FickleBannerman.js
@@ -6,7 +6,9 @@ class FickleBannerman extends DrawCard {
             when: {
                 afterChallenge: event => event.challenge.loser === this.controller && event.challenge.challengeType === 'power'
             },
-            handler: () => {
+            handler: context => {
+                this.challengeWinner = context.event.challenge.winner;
+
                 if(!this.hasToken('gold')) {
                     this.loseControl();
                     return;
@@ -34,9 +36,8 @@ class FickleBannerman extends DrawCard {
     }
 
     loseControl() {
-        var otherPlayer = this.game.getOtherPlayer(this.controller);
-        this.game.takeControl(otherPlayer, this);
-        this.game.addMessage('{0} takes control of {1}', otherPlayer, this);
+        this.game.takeControl(this.challengeWinner, this);
+        this.game.addMessage('{0} takes control of {1}', this.challengeWinner, this);
 
         return true;
     }

--- a/server/game/cards/06.1-AMAF/LateSummerFeast.js
+++ b/server/game/cards/06.1-AMAF/LateSummerFeast.js
@@ -4,14 +4,10 @@ class LateSummerFeast extends PlotCard {
     setupCardAbilities() {
         this.forcedReaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller
+                afterChallenge: event => event.challenge.winner === this.controller
             },
-            handler: () => {
-                var otherPlayer = this.game.getOtherPlayer(this.controller);
-
-                if(!otherPlayer) {
-                    return;
-                }
+            handler: context => {
+                let otherPlayer = context.event.loser;
 
                 this.game.addMessage('{0} is forced by {1} to allow {2} to draw 1 card', this.controller, this, otherPlayer);
                 this.game.promptWithMenu(otherPlayer, this, {

--- a/server/game/cards/06.1-AMAF/SlaversBayPort.js
+++ b/server/game/cards/06.1-AMAF/SlaversBayPort.js
@@ -7,13 +7,17 @@ class SlaversBayPort extends DrawCard {
             phase: 'marshal',
             cost: ability.costs.kneelSelf(),
             handler: context => {
-                let opponent = this.game.getOtherPlayer(this.controller);
-                let gold = opponent && opponent.deadPile.size() >= 4 ? 2 : 1;
+                let gold = this.opponentDeadPileHas4() >= 4 ? 2 : 1;
 
                 this.game.addGold(context.player, gold);
                 this.game.addMessage('{0} kneels {1} to gain {2} gold', context.player, this, gold);
             }
         });
+    }
+
+    opponentDeadPileHas4() {
+        let opponents = this.game.getOpponents(this.controller);
+        return opponents.some(opponent => opponent.deadPile.size() >= 4);
     }
 }
 

--- a/server/game/cards/06.1-AMAF/SlaversBayPort.js
+++ b/server/game/cards/06.1-AMAF/SlaversBayPort.js
@@ -7,7 +7,7 @@ class SlaversBayPort extends DrawCard {
             phase: 'marshal',
             cost: ability.costs.kneelSelf(),
             handler: context => {
-                let gold = this.opponentDeadPileHas4() >= 4 ? 2 : 1;
+                let gold = this.opponentDeadPileHas4() ? 2 : 1;
 
                 this.game.addGold(context.player, gold);
                 this.game.addMessage('{0} kneels {1} to gain {2} gold', context.player, this, gold);

--- a/server/game/cards/06.1-AMAF/StoneCrows.js
+++ b/server/game/cards/06.1-AMAF/StoneCrows.js
@@ -4,14 +4,14 @@ class StoneCrows extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.winner === this.controller &&
-                    challenge.isAttacking(this) &&
-                    challenge.defenders.length >= 1)
+                afterChallenge: event => (
+                    event.challenge.winner === this.controller &&
+                    event.challenge.isAttacking(this) &&
+                    event.challenge.defenders.length >= 1)
             },
             cost: ability.costs.discardGold(),
-            handler: () => {
-                var otherPlayer = this.game.getOtherPlayer(this.controller);
+            handler: context => {
+                let otherPlayer = context.event.challenge.loser;
                 this.game.promptForSelect(otherPlayer, {
                     cardCondition: card => (
                         this.game.currentChallenge.isDefending(card) &&

--- a/server/game/cards/06.2-GtR/IronIslandsMarket.js
+++ b/server/game/cards/06.2-GtR/IronIslandsMarket.js
@@ -7,13 +7,17 @@ class IronIslandsMarket extends DrawCard {
             phase: 'marshal',
             cost: ability.costs.kneelSelf(),
             handler: context => {
-                let otherPlayer = this.game.getOtherPlayer(this.controller);
-                let gold = otherPlayer && otherPlayer.discardPile.size() >= 8 ? 2 : 1;
+                let gold = this.opponentDiscardPileHas8() ? 2 : 1;
 
                 this.game.addGold(context.player, gold);
                 this.game.addMessage('{0} kneels {1} to gain {2} gold', context.player, this, gold);
             }
         });
+    }
+
+    opponentDiscardPileHas8() {
+        let opponents = this.game.getOpponents(this.controller);
+        return opponents.some(opponent => opponent.discardPile.size() >= 8);
     }
 }
 

--- a/server/game/cards/06.2-GtR/Polliver.js
+++ b/server/game/cards/06.2-GtR/Polliver.js
@@ -4,24 +4,18 @@ class Polliver extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onPillage: event => event.source === this && event.discardedCard.getType() === 'character' && this.opponentHasGold()
+                onPillage: event => (
+                    event.source === this &&
+                    event.discardedCard.getType() === 'character' &&
+                    event.discardedCard.owner.gold >= 1
+                )
             },
-            handler: () => {
-                let otherPlayer = this.game.getOtherPlayer(this.controller);
+            handler: context => {
+                let otherPlayer = context.event.discardedCard.owner;
                 this.game.addGold(otherPlayer, -2);
                 this.game.addMessage('{0} uses {1} have {2} return 2 gold to the treasury', this.controller, this, otherPlayer);
             }
         });
-    }
-
-    opponentHasGold() {
-        let otherPlayer = this.game.getOtherPlayer(this.controller);
-
-        if(!otherPlayer) {
-            return false;
-        }
-
-        return otherPlayer.gold >= 1;
     }
 }
 

--- a/server/game/cards/06.3-TFoA/CerseisAttendant.js
+++ b/server/game/cards/06.3-TFoA/CerseisAttendant.js
@@ -10,8 +10,15 @@ class CerseisAttendant extends DrawCard {
     }
 
     opponentHasNoCardsInHand() {
-        let opponent = this.game.getOtherPlayer(this.controller);
-        return opponent && opponent.hand.size() === 0;
+        let challenge = this.game.currentChallenge;
+        if(!challenge) {
+            return false;
+        }
+
+        return (
+            (challenge.isAttacking(this) && challenge.defendingPlayer.hand.size() === 0) ||
+            (challenge.isDefending(this) && challenge.attackingPlayer.hand.size() === 0)
+        );
     }
 }
 

--- a/server/game/cards/06.3-TFoA/CorsairsDirk.js
+++ b/server/game/cards/06.3-TFoA/CorsairsDirk.js
@@ -8,23 +8,18 @@ class CorsairsDirk extends DrawCard {
 
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.winner === this.controller &&
-                    challenge.isAttacking(this.parent) &&
-                    this.opponentHasGold())
+                afterChallenge: event => (
+                    event.challenge.winner === this.controller &&
+                    event.challenge.isAttacking(this.parent) &&
+                    event.challenge.defendingPlayer.gold >= 1)
             },
-            handler: () => {
-                let opponent = this.game.getOtherPlayer(this.controller);
+            handler: context => {
+                let opponent = context.event.challenge.defendingPlayer;
                 this.game.transferGold(this.controller, opponent, 1);
                 this.game.addMessage('{0} uses {1} to move 1 gold from {2}\'s gold pool to their own',
                     this.controller, this, opponent);
             }
         });
-    }
-
-    opponentHasGold() {
-        let opponent = this.game.getOtherPlayer(this.controller);
-        return opponent && opponent.gold >= 1;
     }
 
     canAttach(player, card) {

--- a/server/game/cards/06.3-TFoA/UndergroundVault.js
+++ b/server/game/cards/06.3-TFoA/UndergroundVault.js
@@ -7,13 +7,17 @@ class UndergroundVault extends DrawCard {
             phase: 'marshal',
             cost: ability.costs.kneelSelf(),
             handler: context => {
-                let opponent = this.game.getOtherPlayer(this.controller);
-                let gold = opponent && opponent.activePlot.getIncome() >= 5 ? 2 : 1;
+                let gold = this.opponentHasIncomeOf5() ? 2 : 1;
 
                 this.game.addGold(context.player, gold);
                 this.game.addMessage('{0} kneels {1} to gain {2} gold', context.player, this, gold);
             }
         });
+    }
+
+    opponentHasIncomeOf5() {
+        let opponents = this.game.getOpponents(this.controller);
+        return opponents.some(opponent => opponent.activePlot.getIncome() >= 5);
     }
 }
 

--- a/server/game/cards/06.5-OR/DornishRevenge.js
+++ b/server/game/cards/06.5-OR/DornishRevenge.js
@@ -32,7 +32,7 @@ class DornishRevenge extends DrawCard {
             return;
         }
 
-        let opponent = this.game.getOtherPlayer(this.controller);
+        let opponent = challenge.defendingPlayer;
 
         this.game.addMessage('{0} uses {1} to have {2} choose and kill a defending character',
             this.controller, this, opponent);

--- a/server/game/cards/07-WotW/CrowKillers.js
+++ b/server/game/cards/07-WotW/CrowKillers.js
@@ -10,13 +10,16 @@ class CrowKillers extends DrawCard {
     }
 
     opponentHasHigherReserve() {
-        let opponent = this.game.getOtherPlayer(this.controller);
+        let challenge = this.game.currentChallenge;
 
-        if(!opponent) {
+        if(!challenge) {
             return false;
         }
 
-        return this.controller.getTotalReserve() < opponent.getTotalReserve();
+        return (
+            challenge.attackingPlayer === this.controller &&
+            this.controller.getTotalReserve() < challenge.defendingPlayer.getTotalReserve()
+        );
     }
 }
 

--- a/server/game/cards/07-WotW/Grenn.js
+++ b/server/game/cards/07-WotW/Grenn.js
@@ -4,10 +4,10 @@ class Grenn extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.winner === this.controller &&
-                    challenge.isAttacking(this)) &&
-                    this.opponentHasFactionPower()
+                afterChallenge: event => (
+                    event.challenge.winner === this.controller &&
+                    event.challenge.isAttacking(this)) &&
+                    event.challenge.loser.power > 0
             },
             target: {
                 activePromptTitle: 'Select a character',
@@ -19,7 +19,7 @@ class Grenn extends DrawCard {
                     card.getType() === 'character')
             },
             handler: context => {
-                var otherPlayer = this.game.getOtherPlayer(this.controller);
+                var otherPlayer = context.event.challenge.loser;
                 var power = otherPlayer.faction.power > 1 && context.target.kneeled === false ? 2 : 1;
                 this.game.addPower(otherPlayer, -power);
                 context.target.modifyPower(power);
@@ -28,16 +28,6 @@ class Grenn extends DrawCard {
                     this.controller, this, power, otherPlayer, context.target);
             }
         });
-    }
-
-    opponentHasFactionPower() {
-        var otherPlayer = this.game.getOtherPlayer(this.controller);
-
-        if(!otherPlayer) {
-            return false;
-        }
-
-        return otherPlayer.faction.power > 0;
     }
 }
 

--- a/server/game/cards/07-WotW/OldBearMormont.js
+++ b/server/game/cards/07-WotW/OldBearMormont.js
@@ -4,13 +4,13 @@ class OldBearMormont extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isParticipating(this)
+                afterChallenge: event => event.challenge.winner === this.controller && event.challenge.isParticipating(this)
             },
             target: {
-                cardCondition: card => (
+                cardCondition: (card, context) => (
                     !card.isUnique() &&
                     card.getType() === 'character' &&
-                    card.controller !== this.controller &&
+                    card.controller === context.event.challenge.loser &&
                     card.location === 'discard pile')
             },
             handler: context => {

--- a/server/game/cards/08.1-TAK/QueensMen.js
+++ b/server/game/cards/08.1-TAK/QueensMen.js
@@ -10,6 +10,8 @@ class QueensMen extends DrawCard {
             handler: context => {
                 let opponent = context.opponent;
 
+                this.chosenOpponent = opponent;
+
                 let buttons = opponent.hand.map(card => {
                     return { card: card, method: 'cardSelected' };
                 });
@@ -47,8 +49,7 @@ class QueensMen extends DrawCard {
     }
 
     doneSelected() {
-        let opponent = this.game.getOtherPlayer(this.controller);
-        this.game.addMessage('{0} uses {1} to look at {2}\'s hand', this.controller, this, opponent);
+        this.game.addMessage('{0} uses {1} to look at {2}\'s hand', this.controller, this, this.chosenOpponent);
         return true;
     }
 

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -102,11 +102,17 @@ class Game extends EventEmitter {
     }
 
     getPlayers() {
-        return _.omit(this.playersAndSpectators, player => this.isSpectator(player));
+        return Object.values(this.playersAndSpectators).filter(player => !this.isSpectator(player));
     }
 
     getPlayerByName(playerName) {
-        return this.getPlayers()[playerName];
+        let player = this.playersAndSpectators[playerName];
+
+        if(!player || this.isSpectator(player)) {
+            return;
+        }
+
+        return player;
     }
 
     getPlayersInFirstPlayerOrder() {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -133,6 +133,10 @@ class Game extends EventEmitter {
         });
     }
 
+    getOpponents(player) {
+        return this.getPlayers().filter(p => p !== player);
+    }
+
     getOtherPlayer(player) {
         var otherPlayer = _.find(this.getPlayers(), p => {
             return p.name !== player.name;

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -163,6 +163,10 @@ class Game extends EventEmitter {
         return foundCards;
     }
 
+    anyCardsInPlay(predicate) {
+        return this.allCards.any(card => card.location === 'play area' && predicate(card));
+    }
+
     anyPlotHasTrait(trait) {
         return _.any(this.getPlayers(), player =>
             player.activePlot &&

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -177,6 +177,10 @@ class Game extends EventEmitter {
         return this.allCards.any(card => card.location === 'play area' && predicate(card));
     }
 
+    filterCardsInPlay(predicate) {
+        return this.allCards.filter(card => card.location === 'play area' && predicate(card));
+    }
+
     anyPlotHasTrait(trait) {
         return _.any(this.getPlayers(), player =>
             player.activePlot &&

--- a/server/game/plotcard.js
+++ b/server/game/plotcard.js
@@ -33,14 +33,14 @@ class PlotCard extends BaseCard {
         return baseValue + this.initiativeModifier;
     }
 
-    getIncome(printed) {
-        if(printed) {
-            return this.cardData.income;
-        }
-
-        var baseValue = this.canProvidePlotModifier['gold'] ? (this.baseIncome || this.cardData.income) : 0;
+    getIncome() {
+        let baseValue = this.canProvidePlotModifier['gold'] ? (this.baseIncome || this.getPrintedIncome()) : 0;
 
         return baseValue + this.goldModifier;
+    }
+
+    getPrintedIncome() {
+        return this.cardData.income;
     }
 
     getReserve() {


### PR DESCRIPTION
* Adds `getOpponents` method to game to get opponents instead of the only other player.
* Replaces in-challenge opponent with the appropriate player within the challenge (winner, loser, defendingPlayer, attackingPlayer)
* Records the appropriate opponent when the usage is in another method after a separate prompt or in an ability Then clause.
* Updates most other usages of getOtherPlayer, including abilities that affect each opponent or need one/all opponents to meet a check.

Does not update:
* Cards that interact with an opponent faction card (Chamber of the Painted Table, Vanguard Lancer) - need to rework click handlers to allow clicking on the faction card.
* Cards that require each player to do something - A Gift of Arbor Red (already hugely complicated card, probably will be a PR on its own) and Jojen Reed.
* Loot - there is an implicit 'choose opponent' that needs to be executed prior to costs, while the current `chooseOpponent` option executes just prior to targets.
* Varys' Riddle - probably could be done by converting it into the target API but like Chamber of the Painted Table, it would be better if it were automatic in 2 player mode.

Progress toward #1237.