### PR TITLE
Treat faction card like a normal card

### DIFF
--- a/client/GameBoard.jsx
+++ b/client/GameBoard.jsx
@@ -189,10 +189,6 @@ export class InnerGameBoard extends React.Component {
         this.props.sendGameMessage('cardClicked', card.uuid);
     }
 
-    onFactionCardClick() {
-        this.props.sendGameMessage('factionCardClicked');
-    }
-
     onDrawClick() {
         this.props.sendGameMessage('showDrawDeck');
 
@@ -501,7 +497,6 @@ export class InnerGameBoard extends React.Component {
                                 onMouseOut={ this.onMouseOut }
                                 numDrawCards={ thisPlayer.numDrawCards }
                                 onDrawClick={ this.onDrawClick }
-                                onFactionCardClick={ this.onFactionCardClick.bind(this) }
                                 onShuffleClick={ this.onShuffleClick }
                                 outOfGamePile={ thisPlayer.cardPiles.outOfGamePile }
                                 showDrawDeck={ this.state.showDrawDeck }

--- a/client/GameComponents/PlayerRow.jsx
+++ b/client/GameComponents/PlayerRow.jsx
@@ -131,12 +131,6 @@ class PlayerRow extends React.Component {
         );
     }
 
-    onFactionCardClick() {
-        if(this.props.onFactionCardClick) {
-            this.props.onFactionCardClick();
-        }
-    }
-
     render() {
         var drawDeckMenu = this.props.isMe && !this.props.spectating ? [
             { text: 'Show', handler: this.onShowDeckClick, showPopup: true },
@@ -151,7 +145,7 @@ class PlayerRow extends React.Component {
             <div className='player-home-row-container'>
                 <CardPile className='faction' source='faction' cards={ [] } topCard={ this.props.faction }
                     onMouseOver={ this.onMouseOver } onMouseOut={ this.onMouseOut } disablePopup
-                    onCardClick={ this.props.isMe && !this.props.spectating ? this.onFactionCardClick.bind(this) : null }
+                    onCardClick={ this.props.onCardClick }
                     size={ this.props.cardSize } />
                 { this.getAgenda() }
                 { this.getTitleCard() }
@@ -201,7 +195,6 @@ PlayerRow.propTypes = {
     onCardClick: React.PropTypes.func,
     onDragDrop: React.PropTypes.func,
     onDrawClick: React.PropTypes.func,
-    onFactionCardClick: React.PropTypes.func,
     onMenuItemClick: React.PropTypes.func,
     onMouseOut: React.PropTypes.func,
     onMouseOver: React.PropTypes.func,

--- a/server/game/cards/01-Core/VanguardLancer.js
+++ b/server/game/cards/01-Core/VanguardLancer.js
@@ -6,45 +6,21 @@ class VanguardLancer extends DrawCard {
             when: {
                 onCardEntersPlay: event => event.card === this
             },
-            handler: () => {
-                this.game.promptForSelect(this.controller, {
-                    activePromptTitle: 'Select a card',
-                    source: this,
-                    additionalButtons: [{ text: 'Faction Card', arg: 'faction' }],
-                    cardCondition: card => card.controller !== this.controller && card.getPower() > 0,
-                    onSelect: (player, card) => this.onCardSelected(player, card),
-                    onMenuCommand: (player, arg) => this.selectFactionCard(player, arg),
-                    onCancel: (player) => this.cancelSelection(player)
-                });
+            target: {
+                activePromptTitle: 'Select a card',
+                cardCondition: card => card.controller !== this.controller && card.getPower() > 0,
+                cardType: ['character', 'faction']
+            },
+            handler: context => {
+                if(context.target.getType() === 'faction') {
+                    this.game.addMessage('{0} uses {1} to remove 1 power from {2}\'s faction card', this.controller, this, context.target.owner);
+                } else {
+                    this.game.addMessage('{0} uses {1} to remove 1 power from {2}', this.controller, this, context.target);
+                }
+
+                context.target.modifyPower(-1);
             }
         });
-    }
-
-    onCardSelected(player, card) {
-        this.game.addMessage('{0} uses {1} to remove 1 power from {2}', player, this, card);
-
-        card.modifyPower(-1);
-
-        return true;
-    }
-
-    selectFactionCard(player) {
-        var otherPlayer = this.game.getOtherPlayer(player);
-        if(!otherPlayer) {
-            return true;
-        }
-
-        this.game.addPower(otherPlayer, -1);
-
-        this.game.addMessage('{0} uses {1} to remove 1 power from {2}\'s faction card', player, this, otherPlayer);
-
-        return true;
-    }
-
-    cancelSelection(player) {
-        this.game.addMessage('{0} cancels the resolution of {1}', player, this);
-
-        return true;
     }
 }
 

--- a/server/game/cards/03-WotN/TheLongWinter.js
+++ b/server/game/cards/03-WotN/TheLongWinter.js
@@ -19,35 +19,18 @@ class TheLongWinter extends PlotCard {
         return true;
     }
 
-    selectFactionCard(player, arg) {
-        if(arg !== 'faction') {
-            return false;
-        }
-
-        this.selections.push({ player: player, factionCard: true });
-        this.game.addMessage('{0} selects their faction to lose power from {2}', player, this);
-        this.proceedToNextStep();
-        return true;
-    }
-
     onCardSelected(player, card) {
-        this.selections.push({ player: player, card: card });
-        this.game.addMessage('{0} selects {1} to lose power from {2}', player, card, this);
+        let cardFragment = card.getType() === 'faction' ? 'their faction' : card;
+        this.selections.push({ player: player, card: card, cardFragment: cardFragment });
+        this.game.addMessage('{0} selects {1} to lose power from {2}', player, cardFragment, this);
         this.proceedToNextStep();
         return true;
     }
 
     doPower() {
         _.each(this.selections, selection => {
-            var player = selection.player;
-
-            if(selection.factionCard) {
-                this.game.addPower(player, -1);
-                this.game.addMessage('{0} discards 1 power from their faction card from {1}', player, this);
-            } else if(selection.card) {
-                this.game.addMessage('{0} discards 1 power from {1}', player, selection.card);
-                selection.card.modifyPower(-1);
-            }
+            this.game.addMessage('{0} discards 1 power from {1}', selection.player, selection.cardFragment);
+            selection.card.modifyPower(-1);
         });
 
         this.selections = [];
@@ -59,10 +42,9 @@ class TheLongWinter extends PlotCard {
             this.game.promptForSelect(currentPlayer, {
                 activePromptTitle: 'Select a card',
                 source: this,
-                additionalButtons: [{ text: 'Faction Card', arg: 'faction' }],
                 cardCondition: card => card.controller === currentPlayer && card.getPower() > 0,
+                cardType: ['attachment', 'character', 'faction', 'location'],
                 onSelect: (player, card) => this.onCardSelected(player, card),
-                onMenuCommand: (player, arg) => this.selectFactionCard(player, arg),
                 onCancel: (player) => this.cancelSelection(player)
             });
         } else {

--- a/server/game/chatcommands.js
+++ b/server/game/chatcommands.js
@@ -67,7 +67,8 @@ class ChatCommands {
         this.game.promptForSelect(player, {
             activePromptTitle: 'Select a card to set power for',
             waitingPromptTitle: 'Waiting for opponent to set power',
-            cardCondition: card => card.location === 'play area' && card.controller === player,
+            cardCondition: card => ['faction', 'play area'].includes(card.location) && card.controller === player,
+            cardType: ['attachment', 'character', 'faction', 'location'],
             onSelect: (p, card) => {
                 let power = num - card.power;
                 card.power += power;
@@ -76,7 +77,8 @@ class ChatCommands {
                     card.power = 0;
                 }
 
-                this.game.addAlert('danger', '{0} uses the /power command to set the power of {1} to {2}', p, card, num);
+                let cardFragment = card.getType() === 'faction' ? 'their faction card' : card;
+                this.game.addAlert('danger', '{0} uses the /power command to set the power of {1} to {2}', p, cardFragment, num);
                 return true;
             }
         });

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -197,22 +197,6 @@ class Game extends EventEmitter {
         plot.selected = true;
     }
 
-    factionCardClicked(sourcePlayer) {
-        var player = this.getPlayerByName(sourcePlayer);
-
-        if(!player) {
-            return;
-        }
-
-        if(player.faction.kneeled) {
-            player.standCard(player.faction);
-        } else {
-            player.kneelCard(player.faction);
-        }
-
-        this.addAlert('danger', '{0} {1} their faction card', player, player.faction.kneeled ? 'kneels' : 'stands');
-    }
-
     cardClicked(sourcePlayer, cardId) {
         var player = this.getPlayerByName(sourcePlayer);
 
@@ -244,15 +228,24 @@ class Game extends EventEmitter {
             return;
         }
 
-        if(!card.facedown && card.location === 'play area' && card.controller === player) {
-            if(card.kneeled) {
-                player.standCard(card);
-            } else {
-                player.kneelCard(card);
-            }
+        this.defaultCardClick(player, card);
+    }
 
-            this.addAlert('danger', '{0} {1} {2}', player, card.kneeled ? 'kneels' : 'stands', card);
+    defaultCardClick(player, card) {
+        if(card.facedown || card.controller !== player || !['faction', 'play area'].includes(card.location)) {
+            return;
         }
+
+        if(card.kneeled) {
+            player.standCard(card);
+        } else {
+            player.kneelCard(card);
+        }
+
+        let standStatus = card.kneeled ? 'kneels' : 'stands';
+        let cardFragment = card.getType() === 'faction' ? 'their faction card' : card;
+
+        this.addAlert('danger', '{0} {1} {2}', player, standStatus, cardFragment);
     }
 
     cardHasMenuItem(card, menuItem) {


### PR DESCRIPTION
* Removes special client and server side handling for clicking on a faction card, allowing faction card to be clicked during card select prompts.
* Removes the 'Faction Card' button during prompts for Vanguard Lancer and Long Winter in favor of allowing the faction card to be clicked directly (makes Melee possible for Lancer)
* As a bonus, /power command now works consistently for either cards in play or the faction card.