### PR TITLE
Add canPutIntoPlay check to abilities

### DIFF
--- a/server/game/cards/01-Core/ArianneMartell.js
+++ b/server/game/cards/01-Core/ArianneMartell.js
@@ -7,7 +7,7 @@ class ArianneMartell extends DrawCard {
             limit: ability.limit.perPhase(1),
             target: {
                 cardCondition: card => card.location === 'hand' && card.controller === this.controller &&
-                                       card.getCost() <= 5 && card.getType() === 'character'
+                                       card.getCost() <= 5 && card.getType() === 'character' && this.controller.canPutIntoPlay(card)
             },
             handler: context => {
                 context.player.putIntoPlay(context.target);

--- a/server/game/cards/01-Core/DothrakiSea.js
+++ b/server/game/cards/01-Core/DothrakiSea.js
@@ -8,9 +8,9 @@ class DothrakiSea extends DrawCard {
             },
             cost: ability.costs.sacrificeSelf(),
             target: {
-                activePromptTitle: 'Select a character',
                 cardCondition: (card, context) => card.location === 'hand' && card.getType() === 'character' &&
-                                                  card.controller === context.player && card.hasTrait('Dothraki')
+                                                  card.controller === context.player && card.hasTrait('Dothraki') &&
+                                                  context.player.canPutIntoPlay(card)
             },
             handler: context => {
                 context.target.controller.putIntoPlay(context.target);

--- a/server/game/cards/01-Core/FireAndBlood.js
+++ b/server/game/cards/01-Core/FireAndBlood.js
@@ -9,7 +9,7 @@ class FireAndBlood extends DrawCard {
                 cardCondition: card => card.controller === this.controller && card.location === 'dead pile' && card.isUnique() && card.isFaction('targaryen')
             },
             handler: context => {
-                if(context.target.hasTrait('Hatchling')) {
+                if(context.target.hasTrait('Hatchling') && this.controller.canPutIntoPlay(context.target)) {
                     this.selectedCard = context.target;
                     this.game.promptWithMenu(context.player, this, {
                         activePrompt: {

--- a/server/game/cards/01-Core/HearMeRoar.js
+++ b/server/game/cards/01-Core/HearMeRoar.js
@@ -3,9 +3,10 @@ const DrawCard = require('../../drawcard.js');
 class HearMeRoar extends DrawCard {
     setupCardAbilities() {
         this.action({
-            title: 'Put card into play',
+            title: 'Put character into play',
             target: {
-                cardCondition: card => card.location === 'hand' && card.controller === this.controller && card.getType() === 'character' && card.isFaction('lannister')
+                cardCondition: card => card.location === 'hand' && card.controller === this.controller && card.getType() === 'character' &&
+                                       card.isFaction('lannister') && this.controller.canPutIntoPlay(card)
             },
             handler: context => {
                 context.player.putIntoPlay(context.target);

--- a/server/game/cards/01-Core/OldBearMormont.js
+++ b/server/game/cards/01-Core/OldBearMormont.js
@@ -13,7 +13,8 @@ class OldBearMormont extends DrawCard {
             },
             target: {
                 activePromptTitle: 'Select a card',
-                cardCondition: card => card.location === 'hand' && card.controller === this.controller && card.isFaction('thenightswatch')
+                cardCondition: card => card.location === 'hand' && card.controller === this.controller &&
+                                       card.isFaction('thenightswatch') && this.controller.canPutIntoPlay(card)
             },
             handler: context => {
                 this.controller.putIntoPlay(context.target);

--- a/server/game/cards/01-Core/Reinforcement.js
+++ b/server/game/cards/01-Core/Reinforcement.js
@@ -8,7 +8,8 @@ class Reinforcements extends PlotCard {
                     this.controller === card.controller &&
                     card.getCost() <= 5 &&
                     card.getType() === 'character' &&
-                    ['hand', 'discard pile'].includes(card.location)
+                    ['hand', 'discard pile'].includes(card.location) &&
+                    this.controller.canPutIntoPlay(card)
                 )
             },
             handler: context => {

--- a/server/game/cards/01-Core/TheQueenOfThorns.js
+++ b/server/game/cards/01-Core/TheQueenOfThorns.js
@@ -7,9 +7,9 @@ class TheQueenOfThorns extends DrawCard {
                 afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isParticipating(this) && challenge.challengeType === 'intrigue'
             },
             target: {
-                activePromptTitle: 'Select a character',
                 cardCondition: card => card.location === 'hand' && card.controller === this.controller &&
-                                       card.getPrintedCost() <= 6 && card.getType() === 'character' && card.isFaction('tyrell')
+                                       card.getPrintedCost() <= 6 && card.getType() === 'character' && card.isFaction('tyrell') &&
+                                       this.controller.canPutIntoPlay(card)
             },
             handler: context => {
                 this.controller.putIntoPlay(context.target);

--- a/server/game/cards/01-Core/Yoren.js
+++ b/server/game/cards/01-Core/Yoren.js
@@ -7,7 +7,7 @@ class Yoren extends DrawCard {
                 onCardEntersPlay: event => event.card === this && event.playingType === 'marshal'
             },
             target: {
-                cardCondition: card => card.location === 'discard pile' && card.getType() === 'character' && card.owner !== this.controller && card.getCost() <= 3
+                cardCondition: card => card.location === 'discard pile' && card.getType() === 'character' && card.owner !== this.controller && card.getCost() <= 3 && this.controller.canPutIntoPlay(card)
             },
             handler: context => {
                 this.controller.putIntoPlay(context.target);

--- a/server/game/cards/02.3-TKP/SerAlliserThorne.js
+++ b/server/game/cards/02.3-TKP/SerAlliserThorne.js
@@ -11,7 +11,8 @@ class SerAlliserThorne extends DrawCard {
         this.reaction({
             location: 'hand',
             when: {
-                onChallengeInitiated: event => event.challenge.challengeType === 'military' && event.challenge.defendingPlayer === this.controller
+                onChallengeInitiated: event => event.challenge.challengeType === 'military' && event.challenge.defendingPlayer === this.controller &&
+                                               this.controller.canPutIntoPlay(this)
             },
             cost: [
                 ability.costs.kneelFactionCard(),

--- a/server/game/cards/03-WotN/ATimeForWolves.js
+++ b/server/game/cards/03-WotN/ATimeForWolves.js
@@ -18,7 +18,7 @@ class ATimeForWolves extends PlotCard {
     cardSelected(player, card) {
         player.moveCard(card, 'hand');
 
-        if(card.getCost() > 3) {
+        if(card.getCost() > 3 || !this.controller.canPutIntoPlay(card)) {
             this.game.addMessage('{0} uses {1} to search their deck and add {2} to their hand',
                 player, this, card);
             return;

--- a/server/game/cards/03-WotN/AsHardAsWinter.js
+++ b/server/game/cards/03-WotN/AsHardAsWinter.js
@@ -7,14 +7,13 @@ class AsHardAsWinter extends DrawCard {
                 onSacrificed: event => this.hasUsedWinterPlot() && this.starkCharacterSacrificedOrKilled(event.cardStateWhenSacrificed),
                 onCharacterKilled: event => this.hasUsedWinterPlot() && this.starkCharacterSacrificedOrKilled(event.cardStateWhenKilled)
             },
-
             target: {
-                activePromptTitle: 'Select a character',
                 cardCondition: (card, context) => (
                     card.location === 'hand' &&
                     card.getType() === 'character' &&
                     card.isFaction('stark') &&
-                    card.getCost() <= context.event.card.getCost()
+                    card.getCost() <= context.event.card.getCost() &&
+                    this.controller.canPutIntoPlay(card)
                 )
             },
 

--- a/server/game/cards/04.1-AtSK/BitterbridgeEncampment.js
+++ b/server/game/cards/04.1-AtSK/BitterbridgeEncampment.js
@@ -42,9 +42,9 @@ class BitterbridgeEncampment extends DrawCard {
         if(this.remainingPlayers.length > 0) {
             let currentPlayer = this.remainingPlayers.shift();
             this.game.promptForSelect(currentPlayer, {
-                activePromptTitle: 'Select a character',
                 source: this,
-                cardCondition: card => card.controller === currentPlayer && card.getType() === 'character' && card.location === 'hand',
+                cardCondition: card => card.controller === currentPlayer && card.getType() === 'character' && card.location === 'hand' &&
+                                       this.controller.canPutIntoPlay(card),
                 onSelect: (player, card) => this.onCardSelected(player, card),
                 onCancel: (player) => this.cancelSelection(player)
             });

--- a/server/game/cards/04.3-FFH/Harrenhal.js
+++ b/server/game/cards/04.3-FFH/Harrenhal.js
@@ -7,9 +7,8 @@ class Harrenhal extends DrawCard {
             cost: ability.costs.kneelSelf(),
             phase: 'challenge',
             target: {
-                activePromptTitle: 'Select a character',
                 cardCondition: card => card.location === 'hand' && card.controller === this.controller && card.getType() === 'character' &&
-                                       (card.isFaction('lannister') || card.hasTrait('House Bolton'))
+                                       (card.isFaction('lannister') || card.hasTrait('House Bolton')) && this.controller.canPutIntoPlay(card)
             },
             handler: context => {
                 this.controller.putIntoPlay(context.target);

--- a/server/game/cards/05-LoCR/MoonBrothers.js
+++ b/server/game/cards/05-LoCR/MoonBrothers.js
@@ -8,7 +8,8 @@ class MoonBrothers extends DrawCard {
             condition: () => (
                 this.game.currentChallenge &&
                 this.game.currentChallenge.attackingPlayer === this.controller &&
-                this.hasAttackingClansman()
+                this.hasAttackingClansman() &&
+                this.controller.canPutIntoPlay(this)
             ),
             cost: ability.costs.kneelFactionCard(),
             handler: () => {

--- a/server/game/cards/06.1-AMAF/AttackFromTheMountains.js
+++ b/server/game/cards/06.1-AMAF/AttackFromTheMountains.js
@@ -12,7 +12,8 @@ class AttackFromTheMountains extends DrawCard {
                     card.owner === this.controller &&
                     card.location === 'hand' &&
                     card.hasTrait('Clansman') &&
-                    card.getType() === 'character')
+                    card.getType() === 'character') &&
+                    this.controller.canPutIntoPlay(card)
             },
             handler: context => {
                 context.target.owner.putIntoPlay(context.target);

--- a/server/game/cards/06.2-GtR/GuardingTheRealm.js
+++ b/server/game/cards/06.2-GtR/GuardingTheRealm.js
@@ -6,8 +6,8 @@ class GuardingTheRealm extends DrawCard {
             title: 'Take control of character in discard pile',
             phase: 'marshal',
             target: {
-                activePromptTitle: 'Select a character',
-                cardCondition: card => card.controller !== this.controller && card.location === 'discard pile' && card.getType() === 'character' && card.getCost() <= 3
+                cardCondition: card => card.controller !== this.controller && card.location === 'discard pile' &&
+                                       card.getType() === 'character' && card.getCost() <= 3 && this.controller.canPutIntoPlay(card)
             },
             handler: context => {
                 this.controller.putIntoPlay(context.target);

--- a/server/game/cards/06.4-TRW/BreakerOfChains.js
+++ b/server/game/cards/06.4-TRW/BreakerOfChains.js
@@ -11,12 +11,12 @@ class BreakerOfChains extends DrawCard {
                 onAttackersDeclared: event => event.challenge.isAttacking(this.parent)
             },
             target: {
-                activePromptTitle: 'Select a character',
                 cardCondition: card =>
                     card.location === 'hand'
                     && card.controller === this.controller
                     && card.getType() === 'character'
                     && card.getCost() <= 2
+                    && this.controller.canPutIntoPlay(card)
             },
             handler: context => {
                 this.controller.putIntoPlay(context.target);

--- a/server/game/cards/06.4-TRW/SerOsmundKettleblack.js
+++ b/server/game/cards/06.4-TRW/SerOsmundKettleblack.js
@@ -7,9 +7,8 @@ class SerOsmundKettleblack extends DrawCard {
             phase: 'challenge',
             cost: ability.costs.discardGold(),
             target: {
-                activePromptTitle: 'Select a character',
                 cardCondition: card => card.location === 'hand' && card.controller === this.controller &&
-                                       card.getType() === 'character' && card.hasTrait('Knight')
+                                       card.getType() === 'character' && card.hasTrait('Knight') && this.controller.canPutIntoPlay(card)
             },
             handler: context => {
                 context.player.putIntoPlay(context.target);

--- a/server/game/cards/06.5-OR/ATaskForEveryTool.js
+++ b/server/game/cards/06.5-OR/ATaskForEveryTool.js
@@ -6,9 +6,9 @@ class ATaskForEveryTool extends DrawCard {
             title: 'Put character into play',
             phase: 'challenge',
             target: {
-                activePromptTitle: 'Select character',
                 cardCondition: card => card.location === 'hand' && card.controller === this.controller &&
-                                       card.getType() === 'character' && card.isFaction('lannister') && card.getPrintedStrength() <= 2
+                                       card.getType() === 'character' && card.isFaction('lannister') && card.getPrintedStrength() <= 2 &&
+                                       this.controller.canPutIntoPlay(card)
             },
             handler: context => {
                 context.player.putIntoPlay(context.target);

--- a/server/game/cards/06.5-OR/FleaBottom.js
+++ b/server/game/cards/06.5-OR/FleaBottom.js
@@ -7,7 +7,7 @@ class FleaBottom extends DrawCard {
             phase: 'challenge',
             target: {
                 cardCondition: card => card.location === 'discard pile' && card.controller === this.controller &&
-                                       card.getType() === 'character' && card.getCost() <= 3
+                                       card.getType() === 'character' && card.getCost() <= 3 && this.controller.canPutIntoPlay(card)
             },
             cost: [
                 ability.costs.payGold(1),

--- a/server/game/cards/07-WotW/NowMyWatchBegins.js
+++ b/server/game/cards/07-WotW/NowMyWatchBegins.js
@@ -5,9 +5,10 @@ class NowMyWatchBegins extends DrawCard {
         this.reaction({
             when: {
                 onCardPlaced: event => event.location === 'discard pile' &&
-                                event.player !== this.controller &&
-                                event.card.getType() === 'character' &&
-                                event.card.getCost() <= 5
+                                       event.player !== this.controller &&
+                                       event.card.getType() === 'character' &&
+                                       event.card.getCost() <= 5 &&
+                                       this.controller.canPutIntoPlay(event.card)
             },
             handler: (context) => {
                 this.controller.putIntoPlay(context.event.card);

--- a/server/game/cards/07-WotW/OldBearMormont.js
+++ b/server/game/cards/07-WotW/OldBearMormont.js
@@ -11,7 +11,8 @@ class OldBearMormont extends DrawCard {
                     !card.isUnique() &&
                     card.getType() === 'character' &&
                     card.controller === context.event.challenge.loser &&
-                    card.location === 'discard pile')
+                    card.location === 'discard pile' &&
+                    this.controller.canPutIntoPlay(card))
             },
             handler: context => {
                 let originalPlayer = context.target.controller;

--- a/server/game/cards/07-WotW/TheLastOfTheGiants.js
+++ b/server/game/cards/07-WotW/TheLastOfTheGiants.js
@@ -3,10 +3,10 @@ const DrawCard = require('../../drawcard.js');
 class TheLastOfTheGiants extends DrawCard {
     setupCardAbilities() {
         this.action({
-            title: 'Put card into play',
+            title: 'Put character into play',
             target: {
-                activePromptTitle: 'Select character',
-                cardCondition: card => card.location === 'hand' && card.controller === this.controller && card.getType() === 'character' && card.isFaction('neutral')
+                cardCondition: card => card.location === 'hand' && card.controller === this.controller && card.getType() === 'character' &&
+                                       card.isFaction('neutral') && this.controller.canPutIntoPlay(card)
             },
             handler: context => {
                 context.player.putIntoPlay(context.target);


### PR DESCRIPTION
Previously, when a character that could not be put into play was chosen as a target for such an effect, even though the card would not be put into play, costs were paid and messages for said abilities were printed anyway. This PR fixes that by adding canPutIntoPlay checks as a targeting restriction or play condition on all cards that put characters into play.