### PR TITLE
Remove `getOtherPlayer` from more complex melee cards

### DIFF
--- a/server/game/cards/01-Core/ChamberOfThePaintedTable.js
+++ b/server/game/cards/01-Core/ChamberOfThePaintedTable.js
@@ -8,17 +8,35 @@ class ChamberOfThePaintedTable extends DrawCard {
             },
             cost: ability.costs.kneelSelf(),
             handler: () => {
-                let opponent = this.game.getOtherPlayer(this.controller);
-                this.game.addMessage('{0} kneels {1} to move 1 power from {2}\'s faction card to their own',
-                    this.controller, this, opponent);
-                this.game.transferPower(this.controller, opponent, 1);
+                let opponents = this.game.getOpponents(this.controller).filter(card => card.power > 0);
+
+                if(opponents.length === 1) {
+                    this.stealPowerFromOpponent(opponents[0]);
+                    return;
+                }
+
+                let factionCards = opponents.map(opponent => opponent.faction);
+
+                this.promptForSelect(this.controller, {
+                    activePromptTitle: 'Select a faction card',
+                    cardCondition: card => factionCards.includes(card),
+                    cardType: 'faction',
+                    onSelect: (player, card) => this.stealPowerFromOpponent(card.owner)
+                });
             }
         });
     }
 
+    stealPowerFromOpponent(opponent) {
+        this.game.addMessage('{0} kneels {1} to move 1 power from {2}\'s faction card to their own',
+            this.controller, this, opponent);
+        this.game.transferPower(this.controller, opponent, 1);
+        return true;
+    }
+
     opponentHasPower() {
-        let opponent = this.game.getOtherPlayer(this.controller);
-        return opponent && opponent.faction.power > 0;
+        let opponents = this.game.getOpponents(this.controller);
+        return opponents.some(opponent => opponent.faction.power > 0);
     }
 }
 

--- a/server/game/cards/02.4-NMG/Loot.js
+++ b/server/game/cards/02.4-NMG/Loot.js
@@ -5,11 +5,11 @@ class Loot extends DrawCard {
         this.reaction({
             when: {
                 afterChallenge: event => this.controller === event.challenge.winner && event.challenge.isUnopposed() &&
-                                         this.getOpponentDeckSize() >= 1
+                                         this.getLoserDeckSize(event.challenge) >= 1
             },
-            cost: ability.costs.payXGold(() => 1, () => this.getOpponentDeckSize(), this.game.getOtherPlayer(this.controller)),
+            cost: ability.costs.payXGold(() => 1, context => this.getLoserDeckSize(context.event.challenge), context => context.event.challenge.loser),
             handler: context => {
-                let opponent = this.game.getOtherPlayer(this.controller);
+                let opponent = context.event.challenge.loser;
                 opponent.discardFromDraw(context.goldCostAmount);
                 this.game.addMessage('{0} plays {1} and pays {2} gold from {3}\'s gold pool to discard the top {2} cards from {3}\'s deck',
                     this.controller, this, context.goldCostAmount, opponent);
@@ -17,14 +17,8 @@ class Loot extends DrawCard {
         });
     }
 
-    getOpponentDeckSize() {
-        let opponent = this.game.getOtherPlayer(this.controller);
-
-        if(!opponent) {
-            return false;
-        }
-
-        return opponent.drawDeck.size();
+    getLoserDeckSize(challenge) {
+        return challenge.loser.drawDeck.size();
     }
 }
 

--- a/server/game/cards/04.4-TIMC/JojenReed.js
+++ b/server/game/cards/04.4-TIMC/JojenReed.js
@@ -1,5 +1,3 @@
-const _ = require('underscore');
-
 const DrawCard = require('../../drawcard.js');
 
 class JojenReed extends DrawCard {
@@ -9,17 +7,10 @@ class JojenReed extends DrawCard {
                 onCardStood: event => event.card === this
             },
             handler: () => {
-                var otherPlayer = this.game.getOtherPlayer(this.controller);
-
-                if(!otherPlayer) {
-                    return;
+                for(let player of this.game.getPlayers()) {
+                    let card = player.drawDeck.first();
+                    this.game.addMessage('{0} uses {1} to reveal {2} from {3}\'s deck', this.controller, this, card, player);
                 }
-
-                var ownCard = this.controller.drawDeck.first();
-                var opponentCard = otherPlayer.drawDeck.first();
-
-                this.game.addMessage('{0} uses {1} to reveal {2} from their own deck and {3} from {4}\'s deck',
-                    this.controller, this, ownCard, opponentCard, otherPlayer);
 
                 this.game.promptWithMenu(this.controller, this, {
                     activePrompt: {
@@ -36,9 +27,9 @@ class JojenReed extends DrawCard {
     }
 
     draw() {
-        _.each(this.game.getPlayers(), player => {
+        for(let player of this.game.getPlayers()) {
             player.drawCardsToHand(1);
-        });
+        }
 
         this.game.addMessage('{0} uses {1} to have revealed cards drawn', this.controller, this);
 
@@ -46,9 +37,9 @@ class JojenReed extends DrawCard {
     }
 
     discard() {
-        _.each(this.game.getPlayers(), player => {
+        for(let player of this.game.getPlayers()) {
             player.discardFromDraw(1);
-        });
+        }
 
         this.game.addMessage('{0} uses {1} to have revealed cards discarded', this.controller, this);
 

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -629,30 +629,33 @@ const Costs = {
         };
     },
     /**
-     * Cost where the player gets prompted to pay from 1 up to the lesser of two values: 
+     * Cost where the player gets prompted to pay from 1 up to the lesser of two values:
      * the passed value and either the player's or his opponent's gold.
      * Used by Ritual of R'hllor, Loot and The Things I Do For Love.
      * TODO: needs to be reducable for cards like Littlefinger's Meddling and Paxter Redwyne.
      */
-    payXGold: function(minFunc, maxFunc, opponentObj = false) {
+    payXGold: function(minFunc, maxFunc, opponentFunc) {
         return {
             canPay: function(context) {
+                let opponentObj = opponentFunc && opponentFunc(context);
                 if(!opponentObj) {
-                    return context.player.gold >= minFunc();
+                    return context.player.gold >= minFunc(context);
                 }
-                return opponentObj.gold >= minFunc();
+                return opponentObj.gold >= minFunc(context);
             },
             resolve: function(context, result = { resolved: false }) {
+                let opponentObj = opponentFunc && opponentFunc(context);
                 let gold = opponentObj ? opponentObj.gold : context.player.gold;
-                let max = _.min([maxFunc(), gold]);
+                let max = _.min([maxFunc(context), gold]);
 
-                context.game.queueStep(new PayXGoldPrompt(minFunc(), max, context));
+                context.game.queueStep(new PayXGoldPrompt(minFunc(context), max, context));
 
                 result.value = true;
                 result.resolved = true;
                 return result;
             },
             pay: function(context) {
+                let opponentObj = opponentFunc && opponentFunc(context);
                 if(!opponentObj) {
                     context.game.addGold(context.player, -context.goldCostAmount);
                 } else {


### PR DESCRIPTION
Removes the remaining card usages of `getOtherPlayer` in favor of `getOpponents`. 

Progress toward #1237.