### PR TITLE
Add cannotBeCanceled flag to abilities

### DIFF
--- a/server/game/baseability.js
+++ b/server/game/baseability.js
@@ -22,6 +22,7 @@ class BaseAbility {
     constructor(properties) {
         this.cost = this.buildCost(properties.cost);
         this.targets = this.buildTargets(properties);
+        this.cannotBeCanceled = !!properties.cannotBeCanceled;
         this.chooseOpponentFunc = properties.chooseOpponent;
     }
 

--- a/server/game/cards/02.2-TRtW/LadyInWaiting.js
+++ b/server/game/cards/02.2-TRtW/LadyInWaiting.js
@@ -5,6 +5,7 @@ class LadyInWaiting extends DrawCard {
         this.playAction({
             title: 'Marshal as dupe',
             condition: () => this.canMarshalAsDupe(),
+            cannotBeCanceled: true,
             target: {
                 cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.hasTrait('Lady') &&
                 card.controller === this.controller && card.owner === this.controller

--- a/server/game/cards/06.6-TBWB/BericDondarrion.js
+++ b/server/game/cards/06.6-TBWB/BericDondarrion.js
@@ -7,11 +7,11 @@ class BericDondarrion extends DrawCard {
             effect: ability.effects.dynamicStrength(() => this.tokens['kiss'])
         });
 
-        //TODO: needs an ability flag preventing it from being cancellable
         this.forcedReaction({
             when: {
                 onCardEntersPlay: event => event.card === this && event.playingType === 'marshal'
             },
+            cannotBeCanceled: true,
             handler: () => {
                 this.addToken('kiss', 6);
                 this.game.addMessage('{0} is forced to place 6 kiss tokens on {1}', this.controller, this);

--- a/server/game/gamesteps/abilityresolver.js
+++ b/server/game/gamesteps/abilityresolver.js
@@ -147,7 +147,7 @@ class AbilityResolver extends BaseStep {
         // thus is not subject to cancels such as Treachery.
         if(this.ability.isCardAbility()) {
             let targets = _.flatten(_.values(this.context.targets));
-            this.game.raiseEvent('onCardAbilityInitiated', { player: this.context.player, source: this.context.source, targets: targets }, () => {
+            this.game.raiseEvent('onCardAbilityInitiated', { player: this.context.player, source: this.context.source, targets: targets, cannotBeCanceled: !!this.ability.cannotBeCanceled }, () => {
                 this.ability.executeHandler(this.context);
             });
         } else {

--- a/server/game/promptedtriggeredability.js
+++ b/server/game/promptedtriggeredability.js
@@ -35,6 +35,8 @@ const TriggeredAbility = require('./triggeredability.js');
  *            ability. By default, the player that controls the card will be
  *            prompted. Used for reactions / interrupts that any player can
  *            trigger such as The Red Wedding.
+ * cannotBeCanceled - optional boolean that determines whether an ability can
+ *                    be canceled using a cancel interrupt.
  */
 class PromptedTriggeredAbility extends TriggeredAbility {
     constructor(game, card, type, properties) {

--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -68,6 +68,10 @@ class TriggeredAbility extends BaseAbility {
             return false;
         }
 
+        if(event.cannotBeCanceled && this.eventType === 'cancelinterrupt') {
+            return;
+        }
+
         return listener(...event.params);
     }
 

--- a/test/server/cards/characters/02/02023-ladyinwaiting.spec.js
+++ b/test/server/cards/characters/02/02023-ladyinwaiting.spec.js
@@ -1,14 +1,21 @@
 describe('Lady-in-Waiting', function() {
     integration(function() {
         beforeEach(function() {
-            const deck = this.buildDeck('tyrell', [
+            const deck1 = this.buildDeck('tyrell', [
                 'A Noble Cause',
                 'Lady-in-Waiting', 'Margaery Tyrell (Core)'
             ]);
-            this.player1.selectDeck(deck);
-            this.player2.selectDeck(deck);
+            const deck2 = this.buildDeck('lannister', [
+                'A Noble Cause',
+                'Cersei Lannister (Core)', 'Treachery'
+            ]);
+            this.player1.selectDeck(deck1);
+            this.player2.selectDeck(deck2);
             this.startGame();
             this.keepStartingHands();
+
+            this.player2.clickCard('Cersei Lannister', 'hand');
+
             this.completeSetup();
             this.player1.selectPlot('A Noble Cause');
             this.player2.selectPlot('A Noble Cause');
@@ -63,6 +70,22 @@ describe('Lady-in-Waiting', function() {
                     // 5 gold from plot - 1 from Margaery - 0 for LiW.
                     expect(this.player1Object.gold).toBe(4);
                 });
+            });
+        });
+
+        describe('when marshalling as a dupe', function() {
+            beforeEach(function() {
+                // Give Player 2 some gold for Treachery
+                this.player2Object.gold = 3;
+
+                this.player1.clickCard('Margaery Tyrell', 'hand');
+                this.player1.clickCard('Lady-in-Waiting', 'hand');
+                this.player1.clickPrompt('Marshal as dupe');
+                this.player1.clickCard('Margaery Tyrell', 'play area');
+            });
+
+            it('should not allow it to be canceled', function() {
+                expect(this.player2).not.toHavePromptButton('Treachery');
             });
         });
     });

--- a/test/server/gamesteps/abilityresolver.spec.js
+++ b/test/server/gamesteps/abilityresolver.spec.js
@@ -56,7 +56,7 @@ describe('AbilityResolver', function() {
             });
 
             it('should raise the onCardAbilityInitiated event', function() {
-                expect(this.game.raiseEvent).toHaveBeenCalledWith('onCardAbilityInitiated', { player: this.player, source: this.source, targets: [] }, jasmine.any(Function));
+                expect(this.game.raiseEvent).toHaveBeenCalledWith('onCardAbilityInitiated', { player: this.player, source: this.source, targets: [], cannotBeCanceled: false }, jasmine.any(Function));
             });
         });
 
@@ -197,7 +197,7 @@ describe('AbilityResolver', function() {
                         });
 
                         it('should raise the onCardAbilityInitiated event with appropriate targets', function() {
-                            expect(this.game.raiseEvent).toHaveBeenCalledWith('onCardAbilityInitiated', { player: this.player, source: this.source, targets: [this.target] }, jasmine.any(Function));
+                            expect(this.game.raiseEvent).toHaveBeenCalledWith('onCardAbilityInitiated', { player: this.player, source: this.source, targets: [this.target], cannotBeCanceled: false }, jasmine.any(Function));
                         });
                     });
 


### PR DESCRIPTION
Adds a flag to indicate whether an ability being resolved can be
canceled. This flag is automatically checked for cancel interrupts so
that it isn't necessary to check it in individual card implementations.

Fixes #1239 