### PR TITLE
Include faction card in target eligibility check

### DIFF
--- a/server/game/baseability.js
+++ b/server/game/baseability.js
@@ -145,7 +145,7 @@ class BaseAbility {
      * @returns {Boolean}
      */
     canResolveTargets(context) {
-        const ValidTypes = ['character', 'attachment', 'location', 'event'];
+        const ValidTypes = ['character', 'attachment', 'location', 'event', 'faction'];
         return _.all(this.targets, target => {
             return context.game.allCards.any(card => {
                 if(!ValidTypes.includes(card.getType())) {


### PR DESCRIPTION
Fixes a bug where Vanguard Lancer would not trigger if the opponent's faction card was the only card with power.