### PR TITLE
Update usages of React to remove deprecations

### DIFF
--- a/client/AddDeck.jsx
+++ b/client/AddDeck.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import DeckSummary from './DeckSummary.jsx';
@@ -70,16 +71,16 @@ export class InnerAddDeck extends React.Component {
 
 InnerAddDeck.displayName = 'InnerAddDeck';
 InnerAddDeck.propTypes = {
-    addDeck: React.PropTypes.func,
-    agendas: React.PropTypes.object,
-    apiError: React.PropTypes.string,
-    cards: React.PropTypes.object,
-    deck: React.PropTypes.object,
-    deckSaved: React.PropTypes.bool,
-    factions: React.PropTypes.object,
-    loading: React.PropTypes.bool,
-    navigate: React.PropTypes.func,
-    saveDeck: React.PropTypes.func
+    addDeck: PropTypes.func,
+    agendas: PropTypes.object,
+    apiError: PropTypes.string,
+    cards: PropTypes.object,
+    deck: PropTypes.object,
+    deckSaved: PropTypes.bool,
+    factions: PropTypes.object,
+    loading: PropTypes.bool,
+    navigate: PropTypes.func,
+    saveDeck: PropTypes.func
 };
 
 function mapStateToProps(state) {

--- a/client/Application.jsx
+++ b/client/Application.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import $ from 'jquery';
 import _ from 'underscore';
 import { bindActionCreators } from 'redux';
@@ -392,39 +393,39 @@ class App extends React.Component {
 
 App.displayName = 'Application';
 App.propTypes = {
-    clearGameState: React.PropTypes.func,
-    closeGameSocket: React.PropTypes.func,
-    currentGame: React.PropTypes.object,
-    disconnecting: React.PropTypes.bool,
-    dispatch: React.PropTypes.func,
-    gameSocket: React.PropTypes.object,
-    gameSocketConnectError: React.PropTypes.func,
-    gameSocketConnected: React.PropTypes.func,
-    gameSocketConnecting: React.PropTypes.func,
-    gameSocketDisconnect: React.PropTypes.func,
-    gameSocketReconnecting: React.PropTypes.func,
-    games: React.PropTypes.array,
-    loadCards: React.PropTypes.func,
-    loadFactions: React.PropTypes.func,
-    loadPacks: React.PropTypes.func,
-    loggedIn: React.PropTypes.bool,
-    navigate: React.PropTypes.func,
-    path: React.PropTypes.string,
-    receiveBannerNotice: React.PropTypes.func,
-    receiveGameState: React.PropTypes.func,
-    receiveGames: React.PropTypes.func,
-    receiveJoinGame: React.PropTypes.func,
-    receiveLobbyMessage: React.PropTypes.func,
-    receiveLobbyMessages: React.PropTypes.func,
-    receiveNewGame: React.PropTypes.func,
-    receivePasswordError: React.PropTypes.func,
-    receiveUsers: React.PropTypes.func,
-    sendGameSocketConnectFailed: React.PropTypes.func,
-    setContextMenu: React.PropTypes.func,
-    socketConnected: React.PropTypes.func,
-    token: React.PropTypes.string,
-    user: React.PropTypes.object,
-    username: React.PropTypes.string
+    clearGameState: PropTypes.func,
+    closeGameSocket: PropTypes.func,
+    currentGame: PropTypes.object,
+    disconnecting: PropTypes.bool,
+    dispatch: PropTypes.func,
+    gameSocket: PropTypes.object,
+    gameSocketConnectError: PropTypes.func,
+    gameSocketConnected: PropTypes.func,
+    gameSocketConnecting: PropTypes.func,
+    gameSocketDisconnect: PropTypes.func,
+    gameSocketReconnecting: PropTypes.func,
+    games: PropTypes.array,
+    loadCards: PropTypes.func,
+    loadFactions: PropTypes.func,
+    loadPacks: PropTypes.func,
+    loggedIn: PropTypes.bool,
+    navigate: PropTypes.func,
+    path: PropTypes.string,
+    receiveBannerNotice: PropTypes.func,
+    receiveGameState: PropTypes.func,
+    receiveGames: PropTypes.func,
+    receiveJoinGame: PropTypes.func,
+    receiveLobbyMessage: PropTypes.func,
+    receiveLobbyMessages: PropTypes.func,
+    receiveNewGame: PropTypes.func,
+    receivePasswordError: PropTypes.func,
+    receiveUsers: PropTypes.func,
+    sendGameSocketConnectFailed: PropTypes.func,
+    setContextMenu: PropTypes.func,
+    socketConnected: PropTypes.func,
+    token: PropTypes.string,
+    user: PropTypes.object,
+    username: PropTypes.string
 };
 
 function mapStateToProps(state) {

--- a/client/Avatar.jsx
+++ b/client/Avatar.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class Avatar extends React.Component {
     render() {
@@ -14,9 +15,9 @@ class Avatar extends React.Component {
 
 Avatar.displayName = 'Avatar';
 Avatar.propTypes = {
-    emailHash: React.PropTypes.string,
-    float: React.PropTypes.bool,
-    forceDefault: React.PropTypes.bool
+    emailHash: PropTypes.string,
+    float: PropTypes.bool,
+    forceDefault: PropTypes.bool
 };
 
 export default Avatar;

--- a/client/BlockList.jsx
+++ b/client/BlockList.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import _ from 'underscore';
 
@@ -124,16 +125,16 @@ class InnerBlockList extends React.Component {
 
 InnerBlockList.displayName = 'BlockList';
 InnerBlockList.propTypes = {
-    addBlockListEntry: React.PropTypes.func,
-    apiError: React.PropTypes.string,
-    blockList: React.PropTypes.array,
-    blockListAdded: React.PropTypes.bool,
-    blockListDeleted: React.PropTypes.bool,
-    clearBlockListStatus: React.PropTypes.func,
-    loadBlockList: React.PropTypes.func,
-    loading: React.PropTypes.bool,
-    removeBlockListEntry: React.PropTypes.func,
-    user: React.PropTypes.object
+    addBlockListEntry: PropTypes.func,
+    apiError: PropTypes.string,
+    blockList: PropTypes.array,
+    blockListAdded: PropTypes.bool,
+    blockListDeleted: PropTypes.bool,
+    clearBlockListStatus: PropTypes.func,
+    loadBlockList: PropTypes.func,
+    loading: PropTypes.bool,
+    removeBlockListEntry: PropTypes.func,
+    user: PropTypes.object
 };
 
 function mapStateToProps(state) {

--- a/client/DeckEditor.jsx
+++ b/client/DeckEditor.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import _ from 'underscore';
 import $ from 'jquery';
 import { connect } from 'react-redux';
@@ -407,16 +408,16 @@ class InnerDeckEditor extends React.Component {
 
 InnerDeckEditor.displayName = 'DeckEditor';
 InnerDeckEditor.propTypes = {
-    agendas: React.PropTypes.object,
-    banners: React.PropTypes.array,
-    cards: React.PropTypes.object,
-    deck: React.PropTypes.object,
-    factions: React.PropTypes.object,
-    loading: React.PropTypes.bool,
-    mode: React.PropTypes.string,
-    onDeckSave: React.PropTypes.func,
-    packs: React.PropTypes.array,
-    updateDeck: React.PropTypes.func
+    agendas: PropTypes.object,
+    banners: PropTypes.array,
+    cards: PropTypes.object,
+    deck: PropTypes.object,
+    factions: PropTypes.object,
+    loading: PropTypes.bool,
+    mode: PropTypes.string,
+    onDeckSave: PropTypes.func,
+    packs: PropTypes.array,
+    updateDeck: PropTypes.func
 };
 
 function mapStateToProps(state) {

--- a/client/DeckRow.jsx
+++ b/client/DeckRow.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import moment from 'moment';
 
 class DeckRow extends React.Component {
@@ -17,9 +18,9 @@ class DeckRow extends React.Component {
 
 DeckRow.displayName = 'DeckRow';
 DeckRow.propTypes = {
-    active: React.PropTypes.bool,
-    deck: React.PropTypes.object,
-    onClick: React.PropTypes.func
+    active: PropTypes.bool,
+    deck: PropTypes.object,
+    onClick: PropTypes.func
 };
 
 export default DeckRow;

--- a/client/DeckSummary.jsx
+++ b/client/DeckSummary.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import _ from 'underscore';
 
 import StatusPopOver from './StatusPopOver.jsx';
@@ -122,8 +123,8 @@ class DeckSummary extends React.Component {
 
 DeckSummary.displayName = 'DeckSummary';
 DeckSummary.propTypes = {
-    cards: React.PropTypes.object,
-    deck: React.PropTypes.object
+    cards: PropTypes.object,
+    deck: PropTypes.object
 };
 
 export default DeckSummary;

--- a/client/Decks.jsx
+++ b/client/Decks.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import _ from 'underscore';
 import { connect } from 'react-redux';
 
@@ -125,17 +126,17 @@ class InnerDecks extends React.Component {
 
 InnerDecks.displayName = 'Decks';
 InnerDecks.propTypes = {
-    apiError: React.PropTypes.string,
-    cards: React.PropTypes.object,
-    clearDeckStatus: React.PropTypes.func,
-    deckDeleted: React.PropTypes.bool,
-    decks: React.PropTypes.array,
-    deleteDeck: React.PropTypes.func,
-    loadDecks: React.PropTypes.func,
-    loading: React.PropTypes.bool,
-    navigate: React.PropTypes.func,
-    selectDeck: React.PropTypes.func,
-    selectedDeck: React.PropTypes.object
+    apiError: PropTypes.string,
+    cards: PropTypes.object,
+    clearDeckStatus: PropTypes.func,
+    deckDeleted: PropTypes.bool,
+    decks: PropTypes.array,
+    deleteDeck: PropTypes.func,
+    loadDecks: PropTypes.func,
+    loading: PropTypes.bool,
+    navigate: PropTypes.func,
+    selectDeck: PropTypes.func,
+    selectedDeck: PropTypes.object
 };
 
 function mapStateToProps(state) {

--- a/client/EditDeck.jsx
+++ b/client/EditDeck.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import DeckSummary from './DeckSummary.jsx';
@@ -73,20 +74,20 @@ class InnerEditDeck extends React.Component {
 
 InnerEditDeck.displayName = 'InnerEditDeck';
 InnerEditDeck.propTypes = {
-    agendas: React.PropTypes.object,
-    apiError: React.PropTypes.string,
-    banners: React.PropTypes.array,
-    cards: React.PropTypes.object,
-    deck: React.PropTypes.object,
-    deckId: React.PropTypes.string,
-    deckSaved: React.PropTypes.bool,
-    factions: React.PropTypes.object,
-    loadDeck: React.PropTypes.func,
-    loading: React.PropTypes.bool,
-    navigate: React.PropTypes.func,
-    packs: React.PropTypes.array,
-    saveDeck: React.PropTypes.func,
-    setUrl: React.PropTypes.func
+    agendas: PropTypes.object,
+    apiError: PropTypes.string,
+    banners: PropTypes.array,
+    cards: PropTypes.object,
+    deck: PropTypes.object,
+    deckId: PropTypes.string,
+    deckSaved: PropTypes.bool,
+    factions: PropTypes.object,
+    loadDeck: PropTypes.func,
+    loading: PropTypes.bool,
+    navigate: PropTypes.func,
+    packs: PropTypes.array,
+    saveDeck: PropTypes.func,
+    setUrl: PropTypes.func
 };
 
 function mapStateToProps(state) {

--- a/client/ForgotPassword.jsx
+++ b/client/ForgotPassword.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import _ from 'underscore';
 import $ from 'jquery';
 import {connect} from 'react-redux';
@@ -162,9 +163,9 @@ class InnerForgotPassword extends React.Component {
 
 InnerForgotPassword.displayName = 'ForgotPassword';
 InnerForgotPassword.propTypes = {
-    login: React.PropTypes.func,
-    navigate: React.PropTypes.func,
-    socket: React.PropTypes.object
+    login: PropTypes.func,
+    navigate: PropTypes.func,
+    socket: PropTypes.object
 };
 
 function mapStateToProps(state) {

--- a/client/FormComponents/Checkbox.jsx
+++ b/client/FormComponents/Checkbox.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class Checkbox extends React.Component {
     render() {
@@ -28,14 +29,14 @@ class Checkbox extends React.Component {
 
 Checkbox.displayName = 'Checkbox';
 Checkbox.propTypes = {
-    checked: React.PropTypes.bool,
-    children: React.PropTypes.object,
-    fieldClass: React.PropTypes.string,
-    label: React.PropTypes.string,
-    labelClass: React.PropTypes.string,
-    name: React.PropTypes.string,
-    noGroup: React.PropTypes.bool,
-    onChange: React.PropTypes.func
+    checked: PropTypes.bool,
+    children: PropTypes.object,
+    fieldClass: PropTypes.string,
+    label: PropTypes.string,
+    labelClass: PropTypes.string,
+    name: PropTypes.string,
+    noGroup: PropTypes.bool,
+    onChange: PropTypes.func
 };
 
 export default Checkbox;

--- a/client/FormComponents/Input.jsx
+++ b/client/FormComponents/Input.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class Input extends React.Component {
     render() {
@@ -34,18 +35,18 @@ class Input extends React.Component {
 
 Input.displayName = 'Input';
 Input.propTypes = {
-    children: React.PropTypes.object,
-    fieldClass: React.PropTypes.string,
-    label: React.PropTypes.string,
-    labelClass: React.PropTypes.string,
-    name: React.PropTypes.string,
-    noGroup: React.PropTypes.bool,
-    onBlur: React.PropTypes.func,
-    onChange: React.PropTypes.func,
-    placeholder: React.PropTypes.string,
-    type: React.PropTypes.oneOf(['text', 'password']),
-    validationMessage: React.PropTypes.string,
-    value: React.PropTypes.string
+    children: PropTypes.object,
+    fieldClass: PropTypes.string,
+    label: PropTypes.string,
+    labelClass: PropTypes.string,
+    name: PropTypes.string,
+    noGroup: PropTypes.bool,
+    onBlur: PropTypes.func,
+    onChange: PropTypes.func,
+    placeholder: PropTypes.string,
+    type: PropTypes.oneOf(['text', 'password']),
+    validationMessage: PropTypes.string,
+    value: PropTypes.string
 };
 
 export default Input;

--- a/client/FormComponents/Select.jsx
+++ b/client/FormComponents/Select.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import _ from 'underscore';
 
 class Select extends React.Component {
@@ -54,19 +55,19 @@ class Select extends React.Component {
 
 Select.displayName = 'Select';
 Select.propTypes = {
-    blankOption: React.PropTypes.object,
-    button: React.PropTypes.object,
-    fieldClass: React.PropTypes.string,
-    label: React.PropTypes.string,
-    labelClass: React.PropTypes.string,
-    name: React.PropTypes.string,
-    nameKey: React.PropTypes.string,
-    onBlur: React.PropTypes.func,
-    onChange: React.PropTypes.func,
-    options: React.PropTypes.array,
-    validationMessage: React.PropTypes.string,
-    value: React.PropTypes.string,
-    valueKey: React.PropTypes.string
+    blankOption: PropTypes.object,
+    button: PropTypes.object,
+    fieldClass: PropTypes.string,
+    label: PropTypes.string,
+    labelClass: PropTypes.string,
+    name: PropTypes.string,
+    nameKey: PropTypes.string,
+    onBlur: PropTypes.func,
+    onChange: PropTypes.func,
+    options: PropTypes.array,
+    validationMessage: PropTypes.string,
+    value: PropTypes.string,
+    valueKey: PropTypes.string
 };
 
 export default Select;

--- a/client/FormComponents/TextArea.jsx
+++ b/client/FormComponents/TextArea.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class TextArea extends React.Component {
     render() {
@@ -25,17 +26,17 @@ class TextArea extends React.Component {
 
 TextArea.displayName = 'TextArea';
 TextArea.propTypes = {
-    children: React.PropTypes.object,
-    fieldClass: React.PropTypes.string,
-    label: React.PropTypes.string,
-    labelClass: React.PropTypes.string,
-    name: React.PropTypes.string,
-    onBlur: React.PropTypes.func,
-    onChange: React.PropTypes.func,
-    placeholder: React.PropTypes.string,
-    rows: React.PropTypes.string,
-    validationMessage: React.PropTypes.string,
-    value: React.PropTypes.string
+    children: PropTypes.object,
+    fieldClass: PropTypes.string,
+    label: PropTypes.string,
+    labelClass: PropTypes.string,
+    name: PropTypes.string,
+    onBlur: PropTypes.func,
+    onChange: PropTypes.func,
+    placeholder: PropTypes.string,
+    rows: PropTypes.string,
+    validationMessage: PropTypes.string,
+    value: PropTypes.string
 };
 
 export default TextArea;

--- a/client/FormComponents/Typeahead.jsx
+++ b/client/FormComponents/Typeahead.jsx
@@ -1,5 +1,6 @@
 import { Typeahead } from 'react-bootstrap-typeahead';
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class Input extends React.Component {
     clear() {
@@ -26,24 +27,24 @@ class Input extends React.Component {
 
 Input.displayName = 'TypeAhead';
 Input.propTypes = {
-    autoFocus: React.PropTypes.bool,
-    children: React.PropTypes.object,
-    dropup: React.PropTypes.bool,
-    emptyLabel: React.PropTypes.string,
-    fieldClass: React.PropTypes.string,
-    label: React.PropTypes.string,
-    labelClass: React.PropTypes.string,
-    labelKey: React.PropTypes.string,
-    minLength: React.PropTypes.number,
-    name: React.PropTypes.string,
-    onChange: React.PropTypes.func,
-    onInputChange: React.PropTypes.func,
-    onKeyDown: React.PropTypes.func,
-    options: React.PropTypes.array,
-    placeholder: React.PropTypes.string,
-    submitFormOnEnter: React.PropTypes.bool,
-    validationMessage: React.PropTypes.string,
-    value: React.PropTypes.string
+    autoFocus: PropTypes.bool,
+    children: PropTypes.object,
+    dropup: PropTypes.bool,
+    emptyLabel: PropTypes.string,
+    fieldClass: PropTypes.string,
+    label: PropTypes.string,
+    labelClass: PropTypes.string,
+    labelKey: PropTypes.string,
+    minLength: PropTypes.number,
+    name: PropTypes.string,
+    onChange: PropTypes.func,
+    onInputChange: PropTypes.func,
+    onKeyDown: PropTypes.func,
+    options: PropTypes.array,
+    placeholder: PropTypes.string,
+    submitFormOnEnter: PropTypes.bool,
+    validationMessage: PropTypes.string,
+    value: PropTypes.string
 };
 
 export default Input;

--- a/client/GameBoard.jsx
+++ b/client/GameBoard.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { findDOMNode } from 'react-dom';
 import _ from 'underscore';
@@ -535,17 +536,17 @@ export class InnerGameBoard extends React.Component {
 
 InnerGameBoard.displayName = 'GameBoard';
 InnerGameBoard.propTypes = {
-    cardToZoom: React.PropTypes.object,
-    clearZoom: React.PropTypes.func,
-    closeGameSocket: React.PropTypes.func,
-    currentGame: React.PropTypes.object,
-    dispatch: React.PropTypes.func,
-    sendGameMessage: React.PropTypes.func,
-    setContextMenu: React.PropTypes.func,
-    socket: React.PropTypes.object,
-    user: React.PropTypes.object,
-    username: React.PropTypes.string,
-    zoomCard: React.PropTypes.func
+    cardToZoom: PropTypes.object,
+    clearZoom: PropTypes.func,
+    closeGameSocket: PropTypes.func,
+    currentGame: PropTypes.object,
+    dispatch: PropTypes.func,
+    sendGameMessage: PropTypes.func,
+    setContextMenu: PropTypes.func,
+    socket: PropTypes.object,
+    user: PropTypes.object,
+    username: PropTypes.string,
+    zoomCard: PropTypes.func
 };
 
 function mapStateToProps(state) {

--- a/client/GameComponents/AbilityTargeting.jsx
+++ b/client/GameComponents/AbilityTargeting.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import _ from 'underscore';
 
 class AbilityTargeting extends React.Component {
@@ -38,10 +39,10 @@ class AbilityTargeting extends React.Component {
 
 AbilityTargeting.displayName = 'AbilityTargeting';
 AbilityTargeting.propTypes = {
-    onMouseOut: React.PropTypes.func,
-    onMouseOver: React.PropTypes.func,
-    source: React.PropTypes.object,
-    targets: React.PropTypes.array
+    onMouseOut: PropTypes.func,
+    onMouseOver: PropTypes.func,
+    source: PropTypes.object,
+    targets: PropTypes.array
 };
 
 export default AbilityTargeting;

--- a/client/GameComponents/ActivePlayerPrompt.jsx
+++ b/client/GameComponents/ActivePlayerPrompt.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import _ from 'underscore';
 
 import AbilityTargeting from './AbilityTargeting.jsx';
@@ -205,18 +206,18 @@ class ActivePlayerPrompt extends React.Component {
 
 ActivePlayerPrompt.displayName = 'ActivePlayerPrompt';
 ActivePlayerPrompt.propTypes = {
-    buttons: React.PropTypes.array,
-    controls: React.PropTypes.array,
-    onButtonClick: React.PropTypes.func,
-    onMouseOut: React.PropTypes.func,
-    onMouseOver: React.PropTypes.func,
-    onTimerExpired: React.PropTypes.func,
-    onTitleClick: React.PropTypes.func,
-    phase: React.PropTypes.string,
-    promptTitle: React.PropTypes.string,
-    socket: React.PropTypes.object,
-    title: React.PropTypes.string,
-    user: React.PropTypes.object
+    buttons: PropTypes.array,
+    controls: PropTypes.array,
+    onButtonClick: PropTypes.func,
+    onMouseOut: PropTypes.func,
+    onMouseOver: PropTypes.func,
+    onTimerExpired: PropTypes.func,
+    onTitleClick: PropTypes.func,
+    phase: PropTypes.string,
+    promptTitle: PropTypes.string,
+    socket: PropTypes.object,
+    title: PropTypes.string,
+    user: PropTypes.object
 };
 
 export default ActivePlayerPrompt;

--- a/client/GameComponents/Card.jsx
+++ b/client/GameComponents/Card.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import _ from 'underscore';
 import $ from 'jquery';
 import 'jquery-migrate';
@@ -344,46 +345,46 @@ class Card extends React.Component {
 
 Card.displayName = 'Card';
 Card.propTypes = {
-    card: React.PropTypes.shape({
-        attached: React.PropTypes.bool,
-        attachments: React.PropTypes.array,
-        baseStrength: React.PropTypes.number,
-        code: React.PropTypes.string,
-        controlled: React.PropTypes.bool,
-        dupes: React.PropTypes.array,
-        facedown: React.PropTypes.bool,
-        iconsAdded: React.PropTypes.array,
-        iconsRemoved: React.PropTypes.array,
-        inChallenge: React.PropTypes.bool,
-        inDanger: React.PropTypes.bool,
-        kneeled: React.PropTypes.bool,
-        menu: React.PropTypes.array,
-        name: React.PropTypes.string,
-        new: React.PropTypes.bool,
-        order: React.PropTypes.number,
-        power: React.PropTypes.number,
-        saved: React.PropTypes.bool,
-        selectable: React.PropTypes.bool,
-        selected: React.PropTypes.bool,
-        stealth: React.PropTypes.bool,
-        strength: React.PropTypes.number,
-        tokens: React.PropTypes.object,
-        type: React.PropTypes.string,
-        unselectable: React.PropTypes.bool
+    card: PropTypes.shape({
+        attached: PropTypes.bool,
+        attachments: PropTypes.array,
+        baseStrength: PropTypes.number,
+        code: PropTypes.string,
+        controlled: PropTypes.bool,
+        dupes: PropTypes.array,
+        facedown: PropTypes.bool,
+        iconsAdded: PropTypes.array,
+        iconsRemoved: PropTypes.array,
+        inChallenge: PropTypes.bool,
+        inDanger: PropTypes.bool,
+        kneeled: PropTypes.bool,
+        menu: PropTypes.array,
+        name: PropTypes.string,
+        new: PropTypes.bool,
+        order: PropTypes.number,
+        power: PropTypes.number,
+        saved: PropTypes.bool,
+        selectable: PropTypes.bool,
+        selected: PropTypes.bool,
+        stealth: PropTypes.bool,
+        strength: PropTypes.number,
+        tokens: PropTypes.object,
+        type: PropTypes.string,
+        unselectable: PropTypes.bool
     }).isRequired,
-    className: React.PropTypes.string,
-    disableMouseOver: React.PropTypes.bool,
-    onClick: React.PropTypes.func,
-    onDragDrop: React.PropTypes.func,
-    onMenuItemClick: React.PropTypes.func,
-    onMouseOut: React.PropTypes.func,
-    onMouseOver: React.PropTypes.func,
-    orientation: React.PropTypes.oneOf(['horizontal', 'kneeled', 'vertical']),
-    size: React.PropTypes.string,
-    source: React.PropTypes.oneOf(['hand', 'discard pile', 'play area', 'dead pile', 'draw deck', 'plot deck', 'revealed plots', 'selected plot', 'attachment', 'agenda', 'faction',
+    className: PropTypes.string,
+    disableMouseOver: PropTypes.bool,
+    onClick: PropTypes.func,
+    onDragDrop: PropTypes.func,
+    onMenuItemClick: PropTypes.func,
+    onMouseOut: PropTypes.func,
+    onMouseOver: PropTypes.func,
+    orientation: PropTypes.oneOf(['horizontal', 'kneeled', 'vertical']),
+    size: PropTypes.string,
+    source: PropTypes.oneOf(['hand', 'discard pile', 'play area', 'dead pile', 'draw deck', 'plot deck', 'revealed plots', 'selected plot', 'attachment', 'agenda', 'faction',
         'additional', 'scheme plots']).isRequired,
-    style: React.PropTypes.object,
-    wrapped: React.PropTypes.bool
+    style: PropTypes.object,
+    wrapped: PropTypes.bool
 };
 Card.defaultProps = {
     orientation: 'vertical',

--- a/client/GameComponents/CardCounters.jsx
+++ b/client/GameComponents/CardCounters.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import _ from 'underscore';
 
 import Counter from './Counter.jsx';
@@ -34,7 +35,7 @@ class CardCounters extends React.Component {
 
 CardCounters.displayName = 'CardCounters';
 CardCounters.propTypes = {
-    counters: React.PropTypes.object.isRequired
+    counters: PropTypes.object.isRequired
 };
 
 export default CardCounters;

--- a/client/GameComponents/CardMenu.jsx
+++ b/client/GameComponents/CardMenu.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import _ from 'underscore';
 
 class CardMenu extends React.Component {
@@ -24,8 +25,8 @@ class CardMenu extends React.Component {
 
 CardMenu.displayName = 'CardMenu';
 CardMenu.propTypes = {
-    menu: React.PropTypes.array.isRequired,
-    onMenuItemClick: React.PropTypes.func
+    menu: PropTypes.array.isRequired,
+    onMenuItemClick: PropTypes.func
 };
 
 export default CardMenu;

--- a/client/GameComponents/CardPile.jsx
+++ b/client/GameComponents/CardPile.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import _ from 'underscore';
 import $ from 'jquery';
 
@@ -235,30 +236,30 @@ class CardPile extends React.Component {
 
 CardPile.displayName = 'CardPile';
 CardPile.propTypes = {
-    cardCount: React.PropTypes.number,
-    cards: React.PropTypes.array,
-    className: React.PropTypes.string,
-    closeOnClick: React.PropTypes.bool,
-    disableMouseOver: React.PropTypes.bool,
-    disablePopup: React.PropTypes.bool,
-    hiddenTopCard: React.PropTypes.bool,
-    menu: React.PropTypes.array,
-    onCardClick: React.PropTypes.func,
-    onCloseClick: React.PropTypes.func,
-    onDragDrop: React.PropTypes.func,
-    onMenuItemClick: React.PropTypes.func,
-    onMouseOut: React.PropTypes.func,
-    onMouseOver: React.PropTypes.func,
-    onTouchMove: React.PropTypes.func,
-    orientation: React.PropTypes.string,
-    popupLocation: React.PropTypes.string,
-    popupMenu: React.PropTypes.array,
-    size: React.PropTypes.string,
-    source: React.PropTypes.oneOf(['hand', 'discard pile', 'play area', 'dead pile', 'draw deck', 'plot deck',
+    cardCount: PropTypes.number,
+    cards: PropTypes.array,
+    className: PropTypes.string,
+    closeOnClick: PropTypes.bool,
+    disableMouseOver: PropTypes.bool,
+    disablePopup: PropTypes.bool,
+    hiddenTopCard: PropTypes.bool,
+    menu: PropTypes.array,
+    onCardClick: PropTypes.func,
+    onCloseClick: PropTypes.func,
+    onDragDrop: PropTypes.func,
+    onMenuItemClick: PropTypes.func,
+    onMouseOut: PropTypes.func,
+    onMouseOver: PropTypes.func,
+    onTouchMove: PropTypes.func,
+    orientation: PropTypes.string,
+    popupLocation: PropTypes.string,
+    popupMenu: PropTypes.array,
+    size: PropTypes.string,
+    source: PropTypes.oneOf(['hand', 'discard pile', 'play area', 'dead pile', 'draw deck', 'plot deck',
         'revealed plots', 'selected plot', 'attachment', 'agenda', 'faction', 'additional',
         'scheme plots']).isRequired,
-    title: React.PropTypes.string,
-    topCard: React.PropTypes.object
+    title: PropTypes.string,
+    topCard: PropTypes.object
 };
 CardPile.defaultProps = {
     orientation: 'vertical'

--- a/client/GameComponents/CardZoom.jsx
+++ b/client/GameComponents/CardZoom.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class CardZoom extends React.Component {
     render() {
@@ -22,10 +23,10 @@ class CardZoom extends React.Component {
 
 CardZoom.displayName = 'CardZoom';
 CardZoom.propTypes = {
-    cardName: React.PropTypes.string,
-    imageUrl: React.PropTypes.string,
-    orientation: React.PropTypes.oneOf(['horizontal', 'vertical']),
-    show: React.PropTypes.bool
+    cardName: PropTypes.string,
+    imageUrl: PropTypes.string,
+    orientation: PropTypes.oneOf(['horizontal', 'vertical']),
+    show: PropTypes.bool
 };
 
 export default CardZoom;

--- a/client/GameComponents/Counter.jsx
+++ b/client/GameComponents/Counter.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class Counter extends React.Component {
     render() {
@@ -21,11 +22,11 @@ class Counter extends React.Component {
 
 Counter.displayName = 'Counter';
 Counter.propTypes = {
-    cancel: React.PropTypes.bool,
-    fade: React.PropTypes.bool,
-    name: React.PropTypes.string.isRequired,
-    shortName: React.PropTypes.string,
-    value: React.PropTypes.number
+    cancel: PropTypes.bool,
+    fade: PropTypes.bool,
+    name: PropTypes.string.isRequired,
+    shortName: PropTypes.string,
+    value: PropTypes.number
 };
 
 export default Counter;

--- a/client/GameComponents/GameConfiguration.jsx
+++ b/client/GameComponents/GameConfiguration.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import _ from 'underscore';
 
 import Checkbox from '../FormComponents/Checkbox.jsx';
@@ -112,12 +113,12 @@ class GameConfiguration extends React.Component {
 
 GameConfiguration.displayName = 'GameConfiguration';
 GameConfiguration.propTypes = {
-    actionWindows: React.PropTypes.object,
-    keywordSettings: React.PropTypes.object,
-    onKeywordSettingToggle: React.PropTypes.func,
-    onTimerSettingToggle: React.PropTypes.func,
-    onToggle: React.PropTypes.func,
-    timerSettings: React.PropTypes.object
+    actionWindows: PropTypes.object,
+    keywordSettings: PropTypes.object,
+    onKeywordSettingToggle: PropTypes.func,
+    onTimerSettingToggle: PropTypes.func,
+    onToggle: PropTypes.func,
+    timerSettings: PropTypes.object
 };
 
 export default GameConfiguration;

--- a/client/GameComponents/Messages.jsx
+++ b/client/GameComponents/Messages.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import _ from 'underscore';
 
@@ -117,10 +118,10 @@ class InnerMessages extends React.Component {
 
 InnerMessages.displayName = 'Messages';
 InnerMessages.propTypes = {
-    messages: React.PropTypes.array,
-    onCardMouseOut: React.PropTypes.func,
-    onCardMouseOver: React.PropTypes.func,
-    socket: React.PropTypes.object
+    messages: PropTypes.array,
+    onCardMouseOut: PropTypes.func,
+    onCardMouseOver: PropTypes.func,
+    socket: PropTypes.object
 };
 
 function mapStateToProps(state) {

--- a/client/GameComponents/PlayerHand.jsx
+++ b/client/GameComponents/PlayerHand.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import _ from 'underscore';
 import $ from 'jquery';
 
@@ -114,13 +115,13 @@ class PlayerHand extends React.Component {
 
 PlayerHand.displayName = 'PlayerHand';
 PlayerHand.propTypes = {
-    cardSize: React.PropTypes.string,
-    cards: React.PropTypes.array,
-    isMe: React.PropTypes.bool,
-    onCardClick: React.PropTypes.func,
-    onDragDrop: React.PropTypes.func,
-    onMouseOut: React.PropTypes.func,
-    onMouseOver: React.PropTypes.func
+    cardSize: PropTypes.string,
+    cards: PropTypes.array,
+    isMe: PropTypes.bool,
+    onCardClick: PropTypes.func,
+    onDragDrop: PropTypes.func,
+    onMouseOut: PropTypes.func,
+    onMouseOver: PropTypes.func
 };
 
 export default PlayerHand;

--- a/client/GameComponents/PlayerRow.jsx
+++ b/client/GameComponents/PlayerRow.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import CardPile from './CardPile.jsx';
 import PlayerHand from './PlayerHand.jsx';
@@ -180,31 +181,31 @@ class PlayerRow extends React.Component {
 
 PlayerRow.displayName = 'PlayerRow';
 PlayerRow.propTypes = {
-    agenda: React.PropTypes.object,
-    bannerCards: React.PropTypes.array,
-    cardSize: React.PropTypes.string,
-    conclavePile: React.PropTypes.array,
-    deadPile: React.PropTypes.array,
-    discardPile: React.PropTypes.array,
-    drawDeck: React.PropTypes.array,
-    faction: React.PropTypes.object,
-    hand: React.PropTypes.array,
-    isMe: React.PropTypes.bool,
-    isMelee: React.PropTypes.bool,
-    numDrawCards: React.PropTypes.number,
-    onCardClick: React.PropTypes.func,
-    onDragDrop: React.PropTypes.func,
-    onDrawClick: React.PropTypes.func,
-    onMenuItemClick: React.PropTypes.func,
-    onMouseOut: React.PropTypes.func,
-    onMouseOver: React.PropTypes.func,
-    onShuffleClick: React.PropTypes.func,
-    outOfGamePile: React.PropTypes.array,
-    plotDeck: React.PropTypes.array,
-    power: React.PropTypes.number,
-    showDrawDeck: React.PropTypes.bool,
-    spectating: React.PropTypes.bool,
-    title: React.PropTypes.object
+    agenda: PropTypes.object,
+    bannerCards: PropTypes.array,
+    cardSize: PropTypes.string,
+    conclavePile: PropTypes.array,
+    deadPile: PropTypes.array,
+    discardPile: PropTypes.array,
+    drawDeck: PropTypes.array,
+    faction: PropTypes.object,
+    hand: PropTypes.array,
+    isMe: PropTypes.bool,
+    isMelee: PropTypes.bool,
+    numDrawCards: PropTypes.number,
+    onCardClick: PropTypes.func,
+    onDragDrop: PropTypes.func,
+    onDrawClick: PropTypes.func,
+    onMenuItemClick: PropTypes.func,
+    onMouseOut: PropTypes.func,
+    onMouseOver: PropTypes.func,
+    onShuffleClick: PropTypes.func,
+    outOfGamePile: PropTypes.array,
+    plotDeck: PropTypes.array,
+    power: PropTypes.number,
+    showDrawDeck: PropTypes.bool,
+    spectating: PropTypes.bool,
+    title: PropTypes.object
 };
 
 export default PlayerRow;

--- a/client/GameComponents/PlayerStats.jsx
+++ b/client/GameComponents/PlayerStats.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Avatar from '../Avatar.jsx';
 
@@ -73,13 +74,13 @@ export class PlayerStats extends React.Component {
 
 PlayerStats.displayName = 'PlayerStats';
 PlayerStats.propTypes = {
-    firstPlayer: React.PropTypes.bool,
-    onSettingsClick: React.PropTypes.func,
-    playerName: React.PropTypes.string,
-    sendGameMessage: React.PropTypes.func,
-    showControls: React.PropTypes.bool,
-    stats: React.PropTypes.object,
-    user: React.PropTypes.object
+    firstPlayer: PropTypes.bool,
+    onSettingsClick: PropTypes.func,
+    playerName: PropTypes.string,
+    sendGameMessage: PropTypes.func,
+    showControls: PropTypes.bool,
+    stats: PropTypes.object,
+    user: PropTypes.object
 };
 
 export default PlayerStats;

--- a/client/GameList.jsx
+++ b/client/GameList.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { toastr } from 'react-redux-toastr';
 import _ from 'underscore';
@@ -128,13 +129,13 @@ class InnerGameList extends React.Component {
 
 InnerGameList.displayName = 'GameList';
 InnerGameList.propTypes = {
-    currentGame: React.PropTypes.object,
-    games: React.PropTypes.array,
-    isAdmin: React.PropTypes.bool,
-    joinPasswordGame: React.PropTypes.func,
-    showNodes: React.PropTypes.bool,
-    socket: React.PropTypes.object,
-    username: React.PropTypes.string
+    currentGame: PropTypes.object,
+    games: PropTypes.array,
+    isAdmin: PropTypes.bool,
+    joinPasswordGame: PropTypes.func,
+    showNodes: PropTypes.bool,
+    socket: PropTypes.object,
+    username: PropTypes.string
 };
 
 function mapStateToProps(state) {

--- a/client/GameLobby.jsx
+++ b/client/GameLobby.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import NewGame from './NewGame.jsx';
@@ -75,15 +76,15 @@ class InnerGameLobby extends React.Component {
 
 InnerGameLobby.displayName = 'GameLobby';
 InnerGameLobby.propTypes = {
-    bannerNotice: React.PropTypes.string,
-    currentGame: React.PropTypes.object,
-    games: React.PropTypes.array,
-    isAdmin: React.PropTypes.bool,
-    newGame: React.PropTypes.bool,
-    passwordGame: React.PropTypes.object,
-    setContextMenu: React.PropTypes.func,
-    startNewGame: React.PropTypes.func,
-    username: React.PropTypes.string
+    bannerNotice: PropTypes.string,
+    currentGame: PropTypes.object,
+    games: PropTypes.array,
+    isAdmin: PropTypes.bool,
+    newGame: PropTypes.bool,
+    passwordGame: PropTypes.object,
+    setContextMenu: PropTypes.func,
+    startNewGame: PropTypes.func,
+    username: PropTypes.string
 };
 
 function mapStateToProps(state) {

--- a/client/Link.jsx
+++ b/client/Link.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import * as actions from './actions';
 
@@ -27,10 +28,10 @@ class InnerLink extends React.Component {
 
 InnerLink.displayName = 'Link';
 InnerLink.propTypes = {
-    children: React.PropTypes.string,
-    className: React.PropTypes.string,
-    href: React.PropTypes.string,
-    navigate: React.PropTypes.func
+    children: PropTypes.string,
+    className: PropTypes.string,
+    href: PropTypes.string,
+    navigate: PropTypes.func
 };
 
 const Link = connect(mapStateToProps, actions)(InnerLink);

--- a/client/Lobby.jsx
+++ b/client/Lobby.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import _ from 'underscore';
 import $ from 'jquery';
@@ -217,14 +218,14 @@ class InnerLobby extends React.Component {
 
 InnerLobby.displayName = 'Lobby';
 InnerLobby.propTypes = {
-    bannerNotice: React.PropTypes.string,
-    fetchNews: React.PropTypes.func,
-    loadNews: React.PropTypes.func,
-    loading: React.PropTypes.bool,
-    messages: React.PropTypes.array,
-    news: React.PropTypes.array,
-    socket: React.PropTypes.object,
-    users: React.PropTypes.array
+    bannerNotice: PropTypes.string,
+    fetchNews: PropTypes.func,
+    loadNews: PropTypes.func,
+    loading: PropTypes.bool,
+    messages: PropTypes.array,
+    news: PropTypes.array,
+    socket: PropTypes.object,
+    users: PropTypes.array
 };
 
 function mapStateToProps(state) {

--- a/client/Login.jsx
+++ b/client/Login.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import _ from 'underscore';
 import $ from 'jquery';
 import {connect} from 'react-redux';
@@ -171,9 +172,9 @@ class InnerLogin extends React.Component {
 
 InnerLogin.displayName = 'Login';
 InnerLogin.propTypes = {
-    login: React.PropTypes.func,
-    navigate: React.PropTypes.func,
-    socket: React.PropTypes.object
+    login: PropTypes.func,
+    navigate: PropTypes.func,
+    socket: PropTypes.object
 };
 
 function mapStateToProps(state) {

--- a/client/Logout.jsx
+++ b/client/Logout.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import $ from 'jquery';
 import {connect} from 'react-redux';
 import * as actions from './actions';
@@ -22,8 +23,8 @@ class InnerLogout extends React.Component {
 
 InnerLogout.displayName = 'Logout';
 InnerLogout.propTypes = {
-    logout: React.PropTypes.func,
-    navigate: React.PropTypes.func
+    logout: PropTypes.func,
+    navigate: PropTypes.func
 };
 
 const Logout = connect(function() {

--- a/client/NavBar.jsx
+++ b/client/NavBar.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import _ from 'underscore';
 import { connect } from 'react-redux';
 
@@ -102,12 +103,12 @@ class InnerNavBar extends React.Component {
 
 InnerNavBar.displayName = 'Decks';
 InnerNavBar.propTypes = {
-    context: React.PropTypes.array,
-    currentPath: React.PropTypes.string,
-    leftMenu: React.PropTypes.array,
-    numGames: React.PropTypes.number,
-    rightMenu: React.PropTypes.array,
-    title: React.PropTypes.string
+    context: PropTypes.array,
+    currentPath: PropTypes.string,
+    leftMenu: PropTypes.array,
+    numGames: PropTypes.number,
+    rightMenu: PropTypes.array,
+    title: PropTypes.string
 };
 
 function mapStateToProps(state) {

--- a/client/NewGame.jsx
+++ b/client/NewGame.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import * as actions from './actions';
@@ -157,10 +158,10 @@ class InnerNewGame extends React.Component {
 
 InnerNewGame.displayName = 'NewGame';
 InnerNewGame.propTypes = {
-    allowMelee: React.PropTypes.bool,
-    cancelNewGame: React.PropTypes.func,
-    defaultGameName: React.PropTypes.string,
-    socket: React.PropTypes.object
+    allowMelee: PropTypes.bool,
+    cancelNewGame: PropTypes.func,
+    defaultGameName: PropTypes.string,
+    socket: PropTypes.object
 };
 
 function mapStateToProps(state) {

--- a/client/NewsAdmin.jsx
+++ b/client/NewsAdmin.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import _ from 'underscore';
 import moment from 'moment';
@@ -92,13 +93,13 @@ class InnerNewsAdmin extends React.Component {
 
 InnerNewsAdmin.displayName = 'NewsAdmin';
 InnerNewsAdmin.propTypes = {
-    addNews: React.PropTypes.func,
-    apiError: React.PropTypes.string,
-    clearNewsStatus: React.PropTypes.func,
-    loadNews: React.PropTypes.func,
-    loading: React.PropTypes.bool,
-    news: React.PropTypes.array,
-    newsSaved: React.PropTypes.bool
+    addNews: PropTypes.func,
+    apiError: PropTypes.string,
+    clearNewsStatus: PropTypes.func,
+    loadNews: PropTypes.func,
+    loading: PropTypes.bool,
+    news: PropTypes.array,
+    newsSaved: PropTypes.bool
 };
 
 function mapStateToProps(state) {

--- a/client/PasswordGame.jsx
+++ b/client/PasswordGame.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import AlertPanel from './SiteComponents/AlertPanel.jsx';
@@ -68,11 +69,11 @@ class InnerPasswordGame extends React.Component {
 
 InnerPasswordGame.displayName = 'PasswordGame';
 InnerPasswordGame.propTypes = {
-    cancelPasswordJoin: React.PropTypes.func,
-    passwordError: React.PropTypes.string,
-    passwordGame: React.PropTypes.object,
-    passwordJoinType: React.PropTypes.string,
-    socket: React.PropTypes.object
+    cancelPasswordJoin: PropTypes.func,
+    passwordError: PropTypes.string,
+    passwordGame: PropTypes.object,
+    passwordJoinType: PropTypes.string,
+    socket: PropTypes.object
 };
 
 function mapStateToProps(state) {

--- a/client/PendingGame.jsx
+++ b/client/PendingGame.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
 import { connect } from 'react-redux';
 import $ from 'jquery';
@@ -273,18 +274,18 @@ class InnerPendingGame extends React.Component {
 
 InnerPendingGame.displayName = 'PendingGame';
 InnerPendingGame.propTypes = {
-    apiError: React.PropTypes.string,
-    connecting: React.PropTypes.bool,
-    currentGame: React.PropTypes.object,
-    decks: React.PropTypes.array,
-    gameSocketClose: React.PropTypes.func,
-    host: React.PropTypes.string,
-    loadDecks: React.PropTypes.func,
-    loading: React.PropTypes.bool,
-    sendSocketMessage: React.PropTypes.func,
-    socket: React.PropTypes.object,
-    username: React.PropTypes.string,
-    zoomCard: React.PropTypes.func
+    apiError: PropTypes.string,
+    connecting: PropTypes.bool,
+    currentGame: PropTypes.object,
+    decks: PropTypes.array,
+    gameSocketClose: PropTypes.func,
+    host: PropTypes.string,
+    loadDecks: PropTypes.func,
+    loading: PropTypes.bool,
+    sendSocketMessage: PropTypes.func,
+    socket: PropTypes.object,
+    username: PropTypes.string,
+    zoomCard: PropTypes.func
 };
 
 function mapStateToProps(state) {

--- a/client/Profile.jsx
+++ b/client/Profile.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import _ from 'underscore';
 import $ from 'jquery';
 import { connect } from 'react-redux';
@@ -361,9 +362,9 @@ class InnerProfile extends React.Component {
 
 InnerProfile.displayName = 'Profile';
 InnerProfile.propTypes = {
-    refreshUser: React.PropTypes.func,
-    socket: React.PropTypes.object,
-    user: React.PropTypes.object
+    refreshUser: PropTypes.func,
+    socket: PropTypes.object,
+    user: PropTypes.object
 };
 
 function mapStateToProps(state) {

--- a/client/Register.jsx
+++ b/client/Register.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import $ from 'jquery';
 import _ from 'underscore';
 import {connect} from 'react-redux';
@@ -210,9 +211,9 @@ export class InnerRegister extends React.Component {
 
 InnerRegister.displayName = 'Register';
 InnerRegister.propTypes = {
-    navigate: React.PropTypes.func,
-    register: React.PropTypes.func,
-    socket: React.PropTypes.object
+    navigate: PropTypes.func,
+    register: PropTypes.func,
+    socket: PropTypes.object
 };
 
 function mapStateToProps(state) {

--- a/client/ResetPassword.jsx
+++ b/client/ResetPassword.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import _ from 'underscore';
 import $ from 'jquery';
 
@@ -149,9 +150,9 @@ class InnerResetPassword extends React.Component {
 }
 
 InnerResetPassword.propTypes = {
-    id: React.PropTypes.string,
-    navigate: React.PropTypes.func,
-    token: React.PropTypes.string
+    id: PropTypes.string,
+    navigate: PropTypes.func,
+    token: PropTypes.string
 };
 InnerResetPassword.displayName = 'ResetPassword';
 

--- a/client/SiteComponents/AlertPanel.jsx
+++ b/client/SiteComponents/AlertPanel.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class AlertPanel extends React.Component {
     render() {
@@ -35,11 +36,11 @@ class AlertPanel extends React.Component {
 
 AlertPanel.displayName = 'AlertPanel';
 AlertPanel.propTypes = {
-    children: React.PropTypes.any,
-    message: React.PropTypes.string,
-    noIcon: React.PropTypes.bool,
-    title: React.PropTypes.string,
-    type: React.PropTypes.oneOf(['warning', 'info', 'success', 'error'])
+    children: PropTypes.any,
+    message: PropTypes.string,
+    noIcon: PropTypes.bool,
+    title: PropTypes.string,
+    type: PropTypes.oneOf(['warning', 'info', 'success', 'error'])
 };
 
 export default AlertPanel;

--- a/client/SiteComponents/News.jsx
+++ b/client/SiteComponents/News.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import _ from 'underscore';
 
 import NewsItem from './NewsItem.jsx';
@@ -34,7 +35,7 @@ class News extends React.Component {
 
 News.displayName = 'News';
 News.propTypes = {
-    news: React.PropTypes.array
+    news: PropTypes.array
 };
 
 export default News;

--- a/client/SiteComponents/NewsItem.jsx
+++ b/client/SiteComponents/NewsItem.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import moment from 'moment';
 
 class NewsItem extends React.Component {
@@ -13,9 +14,9 @@ class NewsItem extends React.Component {
 
 NewsItem.displayName = 'NewsItem';
 NewsItem.propTypes = {
-    date: React.PropTypes.string,
-    icon: React.PropTypes.oneOf(['military', 'intrigue', 'power']),
-    text: React.PropTypes.string
+    date: PropTypes.string,
+    icon: PropTypes.oneOf(['military', 'intrigue', 'power']),
+    text: PropTypes.string
 };
 
 export default NewsItem;

--- a/client/StatusPopOver.jsx
+++ b/client/StatusPopOver.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import _ from 'underscore';
 import $ from 'jquery';
 import ReactDOMServer from 'react-dom/server';
@@ -59,9 +60,9 @@ class StatusPopOver extends React.Component {
 
 StatusPopOver.displayName = 'StatusPopOver';
 StatusPopOver.propTypes = {
-    list: React.PropTypes.array,
-    show: React.PropTypes.bool,
-    status: React.PropTypes.string
+    list: PropTypes.array,
+    show: PropTypes.bool,
+    status: PropTypes.string
 };
 
 export default StatusPopOver;

--- a/client/UserAdmin.jsx
+++ b/client/UserAdmin.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import _ from 'underscore';
 
@@ -124,14 +125,14 @@ class InnerUserAdmin extends React.Component {
 
 InnerUserAdmin.displayName = 'UserAdmin';
 InnerUserAdmin.propTypes = {
-    apiError: React.PropTypes.string,
-    apiStatus: React.PropTypes.number,
-    clearUserStatus: React.PropTypes.func,
-    currentUser: React.PropTypes.object,
-    findUser: React.PropTypes.func,
-    loading: React.PropTypes.bool,
-    saveUser: React.PropTypes.func,
-    userSaved: React.PropTypes.bool
+    apiError: PropTypes.string,
+    apiStatus: PropTypes.number,
+    clearUserStatus: PropTypes.func,
+    currentUser: PropTypes.object,
+    findUser: PropTypes.func,
+    loading: PropTypes.bool,
+    saveUser: PropTypes.func,
+    userSaved: PropTypes.bool
 };
 
 function mapStateToProps(state) {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "react-dom": "^15.6.2",
     "react-google-recaptcha": "^0.9.7",
     "react-redux": "^4.4.8",
-    "react-redux-toastr": "^5.0.0",
+    "react-redux-toastr": "^7.1.5",
     "redux": "^3.7.2",
     "redux-thunk": "^2.1.0",
     "sass-loader": "^6.0.6",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "passport": "^0.3.2",
     "passport-local": "^1.0.0",
     "pmx": "^1.5.4",
+    "prop-types": "^15.6.0",
     "raven": "^1.2.1",
     "react": "^15.6.2",
     "react-async-script": "^0.9.1",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "precss": "^2.0.0",
     "pug": "^2.0.0-rc.4",
     "pug-loader": "^2.3.0",
-    "react-addons-test-utils": "^15.6.2",
     "react-hot-loader": "^3.0.0-beta.7",
     "redux-devtools": "^3.4.0",
     "redux-devtools-dock-monitor": "^1.1.2",

--- a/test/client/Card.spec.jsx
+++ b/test/client/Card.spec.jsx
@@ -4,7 +4,7 @@
 import Card from '../../client/GameComponents/Card.jsx';
 import ReactDOM from 'react-dom';
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 
 describe('the <Card /> component', function() {
     beforeEach(function() {

--- a/test/client/GameBoard.spec.jsx
+++ b/test/client/GameBoard.spec.jsx
@@ -10,7 +10,7 @@ import GameConfiguration from '../../client/GameComponents/GameConfiguration.jsx
 import { Provider } from 'react-redux';
 import ReactDOM from 'react-dom';
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import stubComponent from './test-setup.jsx';
 
 var state = { cards: {}, games: { state: {}, currentGame: { players: {} } }, socket: {}, auth: {} };

--- a/test/client/Register.spec.jsx
+++ b/test/client/Register.spec.jsx
@@ -3,7 +3,7 @@
 import { InnerRegister } from '../../client/Register.jsx';
 import ReactDOM from 'react-dom';
 import React from 'react';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import $ from 'jquery';
 
 describe('the <InnerRegister /> component', function () {


### PR DESCRIPTION
TestUtils has moved from a separate package to inside of `react-dom`.
React.PropTypes is deprecated and will be removed in React 16, moved into a separate `prop-types` package.

~~Doesn't quite get rid of deprecation warnings being spit out by karma. I think one of our dependencies may not be using PropTypes but spot-checking the source for most of them didn't immediately reveal which one.~~

Upgrading `react-redux-toastr` got rid of all remaining deprecation warnings from karma.