### PR TITLE
Remove Player.allCards

### DIFF
--- a/server/game/cards/03-WotN/AsHardAsWinter.js
+++ b/server/game/cards/03-WotN/AsHardAsWinter.js
@@ -25,7 +25,7 @@ class AsHardAsWinter extends DrawCard {
     }
 
     hasUsedWinterPlot() {
-        return this.controller.allCards.any(card => (
+        return this.game.allCards.any(card => (
             card.controller === this.controller &&
             card.location === 'revealed plots' &&
             card.hasTrait('Winter')

--- a/server/game/cards/03-WotN/WeaponsAtTheDoor.js
+++ b/server/game/cards/03-WotN/WeaponsAtTheDoor.js
@@ -1,5 +1,3 @@
-const _ = require('underscore');
-
 const PlotCard = require('../../plotcard.js');
 
 class WeaponsAtTheDoor extends PlotCard {
@@ -9,17 +7,12 @@ class WeaponsAtTheDoor extends PlotCard {
                 onPhaseStarted: event => event.phase === 'challenge'
             },
             handler: () => {
-                _.each(this.game.getPlayers(), player => this.returnCardsToHand(player));
+                let attachments = this.game.allCards.filter(card => card.getPrintedType() === 'attachment' && card.parent);
+                for(let card of attachments) {
+                    card.owner.returnCardToHand(card);
+                }
 
                 this.game.addMessage('{0} uses {1} to force both players to return each card with printed attachment card type to their hand', this.controller, this);
-            }
-        });
-    }
-
-    returnCardsToHand(player) {
-        player.allCards.each(card => {
-            if(card.getPrintedType() === 'attachment' && card.parent) {
-                player.returnCardToHand(card);
             }
         });
     }

--- a/server/game/cards/04.4-TIMC/ShadowTowerMason.js
+++ b/server/game/cards/04.4-TIMC/ShadowTowerMason.js
@@ -13,15 +13,7 @@ class ShadowTowerMason extends DrawCard {
     }
 
     getCardCount() {
-        var count = this.controller.allCards.reduce((counter, card) => {
-            if(this.isBlank() || card.location !== 'play area' || !card.isFaction('thenightswatch') || (card.getType() !== 'location' && card.getType() !== 'attachment')) {
-                return counter;
-            }
-
-            return counter + 1;
-        }, 0);
-
-        return count;
+        return this.controller.getNumberOfCardsInPlay(card => ['attachment', 'location'].includes(card.getType()) && card.isFaction('thenightswatch'));
     }
 }
 

--- a/server/game/cards/04.6-TC/TyrionsChain.js
+++ b/server/game/cards/04.6-TC/TyrionsChain.js
@@ -44,8 +44,8 @@ class TyrionsChain extends DrawCard {
         return revealedPlots;
     }
 
-    selectWarPlot(player, card) {
-        var warPlot = this.controller.findCardByUuid(this.game.allCards, card);
+    selectWarPlot(player, cardId) {
+        var warPlot = this.game.findAnyCardInAnyList(cardId);
         this.resolving = true;
 
         this.game.addMessage('{0} uses {1} to initiate the When Revealed ability of {2}', this.controller, this, warPlot);

--- a/server/game/cards/05-LoCR/OldWyk.js
+++ b/server/game/cards/05-LoCR/OldWyk.js
@@ -46,7 +46,7 @@ class OldWyk extends DrawCard {
     }
 
     anyDrownedGodInDeadPile() {
-        return this.controller.allCards.any(card => card.location === 'dead pile' && card.hasTrait('Drowned God'));
+        return this.controller.deadPile.any(card => card.hasTrait('Drowned God'));
     }
 }
 

--- a/server/game/cards/05-LoCR/SummonedToCourt.js
+++ b/server/game/cards/05-LoCR/SummonedToCourt.js
@@ -82,7 +82,7 @@ class SummonedToCourt extends PlotCard {
     }
 
     putChoiceIntoPlay(player, cardId) {
-        let card = player.findCardByUuidInAnyList(cardId);
+        let card = this.game.findAnyCardInAnyList(cardId);
         player.putIntoPlay(card);
         this.game.addMessage('{0} chooses to put {1} into play using {2}', player, card, this);
         this.promptNextPlayerToPutIntoPlay();
@@ -90,7 +90,7 @@ class SummonedToCourt extends PlotCard {
     }
 
     declinePutIntoPlay(player, cardId) {
-        let card = player.findCardByUuidInAnyList(cardId);
+        let card = this.game.findAnyCardInAnyList(cardId);
         this.game.addMessage('{0} declines to put {1} into play using {2}', player, card, this);
         this.promptNextPlayerToPutIntoPlay();
         return true;

--- a/server/game/cards/06.4-TRW/Plunder.js
+++ b/server/game/cards/06.4-TRW/Plunder.js
@@ -16,7 +16,7 @@ class Plunder extends DrawCard {
     }
 
     getGold(opponent) {
-        return opponent.allCards.reduce((num, card) => {
+        return opponent.discardPile.reduce((num, card) => {
             if(card.location === 'discard pile' && (card.getType() === 'location' || card.getType() === 'attachment')) {
                 return num + 1;
             }

--- a/server/game/cards/agendas/ThePowerOfWealth.js
+++ b/server/game/cards/agendas/ThePowerOfWealth.js
@@ -20,8 +20,8 @@ class ThePowerOfWealth extends AgendaCard {
     onDecksPrepared() {
         let factionsInDecks = [];
 
-        this.controller.allCards.each(card => {
-            if(!factionsInDecks.includes(card.getPrintedFaction())) {
+        this.game.allCards.each(card => {
+            if(card.owner === this.owner && !factionsInDecks.includes(card.getPrintedFaction())) {
                 factionsInDecks.push(card.getPrintedFaction());
             }
         });

--- a/server/game/cards/agendas/Treaty.js
+++ b/server/game/cards/agendas/Treaty.js
@@ -36,8 +36,8 @@ class Treaty extends AgendaCard {
     onDecksPrepared() {
         let factionsInDecks = [];
 
-        this.controller.allCards.each(card => {
-            if(!factionsInDecks.includes(card.getPrintedFaction())) {
+        this.game.allCards.each(card => {
+            if(card.owner === this.owner && !factionsInDecks.includes(card.getPrintedFaction())) {
                 factionsInDecks.push(card.getPrintedFaction());
             }
         });

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -433,7 +433,7 @@ const Costs = {
         );
         return {
             canPay: function(context) {
-                return context.player.allCards.any(card => fullCondition(card, context));
+                return context.game.allCards.any(card => fullCondition(card, context));
             },
             resolve: function(context, result = { resolved: false }) {
                 context.game.promptForSelect(context.player, {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -162,12 +162,7 @@ class Game extends EventEmitter {
     }
 
     findAnyCardInAnyList(cardId) {
-        return _.reduce(this.getPlayers(), (card, player) => {
-            if(card) {
-                return card;
-            }
-            return player.findCardByUuidInAnyList(cardId);
-        }, null);
+        return this.allCards.find(card => card.uuid === cardId);
     }
 
     findAnyCardsInPlay(predicate) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -636,7 +636,7 @@ class Game extends EventEmitter {
 
     gatherAllCards() {
         let playerCards = _.reduce(this.getPlayers(), (cards, player) => {
-            return cards.concat(player.allCards.toArray());
+            return cards.concat(player.preparedDeck.allCards);
         }, []);
 
         if(this.isMelee) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -776,7 +776,7 @@ class Game extends EventEmitter {
 
         this.applyGameAction('takeControl', card, card => {
             oldController.removeCardFromPile(card);
-            newController.controlCard(card);
+            card.controller = newController;
             newController.cardsInPlay.push(card);
 
             if(card.location !== 'play area') {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -128,16 +128,16 @@ class Player extends Spectator {
     }
 
     anyCardsInPlay(predicate) {
-        return this.allCards.any(card => card.location === 'play area' && predicate(card));
+        return this.game.allCards.any(card => card.controller === this && card.location === 'play area' && predicate(card));
     }
 
     filterCardsInPlay(predicate) {
-        return this.allCards.filter(card => card.location === 'play area' && predicate(card));
+        return this.game.allCards.filter(card => card.controller === this && card.location === 'play area' && predicate(card));
     }
 
     getNumberOfCardsInPlay(predicate) {
-        return this.allCards.reduce((num, card) => {
-            if(card.location === 'play area' && predicate(card)) {
+        return this.game.allCards.reduce((num, card) => {
+            if(card.controller === this && card.location === 'play area' && predicate(card)) {
                 return num + 1;
             }
 
@@ -154,7 +154,8 @@ class Player extends Spectator {
             return undefined;
         }
 
-        return this.allCards.find(playCard => (
+        return this.game.allCards.find(playCard => (
+            playCard.controller === this &&
             playCard.location === 'play area' &&
             playCard !== card &&
             (playCard.code === card.code || playCard.name === card.name) &&

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -88,10 +88,6 @@ class Player extends Spectator {
         return this.findCard(list, card => card.name === name);
     }
 
-    findCardByUuidInAnyList(uuid) {
-        return this.findCardByUuid(this.allCards, uuid);
-    }
-
     findCardByUuid(list, uuid) {
         return this.findCard(list, card => card.uuid === uuid);
     }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -346,6 +346,7 @@ class Player extends Spectator {
         this.drawDeck = _(preparedDeck.drawCards);
         this.bannerCards = _(preparedDeck.bannerCards);
         this.allCards = _(preparedDeck.allCards);
+        this.preparedDeck = preparedDeck;
     }
 
     initialise() {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -345,7 +345,6 @@ class Player extends Spectator {
         this.faction = preparedDeck.faction;
         this.drawDeck = _(preparedDeck.drawCards);
         this.bannerCards = _(preparedDeck.bannerCards);
-        this.allCards = _(preparedDeck.allCards);
         this.preparedDeck = preparedDeck;
     }
 
@@ -545,9 +544,7 @@ class Player extends Spectator {
             card.facedown = this.game.currentPhase === 'setup';
             card.new = true;
             this.moveCard(card, 'play area', { isDupe: !!dupeCard });
-            if(card.controller !== this) {
-                this.controlCard(card);
-            }
+            card.controller = this;
             card.wasAmbush = (playingType === 'ambush');
 
             if(!dupeCard && !isSetupAttachment) {
@@ -1099,16 +1096,10 @@ class Player extends Spectator {
         return true;
     }
 
-    controlCard(card) {
-        card.controller.allCards = _(card.controller.allCards.reject(c => c === card));
-        this.allCards.push(card);
-        card.controller = this;
-    }
-
     removeCardFromPile(card) {
         if(card.controller !== this) {
             card.controller.removeCardFromPile(card);
-            card.owner.controlCard(card);
+            card.controller = card.owner;
             return;
         }
 

--- a/test/helpers/playerinteractionwrapper.js
+++ b/test/helpers/playerinteractionwrapper.js
@@ -44,8 +44,8 @@ class PlayerInteractionWrapper {
     }
 
     filterCardsByName(name, location = 'any') {
-        var matchFunc = matchCardByNameAndPack(name);
-        var cards = this.player.allCards.filter(card => matchFunc(card.cardData) && (location === 'any' || card.location === location));
+        let matchFunc = matchCardByNameAndPack(name);
+        let cards = this.game.allCards.filter(card => card.controller === this.player && matchFunc(card.cardData) && (location === 'any' || card.location === location));
 
         if(cards.length === 0) {
             var locationString = location === 'any' ? 'any location' : location;
@@ -60,7 +60,7 @@ class PlayerInteractionWrapper {
     }
 
     filterCards(condition) {
-        var cards = this.player.allCards.filter(condition);
+        let cards = this.game.allCards.filter(card => card.controller === this.player && condition(card));
 
         if(cards.length === 0) {
             throw new Error(`Could not find any matching cards for ${this.player.name}`);

--- a/test/server/player/getduplicateinplay.spec.js
+++ b/test/server/player/getduplicateinplay.spec.js
@@ -1,3 +1,4 @@
+const _ = require('underscore');
 const Player = require('../../../server/game/player.js');
 const DrawCard = require('../../../server/game/drawcard.js');
 
@@ -11,7 +12,7 @@ describe('Player', function() {
             this.dupeCard = new DrawCard(this.player, { code: '1', name: 'Test' });
             this.dupeCard.location = 'play area';
 
-            this.player.allCards.push(this.dupeCard);
+            this.game.allCards = _([this.dupeCard]);
 
             this.cardSpy = jasmine.createSpyObj('card', ['isUnique']);
 
@@ -84,7 +85,7 @@ describe('Player', function() {
             beforeEach(function() {
                 this.attachedCard = new DrawCard(this.player, { code: '3', name: 'Attached', type_code: 'attachment' });
                 this.attachedCard.location = 'play area';
-                this.player.allCards.push(this.attachedCard);
+                this.game.allCards.push(this.attachedCard);
                 this.dupeCard.attachments.push(this.attachedCard);
 
                 this.cardSpy.code = '3';

--- a/test/server/player/putintoplay.spec.js
+++ b/test/server/player/putintoplay.spec.js
@@ -281,7 +281,6 @@ describe('Player', function() {
                 this.cardSpy.controller = this.opponent;
                 this.cardSpy.owner = this.opponent;
                 this.opponent.hand.push(this.cardSpy);
-                this.opponent.allCards.push(this.cardSpy);
                 this.player.hand = _([]);
 
                 this.player.putIntoPlay(this.cardSpy, 'marshal');
@@ -293,15 +292,10 @@ describe('Player', function() {
 
             it('should remove the card from the other player', function() {
                 expect(this.opponent.hand).not.toContain(this.cardSpy);
-                expect(this.opponent.allCards).not.toContain(this.cardSpy);
             });
 
             it('should transfer control to the player', function () {
                 expect(this.cardSpy.controller).toBe(this.player);
-            });
-
-            it('should not duplicate the card in the allCards array', function() {
-                expect(this.player.allCards.toArray()).toEqual([this.player.faction, this.cardSpy]);
             });
         });
     });


### PR DESCRIPTION
Replaces usages of Player.allCards with Game.allCards and relevant methods. This simplifies take control because you no longer have to keep Player.allCards in sync with cards that the player controls. Instead, you just query Game.allCards which never changes even when control of a card changes (it's fixed upon game start).