### PR TITLE
Apply plot persistent effects simultaneously

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -328,12 +328,14 @@ class BaseCard {
         });
     }
 
+    getPersistentEffects() {
+        return this.abilities.persistentEffects.filter(effect => effect.location !== 'any');
+    }
+
     applyPersistentEffects() {
-        _.each(this.abilities.persistentEffects, effect => {
-            if(effect.location !== 'any') {
-                this.game.addEffect(this, effect);
-            }
-        });
+        for(let effect of this.getPersistentEffects()) {
+            this.game.addEffect(this, effect);
+        }
     }
 
     leavesPlay() {

--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -26,6 +26,13 @@ class EffectEngine {
         }
     }
 
+    addSimultaneous(effects) {
+        let sortedEffects = _.sortBy(effects, effect => effect.order);
+        for(let effect of sortedEffects) {
+            this.add(effect);
+        }
+    }
+
     getTargets() {
         var validTargets = this.game.allCards.filter(card => card.location === 'play area' || card.location === 'active plot' || card.location === 'hand');
         return validTargets.concat(_.values(this.game.getPlayers()));

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -208,6 +208,11 @@ class Game extends EventEmitter {
         this.effectEngine.add(new Effect(this, source, properties));
     }
 
+    addSimultaneousEffects(effectProperties) {
+        let effects = effectProperties.map(effect => new Effect(this, effect.source, effect.properties));
+        this.effectEngine.addSimultaneous(effects);
+    }
+
     selectPlot(player, plotId) {
         var plot = player.findCardByUuid(player.plotDeck, plotId);
 

--- a/server/game/gamesteps/revealplots.js
+++ b/server/game/gamesteps/revealplots.js
@@ -11,6 +11,12 @@ class RevealPlots extends BaseStep {
     }
 
     continue() {
+        this.game.addSimultaneousEffects(this.getPlotEffects());
+
+        for(let plot of this.plots) {
+            this.game.raiseEvent('onCardEntersPlay', { card: plot, playingType: 'plot' });
+        }
+
         let params = {
             plots: this.plots
         };
@@ -22,6 +28,16 @@ class RevealPlots extends BaseStep {
             }
             this.game.raiseEvent('onPlotsWhenRevealed', params);
         });
+    }
+
+    getPlotEffects() {
+        return this.plots
+            .reduce((memo, plot) => {
+                let effectProperties = plot.getPersistentEffects();
+                let results = effectProperties.map(properties => ({ source: plot, properties: properties }));
+
+                return memo.concat(results);
+            }, []);
     }
 
     needsFirstPlayerChoice() {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -615,10 +615,6 @@ class Player extends Spectator {
     flipPlotFaceup() {
         this.selectedPlot.flipFaceup();
         this.moveCard(this.selectedPlot, 'active plot');
-        this.selectedPlot.applyPersistentEffects();
-
-        this.game.raiseEvent('onCardEntersPlay', { card: this.activePlot, playingType: 'plot' });
-
         this.selectedPlot = undefined;
     }
 

--- a/test/server/integration/plotphase.spec.js
+++ b/test/server/integration/plotphase.spec.js
@@ -1,0 +1,30 @@
+describe('plot phase', function() {
+    integration(function() {
+        describe('when revealing two plots with persistent effects', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('targaryen', [
+                    'Blood of the Dragon', 'A Song of Summer',
+                    'Targaryen Loyalist'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.chud = this.player2.findCardByName('Targaryen Loyalist', 'hand');
+                this.player2.clickCard(this.chud);
+
+                this.completeSetup();
+
+                this.player1.selectPlot('Blood of the Dragon');
+                this.player2.selectPlot('A Song of Summer');
+            });
+
+            it('should apply effects simultaneously', function() {
+                // Since Blood of the Dragon and A Song of Summer are applied
+                // simultaneously, the chud should survive.
+                expect(this.chud.location).toBe('play area');
+            });
+        });
+    });
+});

--- a/test/server/player/flipplotfaceup.spec.js
+++ b/test/server/player/flipplotfaceup.spec.js
@@ -33,10 +33,6 @@ describe('Player', function() {
                 expect(this.selectedPlotSpy.flipFaceup).toHaveBeenCalled();
             });
 
-            it('should apply effects for the selected plot', function() {
-                expect(this.selectedPlotSpy.applyPersistentEffects).toHaveBeenCalled();
-            });
-
             it('should move the plot to the active plot slot', function() {
                 expect(this.selectedPlotSpy.moveTo).toHaveBeenCalledWith('active plot');
                 expect(this.player.activePlot).toBe(this.selectedPlotSpy);


### PR DESCRIPTION
Instead of applying plot effects one at a time as they are flipped (in
player-join order), they are now applied simultaneously per the rules.
This fixes a bug where if the player that created the game revealed
Blood of the Dragon and the opponent revealed A Song of Summer, the
opponent's 1 STR characters would improperly die.

Fixes #1247 