### PR TITLE
Refresh user auth when blocklist is modified

### DIFF
--- a/client/BlockList.jsx
+++ b/client/BlockList.jsx
@@ -47,6 +47,7 @@ class InnerBlockList extends React.Component {
             successPanel = (
                 <AlertPanel message='Block list entry added successfully' type={ 'success' } />
             );
+            this.props.socket.emit('authenticate', this.props.token);
         }
 
         if(this.props.blockListDeleted) {
@@ -56,7 +57,7 @@ class InnerBlockList extends React.Component {
             successPanel = (
                 <AlertPanel message='Block list entry removed successfully' type={ 'success' } />
             );
-
+            this.props.socket.emit('authenticate', this.props.token);
         }
 
         let content;
@@ -134,6 +135,8 @@ InnerBlockList.propTypes = {
     loadBlockList: PropTypes.func,
     loading: PropTypes.bool,
     removeBlockListEntry: PropTypes.func,
+    socket: PropTypes.object,
+    token: PropTypes.string,
     user: PropTypes.object
 };
 
@@ -144,6 +147,8 @@ function mapStateToProps(state) {
         blockListAdded: state.user.blockListAdded,
         blockListDeleted: state.user.blockListDeleted,
         loading: state.api.loading,
+        socket: state.socket.socket,
+        token: state.auth.token,
         user: state.auth.user
     };
 }

--- a/client/reducers/auth.js
+++ b/client/reducers/auth.js
@@ -35,6 +35,13 @@ export default function(state = {}, action) {
                 username: action.user.username,
                 token: action.token
             });
+        case 'BLOCKLIST_ADDED':
+        case 'BLOCKLIST_DELETED':
+            return Object.assign({}, state, {
+                user: action.response.user,
+                username: action.response.user.username,
+                token: action.response.token
+            });
     }
 
     return state;

--- a/server/api/account.js
+++ b/server/api/account.js
@@ -261,21 +261,26 @@ module.exports.init = function(server) {
             });
     });
 
+    function updateUserData(user) {
+        return {
+            user: {
+                username: user.username,
+                email: user.email,
+                emailHash: user.emailHash,
+                _id: user._id,
+                admin: user.admin,
+                settings: user.settings,
+                promptedActionWindows: user.promptedActionWindows,
+                permissions: user.permissions || {}
+            },
+            token: jwt.sign(user, config.secret)
+        };
+    }
+
     function updateUser(res, user) {
         return userService.update(user)
             .then(() => {
-                res.send({
-                    success: true, user: {
-                        username: user.username,
-                        email: user.email,
-                        emailHash: user.emailHash,
-                        _id: user._id,
-                        admin: user.admin,
-                        settings: user.settings,
-                        promptedActionWindows: user.promptedActionWindows,
-                        permissions: user.permissions || {}
-                    }, token: jwt.sign(user, config.secret)
-                });
+                res.send(Object.assign({ success: true }, updateUserData(user)));
             })
             .catch(() => {
                 return res.send({ success: false, message: 'An error occured updating your user profile' });
@@ -357,7 +362,10 @@ module.exports.init = function(server) {
 
         await userService.updateBlockList(user);
 
-        res.send({ success: true, message: 'Block list entry added successfully', username: req.body.username.toLowerCase() });
+        res.send(Object.assign(
+            { success: true, message: 'Block list entry added successfully', username: req.body.username.toLowerCase() },
+            updateUserData(user)
+        ));
     }));
 
     server.delete('/api/account/:username/blocklist/:entry', wrapAsync(async (req, res) => {
@@ -387,7 +395,10 @@ module.exports.init = function(server) {
 
         await userService.updateBlockList(user);
 
-        res.send({ success: true, message: 'Block list entry removed successfully', username: req.params.entry.toLowerCase() });
+        res.send(Object.assign(
+            { success: true, message: 'Block list entry removed successfully', username: req.params.entry.toLowerCase() },
+            updateUserData(user)
+        ));
     }));
 };
 


### PR DESCRIPTION
In order to update the blocklist on both the client side JWT and server
side user objects, a new token is sent back with the updated blocklist,
similar to what is done on profile updates. Then, the client reauths
with the server using the token, which updates the user object on the
corresponding socket on the server side.

Fixes #1505 (once #1507 is merged)