### PR TITLE
Implement a "select exactly X cards" prompt

### DIFF
--- a/server/game/CardSelector.js
+++ b/server/game/CardSelector.js
@@ -11,23 +11,43 @@ const defaultProperties = {
     multiSelect: false
 };
 
+const ModeToSelector = {
+    maxStat: p => new MaxStatCardSelector(p),
+    single: p => new SingleCardSelector(p),
+    unlimited: p => new UnlimitedCardSelector(p),
+    upTo: p => new UpToXCardSelector(p.numCards, p),
+};
+
 class CardSelector {
     static for(properties) {
+        properties = CardSelector.getDefaultedProperties(properties);
+
+        let factory = ModeToSelector[properties.mode];
+
+        if(!factory) {
+            throw new Error(`Unknown card selector mode of ${properties.mode}`);
+        }
+
+        return factory(properties);
+    }
+
+    static getDefaultedProperties(properties) {
         properties = Object.assign({}, defaultProperties, properties);
+        if(properties.mode) {
+            return properties;
+        }
 
         if(properties.maxStat) {
-            return new MaxStatCardSelector(properties);
+            properties.mode = 'maxStat';
+        } else if(properties.numCards === 1 && !properties.multiSelect) {
+            properties.mode = 'single';
+        } else if(properties.numCards === 0) {
+            properties.mode = 'unlimited';
+        } else {
+            properties.mode = 'upTo';
         }
 
-        if(properties.numCards === 1 && !properties.multiSelect) {
-            return new SingleCardSelector(properties);
-        }
-
-        if(properties.numCards === 0) {
-            return new UnlimitedCardSelector(properties);
-        }
-
-        return new UpToXCardSelector(properties.numCards, properties);
+        return properties;
     }
 }
 

--- a/server/game/CardSelector.js
+++ b/server/game/CardSelector.js
@@ -1,5 +1,6 @@
-const SingleCardSelector = require('./CardSelectors/SingleCardSelector');
+const ExactlyXCardSelector = require('./CardSelectors/ExactlyXCardSelector');
 const MaxStatCardSelector = require('./CardSelectors/MaxStatCardSelector');
+const SingleCardSelector = require('./CardSelectors/SingleCardSelector');
 const UnlimitedCardSelector = require('./CardSelectors/UnlimitedCardSelector');
 const UpToXCardSelector = require('./CardSelectors/UpToXCardSelector');
 
@@ -12,10 +13,11 @@ const defaultProperties = {
 };
 
 const ModeToSelector = {
+    exactly: p => new ExactlyXCardSelector(p.numCards, p),
     maxStat: p => new MaxStatCardSelector(p),
     single: p => new SingleCardSelector(p),
     unlimited: p => new UnlimitedCardSelector(p),
-    upTo: p => new UpToXCardSelector(p.numCards, p),
+    upTo: p => new UpToXCardSelector(p.numCards, p)
 };
 
 class CardSelector {

--- a/server/game/CardSelectors/BaseCardSelector.js
+++ b/server/game/CardSelectors/BaseCardSelector.js
@@ -17,6 +17,10 @@ class BaseCardSelector {
         );
     }
 
+    hasEnoughSelected(selectedCards) {
+        return selectedCards.length > 0;
+    }
+
     hasEnoughTargets(context) {
         return context.game.allCards.any(card => this.canTarget(card, context));
     }

--- a/server/game/CardSelectors/ExactlyXCardSelector.js
+++ b/server/game/CardSelectors/ExactlyXCardSelector.js
@@ -1,0 +1,34 @@
+const BaseCardSelector = require('./BaseCardSelector.js');
+
+class ExactlyXCardSelector extends BaseCardSelector {
+    constructor(numCards, properties) {
+        super(properties);
+
+        this.numCards = numCards;
+    }
+
+    defaultActivePromptTitle() {
+        return this.numCards === 1 ? 'Select a character' : `Select ${this.numCards} characters`;
+    }
+
+    hasEnoughSelected(selectedCards) {
+        return selectedCards.length === this.numCards;
+    }
+
+    hasEnoughTargets(context) {
+        let numMatchingCards = context.game.allCards.reduce((total, card) => {
+            if(this.canTarget(card, context)) {
+                return total + 1;
+            }
+            return total;
+        }, 0);
+
+        return numMatchingCards >= this.numCards;
+    }
+
+    hasReachedLimit(selectedCards) {
+        return selectedCards.length >= this.numCards;
+    }
+}
+
+module.exports = ExactlyXCardSelector;

--- a/server/game/cards/04.5-GoH/RitualOfRhllor.js
+++ b/server/game/cards/04.5-GoH/RitualOfRhllor.js
@@ -12,8 +12,8 @@ class RitualOfRhllor extends DrawCard {
             handler: context => {
                 let goldCost = context.goldCostAmount;
                 this.game.promptForSelect(this.controller, {
+                    mode: 'exactly',
                     numCards: goldCost,
-                    multiSelect: true,
                     activePromptTitle: 'Select ' + (goldCost === 1 ? 'a' : goldCost) + ' character' + (goldCost === 1 ? '' : 's'),
                     source: this,
                     cardCondition: card => card.location === 'play area' && !card.kneeled && card.hasTrait('R\'hllor') && card.getType() === 'character',
@@ -24,10 +24,6 @@ class RitualOfRhllor extends DrawCard {
     }
 
     targetsSelected(player, cards, goldCost) {
-        if(cards.length !== goldCost) {
-            return false;
-        }
-
         _.each(cards, card => {
             card.modifyPower(1);
         });

--- a/server/game/cards/06.3-TFoA/Duel.js
+++ b/server/game/cards/06.3-TFoA/Duel.js
@@ -15,6 +15,7 @@ class Duel extends PlotCard {
                     this.controller, this, opponent);
 
                 this.game.promptForSelect(opponent, {
+                    mode: 'exactly',
                     numCards: 2,
                     activePromptTitle: 'Select two characters',
                     source: this,
@@ -30,10 +31,6 @@ class Duel extends PlotCard {
     }
 
     targetsSelected(player, cards) {
-        if(cards.length !== 2) {
-            return false;
-        }
-
         this.targets = cards;
         this.game.addMessage('{0} chooses {1} as the targets for {2}', player, cards, this);
 

--- a/server/game/cards/06.4-TRW/FreyHospitality.js
+++ b/server/game/cards/06.4-TRW/FreyHospitality.js
@@ -12,8 +12,8 @@ class FreyHospitality extends DrawCard {
                 let numTargets = this.game.currentChallenge.strengthDifference >= 20 ? 3 : 1;
 
                 this.game.promptForSelect(this.controller, {
+                    mode: 'exactly',
                     numCards: numTargets,
-                    multiSelect: true,
                     activePromptTitle: 'Select character(s)',
                     source: this,
                     gameAction: 'kill',
@@ -27,10 +27,6 @@ class FreyHospitality extends DrawCard {
     }
 
     targetsSelected(player, cards) {
-        if(this.game.currentChallenge.strengthDifference >= 20 && cards.length !== 3) {
-            return false;
-        }
-
         this.game.killCharacters(cards);
         this.game.addMessage('{0} plays {1} to kill {2}', this.controller, this, cards);
 

--- a/server/game/cards/06.4-TRW/OldtownInformer.js
+++ b/server/game/cards/06.4-TRW/OldtownInformer.js
@@ -11,8 +11,8 @@ class OldtownInformer extends DrawCard {
                 this.game.addMessage('{0} uses {1} to draw {2} cards', this.controller, this, this.tokens['gold']);
 
                 this.game.promptForSelect(this.controller, {
+                    mode: 'exactly',
                     numCards: this.tokens['gold'],
-                    multiSelect: true,
                     activePromptTitle: 'Select ' + this.tokens['gold'] + ' cards',
                     source: this,
                     cardCondition: card => card.location === 'hand' && card.controller === this.controller,
@@ -23,10 +23,6 @@ class OldtownInformer extends DrawCard {
     }
 
     cardsSelected(player, cards) {
-        if(cards.length !== this.tokens['gold']) {
-            return false;
-        }
-
         player.discardCards(cards);
         this.game.addMessage('{0} then discards {1} for {2}', this.controller, cards, this);
         return true;

--- a/server/game/cards/08.1-TAK/ValarDohaeris.js
+++ b/server/game/cards/08.1-TAK/ValarDohaeris.js
@@ -69,15 +69,11 @@ class ValarDohaeris extends PlotCard {
             if(_.size(cardsOwnedByPlayer) >= 2) {
                 this.game.promptForSelect(player, {
                     ordered: true,
-                    multiSelect: true,
+                    mode: 'exactly',
                     numCards: _.size(cardsOwnedByPlayer),
                     activePromptTitle: 'Select bottom deck order (last chosen ends up on bottom)',
                     cardCondition: card => cardsOwnedByPlayer.includes(card),
                     onSelect: (player, selectedCards) => {
-                        if(cardsOwnedByPlayer.length !== selectedCards.length) {
-                            return false;
-                        }
-
                         this.toMove = _.reject(this.toMove, card => card.owner === player).concat(selectedCards);
 
                         return true;

--- a/server/game/cards/09-HoT/MeleeAtBitterbridge.js
+++ b/server/game/cards/09-HoT/MeleeAtBitterbridge.js
@@ -11,8 +11,8 @@ class MeleeAtBitterbridge extends DrawCard {
             handler: context => {
                 let goldCost = context.goldCostAmount;
                 this.game.promptForSelect(this.controller, {
+                    mode: 'exactly',
                     numCards: goldCost,
-                    multiSelect: true,
                     activePromptTitle: 'Select ' + (goldCost === 1 ? 'a' : goldCost) + ' character' + (goldCost === 1 ? '' : 's'),
                     source: this,
                     cardCondition: card => card.location === 'play area' && this.game.currentChallenge.isParticipating(card),
@@ -23,10 +23,6 @@ class MeleeAtBitterbridge extends DrawCard {
     }
 
     targetsSelected(player, cards, goldCost) {
-        if(cards.length !== goldCost) {
-            return false;
-        }
-
         let strengths = _.map(cards, card => card.getStrength());
         let highestStrength = _.max(strengths);
         let renownCharacters = _.filter(cards, card => card.getStrength() === highestStrength);

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -144,14 +144,10 @@ const Costs = {
                 context.game.promptForSelect(context.player, {
                     cardCondition: card => fullCondition(card, context),
                     activePromptTitle: 'Select ' + number + ' cards to kneel',
+                    mode: 'exactly',
                     numCards: number,
-                    multiSelect: true,
                     source: context.source,
                     onSelect: (player, cards) => {
-                        if(cards.length !== number) {
-                            return false;
-                        }
-
                         context.kneelingCostCards = cards;
                         result.value = true;
                         result.resolved = true;
@@ -336,14 +332,10 @@ const Costs = {
                 context.game.promptForSelect(context.player, {
                     cardCondition: card => fullCondition(card, context),
                     activePromptTitle: 'Select ' + number + ' cards to reveal',
+                    mode: 'exactly',
                     numCards: number,
-                    multiSelect: true,
                     source: context.source,
                     onSelect: (player, cards) => {
-                        if(cards.length !== number) {
-                            return false;
-                        }
-
                         context.revealingCostCards = cards;
                         result.value = true;
                         result.resolved = true;

--- a/server/game/gamesteps/keywordwindow.js
+++ b/server/game/gamesteps/keywordwindow.js
@@ -116,15 +116,11 @@ class KeywordWindow extends BaseStep {
         let cards = _.pluck(participants, 'card');
         this.game.promptForSelect(this.challenge.winner, {
             ordered: true,
-            multiSelect: true,
+            mode: 'exactly',
             numCards: _.size(participants),
             activePromptTitle: 'Select order for pillage',
             cardCondition: card => cards.includes(card),
             onSelect: (player, selectedCards) => {
-                if(selectedCards.length !== cards.length) {
-                    return false;
-                }
-
                 let finalParticipants = _.map(selectedCards, card => _.find(participants, participant => participant.card === card));
 
                 this.resolveAbility(ability, finalParticipants);

--- a/server/game/gamesteps/keywordwindow.js
+++ b/server/game/gamesteps/keywordwindow.js
@@ -76,9 +76,8 @@ class KeywordWindow extends BaseStep {
         if(this.challenge.winner.keywordSettings.chooseCards) {
             let cards = _.pluck(participantsWithKeyword, 'card');
             this.game.promptForSelect(this.challenge.winner, {
+                mode: 'unlimited',
                 ordered: true,
-                multiSelect: true,
-                numCards: 0,
                 activePromptTitle: 'Select ' + keyword + ' cards',
                 cardCondition: card => cards.includes(card),
                 onSelect: (player, selectedCards) => {

--- a/server/game/gamesteps/killcharacters.js
+++ b/server/game/gamesteps/killcharacters.js
@@ -71,15 +71,11 @@ class KillCharacters extends BaseStep {
 
         this.game.promptForSelect(player, {
             ordered: true,
-            multiSelect: true,
+            mode: 'exactly',
             numCards: _.size(cardsOwnedByPlayer),
             activePromptTitle: 'Select order to place cards in dead pile (top first)',
             cardCondition: card => cardsOwnedByPlayer.includes(card),
             onSelect: (player, selectedCards) => {
-                if(cardsOwnedByPlayer.length !== selectedCards.length) {
-                    return false;
-                }
-
                 this.moveCardsToDeadPile(selectedCards.reverse());
 
                 return true;

--- a/server/game/gamesteps/selectcardprompt.js
+++ b/server/game/gamesteps/selectcardprompt.js
@@ -179,9 +179,9 @@ class SelectCardPrompt extends UiPrompt {
             return;
         }
 
-        if(this.selectedCards.length > 0) {
+        if(this.selector.hasEnoughSelected(this.selectedCards)) {
             this.fireOnSelect();
-        } else {
+        } else if(this.selectedCards.length === 0) {
             this.properties.onCancel(player);
             this.complete();
         }

--- a/server/game/gamesteps/standingphase.js
+++ b/server/game/gamesteps/standingphase.js
@@ -79,8 +79,7 @@ class StandingPhase extends Phase {
         cardsToStand.automatic = _.filter(cardsToStand.automatic, card => !card.optionalStandDuringStanding);
 
         this.game.promptForSelect(player, {
-            numCards: 0,
-            multiSelect: true,
+            mode: 'unlimited',
             activePromptTitle: 'Select optional cards to stand',
             cardCondition: card => optionalStandCards.includes(card),
             onSelect: (player, cards) => {

--- a/server/game/gamesteps/taxation/discardtoreserveprompt.js
+++ b/server/game/gamesteps/taxation/discardtoreserveprompt.js
@@ -24,20 +24,16 @@ class DiscardToReservePrompt extends BaseStep {
         let overReserve = currentPlayer.hand.size() - currentPlayer.getTotalReserve();
         this.game.promptForSelect(currentPlayer, {
             ordered: true,
+            mode: 'exactly',
             numCards: overReserve,
-            multiSelect: true,
             activePromptTitle: 'Select ' + overReserve + ' cards to discard down to reserve (top first)',
             waitingPromptTitle: 'Waiting for opponent to discard down to reserve',
             cardCondition: card => card.location === 'hand' && card.controller === currentPlayer,
-            onSelect: (player, cards) => this.discardCards(player, cards, overReserve)
+            onSelect: (player, cards) => this.discardCards(player, cards)
         });
     }
 
-    discardCards(player, cards, overReserve) {
-        if(cards.length !== overReserve) {
-            return false;
-        }
-
+    discardCards(player, cards) {
         // Reverse the order selection so that the first card selected ends up
         // on the top of the discard pile.
         cards = cards.reverse();


### PR DESCRIPTION
Natively supports prompts that require the player to select the exact amount of cards (e.g. selecting exactly 2 cards for Duel, selecting all killed cards for dead pile order, etc).

Progress toward #1389.