### PR TITLE
Convert Rise of the Kraken to a replacement effect

### DIFF
--- a/server/game/cards/02.1-TtB/RiseOfTheKraken.js
+++ b/server/game/cards/02.1-TtB/RiseOfTheKraken.js
@@ -4,11 +4,13 @@ class RiseOfTheKraken extends PlotCard {
     setupCardAbilities() {
         this.interrupt({
             when: {
-                onUnopposedWin: event => event.challenge.winner === this.controller
+                onUnopposedGain: event => event.challenge.winner === this.controller
             },
-            handler: () => {
-                this.game.addMessage('{0} uses {1} to gain an additional power from winning an unopposed challenge', this.controller, this);
-                this.game.addPower(this.controller, 1);
+            handler: context => {
+                this.game.addMessage('{0} uses {1} to gain 2 power for winning an unopposed challenge instead of 1', this.controller, this);
+                context.replaceHandler(() => {
+                    this.game.addPower(this.controller, 2);
+                });
             }
         });
     }

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -247,11 +247,11 @@ class ChallengeFlow extends BaseStep {
             if(this.challenge.winner.cannotGainChallengeBonus) {
                 this.game.addMessage('{0} won the challenge unopposed but cannot gain challenge bonuses', this.challenge.winner);
             } else {
-                this.game.addMessage('{0} has gained 1 power from an unopposed challenge', this.challenge.winner);
-                this.game.addPower(this.challenge.winner, 1);
+                this.game.raiseEvent('onUnopposedGain', { challenge: this.challenge }, () => {
+                    this.game.addMessage('{0} has gained 1 power from an unopposed challenge', this.challenge.winner);
+                    this.game.addPower(this.challenge.winner, 1);
+                });
             }
-
-            this.game.raiseEvent('onUnopposedWin', { challenge: this.challenge });
         }
     }
 


### PR DESCRIPTION
Fixes a bug where Rise of the Kraken could still be triggered even if the player was unable to gain challenge bonuses