### PR TITLE
Fix NaN reserve bug

### DIFF
--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -1,5 +1,4 @@
 const _ = require('underscore');
-const logger = require('../log.js');
 
 const Effects = require('./effects.js');
 
@@ -171,26 +170,8 @@ class Effect {
     }
 
     cancel() {
-        this.logDuplicatedTargets();
         _.each(this.targets, target => this.effect.unapply(target, this.context));
         this.targets = [];
-    }
-
-    logDuplicatedTargets() {
-        if(this.targets.length <= 1) {
-            return;
-        }
-
-        let counts = new Map();
-        for(let target of this.targets) {
-            let currentCount = counts.get(target) || 0;
-            counts.set(target, currentCount + 1);
-        }
-        let dupes = Array.from(counts.keys()).filter(target => counts.get(target) > 1).map(target => target.name);
-
-        if(dupes.length > 0) {
-            logger.error('RESERVE BUG:', this.source.name, 'has duplicated targets', dupes.join(', '));
-        }
     }
 
     reapply(newTargets) {

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -6,7 +6,6 @@ const PlayableLocation = require('./playablelocation.js');
 const CannotRestriction = require('./cannotrestriction.js');
 const ChallengeRestriction = require('./ChallengeRestriction.js');
 const ImmunityRestriction = require('./immunityrestriction.js');
-const logger = require('../log.js');
 
 function cannotEffect(type) {
     return function(predicate) {
@@ -730,15 +729,12 @@ const Effects = {
         return {
             apply: function(player, context) {
                 context.setMinReserve = context.setMinReserve || {};
-                context.setMinReserve[player.id] = player.minReserve;
+                context.setMinReserve[player.name] = player.minReserve;
                 player.minReserve = min;
             },
             unapply: function(player, context) {
-                if(!_.isNumber(context.setMinReserve[player.id])) {
-                    logger.error('RESERVE BUG', new Error('Unapplying without previous value'));
-                }
-                player.minReserve = context.setMinReserve[player.id];
-                delete context.setMinReserve[player.id];
+                player.minReserve = context.setMinReserve[player.name];
+                delete context.setMinReserve[player.name];
             }
         };
     },
@@ -786,12 +782,12 @@ const Effects = {
         return {
             apply: function(player, context) {
                 context.setChallengerLimit = context.setChallengerLimit || {};
-                context.setChallengerLimit[player.id] = player.challengerLimit;
+                context.setChallengerLimit[player.name] = player.challengerLimit;
                 player.challengerLimit = value;
             },
             unapply: function(player, context) {
-                player.challengerLimit = context.setChallengerLimit[player.id];
-                delete context.setChallengerLimit[player.id];
+                player.challengerLimit = context.setChallengerLimit[player.name];
+                delete context.setChallengerLimit[player.name];
             }
         };
     },

--- a/test/helpers/playerinteractionwrapper.js
+++ b/test/helpers/playerinteractionwrapper.js
@@ -1,4 +1,5 @@
 const _ = require('underscore');
+const uuid = require('uuid');
 
 const { matchCardByNameAndPack } = require('./cardutil.js');
 
@@ -134,6 +135,11 @@ class PlayerInteractionWrapper {
 
     toggleKeywordSettings(setting, value) {
         this.player.keywordSettings[setting] = value;
+    }
+
+    reconnect() {
+        let newSocket = { id: uuid.v1() };
+        this.game.reconnect(newSocket, this.player.name);
     }
 }
 

--- a/test/server/cards/02.4-NMG/WraithsInTheirMidst.spec.js
+++ b/test/server/cards/02.4-NMG/WraithsInTheirMidst.spec.js
@@ -2,7 +2,7 @@ describe('WraithsInTheirMidst', function() {
     integration(function() {
         beforeEach(function() {
             const deck1 = this.buildDeck('greyjoy', [
-                'Wraiths in Their Midst',
+                'Wraiths in Their Midst', 'A Noble Cause',
                 'Alannys Greyjoy'
             ]);
             const deck2 = this.buildDeck('lannister', [
@@ -68,6 +68,31 @@ describe('WraithsInTheirMidst', function() {
 
             it('should reduce the new plot revealed', function() {
                 // Reduce 6 by 2 from plot, 0 from Alannys since not first player
+                expect(this.player2Object.getTotalReserve()).toBe(4);
+            });
+        });
+
+        describe('when a player reconnects after revealing Wraiths', function() {
+            beforeEach(function() {
+                this.player1.selectPlot('Wraiths in Their Midst');
+                this.player2.selectPlot('A Noble Cause');
+                this.selectFirstPlayer(this.player2);
+
+                // Explicitly reconnect the player affected by Wraiths
+                this.player2.reconnect();
+
+                this.completeMarshalPhase();
+                this.completeChallengesPhase();
+
+                this.player1.selectPlot('A Noble Cause');
+                this.player2.selectPlot('A Feast for Crows');
+                this.selectFirstPlayer(this.player2);
+
+                this.completeMarshalPhase();
+                this.completeChallengesPhase();
+            });
+
+            it('should not get a NaN reserve prompt', function() {
                 expect(this.player2Object.getTotalReserve()).toBe(4);
             });
         });


### PR DESCRIPTION
Previously, the setMinReserve effect stored the previous value for the
player's min reserve using the player ID as a key. This lead to a bug
where if a player who was affected by Wraiths in their Midst reconnected
after it was revealed but before the next plot was revealed, their ID
would change. Thus, when the effect was unapplied, the stored value
could not be retrieved because it was under the original ID.

Now, the original min reserve is stored under the player's name, which
should not be able to change mid-game.

Fixes #1506  
Fixes #1325 