### PR TITLE
Apply Sunspear effect to "revealed plot"

### DIFF
--- a/server/game/cards/01-Core/Sunspear.js
+++ b/server/game/cards/01-Core/Sunspear.js
@@ -16,7 +16,7 @@ class Sunspear extends DrawCard {
                         this.game.currentChallenge &&
                         this.game.currentChallenge.challengeType === challengeType
                     ),
-                    match: this.controller.activePlot,
+                    match: card => card === this.controller.activePlot,
                     effect: ability.effects.modifyClaim(1)
                 }));
             }


### PR DESCRIPTION
Sunspear's claim modification should apply to the currently revealed
plot, not just the plot that was active at the time Sunspear triggered.
This is because "your revealed plot" refers to a game area, not the
specific plot revealed.

See ruling:
http://www.cardgamedb.com/forums/index.php?/topic/33992-calm-over-westeros-rains-of-castamere/?p=298061