### PR TITLE
Minor bug fix that resolve user being stuck on game list.

### DIFF
--- a/server/pendinggame.js
+++ b/server/pendinggame.js
@@ -89,7 +89,7 @@ class PendingGame {
     addSpectator(id, user) {
         this.spectators[user.username] = {
             id: id,
-            name: user.userame,
+            name: user.username,
             user: user,
             emailHash: user.emailHash
         };


### PR DESCRIPTION
Bug description:
When user click on "watch" on a game still pending nothing happen, nevertheless he could no watch nor join any other game in list. Page refresh was needed or wait until game starts.

Ps. 
I hope I have not make any mess 'cause these are my very first steps with "git".