### PR TITLE
Refactor costs

### DIFF
--- a/server/game/AbilityContext.js
+++ b/server/game/AbilityContext.js
@@ -1,0 +1,14 @@
+const ResolvedTargets = require('./gamesteps/ResolvedTargets.js');
+
+class AbilityContext {
+    constructor(properties) {
+        this.challenge = properties.challenge;
+        this.game = properties.game;
+        this.source = properties.source;
+        this.player = properties.player;
+        this.costs = {};
+        this.targets = new ResolvedTargets();
+    }
+}
+
+module.exports = AbilityContext;

--- a/server/game/TriggeredAbilityContext.js
+++ b/server/game/TriggeredAbilityContext.js
@@ -1,0 +1,19 @@
+const AbilityContext = require('./AbilityContext');
+
+class TriggeredAbilityContext extends AbilityContext {
+    constructor(properties) {
+        super(properties);
+
+        this.event = properties.event;
+    }
+
+    cancel() {
+        this.event.cancel();
+    }
+
+    replaceHandler(handler) {
+        this.event.replaceHandler(handler);
+    }
+}
+
+module.exports = TriggeredAbilityContext;

--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -1,5 +1,6 @@
 const _ = require('underscore');
 
+const AbilityContext = require('./AbilityContext.js');
 const BaseAbility = require('./baseability.js');
 const Costs = require('./costs.js');
 const EventRegistrar = require('./eventregistrar.js');
@@ -76,13 +77,12 @@ class CardAction extends BaseAbility {
         return ['play area', 'agenda', 'active plot'].includes(this.location);
     }
 
-    createContext(player, arg) {
-        return {
-            arg: arg,
+    createContext(player) {
+        return new AbilityContext({
             game: this.game,
             player: player,
             source: this.card
-        };
+        });
     }
 
     meetsRequirements(context) {

--- a/server/game/cards/00-VDS/BlackcrownKnights.js
+++ b/server/game/cards/00-VDS/BlackcrownKnights.js
@@ -11,7 +11,7 @@ class BlackcrownKnights extends DrawCard {
             handler: context => {
                 this.modifyPower(2);
                 this.game.addMessage('{0} uses {1} and discards {2} from their hand to gain 2 power on {1}',
-                    this.controller, this, context.discardCostCard);
+                    this.controller, this, context.costs.discardFromHand);
             }
         });
     }

--- a/server/game/cards/00-VDS/Muster.js
+++ b/server/game/cards/00-VDS/Muster.js
@@ -10,7 +10,7 @@ class Muster extends DrawCard {
                 this.game.promptForDeckSearch(this.controller, {
                     activePromptTitle: 'Select a card',
                     cardCondition: card => card.hasTrait('Knight'),
-                    onSelect: (player, card) => this.cardSelected(player, card, context.kneelingCostCard),
+                    onSelect: (player, card) => this.cardSelected(player, card, context.costs.kneel),
                     onCancel: player => this.doneSelecting(player),
                     source: this
                 });

--- a/server/game/cards/01-Core/Dracarys.js
+++ b/server/game/cards/01-Core/Dracarys.js
@@ -10,7 +10,7 @@ class Dracarys extends DrawCard {
                 cardCondition: card => card.location === 'play area' && this.game.currentChallenge.isParticipating(card)
             },
             handler: context => {
-                this.game.addMessage('{0} plays {1} to kneel {2} and give {3} -4 STR until the end of the phase', context.player, this, context.kneelingCostCard, context.target);
+                this.game.addMessage('{0} plays {1} to kneel {2} and give {3} -4 STR until the end of the phase', context.player, this, context.costs.kneel, context.target);
                 this.untilEndOfPhase(ability => ({
                     match: context.target,
                     effect: ability.effects.killByStrength(-4)

--- a/server/game/cards/01-Core/LikeWarmRain.js
+++ b/server/game/cards/01-Core/LikeWarmRain.js
@@ -14,7 +14,7 @@ class LikeWarmRain extends DrawCard {
             },
             handler: context => {
                 context.target.owner.killCharacter(context.target);
-                this.game.addMessage('{0} plays {1} and kneels {2} to kill {3}', context.player, context.source, context.kneelingCostCard, context.target);
+                this.game.addMessage('{0} plays {1} and kneels {2} to kill {3}', context.player, context.source, context.costs.kneel, context.target);
             }
         });
     }

--- a/server/game/cards/01-Core/OldForestHunter.js
+++ b/server/game/cards/01-Core/OldForestHunter.js
@@ -10,7 +10,7 @@ class OldForestHunter extends DrawCard {
             handler: context => {
                 this.game.addGold(this.controller, 1);
                 this.game.addMessage('{0} uses {1} and discards {2} from their hand to gain 1 gold',
-                    this.controller, this, context.discardCostCard);
+                    this.controller, this, context.costs.discardFromHand);
             }
         });
     }

--- a/server/game/cards/02.1-TtB/VaesDothrak.js
+++ b/server/game/cards/02.1-TtB/VaesDothrak.js
@@ -16,11 +16,11 @@ class VaesDothrak extends DrawCard {
                     cardCondition: card => (
                         card.location === 'play area' &&
                         card.getType() === 'attachment' &&
-                        card.getCost(true) <= context.discardCostCard.getCost(true)),
+                        card.getCost(true) <= context.costs.discardFromHand.getCost(true)),
                     onSelect: (p, card) => {
                         card.controller.discardCard(card);
                         this.game.addMessage('{0} uses {1} and discards {2} from their hand to discard {3} from play',
-                            this.controller, this, context.discardCostCard, card);
+                            this.controller, this, context.costs.discardFromHand, card);
 
                         return true;
                     }

--- a/server/game/cards/02.2-TRtW/WinterfellKennelMaster.js
+++ b/server/game/cards/02.2-TRtW/WinterfellKennelMaster.js
@@ -9,7 +9,7 @@ class WinterfellKennelMaster extends DrawCard {
             condition: () => this.isStarkCardParticipatingInChallenge(),
             cost: ability.costs.kneel(card => this.isDirewolfOrHasAttachment(card) && card.canParticipateInChallenge()),
             handler: context => {
-                var card = context.kneelingCostCard;
+                var card = context.costs.kneel;
                 if(this.game.currentChallenge.attackingPlayer === context.player) {
                     this.game.currentChallenge.addAttacker(card);
                 } else {

--- a/server/game/cards/02.4-NMG/Halder.js
+++ b/server/game/cards/02.4-NMG/Halder.js
@@ -12,7 +12,7 @@ class Halder extends DrawCard {
                 cardCondition: card => card.isFaction('thenightswatch') && card.getType() === 'character'
             },
             handler: (context) => {
-                this.game.addMessage('{0} uses {1} and kneels {2} to give {3} +1 STR until the end of the phase', this.controller, this, context.kneelingCostCard, context.target);
+                this.game.addMessage('{0} uses {1} and kneels {2} to give {3} +1 STR until the end of the phase', this.controller, this, context.costs.kneel, context.target);
 
                 this.untilEndOfPhase(ability => ({
                     match: context.target,

--- a/server/game/cards/02.4-NMG/WardensOfTheNorth.js
+++ b/server/game/cards/02.4-NMG/WardensOfTheNorth.js
@@ -9,7 +9,7 @@ class WardensOfTheNorth extends PlotCard {
             condition: () => this.isStarkCardParticipatingInChallenge(),
             cost: ability.costs.kneel(card => card.getType() === 'character' && card.isFaction('stark') && card.canParticipateInChallenge()),
             handler: context => {
-                let card = context.kneelingCostCard;
+                let card = context.costs.kneel;
                 if(this.game.currentChallenge.attackingPlayer === context.player) {
                     this.game.currentChallenge.addAttacker(card);
                 } else {

--- a/server/game/cards/02.5-COW/Chett.js
+++ b/server/game/cards/02.5-COW/Chett.js
@@ -18,7 +18,7 @@ class Chett extends DrawCard {
             handler: context => {
                 this.controller.moveCard(context.target, 'hand');
                 this.game.addMessage('{0} uses {1} to kneel {2} to return {3} to their hand',
-                    context.player, this, context.kneelingCostCard, context.target);
+                    context.player, this, context.costs.kneel, context.target);
             }
         });
     }

--- a/server/game/cards/03-WotN/HealingExpertise.js
+++ b/server/game/cards/03-WotN/HealingExpertise.js
@@ -15,7 +15,7 @@ class HealingExpertise extends DrawCard {
             handler: context => {
                 context.event.saveCard(context.target);
                 this.game.addMessage('{0} plays {1} to kneel {2} to save {3}',
-                    this.controller, this, context.kneelingCostCard, context.target);
+                    this.controller, this, context.costs.kneel, context.target);
             }
         });
     }

--- a/server/game/cards/03-WotN/HouseTullySepton.js
+++ b/server/game/cards/03-WotN/HouseTullySepton.js
@@ -17,7 +17,7 @@ class HouseTullySepton extends DrawCard {
                 }));
 
                 this.game.addMessage('{0} uses {1} and discards a power from {2} to reduce the cost of the next House Tully or The Seven character they marshal this phase by 2',
-                    context.player, this, context.discardPowerCostCard);
+                    context.player, this, context.costs.discardPower);
             }
         });
     }

--- a/server/game/cards/03-WotN/JonSnow.js
+++ b/server/game/cards/03-WotN/JonSnow.js
@@ -17,7 +17,7 @@ class JonSnow extends DrawCard {
                 gameAction: 'stand'
             },
             handler: context => {
-                this.game.addMessage('{0} uses {1} and sacrifices {2} to stand {3}', this.controller, this, context.sacrificeCostCard, context.target);
+                this.game.addMessage('{0} uses {1} and sacrifices {2} to stand {3}', this.controller, this, context.costs.sacrifice, context.target);
                 context.target.controller.standCard(context.target);
             }
 

--- a/server/game/cards/03-WotN/ThePackSurvives.js
+++ b/server/game/cards/03-WotN/ThePackSurvives.js
@@ -19,7 +19,7 @@ class ThePackSurvives extends DrawCard {
                         this.controller, this, context.sacrificeCostCard, context.event.source);
                 } else {
                     this.game.addMessage('{0} plays {1} and kneels {2} to cancel {3}',
-                        this.controller, this, context.kneelingCostCards, context.event.source);
+                        this.controller, this, context.costs.kneel, context.event.source);
                 }
             }
         });

--- a/server/game/cards/03-WotN/ThePackSurvives.js
+++ b/server/game/cards/03-WotN/ThePackSurvives.js
@@ -14,9 +14,9 @@ class ThePackSurvives extends DrawCard {
             handler: context => {
                 context.event.cancel();
 
-                if(context.sacrificeCostCard) {
+                if(context.costs.sacrifice) {
                     this.game.addMessage('{0} plays {1} and sacrifices {2} to cancel {3}',
-                        this.controller, this, context.sacrificeCostCard, context.event.source);
+                        this.controller, this, context.costs.sacrifice, context.event.source);
                 } else {
                     this.game.addMessage('{0} plays {1} and kneels {2} to cancel {3}',
                         this.controller, this, context.costs.kneel, context.event.source);

--- a/server/game/cards/03-WotN/Tithe.js
+++ b/server/game/cards/03-WotN/Tithe.js
@@ -8,7 +8,7 @@ class Tithe extends DrawCard {
             handler: context => {
                 this.game.addGold(this.controller, 2);
                 this.game.addMessage('{0} uses {1} to kneel {2} to gain 2 gold',
-                    this.controller, this, context.kneelingCostCard);
+                    this.controller, this, context.costs.kneel);
             }
         });
     }

--- a/server/game/cards/03-WotN/TowerOfTheHand.js
+++ b/server/game/cards/03-WotN/TowerOfTheHand.js
@@ -13,10 +13,10 @@ class TowerOfTheHand extends DrawCard {
             target: {
                 activePromptTitle: 'Select a character',
                 cardCondition: (card, context) => card.location === 'play area' && card.getType() === 'character' && card.controller !== this.controller &&
-                                                  (!context.costs.returnedToHandCard || card.getPrintedCost() < context.costs.returnedToHandCard.getPrintedCost())
+                                                  (!context.costs.returnToHand || card.getPrintedCost() < context.costs.returnToHand.getPrintedCost())
             },
             handler: context => {
-                let returnedCostCard = context.costs.returnedToHandCard;
+                let returnedCostCard = context.costs.returnToHand;
                 context.target.owner.returnCardToHand(context.target);
                 this.game.addMessage('{0} kneels {1} and returns {2} to their hand to return {3} to {4}\'s hand',
                     this.controller, this, returnedCostCard, context.target, context.target.owner);

--- a/server/game/cards/04.2-CtA/BalonGreyjoy.js
+++ b/server/game/cards/04.2-CtA/BalonGreyjoy.js
@@ -24,7 +24,7 @@ class BalonGreyjoy extends DrawCard {
                 }));
 
                 this.game.addMessage('{0} uses {1} to kneel {2} and give +1 STR to each loyal character they control until the end of the challenge',
-                    this.controller, this, context.kneelingCostCard);
+                    this.controller, this, context.costs.kneel);
             }
         });
     }

--- a/server/game/cards/04.3-FFH/HotPie.js
+++ b/server/game/cards/04.3-FFH/HotPie.js
@@ -16,7 +16,7 @@ class HotPie extends DrawCard {
                 }));
 
                 this.game.addMessage('{0} uses {1} and kneels {2} to reduce the cost of the next unique character they marshal this phase by 1',
-                    context.player, this, context.kneelingCostCard);
+                    context.player, this, context.costs.kneel);
             }
         });
     }

--- a/server/game/cards/04.3-FFH/crownofgoldenroses.js
+++ b/server/game/cards/04.3-FFH/crownofgoldenroses.js
@@ -20,7 +20,7 @@ class CrownOfGoldenRoses extends DrawCard {
                 }));
 
                 this.game.addMessage('{0} uses {1} and discards {2} from their hand to give +{3} STR to {4} until the end of the phase',
-                    this.controller, this, context.discardCostCard, strBoost, this.parent);
+                    this.controller, this, context.costs.discardFromHand, strBoost, this.parent);
             }
         });
 

--- a/server/game/cards/04.5-GoH/ChatayasBrothel.js
+++ b/server/game/cards/04.5-GoH/ChatayasBrothel.js
@@ -9,7 +9,7 @@ class ChatayasBrothel extends DrawCard {
             cost: ability.costs.kneel(card => card.hasIcon('intrigue')),
             handler: context => {
                 this.game.addGold(context.player, 1);
-                this.game.addMessage('{0} uses {1} and kneels {2} to gain 1 gold', context.player, context.source, context.kneelingCostCard);
+                this.game.addMessage('{0} uses {1} and kneels {2} to gain 1 gold', context.player, context.source, context.costs.kneel);
             }
         });
     }

--- a/server/game/cards/05-LoCR/TaenaMerryweather.js
+++ b/server/game/cards/05-LoCR/TaenaMerryweather.js
@@ -10,7 +10,7 @@ class TaenaMerryweather extends DrawCard {
             handler: context => {
                 this.controller.drawCardsToHand(1);
                 this.game.addMessage('{0} uses {1} and discards {2} from their hand to draw 1 card',
-                    this.controller, this, context.discardCostCard);
+                    this.controller, this, context.costs.discardFromHand);
             }
         });
     }

--- a/server/game/cards/05-LoCR/TyrionLannister.js
+++ b/server/game/cards/05-LoCR/TyrionLannister.js
@@ -12,12 +12,12 @@ class TyrionLannister extends DrawCard {
                 'Draw 2 cards': context => {
                     this.controller.drawCardsToHand(2);
                     this.game.addMessage('{0} uses {1} to return {2} to their hand to draw 2 cards',
-                        this.controller, this, context.costs.returnedToHandCard);
+                        this.controller, this, context.costs.returnToHand);
                 },
                 'Gain 3 gold': context => {
                     this.game.addGold(this.controller, 3);
                     this.game.addMessage('{0} uses {1} to return {2} to their hand to gain 3 gold',
-                        this.controller, this, context.costs.returnedToHandCard);
+                        this.controller, this, context.costs.returnToHand);
                 },
                 'Raise claim by 1': context => {
                     this.untilEndOfChallenge(ability => ({
@@ -25,7 +25,7 @@ class TyrionLannister extends DrawCard {
                         effect: ability.effects.modifyClaim(1)
                     }));
                     this.game.addMessage('{0} uses {1} to return {2} to their hand to raise their claim by 1',
-                        this.controller, this, context.costs.returnedToHandCard);
+                        this.controller, this, context.costs.returnToHand);
                 }
             }
         });

--- a/server/game/cards/06.4-TRW/OthellYarwyck.js
+++ b/server/game/cards/06.4-TRW/OthellYarwyck.js
@@ -18,7 +18,7 @@ class OthellYarwyck extends DrawCard {
                     }));
 
                     this.game.addMessage('{0} uses {1} and kneels {2} to give {3} {4} {5} icon until the end of the phase',
-                        this.controller, this, context.kneelingCostCard, context.target, icon === 'intrigue' ? 'an' : 'a', icon);
+                        this.controller, this, context.costs.kneel, context.target, icon === 'intrigue' ? 'an' : 'a', icon);
                 });
             }
         });

--- a/server/game/cards/06.5-OR/MutinyAtCrastersKeep.js
+++ b/server/game/cards/06.5-OR/MutinyAtCrastersKeep.js
@@ -15,7 +15,7 @@ class MutinyAtCrastersKeep extends DrawCard {
             handler: context => {
                 context.target.owner.discardCard(context.target);
                 this.game.addMessage('{0} plays {1} and sacrifices {2} to discard {3} from play',
-                    context.player, this, context.sacrificeCostCard, context.target);
+                    context.player, this, context.costs.sacrifice, context.target);
             }
         });
     }

--- a/server/game/cards/06.5-OR/TheIronBankWillHaveItsDue.js
+++ b/server/game/cards/06.5-OR/TheIronBankWillHaveItsDue.js
@@ -10,7 +10,7 @@ class TheIronBankWillHaveItsDue extends DrawCard {
                 ability.costs.returnToHand(card => card.getType() === 'character')
             ],
             handler: context => {
-                let returnedCard = context.costs.returnedToHandCard;
+                let returnedCard = context.costs.returnToHand;
                 let gold = returnedCard.getPrintedCost();
                 this.game.addGold(this.controller, gold);
 

--- a/server/game/cards/07-WotW/CastleBlackMason.js
+++ b/server/game/cards/07-WotW/CastleBlackMason.js
@@ -11,8 +11,8 @@ class CastleBlackMason extends DrawCard {
                     numCards: 10,
                     activePromptTitle: 'Select a card',
                     cardType: ['attachment', 'location'],
-                    onSelect: (player, card) => this.cardSelected(player, card, context.kneelingCostCards),
-                    onCancel: player => this.doneSelecting(player, context.kneelingCostCards),
+                    onSelect: (player, card) => this.cardSelected(player, card, context.costs.kneel),
+                    onCancel: player => this.doneSelecting(player, context.costs.kneel),
                     source: this
                 });
             }

--- a/server/game/cards/07-WotW/IShallWinNoGlory.js
+++ b/server/game/cards/07-WotW/IShallWinNoGlory.js
@@ -13,7 +13,7 @@ class IShallWinNoGlory extends DrawCard {
             }),
             handler: (context) => {
                 this.game.addMessage('{0} plays {1} and kneels {2} to end the challenge immediately with no winner or loser',
-                    this.controller, this, context.kneelingCostCards);
+                    this.controller, this, context.costs.kneel);
 
                 this.game.currentChallenge.cancelChallenge();
             }

--- a/server/game/cards/07-WotW/PlazaOfPride.js
+++ b/server/game/cards/07-WotW/PlazaOfPride.js
@@ -17,8 +17,8 @@ class PlazaOfPride extends DrawCard {
                         card.location === 'play area'
                         && card.getType() === 'character'
                         && card.kneeled
-                        && card.getCost() <= context.discardCostCard.getCost() + 3,
-                    onSelect: (player, card) => this.onCardSelected(player, card, context.discardCostCard)
+                        && card.getCost() <= context.costs.discardFromHand.getCost() + 3,
+                    onSelect: (player, card) => this.onCardSelected(player, card, context.costs.discardFromHand)
                 });
             }
         });

--- a/server/game/cards/07-WotW/TheNewGift.js
+++ b/server/game/cards/07-WotW/TheNewGift.js
@@ -9,7 +9,7 @@ class TheNewGift extends DrawCard {
             cost: ability.costs.kneel(card => card.hasTrait('Steward') && card.getType() === 'character'),
             handler: context => {
                 this.game.addGold(context.player, 1);
-                this.game.addMessage('{0} uses {1} and kneels {2} to gain 1 gold', context.player, context.source, context.kneelingCostCard);
+                this.game.addMessage('{0} uses {1} and kneels {2} to gain 1 gold', context.player, context.source, context.costs.kneel);
             }
         });
 
@@ -20,7 +20,7 @@ class TheNewGift extends DrawCard {
             cost: ability.costs.kneel(card => card.hasTrait('Steward') && card.getType() === 'character'),
             handler: context => {
                 this.controller.drawCardsToHand(1);
-                this.game.addMessage('{0} uses {1} and kneels {2} to draw 1 card', context.player, context.source, context.kneelingCostCard);
+                this.game.addMessage('{0} uses {1} and kneels {2} to draw 1 card', context.player, context.source, context.costs.kneel);
             }
         });
     }

--- a/server/game/cards/08.3-Km/SparringInSecret.js
+++ b/server/game/cards/08.3-Km/SparringInSecret.js
@@ -12,7 +12,7 @@ class SparringInSecret extends DrawCard {
             handler: context => {
                 context.target.controller.standCard(context.target);
                 this.game.addMessage('{0} plays {1} and kneels {2} to stand {3}',
-                    context.player, this, context.kneelingCostCard, context.target);
+                    context.player, this, context.costs.kneel, context.target);
             }
         });
     }

--- a/server/game/cards/09-HoT/ArchmaesterEbrose.js
+++ b/server/game/cards/09-HoT/ArchmaesterEbrose.js
@@ -13,7 +13,7 @@ class ArchmaesterEbrose extends DrawCard {
             handler: context => {
                 context.target.controller.standCard(context.target);
                 this.game.addMessage('{0} uses {1} and kneels {2} to stand {3}',
-                    context.player, this, context.kneelingCostCard, context.target);
+                    context.player, this, context.costs.kneel, context.target);
             }
         });
     }

--- a/server/game/cards/09-HoT/QueenOfTheSevenKingdoms.js
+++ b/server/game/cards/09-HoT/QueenOfTheSevenKingdoms.js
@@ -11,7 +11,7 @@ class QueenOfTheSevenKingdoms extends DrawCard {
             condition: () => this.game.currentChallenge,
             cost: [
                 ability.costs.standParent(),
-                ability.costs.removeParentFromChallenge(() => this.game.currentChallenge)
+                ability.costs.removeParentFromChallenge()
             ],
             target: {
                 cardCondition: card => this.game.currentChallenge.isParticipating(card)

--- a/server/game/cards/09-HoT/SerGarlanTyrell.js
+++ b/server/game/cards/09-HoT/SerGarlanTyrell.js
@@ -14,7 +14,7 @@ class SerGarlanTyrell extends DrawCard {
                     effect: ability.effects.modifyClaim(1)
                 }));
                 this.game.addMessage('{0} uses {1} and discards {2} from their hand to raise the claim value on their revealed plot card by 1 until the end of the challenge',
-                    this.controller, this, context.discardCostCard);
+                    this.controller, this, context.costs.discardFromHand);
             }
         });
     }

--- a/server/game/cards/09-HoT/TheQueenOfThorns.js
+++ b/server/game/cards/09-HoT/TheQueenOfThorns.js
@@ -11,7 +11,7 @@ class TheQueenOfThorns extends DrawCard {
                 this.game.promptForDeckSearch(this.controller, {
                     activePromptTitle: 'Select a card',
                     cardCondition: card => card.getType() === 'event',
-                    onSelect: (player, card) => this.cardSelected(player, card, context.discardCostCard),
+                    onSelect: (player, card) => this.cardSelected(player, card, context.costs.discardFromHand),
                     onCancel: player => this.doneSelecting(player),
                     source: this
                 });

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -102,29 +102,11 @@ const Costs = {
      * Cost that will stand the card that initiated the ability (e.g.,
      * Barristan Selmy (TS)).
      */
-    standSelf: function() {
-        return {
-            canPay: function(context) {
-                return context.source.kneeled;
-            },
-            pay: function(context) {
-                context.source.controller.standCard(context.source);
-            }
-        };
-    },
+    standSelf: () => CostBuilders.stand.self(),
     /**
      * Cost that will stand the parent card the current card is attached to.
      */
-    standParent: function() {
-        return {
-            canPay: function(context) {
-                return !!context.source.parent && context.source.parent.kneeled;
-            },
-            pay: function(context) {
-                context.source.parent.controller.standCard(context.source.parent);
-            }
-        };
-    },
+    standParent: () => CostBuilders.stand.parent(),
     /**
      * Cost that will remove the parent card the current card is attached to from the challenge.
      */

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -111,54 +111,11 @@ const Costs = {
      * Cost that requires you return a card matching the condition to the
      * player's hand.
      */
-    returnToHand: function(condition) {
-        var fullCondition = (card, context) => (
-            card.location === 'play area' &&
-            card.controller === context.player &&
-            condition(card)
-        );
-        return {
-            canPay: function(context) {
-                return context.player.anyCardsInPlay(card => fullCondition(card, context));
-            },
-            resolve: function(context, result = { resolved: false }) {
-                context.game.promptForSelect(context.player, {
-                    cardCondition: card => fullCondition(card, context),
-                    activePromptTitle: 'Select card to return to hand',
-                    source: context.source,
-                    onSelect: (player, card) => {
-                        context.costs.returnedToHandCard = card;
-                        result.value = true;
-                        result.resolved = true;
-
-                        return true;
-                    },
-                    onCancel: () => {
-                        result.value = false;
-                        result.resolved = true;
-                    }
-                });
-
-                return result;
-            },
-            pay: function(context) {
-                context.player.returnCardToHand(context.costs.returnedToHandCard, false);
-            }
-        };
-    },
+    returnToHand: condition => CostBuilders.returnToHand.select(condition),
     /**
      * Cost that will return to hand the card that initiated the ability.
      */
-    returnSelfToHand: function() {
-        return {
-            canPay: function() {
-                return true;
-            },
-            pay: function(context) {
-                context.source.controller.returnCardToHand(context.source, false);
-            }
-        };
-    },
+    returnSelfToHand: () => CostBuilders.returnToHand.self(),
     /**
      * Cost that reveals a specific card passed into the function
      */

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -75,16 +75,7 @@ const Costs = {
     /**
      * Cost that will put into play the card that initiated the ability.
      */
-    putSelfIntoPlay: function() {
-        return {
-            canPay: function(context) {
-                return context.source.controller.canPutIntoPlay(context.source);
-            },
-            pay: function(context) {
-                context.source.controller.putIntoPlay(context.source);
-            }
-        };
-    },
+    putSelfIntoPlay: () => CostBuilders.putIntoPlay.self(),
     /**
      * Cost that will remove from game the card that initiated the ability.
      */

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -277,41 +277,7 @@ const Costs = {
      * Cost that requires discarding a card from hand matching the passed
      * condition predicate function.
      */
-    discardFromHand: function(condition = () => true) {
-        var fullCondition = (card, context) => (
-            card.location === 'hand' &&
-            card.controller === context.player &&
-            condition(card)
-        );
-        return {
-            canPay: function(context) {
-                return context.game.allCards.any(card => fullCondition(card, context));
-            },
-            resolve: function(context, result = { resolved: false }) {
-                context.game.promptForSelect(context.player, {
-                    cardCondition: card => fullCondition(card, context),
-                    activePromptTitle: 'Select card to discard',
-                    source: context.source,
-                    onSelect: (player, card) => {
-                        context.discardCostCard = card;
-                        result.value = true;
-                        result.resolved = true;
-
-                        return true;
-                    },
-                    onCancel: () => {
-                        result.value = false;
-                        result.resolved = true;
-                    }
-                });
-
-                return result;
-            },
-            pay: function(context) {
-                context.player.discardCard(context.discardCostCard);
-            }
-        };
-    },
+    discardFromHand: condition => CostBuilders.discardFromHand.select(condition),
     /**
      * Cost that will pay the reduceable gold cost associated with an event card
      * and place it in discard.

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -92,59 +92,12 @@ const Costs = {
     /**
      * Cost that reveals a specific card passed into the function
      */
-    revealSpecific: function(cardFunc) {
-        return {
-            canPay: function() {
-                return true;
-            },
-            pay: function(context) {
-                let card = cardFunc(context);
-                context.game.addMessage('{0} reveals {1} from their hand', context.player, card);
-            }
-        };
-    },
+    revealSpecific: cardFunc => CostBuilders.reveal.specific(cardFunc),
     /**
      * Cost that requires revealing a certain number of cards in hand that match
      * the passed condition predicate function.
      */
-    revealCards: function(number, condition) {
-        var fullCondition = (card, context) => (
-            card.location === 'hand' &&
-            card.controller === context.player &&
-            condition(card)
-        );
-        return {
-            canPay: function(context) {
-                let potentialCards = context.player.findCards(context.player.hand, card => fullCondition(card, context));
-                return _.size(potentialCards) >= number;
-            },
-            resolve: function(context, result = { resolved: false }) {
-                context.game.promptForSelect(context.player, {
-                    cardCondition: card => fullCondition(card, context),
-                    activePromptTitle: 'Select ' + number + ' cards to reveal',
-                    mode: 'exactly',
-                    numCards: number,
-                    source: context.source,
-                    onSelect: (player, cards) => {
-                        context.revealingCostCards = cards;
-                        result.value = true;
-                        result.resolved = true;
-
-                        return true;
-                    },
-                    onCancel: () => {
-                        result.value = false;
-                        result.resolved = true;
-                    }
-                });
-
-                return result;
-            },
-            pay: function(context) {
-                context.game.addMessage('{0} reveals {1} from their hand', context.player, context.revealingCostCards);
-            }
-        };
-    },
+    revealCards: (number, condition) => CostBuilders.reveal.selectMultiple(number, condition),
     /**
      * Cost that will stand the card that initiated the ability (e.g.,
      * Barristan Selmy (TS)).

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -79,16 +79,7 @@ const Costs = {
     /**
      * Cost that will remove from game the card that initiated the ability.
      */
-    removeSelfFromGame: function() {
-        return {
-            canPay: function() {
-                return true;
-            },
-            pay: function(context) {
-                context.source.controller.moveCard(context.source, 'out of game');
-            }
-        };
-    },
+    removeSelfFromGame: () => CostBuilders.removeFromGame.self(),
     /**
      * Cost that requires you return a card matching the condition to the
      * player's hand.

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -62,55 +62,12 @@ const Costs = {
     /**
      * Cost that will sacrifice the card that initiated the ability.
      */
-    sacrificeSelf: function() {
-        return {
-            canPay: function() {
-                return true;
-            },
-            pay: function(context) {
-                context.source.controller.sacrificeCard(context.source);
-            }
-        };
-    },
+    sacrificeSelf: () => CostBuilders.sacrifice.self(),
     /**
      * Cost that requires sacrificing a card that matches the passed condition
      * predicate function.
      */
-    sacrifice: function(condition) {
-        var fullCondition = (card, context) => (
-            card.location === 'play area' &&
-            card.controller === context.player &&
-            condition(card)
-        );
-        return {
-            canPay: function(context) {
-                return context.player.anyCardsInPlay(card => fullCondition(card, context));
-            },
-            resolve: function(context, result = { resolved: false }) {
-                context.game.promptForSelect(context.player, {
-                    cardCondition: card => fullCondition(card, context),
-                    activePromptTitle: 'Select card to sacrifice',
-                    source: context.source,
-                    onSelect: (player, card) => {
-                        context.sacrificeCostCard = card;
-                        result.value = true;
-                        result.resolved = true;
-
-                        return true;
-                    },
-                    onCancel: () => {
-                        result.value = false;
-                        result.resolved = true;
-                    }
-                });
-
-                return result;
-            },
-            pay: function(context) {
-                context.player.sacrificeCard(context.sacrificeCostCard);
-            }
-        };
-    },
+    sacrifice: condition => CostBuilders.sacrifice.select(condition),
     /**
      * Cost that will kill the card that initiated the ability.
      */

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -202,21 +202,7 @@ const Costs = {
     /**
      * Cost that will remove the parent card the current card is attached to from the challenge.
      */
-    removeParentFromChallenge: function(challengeFunc) {
-        return {
-            canPay: function(context) {
-                let challenge = challengeFunc();
-                return !!context.source.parent && challenge && challenge.isParticipating(context.source.parent);
-            },
-            pay: function(context) {
-                let challenge = challengeFunc();
-
-                if(challenge) {
-                    challenge.removeFromChallenge(context.source.parent);
-                }
-            }
-        };
-    },
+    removeParentFromChallenge: () => CostBuilders.removeFromChallenge.parent(),
     /**
      * Cost that will place the played event card in the player's discard pile.
      */

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -294,95 +294,24 @@ const Costs = {
      * Cost that will discard a gold from the card. Used mainly by cards
      * having the bestow keyword.
      */
-    discardGold: function() {
-        return {
-            canPay: function(context) {
-                return context.source.hasToken('gold');
-            },
-            pay: function(context) {
-                context.source.removeToken('gold', 1);
-            }
-        };
-    },
+    discardGold: amount => CostBuilders.discardToken('gold', amount).self(),
     /**
      * Cost that will discard a fixed amount of power from the current card.
      */
-    discardPowerFromSelf: function(amount = 1) {
-        return {
-            canPay: function(context) {
-                return context.source.power >= amount;
-            },
-            pay: function(context) {
-                context.source.modifyPower(-amount);
-            }
-        };
-    },
+    discardPowerFromSelf: amount => CostBuilders.discardPower(amount).self(),
     /**
      * Cost that will discard a fixed amount of a passed type token from the current card.
      */
-    discardTokenFromSelf: function(type, amount = 1) {
-        return {
-            canPay: function(context) {
-                return context.source.tokens[type] >= amount;
-            },
-            pay: function(context) {
-                context.source.removeToken(type, amount);
-            }
-        };
-    },
+    discardTokenFromSelf: (type, amount) => CostBuilders.discardToken(type, amount).self(),
     /**
      * Cost that will discard faction power matching the passed amount.
      */
-    discardFactionPower: function(amount) {
-        return {
-            canPay: function(context) {
-                return context.player.faction.power >= amount;
-            },
-            pay: function(context) {
-                context.source.game.addPower(context.player, -amount);
-            }
-        };
-    },
+    discardFactionPower: amount => CostBuilders.discardPower(amount).faction(),
     /**
      * Cost that requires discarding a power from a card that matches the passed condition
      * predicate function.
      */
-    discardPower: function(amount, condition) {
-        var fullCondition = (card, context) => (
-            card.getPower() >= amount &&
-            card.location === 'play area' &&
-            card.controller === context.player &&
-            condition(card)
-        );
-        return {
-            canPay: function(context) {
-                return context.player.anyCardsInPlay(card => fullCondition(card, context));
-            },
-            resolve: function(context, result = { resolved: false }) {
-                context.game.promptForSelect(context.player, {
-                    cardCondition: card => fullCondition(card, context),
-                    activePromptTitle: 'Select card to discard ' + amount + ' power from',
-                    source: context.source,
-                    onSelect: (player, card) => {
-                        context.discardPowerCostCard = card;
-                        result.value = true;
-                        result.resolved = true;
-
-                        return true;
-                    },
-                    onCancel: () => {
-                        result.value = false;
-                        result.resolved = true;
-                    }
-                });
-
-                return result;
-            },
-            pay: function(context) {
-                context.discardPowerCostCard.modifyPower(-amount);
-            }
-        };
-    },
+    discardPower: (amount, condition) => CostBuilders.discardPower(amount).select(condition),
     /**
      * Cost that ensures that the player can still play a Limited card this
      * round.

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -71,16 +71,7 @@ const Costs = {
     /**
      * Cost that will kill the card that initiated the ability.
      */
-    killSelf: function() {
-        return {
-            canPay: function(context) {
-                return context.source.canBeKilled();
-            },
-            pay: function(context) {
-                context.game.killCharacter(context.source, { allowSave: false });
-            }
-        };
-    },
+    killSelf: () => CostBuilders.kill.self(),
     /**
      * Cost that will put into play the card that initiated the ability.
      */

--- a/server/game/costs/CostBuilder.js
+++ b/server/game/costs/CostBuilder.js
@@ -1,0 +1,68 @@
+const FactionCardCost = require('./FactionCardCost.js');
+const ParentCost = require('./ParentCost.js');
+const SelectCardCost = require('./SelectCardCost.js');
+const SelfCost = require('./SelfCost.js');
+const SpecificCardCost = require('./SpecificCardCost.js');
+
+class CostBuilder {
+    constructor(action, titles = {}) {
+        this.action = action;
+        this.titles = titles;
+    }
+
+    /**
+     * Returns a cost that is applied to the player's faction card.
+     */
+    faction() {
+        return new FactionCardCost(this.action);
+    }
+
+    /**
+     * Returns a cost that is applied to the card that activated the ability.
+     */
+    self() {
+        return new SelfCost(this.action);
+    }
+
+    /**
+     * Returns a cost that is applied to the card returned by the cardFunc param.
+     * @param {function} cardFunc Function that takes the ability context and return a card.
+     */
+    specific(cardFunc) {
+        return new SpecificCardCost(this.action, cardFunc);
+    }
+
+    /**
+     * Returns a cost that asks the player to select a card matching the passed condition.
+     * @param {function} condition Function that takes a card and ability context and returns whether to allow the player to select it.
+     */
+    select(condition = () => true) {
+        return new SelectCardCost(this.action, {
+            activePromptTitle: this.titles.select,
+            cardCondition: condition
+        });
+    }
+
+    /**
+     * Returns a cost that asks the player to select an exact number of cards matching the passed condition.
+     * @param {number} number The number of cards that must be selected.
+     * @param {function} condition Function that takes a card and ability context and returns whether to allow the player to select it.
+     */
+    selectMultiple(number, condition = () => true) {
+        return new SelectCardCost(this.action, {
+            mode: 'exactly',
+            numCards: number,
+            activePromptTitle: this.titles.selectMultiple(number),
+            cardCondition: condition
+        });
+    }
+
+    /**
+     * Returns a cost that is applied to the parent card that the activating card is attached to.
+     */
+    parent() {
+        return new ParentCost(this.action);
+    }
+}
+
+module.exports = CostBuilder;

--- a/server/game/costs/CostBuilders.js
+++ b/server/game/costs/CostBuilders.js
@@ -1,0 +1,70 @@
+const CostBuilder = require('./CostBuilder.js');
+const DiscardFromHandCost = require('./DiscardFromHandCost.js');
+const DiscardPowerCost = require('./DiscardPowerCost.js');
+const DiscardTokenCost = require('./DiscardTokenCost.js');
+const KillCost = require('./KillCost.js');
+const KneelCost = require('./KneelCost.js');
+const PutIntoPlayCost = require('./PutIntoPlayCost.js');
+const RemoveFromChallengeCost = require('./RemoveFromChallengeCost.js');
+const RemoveFromGameCost = require('./RemoveFromGameCost.js');
+const ReturnToHandCost = require('./ReturnToHandCost.js');
+const RevealCost = require('./RevealCost.js');
+const SacrificeCost = require('./SacrificeCost.js');
+const StandCost = require('./StandCost.js');
+
+const CostBuilders = {
+    discardFromHand: new CostBuilder(new DiscardFromHandCost(), {
+        select: 'Select card to discard from hand',
+        selectMultiple: number => `Select ${number} cards to discard from hand`
+    }),
+    discardPower: function(amount = 1) {
+        return new CostBuilder(new DiscardPowerCost(amount), {
+            select: `Select card to discard ${amount} power`,
+            selectMultiple: number => `Select ${number} cards to discard ${amount} power`
+        });
+    },
+    discardToken: function(token, amount = 1) {
+        return new CostBuilder(new DiscardTokenCost(token, amount), {
+            select: `Select card to discard ${amount} ${token}`,
+            selectMultiple: number => `Select ${number} cards to discard ${amount} ${token}`
+        });
+    },
+    kill: new CostBuilder(new KillCost(), {
+        select: 'Select card to kill',
+        selectMultiple: number => `Select ${number} cards to kill`
+    }),
+    kneel: new CostBuilder(new KneelCost(), {
+        select: 'Select card to kneel',
+        selectMultiple: number => `Select ${number} cards to kneel`
+    }),
+    putIntoPlay: new CostBuilder(new PutIntoPlayCost(), {
+        select: 'Select card to put into play',
+        selectMultiple: number => `Select ${number} cards to put into play`
+    }),
+    removeFromChallenge: new CostBuilder(new RemoveFromChallengeCost(), {
+        select: 'Select card to remove from challenge',
+        selectMultiple: number => `Select ${number} cards to remove from challenge`
+    }),
+    removeFromGame: new CostBuilder(new RemoveFromGameCost(), {
+        select: 'Select card to remove from game',
+        selectMultiple: number => `Select ${number} cards to remove from game`
+    }),
+    returnToHand: new CostBuilder(new ReturnToHandCost(), {
+        select: 'Select card to return to hand',
+        selectMultiple: number => `Select ${number} cards to return to hand`
+    }),
+    reveal: new CostBuilder(new RevealCost(), {
+        select: 'Select card to reveal',
+        selectMultiple: number => `Select ${number} cards to reveal`
+    }),
+    sacrifice: new CostBuilder(new SacrificeCost(), {
+        select: 'Select card to sacrifice',
+        selectMultiple: number => `Select ${number} cards to sacrifice`
+    }),
+    stand: new CostBuilder(new StandCost(), {
+        select: 'Select card to stand',
+        selectMultiple: number => `Select ${number} cards to stand`
+    })
+};
+
+module.exports = CostBuilders;

--- a/server/game/costs/DiscardFromHandCost.js
+++ b/server/game/costs/DiscardFromHandCost.js
@@ -1,0 +1,15 @@
+class DiscardFromHandCost {
+    constructor() {
+        this.name = 'discardFromHand';
+    }
+
+    isEligible(card) {
+        return card.location === 'hand';
+    }
+
+    pay(cards, context) {
+        context.player.discardCards(cards, false);
+    }
+}
+
+module.exports = DiscardFromHandCost;

--- a/server/game/costs/DiscardPowerCost.js
+++ b/server/game/costs/DiscardPowerCost.js
@@ -1,0 +1,18 @@
+class DiscardPowerCost {
+    constructor(amount) {
+        this.name = 'discardPower';
+        this.amount = amount;
+    }
+
+    isEligible(card) {
+        return ['faction', 'play area'].includes(card.location) && card.getPower() >= this.amount;
+    }
+
+    pay(cards) {
+        for(let card of cards) {
+            card.modifyPower(-this.amount);
+        }
+    }
+}
+
+module.exports = DiscardPowerCost;

--- a/server/game/costs/DiscardTokenCost.js
+++ b/server/game/costs/DiscardTokenCost.js
@@ -1,0 +1,19 @@
+class DiscardTokenCost {
+    constructor(token, amount) {
+        this.name = 'discardToken';
+        this.token = token;
+        this.amount = amount;
+    }
+
+    isEligible(card) {
+        return card.tokens[this.token] >= this.amount;
+    }
+
+    pay(cards) {
+        for(let card of cards) {
+            card.removeToken(this.token, this.amount);
+        }
+    }
+}
+
+module.exports = DiscardTokenCost;

--- a/server/game/costs/FactionCardCost.js
+++ b/server/game/costs/FactionCardCost.js
@@ -1,0 +1,23 @@
+class FactionCardCost {
+    constructor(action) {
+        this.action = action;
+    }
+
+    canPay(context) {
+        return this.action.isEligible(context.player.faction, context);
+    }
+
+    resolve(context, result = { resolved: false }) {
+        context.costs[this.action.name] = context.player.faction;
+
+        result.resolved = true;
+        result.value = context.player.faction;
+        return result;
+    }
+
+    pay(context) {
+        this.action.pay([context.costs[this.action.name]], context);
+    }
+}
+
+module.exports = FactionCardCost;

--- a/server/game/costs/KillCost.js
+++ b/server/game/costs/KillCost.js
@@ -1,0 +1,15 @@
+class KillCost {
+    constructor() {
+        this.name = 'kill';
+    }
+
+    isEligible(card) {
+        return card.canBeKilled();
+    }
+
+    pay(cards, context) {
+        context.game.killCharacters(cards, { allowSave: false });
+    }
+}
+
+module.exports = KillCost;

--- a/server/game/costs/KneelCost.js
+++ b/server/game/costs/KneelCost.js
@@ -1,0 +1,17 @@
+class KneelCost {
+    constructor() {
+        this.name = 'kneel';
+    }
+
+    isEligible(card) {
+        return ['faction', 'play area'].includes(card.location) && !card.kneeled;
+    }
+
+    pay(cards, context) {
+        for(let card of cards) {
+            context.player.kneelCard(card);
+        }
+    }
+}
+
+module.exports = KneelCost;

--- a/server/game/costs/ParentCost.js
+++ b/server/game/costs/ParentCost.js
@@ -1,0 +1,23 @@
+class ParentCost {
+    constructor(action) {
+        this.action = action;
+    }
+
+    canPay(context) {
+        return !!context.source.parent && this.action.isEligible(context.source.parent, context);
+    }
+
+    resolve(context, result = { resolved: false }) {
+        context.costs[this.action.name] = context.source.parent;
+
+        result.resolved = true;
+        result.value = context.source.parent;
+        return result;
+    }
+
+    pay(context) {
+        this.action.pay([context.costs[this.action.name]], context);
+    }
+}
+
+module.exports = ParentCost;

--- a/server/game/costs/PutIntoPlayCost.js
+++ b/server/game/costs/PutIntoPlayCost.js
@@ -1,0 +1,17 @@
+class PutIntoPlayCost {
+    constructor() {
+        this.name = 'putIntoPlay';
+    }
+
+    isEligible(card, context) {
+        return card.location !== 'play area' && context.player.canPutIntoPlay(card);
+    }
+
+    pay(cards, context) {
+        for(let card of cards) {
+            context.player.putIntoPlay(card);
+        }
+    }
+}
+
+module.exports = PutIntoPlayCost;

--- a/server/game/costs/RemoveFromChallengeCost.js
+++ b/server/game/costs/RemoveFromChallengeCost.js
@@ -1,0 +1,19 @@
+class RemoveFromChallengeCost {
+    constructor() {
+        this.name = 'removeFromChallenge';
+    }
+
+    isEligible(card, context) {
+        let challenge = context.game.currentChallenge;
+        return !!challenge && challenge.isParticipating(card);
+    }
+
+    pay(cards, context) {
+        let challenge = context.game.currentChallenge;
+        for(let card of cards) {
+            challenge.removeFromChallenge(card);
+        }
+    }
+}
+
+module.exports = RemoveFromChallengeCost;

--- a/server/game/costs/RemoveFromGameCost.js
+++ b/server/game/costs/RemoveFromGameCost.js
@@ -1,0 +1,17 @@
+class RemoveFromGameCost {
+    constructor() {
+        this.name = 'removeFromGame';
+    }
+
+    isEligible(card) {
+        return card.location !== 'out of game';
+    }
+
+    pay(cards) {
+        for(let card of cards) {
+            card.owner.moveCard(card, 'out of game');
+        }
+    }
+}
+
+module.exports = RemoveFromGameCost;

--- a/server/game/costs/ReturnToHandCost.js
+++ b/server/game/costs/ReturnToHandCost.js
@@ -1,0 +1,17 @@
+class ReturnToHandCost {
+    constructor() {
+        this.name = 'returnToHand';
+    }
+
+    isEligible(card) {
+        return card.location === 'play area';
+    }
+
+    pay(cards, context) {
+        for(let card of cards) {
+            context.player.returnCardToHand(card, false);
+        }
+    }
+}
+
+module.exports = ReturnToHandCost;

--- a/server/game/costs/RevealCost.js
+++ b/server/game/costs/RevealCost.js
@@ -1,0 +1,15 @@
+class RevealCost {
+    constructor() {
+        this.name = 'reveal';
+    }
+
+    isEligible(card) {
+        return card.location === 'hand';
+    }
+
+    pay(cards, context) {
+        context.game.addMessage('{0} reveals {1} from their hand', context.player, cards);
+    }
+}
+
+module.exports = RevealCost;

--- a/server/game/costs/SacrificeCost.js
+++ b/server/game/costs/SacrificeCost.js
@@ -1,0 +1,17 @@
+class SacrificeCost {
+    constructor() {
+        this.name = 'sacrifice';
+    }
+
+    isEligible(card) {
+        return card.location === 'play area';
+    }
+
+    pay(cards, context) {
+        for(let card of cards) {
+            context.player.sacrificeCard(card);
+        }
+    }
+}
+
+module.exports = SacrificeCost;

--- a/server/game/costs/SelectCardCost.js
+++ b/server/game/costs/SelectCardCost.js
@@ -1,0 +1,53 @@
+const CardSelector = require('../CardSelector.js');
+
+class SelectCardCost {
+    constructor(action, promptProperties) {
+        this.action = action;
+        this.selector = this.createSelector(action, promptProperties);
+        this.activePromptTitle = promptProperties.activePromptTitle;
+    }
+
+    createSelector(action, properties) {
+        let condition = (card, context) => {
+            return card.controller === context.player && action.isEligible(card, context) && properties.cardCondition(card, context);
+        };
+
+        let fullProperties = Object.assign({ }, properties, { cardCondition: condition });
+
+        return CardSelector.for(fullProperties);
+    }
+
+    canPay(context) {
+        return this.selector.hasEnoughTargets(context);
+    }
+
+    resolve(context, result = { resolved: false }) {
+        context.game.promptForSelect(context.player, {
+            activePromptTitle: this.activePromptTitle,
+            context: context,
+            selector: this.selector,
+            source: context.source,
+            onSelect: (player, cards) => {
+                context.costs[this.action.name] = cards;
+                result.value = true;
+                result.resolved = true;
+
+                return true;
+            },
+            onCancel: () => {
+                result.value = false;
+                result.resolved = true;
+            }
+        });
+
+        return result;
+    }
+
+    pay(context) {
+        let selected = context.costs[this.action.name];
+        let selectedAsArray = Array.isArray(selected) ? selected : [selected];
+        this.action.pay(selectedAsArray, context);
+    }
+}
+
+module.exports = SelectCardCost;

--- a/server/game/costs/SelfCost.js
+++ b/server/game/costs/SelfCost.js
@@ -1,0 +1,32 @@
+class SelfCost {
+    constructor(action, unpayAction) {
+        this.action = action;
+        this.unpayAction = unpayAction;
+    }
+
+    canPay(context) {
+        return this.action.isEligible(context.source, context);
+    }
+
+    resolve(context, result = { resolved: false }) {
+        context.costs[this.action.name] = context.source;
+
+        result.resolved = true;
+        result.value = context.source;
+        return result;
+    }
+
+    pay(context) {
+        this.action.pay([context.costs[this.action.name]], context);
+    }
+
+    canUnpay(context) {
+        return !!this.unpayAction && this.unpayAction.isEligible(context.source, context);
+    }
+
+    unpay(context) {
+        this.unpayAction.pay([context.source], context);
+    }
+}
+
+module.exports = SelfCost;

--- a/server/game/costs/SpecificCardCost.js
+++ b/server/game/costs/SpecificCardCost.js
@@ -1,0 +1,25 @@
+class SpecificCardCost {
+    constructor(action, cardFunc) {
+        this.action = action;
+        this.cardFunc = cardFunc;
+    }
+
+    canPay(context) {
+        return this.action.isEligible(this.cardFunc(), context);
+    }
+
+    resolve(context, result = { resolved: false }) {
+        let card = this.cardFunc();
+        context.costs[this.action.name] = card;
+
+        result.resolved = true;
+        result.value = card;
+        return result;
+    }
+
+    pay(context) {
+        this.action.pay([context.costs[this.action.name]], context);
+    }
+}
+
+module.exports = SpecificCardCost;

--- a/server/game/costs/StandCost.js
+++ b/server/game/costs/StandCost.js
@@ -1,0 +1,17 @@
+class StandCost {
+    constructor() {
+        this.name = 'stand';
+    }
+
+    isEligible(card) {
+        return card.location === 'play area' && card.kneeled;
+    }
+
+    pay(cards, context) {
+        for(let card of cards) {
+            context.player.standCard(card);
+        }
+    }
+}
+
+module.exports = StandCost;

--- a/server/game/gamesteps/abilityresolver.js
+++ b/server/game/gamesteps/abilityresolver.js
@@ -2,7 +2,6 @@ const _ = require('underscore');
 
 const BaseStep = require('./basestep.js');
 const GamePipeline = require('../gamepipeline.js');
-const ResolvedTargets = require('./ResolvedTargets.js');
 const SimpleStep = require('./simplestep.js');
 
 class AbilityResolver extends BaseStep {
@@ -80,7 +79,6 @@ class AbilityResolver extends BaseStep {
     }
 
     resolveCosts() {
-        this.context.costs = {};
         this.canPayResults = this.ability.resolveCosts(this.context);
     }
 
@@ -122,7 +120,6 @@ class AbilityResolver extends BaseStep {
             return;
         }
 
-        this.context.targets = new ResolvedTargets();
         this.targetResults = this.ability.resolveTargets(this.context);
     }
 

--- a/server/game/gamesteps/keywordwindow.js
+++ b/server/game/gamesteps/keywordwindow.js
@@ -1,5 +1,6 @@
 const _ = require('underscore');
 
+const AbilityContext = require('../AbilityContext.js');
 const BaseStep = require('./basestep.js');
 const GameKeywords = require('../gamekeywords.js');
 
@@ -10,7 +11,7 @@ class KeywordWindow extends BaseStep {
         super(game);
         this.challenge = challenge;
         this.winnerCardsWithContext = _.map(challenge.getWinnerCards(), card => {
-            return { card: card, context: { game: this.game, challenge: this.challenge, source: card } };
+            return { card: card, context: new AbilityContext({ game: this.game, challenge: this.challenge, source: card }) };
         });
         this.firstPlayer = game.getFirstPlayer();
         this.remainingKeywords = challengeKeywords;

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -3,6 +3,7 @@ const _ = require('underscore');
 const Spectator = require('./spectator.js');
 const DrawCard = require('./drawcard.js');
 const Deck = require('./deck.js');
+const AbilityContext = require('./AbilityContext.js');
 const AttachmentPrompt = require('./gamesteps/attachmentprompt.js');
 const BestowPrompt = require('./gamesteps/bestowprompt.js');
 const ChallengeTracker = require('./challengetracker.js');
@@ -455,11 +456,11 @@ class Player extends Spectator {
             return false;
         }
 
-        var context = {
+        let context = new AbilityContext({
             game: this.game,
             player: this,
             source: card
-        };
+        });
         var playActions = _.filter(card.getPlayActions(), action => action.meetsRequirements(context) && action.canPayCosts(context) && action.canResolveTargets(context));
 
         if(playActions.length === 0) {

--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -2,24 +2,7 @@ const _ = require('underscore');
 
 const BaseAbility = require('./baseability.js');
 const Costs = require('./costs.js');
-
-class TriggeredAbilityContext {
-    constructor(event, game, source, player) {
-        this.event = event;
-        this.game = game;
-        this.source = source;
-        this.player = player;
-        this.costs = {};
-    }
-
-    cancel() {
-        this.event.cancel();
-    }
-
-    replaceHandler(handler) {
-        this.event.replaceHandler(handler);
-    }
-}
+const TriggeredAbilityContext = require('./TriggeredAbilityContext.js');
 
 class TriggeredAbility extends BaseAbility {
     constructor(game, card, eventType, properties) {
@@ -57,7 +40,7 @@ class TriggeredAbility extends BaseAbility {
     }
 
     createContext(event) {
-        return new TriggeredAbilityContext(event, this.game, this.card, this.playerFunc());
+        return new TriggeredAbilityContext({ event: event, game: this.game, source: this.card, player: this.playerFunc() });
     }
 
     isTriggeredByEvent(event) {

--- a/test/server/gamesteps/abilityresolver.spec.js
+++ b/test/server/gamesteps/abilityresolver.spec.js
@@ -15,7 +15,10 @@ describe('AbilityResolver', function() {
         this.ability.isCardAbility.and.returnValue(true);
         this.source = jasmine.createSpyObj('source', ['createSnapshot', 'getType']);
         this.player = { player: 1 };
-        this.context = { foo: 'bar', player: this.player, source: this.source };
+        let targets = jasmine.createSpyObj('targets', ['getTargets', 'hasTargets', 'setSelections', 'updateTargets']);
+        targets.hasTargets.and.returnValue(true);
+        targets.getTargets.and.returnValue([]);
+        this.context = { foo: 'bar', player: this.player, source: this.source, targets: targets };
         this.resolver = new AbilityResolver(this.game, this.ability, this.context);
     });
 
@@ -184,11 +187,12 @@ describe('AbilityResolver', function() {
                     describe('and the target name is arbitrary', function() {
                         beforeEach(function() {
                             this.targetResult.name = 'foo';
+                            this.context.targets.getTargets.and.returnValue([this.target]);
                             this.resolver.continue();
                         });
 
-                        it('should add the target to context.targets', function() {
-                            expect(this.context.targets.foo).toBe(this.target);
+                        it('should set target selections', function() {
+                            expect(this.context.targets.setSelections).toHaveBeenCalledWith([jasmine.objectContaining({ name: 'foo', value: this.target })]);
                         });
 
                         it('should not add the target directly to context', function() {
@@ -207,11 +211,12 @@ describe('AbilityResolver', function() {
                     describe('and the target name is "target"', function() {
                         beforeEach(function() {
                             this.targetResult.name = 'target';
+                            this.context.targets.defaultTarget = this.target;
                             this.resolver.continue();
                         });
 
-                        it('should add the target to context.targets', function() {
-                            expect(this.context.targets.target).toBe(this.target);
+                        it('should set target selections', function() {
+                            expect(this.context.targets.setSelections).toHaveBeenCalledWith([jasmine.objectContaining({ value: this.target })]);
                         });
 
                         it('should add the target directly to context', function() {

--- a/test/server/player/playcard.spec.js
+++ b/test/server/player/playcard.spec.js
@@ -48,7 +48,7 @@ describe('Player', function() {
 
                 it('should resolve the play action', function() {
                     this.player.playCard(this.cardSpy);
-                    expect(this.gameSpy.resolveAbility).toHaveBeenCalledWith(this.playActionSpy, { game: this.gameSpy, player: this.player, source: this.cardSpy });
+                    expect(this.gameSpy.resolveAbility).toHaveBeenCalledWith(this.playActionSpy, jasmine.objectContaining({ game: this.gameSpy, player: this.player, source: this.cardSpy }));
                 });
 
                 it('should return true', function() {


### PR DESCRIPTION
* Separates logic for what costs do (e.g. kneel, sacrifice, etc) from which card it is applied to (e.g. self, selected by player, etc).
* The applied card now is always stored even if the player didn't explicitly select the card.
* Accessing the applied card is now always done via `context.costs.gameAction`. For example, the card that got kneeled for cost is stored at `context.costs.kneel`.
* Adds a cost builder class to make it easy to expose different card selections for the same cost action.