### PR TITLE
Fix Mace Tyrell's remove from game ability

### DIFF
--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -103,7 +103,7 @@ class EffectEngine {
     removeTargetFromEffects(card, location) {
         let area = location === 'hand' ? 'hand' : 'play area';
         _.each(this.effects, effect => {
-            if(effect.targetLocation === area && effect.location !== 'any' || location === 'play area' && effect.duration !== 'persistent') {
+            if(effect.targetLocation === area && effect.location !== 'any' || location === 'play area' && !['custom', 'persistent'].includes(effect.duration)) {
                 effect.removeTarget(card);
             }
         });

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -562,7 +562,7 @@ const Effects = {
                 card.owner.moveCard(card, 'out of game');
             },
             unapply: function(card, context) {
-                card.owner.putIntoPlay(card);
+                card.owner.putIntoPlay(card, 'play', { isEffectExpiration: true });
                 context.game.addMessage('{0} is put into play because of {1}', card, context.source);
             }
         };

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -479,8 +479,8 @@ class Player extends Spectator {
         return !_.any(this.playCardRestrictions, restriction => restriction(card, playingType));
     }
 
-    canPutIntoPlay(card, playingType = 'play') {
-        if(!this.canPlay(card, playingType)) {
+    canPutIntoPlay(card, playingType = 'play', options = {}) {
+        if(!options.isEffectExpiration && !this.canPlay(card, playingType)) {
             return false;
         }
 
@@ -521,8 +521,8 @@ class Player extends Spectator {
         return this.deadPile.includes(card) && (!card.isUnique() || this.deadPile.filter(c => c.name === card.name).length === 1);
     }
 
-    putIntoPlay(card, playingType = 'play') {
-        if(!this.canPutIntoPlay(card, playingType)) {
+    putIntoPlay(card, playingType = 'play', options = {}) {
+        if(!this.canPutIntoPlay(card, playingType, options)) {
             return;
         }
 

--- a/test/server/cards/09-HoT/MaceTyrell.spec.js
+++ b/test/server/cards/09-HoT/MaceTyrell.spec.js
@@ -1,0 +1,104 @@
+describe('Mace Tyrell', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck1 = this.buildDeck('tyrell', [
+                'A Noble Cause',
+                'Mace Tyrell', 'Left', 'Left'
+            ]);
+            const deck2 = this.buildDeck('stark', [
+                'A Noble Cause', 'Barring the Gates'
+            ]);
+
+            this.player1.selectDeck(deck1);
+            this.player2.selectDeck(deck2);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.mace = this.player1.findCardByName('Mace Tyrell', 'hand');
+            [this.character, this.characterCopy] = this.player1.filterCardsByName('Left', 'hand');
+
+            this.player1.clickCard(this.mace);
+
+            this.completeSetup();
+        });
+
+        describe('when removing a character from the game', function() {
+            beforeEach(function() {
+                this.player1.selectPlot('A Noble Cause');
+                this.player2.selectPlot('A Noble Cause');
+                this.selectFirstPlayer(this.player1);
+
+                this.player1.clickCard(this.character);
+
+                expect(this.character.location).toBe('play area');
+
+                this.player1.clickPrompt('Mace Tyrell');
+
+                this.player1.clickMenu(this.mace, 'Remove character from game');
+                this.player1.clickCard(this.character);
+
+                expect(this.character.location).toBe('out of game');
+
+                this.completeMarshalPhase();
+            });
+
+            it('should return to play the following phase', function() {
+                expect(this.character.location).toBe('play area');
+            });
+        });
+
+        describe('when a removed character is placed in the dead pile', function() {
+            beforeEach(function() {
+                this.player1.selectPlot('A Noble Cause');
+                this.player2.selectPlot('A Noble Cause');
+                this.selectFirstPlayer(this.player1);
+
+                this.player1.clickCard(this.character);
+
+                expect(this.character.location).toBe('play area');
+
+                this.player1.clickPrompt('Mace Tyrell');
+
+                this.player1.clickMenu(this.mace, 'Remove character from game');
+                this.player1.clickCard(this.character);
+
+                expect(this.character.location).toBe('out of game');
+
+                this.player1.dragCard(this.characterCopy, 'dead pile');
+
+                this.completeMarshalPhase();
+            });
+
+            it('should not return to play the following phase', function() {
+                expect(this.character.location).toBe('out of game');
+            });
+        });
+
+        describe('vs Barring the Gates', function() {
+            // Ruling: http://www.cardgamedb.com/forums/index.php?/topic/36886-mace-tyrell/
+
+            beforeEach(function() {
+                this.player1.selectPlot('A Noble Cause');
+                this.player2.selectPlot('Barring the Gates');
+                this.selectFirstPlayer(this.player1);
+
+                this.player1.clickCard(this.character);
+
+                expect(this.character.location).toBe('play area');
+
+                this.player1.clickPrompt('Mace Tyrell');
+
+                this.player1.clickMenu(this.mace, 'Remove character from game');
+                this.player1.clickCard(this.character);
+
+                expect(this.character.location).toBe('out of game');
+
+                this.completeMarshalPhase();
+            });
+
+            it('should return to play the following phase', function() {
+                expect(this.character.location).toBe('play area');
+            });
+        });
+    });
+});


### PR DESCRIPTION
Previously, when using Mace Tyrell's ability to remove a card from the
game, the card would leave then immediately re-enter play. This is
because the effects engine was fixed to remove effects from cards that
leave play.

Now, 'custom' duration lasting effects are not removed from cards when
they leave play. This change should have no effect on other cards using
custom lasting effects as they explicitly listen to onCardLeftPlay
already where appropriate.

Additionally, Barring the Gates will no longer prevent the card from
re-entering play.