### PR TITLE
Do not place events in discard immediately

### DIFF
--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -120,7 +120,11 @@ const Costs = {
                 return context.player.isCardInPlayableLocation(context.source, 'play') && context.player.canPlay(context.source, 'play');
             },
             pay: function(context) {
-                context.source.controller.moveCard(context.source, 'discard pile');
+                // Events become in a "state of being played" while they resolve
+                // and are not placed in discard until after resolution / cancel
+                // of their effects.
+                // Ruling: http://www.cardgamedb.com/forums/index.php?/topic/35981-the-annals-of-castle-black/
+                context.source.controller.moveCard(context.source, 'being played');
             }
         };
     },

--- a/server/game/gamesteps/abilityresolver.js
+++ b/server/game/gamesteps/abilityresolver.js
@@ -178,6 +178,7 @@ class AbilityResolver extends BaseStep {
         // then this event will need to wrap the execution of the entire
         // ability instead.
         if(this.ability.isPlayableEventAbility()) {
+            this.context.source.owner.moveCard(this.context.source, 'discard pile');
             this.game.raiseEvent('onCardPlayed', { player: this.context.player, card: this.context.source });
         }
     }

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -20,6 +20,7 @@ class Player extends Spectator {
     constructor(id, user, owner, game) {
         super(id, user);
 
+        this.beingPlayed = _([]);
         this.drawDeck = _([]);
         this.plotDeck = _([]);
         this.plotDiscard = _([]);
@@ -713,6 +714,7 @@ class Player extends Spectator {
         const DrawDeckCardTypes = ['attachment', 'character', 'event', 'location'];
         const AllowedTypesForPile = {
             'active plot': PlotCardTypes,
+            'being played': ['event'],
             'dead pile': ['character'],
             'discard pile': DrawDeckCardTypes,
             'draw deck': DrawDeckCardTypes,
@@ -737,6 +739,8 @@ class Player extends Spectator {
 
     getSourceList(source) {
         switch(source) {
+            case 'being played':
+                return this.beingPlayed;
             case 'hand':
                 return this.hand;
             case 'draw deck':
@@ -765,6 +769,9 @@ class Player extends Spectator {
 
     updateSourceList(source, targetList) {
         switch(source) {
+            case 'being played':
+                this.beingPlayed = targetList;
+                return;
             case 'hand':
                 this.hand = targetList;
                 break;
@@ -1231,6 +1238,7 @@ class Player extends Spectator {
     getState(activePlayer) {
         let isActivePlayer = activePlayer === this;
         let promptState = isActivePlayer ? this.promptState.getState() : {};
+        let fullDiscardPile = this.discardPile.toArray().concat(this.beingPlayed.toArray());
         let state = {
             activePlot: this.activePlot ? this.activePlot.getSummary(activePlayer) : undefined,
             agenda: this.agenda ? this.agenda.getSummary(activePlayer) : undefined,
@@ -1239,7 +1247,7 @@ class Player extends Spectator {
                 cardsInPlay: this.getSummaryForCardList(this.cardsInPlay, activePlayer),
                 conclavePile: this.getSummaryForCardList(this.conclavePile, activePlayer, true),
                 deadPile: this.getSummaryForCardList(this.deadPile, activePlayer).reverse(),
-                discardPile: this.getSummaryForCardList(this.discardPile, activePlayer).reverse(),
+                discardPile: this.getSummaryForCardList(fullDiscardPile, activePlayer).reverse(),
                 hand: this.getSummaryForCardList(this.hand, activePlayer, true),
                 outOfGamePile: this.getSummaryForCardList(this.outOfGamePile, activePlayer, false),
                 plotDeck: this.getSummaryForCardList(this.plotDeck, activePlayer, true),

--- a/test/server/cards/01-Core/RisenFromTheSea.spec.js
+++ b/test/server/cards/01-Core/RisenFromTheSea.spec.js
@@ -73,7 +73,7 @@ describe('Risen from the Sea', function() {
 
             it('should not attach the event to the character', function() {
                 expect(this.noAttachmentCharacter.attachments.size()).toBe(0);
-                expect(this.event.location).toBe('discard pile');
+                expect(this.event.location).toBe('being played');
             });
 
             it('should not provide +1 STR', function() {

--- a/test/server/gamesteps/abilityresolver.spec.js
+++ b/test/server/gamesteps/abilityresolver.spec.js
@@ -13,8 +13,9 @@ describe('AbilityResolver', function() {
         });
         this.ability = jasmine.createSpyObj('ability', ['incrementLimit', 'isAction', 'isCardAbility', 'isForcedAbility', 'isPlayableEventAbility', 'needsChooseOpponent', 'resolveCosts', 'payCosts', 'resolveTargets', 'executeHandler']);
         this.ability.isCardAbility.and.returnValue(true);
+        this.player = jasmine.createSpyObj('player', ['moveCard']);
         this.source = jasmine.createSpyObj('source', ['createSnapshot', 'getType']);
-        this.player = { player: 1 };
+        this.source.owner = this.player;
         let targets = jasmine.createSpyObj('targets', ['getTargets', 'hasTargets', 'setSelections', 'updateTargets']);
         targets.hasTargets.and.returnValue(true);
         targets.getTargets.and.returnValue([]);
@@ -84,6 +85,10 @@ describe('AbilityResolver', function() {
                 this.ability.resolveCosts.and.returnValue([{ resolved: true, value: true }, { resolved: true, value: true }]);
                 this.ability.isPlayableEventAbility.and.returnValue(true);
                 this.resolver.continue();
+            });
+
+            it('should move the card to discard', function() {
+                expect(this.player.moveCard).toHaveBeenCalledWith(this.source, 'discard pile');
             });
 
             it('should raise the onCardPlayed event', function() {

--- a/test/server/integration/marshalphase.spec.js
+++ b/test/server/integration/marshalphase.spec.js
@@ -55,7 +55,7 @@ describe('marshal phase', function() {
             it('should allow events to be played', function() {
                 this.player1.clickCard(this.hearMeRoar);
 
-                expect(this.hearMeRoar.location).toBe('discard pile');
+                expect(this.hearMeRoar.location).toBe('being played');
             });
 
             describe('when marshaling dupes', function() {


### PR DESCRIPTION
When an event card is played, it goes into a temporary "being played"
pile to indicate that it is currently resolving. Once the resolution of
the ability has completed, it is then placed in discard.

From a UI perspective, cards that are currently being played are
displayed as if they are already in the discard pile.