### PR TITLE
Default to match any card for cost reducers

### DIFF
--- a/server/game/costreducer.js
+++ b/server/game/costreducer.js
@@ -6,7 +6,7 @@ class CostReducer {
         this.source = source;
         this.uses = 0;
         this.limit = properties.limit;
-        this.match = properties.match;
+        this.match = properties.match || (() => true);
         this.amount = properties.amount || 1;
         this.playingTypes = _.isArray(properties.playingTypes) ? properties.playingTypes : [properties.playingTypes];
         if(this.limit) {


### PR DESCRIPTION
Previously, CostReducer expected that a `match` function was passed into
the constructor to determine which cards the reduction could be applied
to. The Bastard of Godsgrace, however, matches all cards either being
played or ambush, so the match function was omitted, causing crashes.

Fixes THRONETEKI-1K4
Fixes THRONETEKI-1K5
Fixes THRONETEKI-1KF