### PR TITLE
Do not allow removal of non-existent tokens

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -525,6 +525,10 @@ class BaseCard {
     }
 
     removeToken(type, number) {
+        if(_.isUndefined(this.tokens[type])) {
+            return;
+        }
+
         this.tokens[type] -= number;
 
         if(this.tokens[type] < 0) {

--- a/test/server/card/basecard.spec.js
+++ b/test/server/card/basecard.spec.js
@@ -213,4 +213,44 @@ describe('BaseCard', function () {
             });
         });
     });
+
+    describe('tokens', function() {
+        it('should not have tokens by default', function() {
+            expect(this.card.hasToken('foo')).toBe(false);
+        });
+
+        describe('adding a token', function() {
+            it('should increase the tokens by the given amount', function() {
+                this.card.addToken('foo', 1);
+
+                expect(this.card.tokens.foo).toBe(1);
+                expect(this.card.hasToken('foo')).toBe(true);
+            });
+        });
+
+        describe('removing an existing tokens', function() {
+            beforeEach(function() {
+                this.card.addToken('foo', 2);
+            });
+
+            it('should reduce the tokens by the given amount', function() {
+                this.card.removeToken('foo', 1);
+
+                expect(this.card.tokens.foo).toBe(1);
+                expect(this.card.hasToken('foo')).toBe(true);
+
+                this.card.removeToken('foo', 1);
+                expect(this.card.hasToken('foo')).toBe(false);
+            });
+        });
+
+        describe('remove a missing token', function() {
+            it('should not set the token value', function() {
+                this.card.removeToken('foo', 1);
+
+                expect(this.card.tokens.foo).toBeUndefined();
+                expect(this.card.hasToken('foo')).toBe(false);
+            });
+        });
+    });
 });


### PR DESCRIPTION
Previously, if an ability attempted to remove a token from a card that
didn't have that token, it would set the token value to NaN. This
displayed the token in the UI but did not count as having the token for
the purpose of the `hasToken` method. The main scenario involved is
Jaqen places a Valar token on a character. That character leaves and
re-enters play. Then Jaqen leaves play and tries to remove the original
token placed, which was already removed when the targeted character left
play.

Fixes #1550 