### PR TITLE
Fix targeting for challenge-related abilities

### DIFF
--- a/server/game/cards/01-Core/BalonGreyjoy.js
+++ b/server/game/cards/01-Core/BalonGreyjoy.js
@@ -5,7 +5,7 @@ class BalonGreyjoy extends DrawCard {
         this.persistentEffect({
             condition: () => this.game.currentChallenge && this.game.currentChallenge.isAttacking(this),
             match: card => (
-                card.controller !== this.controller &&
+                this.game.currentChallenge.isDefending(card) &&
                 card.getType() === 'character' &&
                 card.getStrength() < this.getStrength()
             ),

--- a/server/game/cards/01-Core/DornishParamour.js
+++ b/server/game/cards/01-Core/DornishParamour.js
@@ -7,11 +7,10 @@ class DornishParamour extends DrawCard {
                 onAttackersDeclared: event => event.challenge.isAttacking(this)
             },
             target: {
-                activePromptTitle: 'Select a character',
                 cardCondition: card => (
                     card.location === 'play area' &&
                     card.getType() === 'character' &&
-                    card.controller !== this.controller)
+                    card.controller === this.game.currentChallenge.defendingPlayer)
             },
             handler: context => {
                 this.untilEndOfChallenge(ability => ({

--- a/server/game/cards/01-Core/EuronCrowsEye.js
+++ b/server/game/cards/01-Core/EuronCrowsEye.js
@@ -18,7 +18,7 @@ class EuronCrowsEye extends DrawCard {
     }
 
     cardCondition(card) {
-        return card.controller !== this.controller && card.getType() === 'location' && card.location === 'discard pile' && this.controller.canPutIntoPlay(card);
+        return card.controller === this.game.currentChallenge.loser && card.getType() === 'location' && card.location === 'discard pile' && this.controller.canPutIntoPlay(card);
     }
 }
 

--- a/server/game/cards/01-Core/Ice.js
+++ b/server/game/cards/01-Core/Ice.js
@@ -15,8 +15,7 @@ class Ice extends DrawCard {
             },
             cost: ability.costs.sacrificeSelf(),
             target: {
-                activePromptTitle: 'Select a character',
-                cardCondition: card => card.location === 'play area' && card.controller !== this.controller && card.getType() === 'character',
+                cardCondition: card => card.location === 'play area' && card.controller === this.game.currentChallenge.loser && card.getType() === 'character',
                 gameAction: 'kill'
             },
             handler: context => {

--- a/server/game/cards/01-Core/PutToTheSword.js
+++ b/server/game/cards/01-Core/PutToTheSword.js
@@ -9,7 +9,7 @@ class PutToTheSword extends DrawCard {
                                          event.challenge.attackingPlayer === this.controller && event.challenge.strengthDifference >= 5
             },
             target: {
-                cardCondition: card => card.location === 'play area' && card.controller !== this.controller && card.getType() === 'character',
+                cardCondition: card => card.location === 'play area' && card.controller === this.game.currentChallenge.loser && card.getType() === 'character',
                 gameAction: 'kill'
             },
             handler: (context) => {

--- a/server/game/cards/01-Core/PutToTheTorch.js
+++ b/server/game/cards/01-Core/PutToTheTorch.js
@@ -10,7 +10,7 @@ class PutToTheTorch extends DrawCard {
             },
             target: {
                 activePromptTitle: 'Select a location',
-                cardCondition: card => card.location === 'play area' && card.controller !== this.controller && card.getType() === 'location',
+                cardCondition: card => card.location === 'play area' && card.controller === this.game.currentChallenge.loser && card.getType() === 'location',
                 gameAction: 'discard'
             },
             handler: (context) => {

--- a/server/game/cards/01-Core/TearsOfLys.js
+++ b/server/game/cards/01-Core/TearsOfLys.js
@@ -10,7 +10,7 @@ class TearsOfLys extends DrawCard {
             },
             target: {
                 type: 'select',
-                cardCondition: card => card.location === 'play area' && card.controller !== this.controller &&
+                cardCondition: card => card.location === 'play area' && card.controller === this.game.currentChallenge.loser &&
                                        card.getType() === 'character' && !card.hasIcon('intrigue')
             },
             handler: context => {

--- a/server/game/cards/01-Core/TheQueensAssassin.js
+++ b/server/game/cards/01-Core/TheQueensAssassin.js
@@ -9,9 +9,8 @@ class TheQueensAssassin extends DrawCard {
             chooseOpponent: opponent => opponent.hand.size() < this.controller.hand.size(),
             handler: context => {
                 this.game.promptForSelect(context.opponent, {
-                    activePromptTitle: 'Select a character',
                     source: this,
-                    cardCondition: card => card.location === 'play area' && card.controller !== this.controller && card.getType() === 'character',
+                    cardCondition: card => card.location === 'play area' && card.controller === context.opponent && card.getType() === 'character',
                     gameAction: 'kill',
                     onSelect: (p, card) => this.onCardSelected(p, card)
                 });

--- a/server/game/cards/02.1-TtB/TheSeastoneChair.js
+++ b/server/game/cards/02.1-TtB/TheSeastoneChair.js
@@ -11,9 +11,8 @@ class TheSeastoneChair extends DrawCard {
             },
             cost: ability.costs.kneelFactionCard(),
             target: {
-                activePromptTitle: 'Select a character',
                 cardCondition: card => card.location === 'play area' && card.getType() === 'character' &&
-                                       card.controller !== this.controller && card.attachments.size() === 0,
+                                       card.controller === this.game.currentChallenge.loser && card.attachments.size() === 0,
                 gameAction: 'kill'
             },
             handler: context => {

--- a/server/game/cards/02.2-TRtW/WardensOfTheWest.js
+++ b/server/game/cards/02.2-TRtW/WardensOfTheWest.js
@@ -14,7 +14,7 @@ class WardensOfTheWest extends PlotCard {
                     numCards: 2,
                     activePromptTitle: 'Select 2 cards to discard',
                     source: this,
-                    cardCondition: card => card.controller !== this.controller && card.location === 'hand',
+                    cardCondition: card => card.controller === this.game.currentChallenge.loser && card.location === 'hand',
                     onSelect: (player, cards) => this.onSelect(player, cards),
                     onCancel: (player) => this.cancelSelection(player)
                 });

--- a/server/game/cards/02.5-COW/MirriMazDuur.js
+++ b/server/game/cards/02.5-COW/MirriMazDuur.js
@@ -11,7 +11,7 @@ class MirriMazDuur extends DrawCard {
                 )
             },
             target: {
-                cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.controller !== this.controller,
+                cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.controller === this.game.currentChallenge.loser,
                 gameAction: 'kill'
             },
             handler: context => {

--- a/server/game/cards/02.6-TS/DagmerCleftjaw.js
+++ b/server/game/cards/02.6-TS/DagmerCleftjaw.js
@@ -17,7 +17,7 @@ class DagmerCleftjaw extends DrawCard {
                     card.getType() === 'location' &&
                     card.getCost() <= 3 &&
                     !card.isLimited() &&
-                    card.controller !== this.controller)
+                    card.controller === this.game.currentChallenge.loser)
             },
             handler: context => {
                 this.game.addMessage('{0} uses {1} to take control of {2} instead of normal claim effects', context.player, this, context.target);

--- a/server/game/cards/03-WotN/EvenHandedJustice.js
+++ b/server/game/cards/03-WotN/EvenHandedJustice.js
@@ -6,6 +6,7 @@ class EvenHandedJustice extends DrawCard {
     setupCardAbilities() {
         this.action({
             title: 'Kneel a character for each player',
+            // TODO: Rework for Melee
             targets: {
                 yourCard: {
                     activePromptTitle: 'Select a character of yours',

--- a/server/game/cards/03-WotN/TheShadowTower.js
+++ b/server/game/cards/03-WotN/TheShadowTower.js
@@ -8,8 +8,7 @@ class TheShadowTower extends DrawCard {
             },
             cost: ability.costs.kneelSelf(),
             target: {
-                activePromptTitle: 'Select a character',
-                cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.controller !== this.controller
+                cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.controller === this.game.currentChallenge.loser
             },
             handler: context => {
                 this.game.addMessage('{0} kneels {1} to make {2} unable to be declared as attacker this phase',

--- a/server/game/cards/03-WotN/TowerOfTheHand.js
+++ b/server/game/cards/03-WotN/TowerOfTheHand.js
@@ -11,8 +11,7 @@ class TowerOfTheHand extends DrawCard {
                 ability.costs.returnToHand(card => this.isParticipatingLannister(card))
             ],
             target: {
-                activePromptTitle: 'Select a character',
-                cardCondition: (card, context) => card.location === 'play area' && card.getType() === 'character' && card.controller !== this.controller &&
+                cardCondition: (card, context) => card.location === 'play area' && card.getType() === 'character' && card.controller === this.game.currentChallenge.loser &&
                                                   (!context.costs.returnToHand || card.getPrintedCost() < context.costs.returnToHand.getPrintedCost())
             },
             handler: context => {

--- a/server/game/cards/04.3-FFH/Spearmaiden.js
+++ b/server/game/cards/04.3-FFH/Spearmaiden.js
@@ -7,10 +7,9 @@ class Spearmaiden extends DrawCard {
                 onAttackersDeclared: event => event.challenge.challengeType === 'military' && event.challenge.isAttacking(this)
             },
             target: {
-                activePromptTitle: 'Select character',
                 cardCondition: card => (
                     card.location === 'play area' &&
-                    card.controller !== this.controller &&
+                    card.controller === this.game.currentChallenge.defendingPlayer &&
                     card.getType() === 'character')
             },
             handler: context => {

--- a/server/game/cards/04.5-GoH/RooseBolton.js
+++ b/server/game/cards/04.5-GoH/RooseBolton.js
@@ -17,7 +17,7 @@ class RooseBolton extends DrawCard {
                 activePromptTitle: 'Select character(s)',
                 maxStat: () => this.strengthAtInitiation,
                 cardStat: card => card.getStrength(),
-                cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.controller !== this.controller,
+                cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.controller === this.game.currentChallenge.loser,
                 gameAction: 'kill'
             },
             handler: context => {

--- a/server/game/cards/04.6-TC/QhorinHalfhand.js
+++ b/server/game/cards/04.6-TC/QhorinHalfhand.js
@@ -11,8 +11,7 @@ class QhorinHalfhand extends DrawCard {
                 )
             },
             target: {
-                activePromptTitle: 'Select a character',
-                cardCondition: card => card.location === 'play area' && card.controller !== this.controller && card.getType() === 'character' &&
+                cardCondition: card => card.location === 'play area' && card.controller === this.game.currentChallenge.loser && card.getType() === 'character' &&
                                        !card.isUnique() && card.getStrength() < this.getStrength(),
                 gameAction: 'kill'
             },

--- a/server/game/cards/06.4-TRW/FreyHospitality.js
+++ b/server/game/cards/06.4-TRW/FreyHospitality.js
@@ -18,7 +18,7 @@ class FreyHospitality extends DrawCard {
                     source: this,
                     gameAction: 'kill',
                     cardCondition: card => card.location === 'play area' &&
-                                           card.controller !== this.controller &&
+                                           card.controller === this.game.currentChallenge.loser &&
                                            card.getType() === 'character',
                     onSelect: (player, cards) => this.targetsSelected(player, cards)
                 });

--- a/server/game/cards/06.4-TRW/TywinsStratagem.js
+++ b/server/game/cards/06.4-TRW/TywinsStratagem.js
@@ -7,6 +7,7 @@ class TywinsStratagem extends DrawCard {
         this.action({
             title: 'Return characters to hand',
             phase: 'challenge',
+            // TODO: Rework for Melee
             targets: {
                 ownToReturn: {
                     activePromptTitle: 'Select a character',

--- a/server/game/cards/06.5-OR/DornishRevenge.js
+++ b/server/game/cards/06.5-OR/DornishRevenge.js
@@ -7,11 +7,10 @@ class DornishRevenge extends DrawCard {
                 onChallengeInitiated: event => event.challenge.attackingPlayer === this.controller
             },
             target: {
-                activePromptTitle: 'Select a character to force as defender',
                 cardCondition: card => (
                     card.location === 'play area' &&
                     card.getType() === 'character' &&
-                    card.controller !== this.controller)
+                    card.controller === this.game.currentChallenge.defendingPlayer)
             },
             handler: context => {
                 this.untilEndOfChallenge(ability => ({

--- a/server/game/cards/07-WotW/RaidingTheBayOfIce.js
+++ b/server/game/cards/07-WotW/RaidingTheBayOfIce.js
@@ -13,7 +13,7 @@ class RaidingTheBayOfIce extends DrawCard {
                     card.location === 'play area' &&
                     !card.isLimited() &&
                     card.getType() === 'location' &&
-                    card.controller !== this.controller)
+                    card.controller === this.game.currentChallenge.loser)
             },
             handler: context => {
                 context.target.owner.moveCardToTopOfDeck(context.target);

--- a/server/game/cards/09-HoT/MargaeryTyrell.js
+++ b/server/game/cards/09-HoT/MargaeryTyrell.js
@@ -13,9 +13,8 @@ class MargaeryTyrell extends DrawCard {
                 onAttackersDeclared: event => event.challenge.isAttacking(this)
             },
             target: {
-                activePromptTitle: 'Select a character',
                 cardCondition: card => card.location === 'play area' && card.getType() === 'character' &&
-                                       card.controller !== this.controller
+                                       card.controller === this.game.currentChallenge.defendingPlayer
             },
             handler: context => {
                 context.target.controller.kneelCard(context.target);


### PR DESCRIPTION
Previously, cards that were supposed to target a specific player during
a challenge (the defending player, the losing opponent, etc) were simply
targeting any opponent. For Melee games this would allow targets to be
chosen inappropriately outside the players in the challenge.

Progress toward #1237 