### PR TITLE
Record costs in array to prevent overwriting

### DIFF
--- a/server/game/AbilityContext.js
+++ b/server/game/AbilityContext.js
@@ -7,7 +7,22 @@ class AbilityContext {
         this.source = properties.source;
         this.player = properties.player;
         this.costs = {};
+        this.costValues = {};
         this.targets = new ResolvedTargets();
+    }
+
+    addCost(name, value) {
+        if(!this.costValues[name]) {
+            this.costValues[name] = [];
+        }
+
+        let valueAsArray = Array.isArray(value) ? value : [value];
+        this.costValues[name] = this.costValues[name].concat(valueAsArray);
+        this.costs[name] = value;
+    }
+
+    getCostValuesFor(name) {
+        return this.costValues[name] || [];
     }
 }
 

--- a/server/game/costs/FactionCardCost.js
+++ b/server/game/costs/FactionCardCost.js
@@ -8,7 +8,7 @@ class FactionCardCost {
     }
 
     resolve(context, result = { resolved: false }) {
-        context.costs[this.action.name] = context.player.faction;
+        context.addCost(this.action.name, context.player.faction);
 
         result.resolved = true;
         result.value = context.player.faction;
@@ -16,7 +16,7 @@ class FactionCardCost {
     }
 
     pay(context) {
-        this.action.pay([context.costs[this.action.name]], context);
+        this.action.pay(context.getCostValuesFor(this.action.name), context);
     }
 }
 

--- a/server/game/costs/ParentCost.js
+++ b/server/game/costs/ParentCost.js
@@ -8,7 +8,7 @@ class ParentCost {
     }
 
     resolve(context, result = { resolved: false }) {
-        context.costs[this.action.name] = context.source.parent;
+        context.addCost(this.action.name, context.source.parent);
 
         result.resolved = true;
         result.value = context.source.parent;
@@ -16,7 +16,7 @@ class ParentCost {
     }
 
     pay(context) {
-        this.action.pay([context.costs[this.action.name]], context);
+        this.action.pay(context.getCostValuesFor(this.action.name), context);
     }
 }
 

--- a/server/game/costs/SelectCardCost.js
+++ b/server/game/costs/SelectCardCost.js
@@ -28,7 +28,7 @@ class SelectCardCost {
             selector: this.selector,
             source: context.source,
             onSelect: (player, cards) => {
-                context.costs[this.action.name] = cards;
+                context.addCost(this.action.name, cards);
                 result.value = true;
                 result.resolved = true;
 
@@ -44,7 +44,7 @@ class SelectCardCost {
     }
 
     pay(context) {
-        let selected = context.costs[this.action.name];
+        let selected = context.getCostValuesFor(this.action.name);
         let selectedAsArray = Array.isArray(selected) ? selected : [selected];
         this.action.pay(selectedAsArray, context);
     }

--- a/server/game/costs/SelfCost.js
+++ b/server/game/costs/SelfCost.js
@@ -9,7 +9,7 @@ class SelfCost {
     }
 
     resolve(context, result = { resolved: false }) {
-        context.costs[this.action.name] = context.source;
+        context.addCost(this.action.name, context.source);
 
         result.resolved = true;
         result.value = context.source;
@@ -17,7 +17,7 @@ class SelfCost {
     }
 
     pay(context) {
-        this.action.pay([context.costs[this.action.name]], context);
+        this.action.pay(context.getCostValuesFor(this.action.name), context);
     }
 
     canUnpay(context) {

--- a/server/game/costs/SpecificCardCost.js
+++ b/server/game/costs/SpecificCardCost.js
@@ -11,7 +11,7 @@ class SpecificCardCost {
 
     resolve(context, result = { resolved: false }) {
         let card = this.cardFunc(context);
-        context.costs[this.action.name] = card;
+        context.addCost(this.action.name, card);
 
         result.resolved = true;
         result.value = card;
@@ -19,7 +19,7 @@ class SpecificCardCost {
     }
 
     pay(context) {
-        this.action.pay([context.costs[this.action.name]], context);
+        this.action.pay(context.getCostValuesFor(this.action.name), context);
     }
 }
 


### PR DESCRIPTION
The previous cost refactor introduced a bug where if a card used the
same cost action on two different cards (e.g. Joffrey (GoH) kneeling the
loyal card and the faction card), only one of the cards would get the
cost action applied. This was due to the entry in the costs object being
overwritten, whereas previously each cost was written manually and
didn't always store an entry on the costs object.

Now, when a cost choice is made, its recorded to a separate parallel
object that always stores the costs as an array. The previous mechanism
is left in place for compatibility with abilities that need to look up
the exact card (typically for the message in chat).

Fixes #1571 