### PR TITLE
Only fire onDeclaredAsDefender for chosen cards

### DIFF
--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -218,7 +218,7 @@ class ChallengeFlow extends BaseStep {
             { name: 'onDefendersDeclared', params: { challenge: this.challenge } }
         ];
 
-        let defenderEvents = _.map(this.challenge.defenders, card => {
+        let defenderEvents = _.map(defenders, card => {
             return { name: 'onDeclaredAsDefender', params: { card: card } };
         });
 


### PR DESCRIPTION
Previously, the onDeclaredAsDefender event was being fired for all
defenders within a challenge. However, it should only fire for cards
specifically chosen / forced to be chosen by the player. This lead to a
bug where cards added to the challenge by an ability (e.g. HoT Margaery)
would be declared as a defender even though they weren't actually
declared.

Fixes #1569 