### PR TITLE
Old Wyk: kneel character that enters play

### DIFF
--- a/server/game/cards/05-LoCR/OldWyk.js
+++ b/server/game/cards/05-LoCR/OldWyk.js
@@ -16,7 +16,7 @@ class OldWyk extends DrawCard {
 
                 this.controller.putIntoPlay(card);
                 //Manually kneel instead of firing kneel event as character is put into play knelt
-                this.kneeled = true;
+                card.kneeled = true;
                 this.game.currentChallenge.addAttacker(card);
 
                 this.game.addMessage('{0} kneels {1} to put {2} into play from their dead pile knelt as an attacker',


### PR DESCRIPTION
The bug was most likely due to copy-pasting from Edd, where the trigger and the
character entering play were the same card, which is not the case for Old Wyk.

Fixes #1599