### PR TITLE
uniform messages for defender limits to use min/max as needed

### DIFF
--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -153,7 +153,7 @@ class ChallengeFlow extends BaseStep {
             restrictions.push(`min ${defenderMinimum}`);
         }
         if(defenderLimit !== 0) {
-            restrictions.push(`limit ${defenderLimit}`);
+            restrictions.push(`max ${defenderLimit}`);
         }
         if(restrictions.length !== 0) {
             title += ` (${restrictions.join(', ')})`;


### PR DESCRIPTION
Rationale: now that there are both max (e.g., Knight of Flowers) and min (e.g.,
Beseiged) defender limits, having messages that specify a "limit", without
clarifying if it's min or max, is confusing.