### PR TITLE
Make image fetch more forgiving of missing packs

### DIFF
--- a/server/scripts/fetchdata/CardgameDbImageSource.js
+++ b/server/scripts/fetchdata/CardgameDbImageSource.js
@@ -10,6 +10,11 @@ class CardgameDbImageSource {
 
     fetchImage(card, imagePath) {
         let pack = this.packs.find(pack => pack.code === card.pack_code);
+        if(!pack) {
+            console.log(`Could not find pack '${card.pack_code}' for ${card.name}, submodule data may be out of date.`);
+            return;
+        }
+
         let cgdbId = pack.cgdb_id.toString().padStart(2, '0');
         let url = `http://lcg-cdn.fantasyflightgames.com/got2nd/GT${cgdbId}_${card.position}.jpg`;
 

--- a/test/server/cards/01-Core/SelyseBaratheon.spec.js
+++ b/test/server/cards/01-Core/SelyseBaratheon.spec.js
@@ -1,9 +1,9 @@
-describe('Selyse Baratheon', function() {
+describe('Selyse Baratheon (Core)', function() {
     integration(function() {
         beforeEach(function() {
             const deck1 = this.buildDeck('baratheon', [
                 'Sneak Attack',
-                'Selyse Baratheon'
+                'Selyse Baratheon (Core)'
             ]);
             const deck2 = this.buildDeck('martell', [
                 'Sneak Attack',

--- a/test/server/cards/02.5-COW/MirriMazDuur.spec.js
+++ b/test/server/cards/02.5-COW/MirriMazDuur.spec.js
@@ -3,7 +3,7 @@ describe('Mirri Maz Duur', function() {
         beforeEach(function() {
             const deck1 = this.buildDeck('targaryen', [
                 'Marching Orders',
-                'Mirri Maz Duur', 'The Hound', 'Targaryen Loyalist'
+                'Mirri Maz Duur', 'The Hound (TtB)', 'Targaryen Loyalist'
             ]);
             const deck2 = this.buildDeck('targaryen', [
                 'Marching Orders',

--- a/test/server/cards/agendas/TheLordOfTheCrossing.spec.js
+++ b/test/server/cards/agendas/TheLordOfTheCrossing.spec.js
@@ -4,7 +4,7 @@ describe('The Lord of the Crossing', function() {
             const deck = this.buildDeck('baratheon', [
                 'The Lord of the Crossing',
                 'A Noble Cause', 'Blood of the Dragon',
-                'Selyse Baratheon', 'Bastard in Hiding', 'Fiery Followers'
+                'Selyse Baratheon (Core)', 'Bastard in Hiding', 'Fiery Followers'
             ]);
             this.player1.selectDeck(deck);
             this.player2.selectDeck(deck);

--- a/test/server/integration/challengesphase.spec.js
+++ b/test/server/integration/challengesphase.spec.js
@@ -161,7 +161,7 @@ describe('challenges phase', function() {
             beforeEach(function() {
                 const deck = this.buildDeck('tyrell', [
                     'Sneak Attack',
-                    'Renly Baratheon (FFH)', 'Brienne of Tarth', 'Ser Garlan Tyrell (OR)', 'Garden Caretaker'
+                    'Renly Baratheon (FFH)', 'Brienne of Tarth (GoH)', 'Ser Garlan Tyrell (OR)', 'Garden Caretaker'
                 ]);
                 this.player1.selectDeck(deck);
                 this.player2.selectDeck(deck);

--- a/test/server/integration/forcedreactionorder.spec.js
+++ b/test/server/integration/forcedreactionorder.spec.js
@@ -3,7 +3,7 @@ describe('forced reaction order', function() {
         beforeEach(function() {
             const deck1 = this.buildDeck('lannister', [
                 'Trading with the Pentoshi',
-                'The Hound', 'The Hound'
+                'The Hound (TtB)', 'The Hound (TtB)'
             ]);
             const deck2 = this.buildDeck('thenightswatch', [
                 'Trading with the Pentoshi',


### PR DESCRIPTION
Adds an error message when the image fetch script can't find the appropriate pack code for a card instead of crashing. Also updates the submodule to the latest data.