### PR TITLE
Handle setting multiple challenge limits at once

### DIFF
--- a/server/game/MinMaxProperty.js
+++ b/server/game/MinMaxProperty.js
@@ -1,0 +1,50 @@
+const _ = require('underscore');
+
+class MinMaxProperty {
+    constructor(options) {
+        this.minValues = [];
+        this.maxValues = [];
+        this.defaultMin = options.defaultMin;
+        this.defaultMax = options.defaultMax;
+    }
+
+    setMin(value) {
+        this.minValues.push(value);
+    }
+
+    removeMin(value) {
+        let index = this.minValues.indexOf(value);
+        if(index !== -1) {
+            this.minValues.splice(index, 1);
+        }
+    }
+
+    setMax(value) {
+        this.maxValues.push(value);
+    }
+
+    removeMax(value) {
+        let index = this.maxValues.indexOf(value);
+        if(index !== -1) {
+            this.maxValues.splice(index, 1);
+        }
+    }
+
+    getMin() {
+        if(this.minValues.length === 0) {
+            return this.defaultMin;
+        }
+
+        return _.max(this.minValues);
+    }
+
+    getMax() {
+        if(this.maxValues.length === 0) {
+            return this.defaultMax;
+        }
+
+        return _.min(this.maxValues);
+    }
+}
+
+module.exports = MinMaxProperty;

--- a/server/game/cards/01-Core/JoustingContest.js
+++ b/server/game/cards/01-Core/JoustingContest.js
@@ -5,7 +5,10 @@ class JoustingContest extends PlotCard {
         this.persistentEffect({
             targetType: 'player',
             targetController: 'any',
-            effect: ability.effects.setChallengerLimit(1)
+            effect: [
+                ability.effects.setAttackerMaximum(1),
+                ability.effects.setDefenderMaximum(1)
+            ]
         });
     }
 }

--- a/server/game/cards/01-Core/TheKnightOfFlowers.js
+++ b/server/game/cards/01-Core/TheKnightOfFlowers.js
@@ -10,7 +10,7 @@ class TheKnightOfFlowers extends DrawCard {
                 && this.game.currentChallenge.attackers.length === 1,
             targetType: 'player',
             targetController: 'opponent',
-            effect: ability.effects.setChallengerLimit(1)
+            effect: ability.effects.setDefenderMaximum(1)
         });
     }
 

--- a/server/game/cards/09-HoT/Besieged.js
+++ b/server/game/cards/09-HoT/Besieged.js
@@ -1,6 +1,6 @@
 const PlotCard = require('../../plotcard.js');
 
-class Beseiged extends PlotCard {
+class Besieged extends PlotCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             targetType: 'player',
@@ -10,6 +10,6 @@ class Beseiged extends PlotCard {
     }
 }
 
-Beseiged.code = '09047';
+Besieged.code = '09047';
 
-module.exports = Beseiged;
+module.exports = Besieged;

--- a/server/game/cards/09-HoT/TourneyLance.js
+++ b/server/game/cards/09-HoT/TourneyLance.js
@@ -11,7 +11,7 @@ class TourneyLance extends DrawCard {
                              this.game.currentChallenge.attackers.length === 1,
             targetType: 'player',
             targetController: 'opponent',
-            effect: ability.effects.setChallengerLimit(1)
+            effect: ability.effects.setDefenderMaximum(1)
         });
     }
 

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -808,29 +808,33 @@ const Effects = {
             }
         };
     },
-    setDefenderMinimum: function(value) {
+    setAttackerMaximum: function(value) {
         return {
-            apply: function(player, context) {
-                context.setDefenderMinimum = context.setDefenderMinimum || {};
-                context.setDefenderMinimum[player.name] = player.defenderMinimum;
-                player.defenderMinimum = value;
+            apply: function(player) {
+                player.attackerLimits.setMax(value);
             },
-            unapply: function(player, context) {
-                player.defenderMinimum = context.setDefenderMinimum[player.name];
-                delete context.setDefenderMinimum[player.name];
+            unapply: function(player) {
+                player.attackerLimits.removeMax(value);
             }
         };
     },
-    setChallengerLimit: function(value) {
+    setDefenderMinimum: function(value) {
         return {
-            apply: function(player, context) {
-                context.setChallengerLimit = context.setChallengerLimit || {};
-                context.setChallengerLimit[player.name] = player.challengerLimit;
-                player.challengerLimit = value;
+            apply: function(player) {
+                player.defenderLimits.setMin(value);
             },
-            unapply: function(player, context) {
-                player.challengerLimit = context.setChallengerLimit[player.name];
-                delete context.setChallengerLimit[player.name];
+            unapply: function(player) {
+                player.defenderLimits.removeMin(value);
+            }
+        };
+    },
+    setDefenderMaximum: function(value) {
+        return {
+            apply: function(player) {
+                player.defenderLimits.setMax(value);
+            },
+            unapply: function(player) {
+                player.defenderLimits.removeMax(value);
             }
         };
     },

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -41,13 +41,14 @@ class ChallengeFlow extends BaseStep {
     }
 
     promptForAttackers() {
-        var title = 'Select challenge attackers';
-        if(this.challenge.attackingPlayer.challengerLimit !== 0) {
-            title += ' (limit ' + this.challenge.attackingPlayer.challengerLimit + ')';
+        let title = 'Select challenge attackers';
+        let attackerMax = this.challenge.attackingPlayer.attackerLimits.getMax();
+        if(attackerMax !== 0) {
+            title += ' (max ' + attackerMax + ')';
         }
 
         this.game.promptForSelect(this.challenge.attackingPlayer, {
-            numCards: this.challenge.attackingPlayer.challengerLimit,
+            numCards: attackerMax,
             multiSelect: true,
             activePromptTitle: title,
             waitingPromptTitle: 'Waiting for opponent to select attackers',
@@ -124,12 +125,12 @@ class ChallengeFlow extends BaseStep {
                 card.challengeOptions.mustBeDeclaredAsDefender;
         });
 
-        let defenderLimit = this.challenge.defendingPlayer.challengerLimit;
-        let defenderMinimum = this.challenge.defendingPlayer.defenderMinimum;
-        let selectableLimit = defenderLimit;
+        let defenderMaximum = this.challenge.defendingPlayer.defenderLimits.getMax();
+        let defenderMinimum = this.challenge.defendingPlayer.defenderLimits.getMin();
+        let selectableLimit = defenderMaximum;
 
         if(!_.isEmpty(this.forcedDefenders)) {
-            if(this.forcedDefenders.length === defenderLimit) {
+            if(this.forcedDefenders.length === defenderMaximum) {
                 this.game.addMessage('{0} {1} automatically declared as {2}',
                     this.forcedDefenders, this.forcedDefenders.length > 1 ? 'are' : 'is', this.forcedDefenders.length > 1 ? 'defenders' : 'defender');
 
@@ -137,11 +138,11 @@ class ChallengeFlow extends BaseStep {
                 return;
             }
 
-            if(this.forcedDefenders.length < defenderLimit || defenderLimit === 0) {
+            if(this.forcedDefenders.length < defenderMaximum || defenderMaximum === 0) {
                 this.game.addMessage('{0} {1} automatically declared as {2}',
                     this.forcedDefenders, this.forcedDefenders.length > 1 ? 'are' : 'is', this.forcedDefenders.length > 1 ? 'defenders' : 'defender');
 
-                if(defenderLimit !== 0) {
+                if(defenderMaximum !== 0) {
                     selectableLimit -= this.forcedDefenders.length;
                 }
             }
@@ -152,8 +153,8 @@ class ChallengeFlow extends BaseStep {
         if(defenderMinimum !== 0) {
             restrictions.push(`min ${defenderMinimum}`);
         }
-        if(defenderLimit !== 0) {
-            restrictions.push(`max ${defenderLimit}`);
+        if(defenderMaximum !== 0) {
+            restrictions.push(`max ${defenderMaximum}`);
         }
         if(restrictions.length !== 0) {
             title += ` (${restrictions.join(', ')})`;
@@ -182,8 +183,8 @@ class ChallengeFlow extends BaseStep {
             return true;
         }
 
-        let defenderLimit = this.challenge.defendingPlayer.challengerLimit;
-        if(this.forcedDefenders.length < defenderLimit || defenderLimit === 0) {
+        let defenderMax = this.challenge.defendingPlayer.defenderLimits.getMax();
+        if(this.forcedDefenders.length < defenderMax || defenderMax === 0) {
             return !this.forcedDefenders.includes(card);
         }
 
@@ -192,9 +193,9 @@ class ChallengeFlow extends BaseStep {
 
     chooseDefenders(defenders) {
         let defendingPlayer = this.challenge.defendingPlayer;
-        let defenderLimit = defendingPlayer.challengerLimit;
-        let defenderMinimum = defendingPlayer.defenderMinimum;
-        if(this.forcedDefenders.length <= defenderLimit || defenderLimit === 0) {
+        let defenderMaximum = defendingPlayer.defenderLimits.getMax();
+        let defenderMinimum = defendingPlayer.defenderLimits.getMin();
+        if(this.forcedDefenders.length <= defenderMaximum || defenderMaximum === 0) {
             defenders = defenders.concat(this.forcedDefenders);
         }
 
@@ -235,7 +236,7 @@ class ChallengeFlow extends BaseStep {
 
     hasMetDefenderMinimum(defenders) {
         let defendingPlayer = this.challenge.defendingPlayer;
-        let defenderMinimum = defendingPlayer.defenderMinimum;
+        let defenderMinimum = defendingPlayer.defenderLimits.getMin();
 
         if(defenderMinimum === 0) {
             return true;

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -10,6 +10,7 @@ const ChallengeTracker = require('./challengetracker.js');
 const PlayableLocation = require('./playablelocation.js');
 const PlayActionPrompt = require('./gamesteps/playactionprompt.js');
 const PlayerPromptState = require('./playerpromptstate.js');
+const MinMaxProperty = require('./MinMaxProperty.js');
 
 const logger = require('../log.js');
 
@@ -48,7 +49,8 @@ class Player extends Spectator {
         this.costReducers = [];
         this.playableLocations = _.map(['marshal', 'play', 'ambush'], playingType => new PlayableLocation(playingType, card => card.controller === this && card.location === 'hand'));
         this.usedPlotsModifier = 0;
-        this.defenderMinimum = 0;
+        this.attackerLimits = new MinMaxProperty({ defaultMin: 0, defaultMax: 0 });
+        this.defenderLimits = new MinMaxProperty({ defaultMin: 0, defaultMax: 0 });
         this.cannotGainGold = false;
         this.doesNotReturnUnspentGold = false;
         this.cannotGainChallengeBonus = false;
@@ -610,7 +612,6 @@ class Player extends Spectator {
 
         this.challenges.reset();
 
-        this.challengerLimit = 0;
         this.drawPhaseCards = DrawPhaseCards;
 
         this.cardsInPlay.each(card => {

--- a/test/server/cards/09-HoT/Besieged.spec.js
+++ b/test/server/cards/09-HoT/Besieged.spec.js
@@ -1,0 +1,48 @@
+describe('Besieged', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck = this.buildDeck('lannister', [
+                'Besieged', 'A Noble Cause'
+            ]);
+
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.keepStartingHands();
+            this.completeSetup();
+        });
+
+        describe('when Besieged is selected', function() {
+            beforeEach(function() {
+                this.player1.selectPlot('Besieged');
+                this.player2.selectPlot('A Noble Cause');
+                this.selectFirstPlayer(this.player1);
+            });
+
+            it('should set a minimum on both players', function() {
+                expect(this.player1Object.defenderLimits.getMin()).toBe(1);
+                expect(this.player2Object.defenderLimits.getMin()).toBe(1);
+            });
+        });
+
+        describe('when double Besieged is selected', function() {
+            beforeEach(function() {
+                this.player1.selectPlot('Besieged');
+                this.player2.selectPlot('Besieged');
+                this.selectFirstPlayer(this.player1);
+
+                this.completeMarshalPhase();
+                this.completeChallengesPhase();
+
+                this.player1.selectPlot('A Noble Cause');
+                this.player2.selectPlot('A Noble Cause');
+                this.selectFirstPlayer(this.player1);
+            });
+
+            it('should properly reset the defender limit', function() {
+                expect(this.player1Object.defenderLimits.getMin()).toBe(0);
+                expect(this.player2Object.defenderLimits.getMin()).toBe(0);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Previously, if two copies of Besieged were revealed at the same time,
the defender minimum would not reset properly after the next set of
plots were revealed. This was due to the second copy of Besieged seeing
the value set by the first one, and reseting it to that value. The bug
did not occur with double Jousting Contest because the maximum was being
explicitly reset at the start of the plot phase.

Now, both mins and maxs are stored on an array. Once all values are
unset, the default value will be returned again instead of overwriting
values.

~~Needs #1607 to be merged first~~
Fixes #1602 