### PR TITLE
Redirect immediately after saving deck

### DIFF
--- a/client/AddDeck.jsx
+++ b/client/AddDeck.jsx
@@ -24,7 +24,7 @@ export class InnerAddDeck extends React.Component {
         this.props.addDeck();
     }
 
-    componentWillUpdate() {
+    componentDidUpdate() {
         if(this.props.deckSaved) {
             this.props.navigate('/decks');
 

--- a/client/EditDeck.jsx
+++ b/client/EditDeck.jsx
@@ -25,7 +25,7 @@ class InnerEditDeck extends React.Component {
         }
     }
 
-    componentWillUpdate() {
+    componentDidUpdate() {
         if(this.props.deckSaved) {
             this.props.navigate('/decks');
 


### PR DESCRIPTION
Previously, you had to click the "Add/Save" button when editing decks
twice before it would take you back to the deck list. It was saving both
times, but the navigation check was happening prior to the properties
being updated for the components. Thus, it would only detect the change
the second time the button was pressed.