### PR TITLE
Cycle plots right after When Revealeds have been resolved

### DIFF
--- a/server/game/gamesteps/plotphase.js
+++ b/server/game/gamesteps/plotphase.js
@@ -15,9 +15,9 @@ class PlotPhase extends Phase {
             new SimpleStep(game, () => this.removeActivePlots()),
             new SimpleStep(game, () => this.flipPlotsFaceup()),
             () => new RevealPlots(game, _.map(this.game.getPlayers(), player => player.activePlot)),
+            new SimpleStep(game, () => this.recyclePlots()),
             () => new ChooseTitlePrompt(game, game.titlePool),
-            new ActionWindow(this.game, 'After plots revealed', 'plot'),
-            new SimpleStep(game, () => this.recyclePlots())
+            new ActionWindow(this.game, 'After plots revealed', 'plot')
         ]);
     }
 


### PR DESCRIPTION
As per the RRG, plots should cycle right after When Revealeds have been resolved, and before Melee title selection or plot phase action window.

https://thronesdb.com/rulesreference#1.3_Reveal_plots