### PR TITLE
Fix webpack build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ cd throneteki
 git submodule init
 git submodule update
 npm install
-npm run build-vendor:dev
+npm run build-vendor-dev
 mkdir server/logs
 node server/scripts/fetchdata.js
 node .

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ cd throneteki
 git submodule init
 git submodule update
 npm install
-npm run build-vendor
+npm run build-vendor:dev
 mkdir server/logs
 node server/scripts/fetchdata.js
 node .
@@ -82,6 +82,7 @@ This will get you up and running in development mode.
 For production:
 
 ```
+npm run build-vendor
 npm run build
 NODE_ENV=production PORT=4000 node .
 ```

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "cover": "cross-env JASMINE_CONFIG_PATH=./jasmine.json istanbul cover --include-all-sources jasmine",
     "lint": "eslint server/ test/server/ client/ --ext=js --ext=jsx",
     "build-vendor": "webpack --config webpack.config.vendor.js --env.prod",
-    "build-vendor:dev": "webpack --config webpack.config.vendor.js",
+    "build-vendor-dev": "webpack --config webpack.config.vendor.js",
     "build": "webpack --config webpack.config.js --env.prod"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "jasmine": "cross-env JASMINE_CONFIG_PATH=./jasmine.json jasmine",
     "cover": "cross-env JASMINE_CONFIG_PATH=./jasmine.json istanbul cover --include-all-sources jasmine",
     "lint": "eslint server/ test/server/ client/ --ext=js --ext=jsx",
-    "build-vendor": "webpack --config webpack.config.vendor.js --env.prod",
+    "build-vendor": "webpack -p --config webpack.config.vendor.js --env.prod",
     "build-vendor-dev": "webpack --config webpack.config.vendor.js",
-    "build": "webpack --config webpack.config.js --env.prod"
+    "build": "webpack -p --config webpack.config.js --env.prod"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
     "jasmine": "cross-env JASMINE_CONFIG_PATH=./jasmine.json jasmine",
     "cover": "cross-env JASMINE_CONFIG_PATH=./jasmine.json istanbul cover --include-all-sources jasmine",
     "lint": "eslint server/ test/server/ client/ --ext=js --ext=jsx",
-    "build-vendor": "cross-env NODE_ENV=production webpack -p --config webpack.config.vendor.js --env.prod=true",
-    "build": "cross-env NODE_ENV=production webpack -p --config webpack.config.js --env.prod=true"
+    "build-vendor": "webpack --config webpack.config.vendor.js --env.prod",
+    "build-vendor:dev": "webpack --config webpack.config.vendor.js",
+    "build": "webpack --config webpack.config.js --env.prod"
   },
   "repository": {
     "type": "git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,9 +51,6 @@ module.exports = (env) => {
         },
         output: { path: path.join(__dirname, clientBundleOutputDir) },
         plugins: [
-            new webpack.DefinePlugin({
-                'process.env.NODE_ENV': isDevBuild ? '"development"' : '"production"'
-            }),
             new webpack.DllReferencePlugin({
                 context: __dirname,
                 manifest: require('./public/vendor-manifest.json')
@@ -70,7 +67,6 @@ module.exports = (env) => {
             })
         ] : [
             new ExtractTextPlugin('site-[hash].css'),
-            new webpack.optimize.UglifyJsPlugin(),
             assetsPluginInstance
         ])
     });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,6 +51,9 @@ module.exports = (env) => {
         },
         output: { path: path.join(__dirname, clientBundleOutputDir) },
         plugins: [
+            new webpack.DefinePlugin({
+                'process.env.NODE_ENV': isDevBuild ? '"development"' : '"production"'
+            }),
             new webpack.DllReferencePlugin({
                 context: __dirname,
                 manifest: require('./public/vendor-manifest.json')

--- a/webpack.config.vendor.js
+++ b/webpack.config.vendor.js
@@ -51,9 +51,6 @@ module.exports = (env) => {
         plugins: [
             new webpack.ProvidePlugin({ $: 'jquery', jQuery: 'jquery' }),
             new webpack.NormalModuleReplacementPlugin(/\/iconv-loader$/, require.resolve('node-noop')), // Workaround for https://github.com/andris9/encoding/issues/16
-            new webpack.DefinePlugin({
-                'process.env.NODE_ENV': isDevBuild ? '"development"' : '"production"'
-            }),
             assetsPluginInstance
         ]
     };
@@ -69,9 +66,7 @@ module.exports = (env) => {
                 path: path.join(BUILD_DIR, '[name]-manifest.json'),
                 name: '[name]_[hash]'
             })
-        ].concat(isDevBuild ? [] : [
-            new webpack.optimize.UglifyJsPlugin()
-        ])
+        ]
     });
 
     return clientBundleConfig;


### PR DESCRIPTION
Adds a `build-vendor:dev` script for local development. This fixes the
issue where building the vendor scripts in production mode but running
the server in development mode caused ReactDOMServer.renderToString to
crash.

Removes the `-p` option from the build scripts. This was conflicting
with the usage of UglifyJsPlugin, basically uglifying Javascript code
twice. See:
https://github.com/webpack/webpack/issues/1385#issuecomment-160553651

Removes the unnecessary passing of environment variables to Webpack.
Environment is now controlled completely using the `--env` option.