### PR TITLE
Add alert when using actions outside of window

### DIFF
--- a/server/game/ambushcardaction.js
+++ b/server/game/ambushcardaction.js
@@ -12,6 +12,10 @@ class AmbushCardAction extends BaseAbility {
         this.title = 'Ambush';
     }
 
+    isAction() {
+        return true;
+    }
+
     isCardAbility() {
         return false;
     }

--- a/server/game/baseability.js
+++ b/server/game/baseability.js
@@ -177,7 +177,7 @@ class BaseAbility {
     }
 
     isAction() {
-        return true;
+        return false;
     }
 
     isPlayableEventAbility() {

--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -143,6 +143,10 @@ class CardAction extends BaseAbility {
         return { text: this.title, method: 'doAction', anyPlayer: !!this.anyPlayer, arg: arg };
     }
 
+    isAction() {
+        return true;
+    }
+
     isClickToActivate() {
         return this.clickToActivate;
     }

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -677,7 +677,7 @@ class Game extends EventEmitter {
         if(this.currentActionWindow) {
             this.currentActionWindow.markActionAsTaken();
         } else if(this.currentPhase !== 'marshal') {
-            this.addAlert('danger', '{0} has used {1} outside the proper action window', context.player, context.source);
+            this.addAlert('danger', '{0} uses {1} outside of an action window', context.player, context.source);
         }
     }
 

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -673,9 +673,11 @@ class Game extends EventEmitter {
         this.pipeline.queueStep(new SimpleStep(this, handler));
     }
 
-    markActionAsTaken() {
+    markActionAsTaken(context) {
         if(this.currentActionWindow) {
             this.currentActionWindow.markActionAsTaken();
+        } else if(this.currentPhase !== 'marshal') {
+            this.addAlert('danger', '{0} has used {1} outside the proper action window', context.player, context.source);
         }
     }
 

--- a/server/game/gamesteps/abilityresolver.js
+++ b/server/game/gamesteps/abilityresolver.js
@@ -74,7 +74,7 @@ class AbilityResolver extends BaseStep {
 
     markActionAsTaken() {
         if(this.ability.isAction()) {
-            this.game.markActionAsTaken();
+            this.game.markActionAsTaken(this.context);
         }
     }
 

--- a/server/game/marshalcardaction.js
+++ b/server/game/marshalcardaction.js
@@ -12,6 +12,10 @@ class MarshalCardAction extends BaseAbility {
         this.title = 'Marshal';
     }
 
+    isAction() {
+        return true;
+    }
+
     meetsRequirements(context) {
         var {game, player, source} = context;
 

--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -107,10 +107,6 @@ class TriggeredAbility extends BaseAbility {
         return this.location === location;
     }
 
-    isAction() {
-        return false;
-    }
-
     isPlayableEventAbility() {
         return this.card.getType() === 'event' && this.location === 'hand';
     }


### PR DESCRIPTION
To make it more clear that players are not following the rules, Action
abilities used outside an explicit action window now add a danger alert
in the game log.

![screen shot 2017-12-01 at 11 35 18 pm](https://user-images.githubusercontent.com/145077/33513064-6e0bdc58-d6f0-11e7-977c-09e134dc4442.png)
