### PR TITLE
Use simultaneous event for discarding cards

### DIFF
--- a/server/game/GroupedCardEvent.js
+++ b/server/game/GroupedCardEvent.js
@@ -26,6 +26,21 @@ class GroupedCardEvent extends Event {
         }
     }
 
+    replaceCards(newCards) {
+        if(newCards.length !== this.childEvents.length) {
+            return;
+        }
+
+        let index = 0;
+
+        for(let card of newCards) {
+            this.childEvents[index].card = card;
+            ++index;
+        }
+
+        this.cards = newCards;
+    }
+
     onChildCancelled(event) {
         super.onChildCancelled(event);
         this.removeCard(event.card);

--- a/server/game/cards/05-LoCR/TywinLannister.js
+++ b/server/game/cards/05-LoCR/TywinLannister.js
@@ -35,7 +35,7 @@ class TywinLannister extends DrawCard {
             return false;
         }
 
-        this.eventObj.cards = [card];
+        this.eventObj.replaceCards([card]);
         this.game.addMessage('{0} uses {1} to choose {2} to be discarded for {3}', this.controller, this, card, this.discardingPlayer);
 
         return true;

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -885,32 +885,22 @@ class Player extends Spectator {
         this.game.applyGameAction('discard', cards, cards => {
             var params = {
                 player: this,
-                cards: cards,
                 allowSave: allowSave,
                 automaticSaveWithDupe: true,
                 originalLocation: cards[0].location
             };
-            this.game.raiseEvent('onCardsDiscarded', params, event => {
-                _.each(event.cards, card => {
-                    this.doSingleCardDiscard(card, allowSave);
-                });
-                this.game.queueSimpleStep(() => {
+            this.game.raiseSimultaneousEvent(cards, {
+                eventName: 'onCardsDiscarded',
+                params: params,
+                handler: () => true,
+                perCardEventName: 'onCardDiscarded',
+                perCardHandler: event => {
+                    this.moveCard(event.card, 'discard pile');
+                },
+                postHandler: event => {
                     callback(event.cards);
-                });
+                }
             });
-        });
-    }
-
-    doSingleCardDiscard(card, allowSave = true) {
-        var params = {
-            player: this,
-            card: card,
-            allowSave: allowSave,
-            automaticSaveWithDupe: true,
-            originalLocation: card.location
-        };
-        this.game.raiseEvent('onCardDiscarded', params, event => {
-            this.moveCard(event.card, 'discard pile');
         });
     }
 

--- a/test/server/cards/01-Core/Bodyguard.spec.js
+++ b/test/server/cards/01-Core/Bodyguard.spec.js
@@ -1,0 +1,57 @@
+describe('Bodyguard', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck = this.buildDeck('stark', [
+                'A Noble Cause', 'Valar Morghulis',
+                'Catelyn Stark (Core)', 'Varys', 'Bodyguard'
+            ]);
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.character = this.player1.findCardByName('Catelyn Stark', 'hand');
+            this.player1.clickCard(this.character);
+            this.player1.clickCard('Bodyguard', 'hand');
+
+            this.player2.clickCard('Varys', 'hand');
+
+            this.completeSetup();
+
+            this.player1.clickCard('Bodyguard', 'play area');
+            this.player1.clickCard(this.character);
+        });
+
+        describe('when the character would be killed', function() {
+            beforeEach(function() {
+                this.player1.selectPlot('A Noble Cause');
+                this.player2.selectPlot('Valar Morghulis');
+                this.selectFirstPlayer(this.player1);
+
+                this.player1.clickPrompt('Bodyguard');
+            });
+
+            it('should save the character', function() {
+                expect(this.character.location).toBe('play area');
+            });
+        });
+
+        describe('when the character would be discarded from play', function() {
+            beforeEach(function() {
+                this.player1.selectPlot('A Noble Cause');
+                this.player2.selectPlot('A Noble Cause');
+                this.selectFirstPlayer(this.player2);
+
+                this.completeMarshalPhase();
+                this.completeChallengesPhase();
+                this.player2.clickPrompt('Varys');
+
+                this.player1.clickPrompt('Bodyguard');
+            });
+
+            it('should save the character', function() {
+                expect(this.character.location).toBe('play area');
+            });
+        });
+    });
+});

--- a/test/server/player/discardcards.spec.js
+++ b/test/server/player/discardcards.spec.js
@@ -1,24 +1,25 @@
-const _ = require('underscore');
-
 const Player = require('../../../server/game/player.js');
 
 describe('Player', function() {
 
-    function createCardSpy(num, owner) {
+    function createCardSpy(num) {
         let spy = jasmine.createSpyObj('card', ['moveTo', 'removeDuplicate']);
         spy.num = num;
         spy.location = 'loc';
-        spy.dupes = _([]);
-        spy.owner = owner;
         return spy;
     }
 
     beforeEach(function() {
-        this.gameSpy = jasmine.createSpyObj('game', ['applyGameAction', 'raiseEvent', 'queueSimpleStep', 'addMessage']);
+        this.gameSpy = jasmine.createSpyObj('game', ['applyGameAction', 'raiseSimultaneousEvent']);
         this.gameSpy.applyGameAction.and.callFake((type, cards, handler) => {
             if(cards.length > 0) {
                 handler(cards);
             }
+        });
+        this.gameSpy.raiseSimultaneousEvent.and.callFake((cards, params) => {
+            this.handler = params.handler;
+            this.postHandler = params.postHandler;
+            this.perCardHandler = params.perCardHandler;
         });
 
         this.player = new Player('1', { username: 'Test 1', settings: {} }, true, this.gameSpy);
@@ -26,8 +27,8 @@ describe('Player', function() {
 
         this.callbackSpy = jasmine.createSpy('callback');
 
-        this.card1 = createCardSpy(1, this.player);
-        this.card2 = createCardSpy(2, this.player);
+        this.card1 = createCardSpy(1);
+        this.card2 = createCardSpy(2);
     });
 
     describe('discardCards()', function() {
@@ -37,56 +38,46 @@ describe('Player', function() {
             });
 
             it('should not raise the event', function() {
-                expect(this.gameSpy.raiseEvent).not.toHaveBeenCalled();
+                expect(this.gameSpy.raiseSimultaneousEvent).not.toHaveBeenCalled();
             });
         });
 
         describe('when cards are passed', function() {
             beforeEach(function() {
-                this.eventOuterParams = { player: this.player, cards: [this.card1, this.card2], allowSave: false, automaticSaveWithDupe: true, originalLocation: 'loc' };
                 this.player.discardCards([this.card1, this.card2], false, this.callbackSpy);
             });
 
             it('should raise the onCardsDiscarded event', function() {
-                expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onCardsDiscarded', this.eventOuterParams, jasmine.any(Function));
+                expect(this.gameSpy.raiseSimultaneousEvent).toHaveBeenCalledWith([this.card1, this.card2], jasmine.objectContaining({
+                    eventName: 'onCardsDiscarded',
+                    postHandler: jasmine.any(Function),
+                    perCardEventName: 'onCardDiscarded',
+                    perCardHandler: jasmine.any(Function),
+                    params: jasmine.objectContaining({
+                        allowSave: false,
+                        automaticSaveWithDupe: true,
+                        originalLocation: 'loc'
+                    })
+                }));
             });
 
-            describe('the onCardsDiscarded handler', function() {
+            describe('the perCardHandler', function() {
                 beforeEach(function() {
-                    this.gameSpy.queueSimpleStep.and.callFake(callback => {
-                        this.simpleStepCallback = callback;
-                    });
-                    this.eventInnerParams1 = { player: this.player, card: this.card1, allowSave: false, automaticSaveWithDupe: true, originalLocation: 'loc' };
-                    this.eventInnerParams2 = { player: this.player, card: this.card2, allowSave: false, automaticSaveWithDupe: true, originalLocation: 'loc' };
-                    this.onCardsDiscardedHandler = this.gameSpy.raiseEvent.calls.mostRecent().args[2];
-                    this.onCardsDiscardedHandler(this.eventOuterParams);
+                    this.perCardHandler({ card: this.card1 });
                 });
 
-                it('should raise the onCardDiscarded event for each card', function() {
-                    expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onCardDiscarded', this.eventInnerParams1, jasmine.any(Function));
-                    expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onCardDiscarded', this.eventInnerParams2, jasmine.any(Function));
+                it('should move the card to the discard pile', function() {
+                    expect(this.player.moveCard).toHaveBeenCalledWith(this.card1, 'discard pile');
+                });
+            });
+
+            describe('the postHandler', function() {
+                beforeEach(function() {
+                    this.postHandler({ cards: [this.card1, this.card2] });
                 });
 
-                it('should queue a step to call the callback', function() {
-                    expect(this.gameSpy.queueSimpleStep).toHaveBeenCalled();
-                });
-
-                describe('the simple step callback', function() {
-                    it('should call the original callback', function() {
-                        this.simpleStepCallback();
-                        expect(this.callbackSpy).toHaveBeenCalledWith([this.card1, this.card2]);
-                    });
-                });
-
-                describe('the onCardDiscarded handler', function() {
-                    beforeEach(function() {
-                        this.onCardDiscardedHandler = this.gameSpy.raiseEvent.calls.mostRecent().args[2];
-                        this.onCardDiscardedHandler(this.eventInnerParams1);
-                    });
-
-                    it('should move the card to discard', function() {
-                        expect(this.player.moveCard).toHaveBeenCalledWith(this.card1, 'discard pile');
-                    });
+                it('should call the callback with the appropriate cards', function() {
+                    expect(this.callbackSpy).toHaveBeenCalledWith([this.card1, this.card2]);
                 });
             });
         });
@@ -94,38 +85,11 @@ describe('Player', function() {
 
     describe('discardCard()', function() {
         beforeEach(function() {
-            this.eventOuterParams = { player: this.player, cards: [this.card1], allowSave: false, automaticSaveWithDupe: true, originalLocation: 'loc' };
             this.player.discardCard(this.card1, false);
         });
 
         it('should raise the onCardsDiscarded event', function() {
-            expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onCardsDiscarded', this.eventOuterParams, jasmine.any(Function));
-        });
-
-        describe('the onCardsDiscarded handler', function() {
-            beforeEach(function() {
-                this.gameSpy.queueSimpleStep.and.callFake(callback => {
-                    this.simpleStepCallback = callback;
-                });
-                this.eventInnerParams1 = { player: this.player, card: this.card1, allowSave: false, automaticSaveWithDupe: true, originalLocation: 'loc' };
-                this.onCardsDiscardedHandler = this.gameSpy.raiseEvent.calls.mostRecent().args[2];
-                this.onCardsDiscardedHandler(this.eventOuterParams);
-            });
-
-            it('should raise the onCardDiscarded event for each card', function() {
-                expect(this.gameSpy.raiseEvent).toHaveBeenCalledWith('onCardDiscarded', this.eventInnerParams1, jasmine.any(Function));
-            });
-
-            describe('the onCardDiscarded handler', function() {
-                beforeEach(function() {
-                    this.onCardDiscardedHandler = this.gameSpy.raiseEvent.calls.mostRecent().args[2];
-                    this.onCardDiscardedHandler(this.eventInnerParams1);
-                });
-
-                it('should move the card to discard', function() {
-                    expect(this.player.moveCard).toHaveBeenCalledWith(this.card1, 'discard pile');
-                });
-            });
+            expect(this.gameSpy.raiseSimultaneousEvent).toHaveBeenCalledWith([this.card1], jasmine.objectContaining({ eventName: 'onCardsDiscarded' }));
         });
     });
 });


### PR DESCRIPTION
After refactoring the event system and introducing the GroupedCardEvent,
Bodyguard was crashing when saving against discarding the card from
play. Now, the discard events are all in the same reaction window and
it's possible to save properly.

Fixes THRONETEKI-1P8