### PR TITLE
Fix positioning of Core Arya dupes

### DIFF
--- a/less/cards.less
+++ b/less/cards.less
@@ -254,6 +254,18 @@
 .card-dupe {
   margin-bottom: @attachment-offset;
   margin-top: -(@attachment-offset + @card-height);
+
+  &.small {
+    margin-top: -(@attachment-offset + @card-sm-height);
+  }
+
+  &.large {
+    margin-top: -(@attachment-offset + @card-lg-height);
+  }
+
+  &.x-large {
+    margin-top: -(@attachment-offset + @card-xl-height);
+  }
 }
 
 .generate-card-dupes(@n, @i: 1) when (@i =< @n) {


### PR DESCRIPTION
Positioning for dupes on Core Arya at card sizes other than "normal" did
not fully pull themselves above the parent card, thus pushing down any
additional cards attached.