### PR TITLE
Clarify second Mag kill to resolve only when first was not saved

### DIFF
--- a/server/game/cards/08.1-TAK/MagTheMighty.js
+++ b/server/game/cards/08.1-TAK/MagTheMighty.js
@@ -15,6 +15,7 @@ class MagTheMighty extends DrawCard {
 
                 //TODO Technically should only trigger when the first kill was not saved
                 this.game.promptForSelect(context.event.challenge.loser, {
+                    activePromptTitle: 'Select a character (only when first kill was not saved)',
                     cardCondition: card => card.location === 'play area' && card.controller === context.event.challenge.loser && card.getType() === 'character',
                     source: this,
                     onSelect: (player, card) => this.onCardSelected(player, card)


### PR DESCRIPTION
Have already seen this go wrong a couple of times, so a reminder seems appriopriate.

![mag_screen](https://user-images.githubusercontent.com/23409205/33666617-d275aba8-da9a-11e7-875b-8b1ed2d9eae9.png)
