### PR TITLE
Allow dupes to be moved / discarded

### DIFF
--- a/server/game/cards/02.3-TKP/CroneOfVaesDothrak.js
+++ b/server/game/cards/02.3-TKP/CroneOfVaesDothrak.js
@@ -8,7 +8,8 @@ class CroneOfVaesDothrak extends DrawCard {
                 onCardDiscarded: event =>
                     ((event.originalLocation === 'hand' || event.originalLocation === 'draw deck')
                      && event.card.getType() === 'character'
-                     && event.card.controller !== this.controller)
+                     && event.card.controller !== this.controller
+                     && event.card.location === 'discard pile')
             },
             cost: ability.costs.kneel(card => (
                 card.getType() === 'character' && card.hasTrait('Dothraki')

--- a/server/game/cards/02.3-TKP/SerGregorClegane.js
+++ b/server/game/cards/02.3-TKP/SerGregorClegane.js
@@ -4,7 +4,7 @@ class SerGregorClegane extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onPillage: event => event.source === this && event.discardedCard.getType() === 'character'
+                onPillage: event => event.source === this && event.discardedCard.getType() === 'character' && event.discardedCard.location === 'discard pile'
             },
             handler: context => {
                 let discarded = context.event.discardedCard;

--- a/server/game/cards/04.6-TC/BattleOfTheBlackwater.js
+++ b/server/game/cards/04.6-TC/BattleOfTheBlackwater.js
@@ -1,5 +1,3 @@
-const _ = require('underscore');
-
 const PlotCard = require('../../plotcard.js');
 
 class BattleOfTheBlackwater extends PlotCard {
@@ -22,11 +20,8 @@ class BattleOfTheBlackwater extends PlotCard {
         // control, not discarding the dupes on cards you or the opponent
         // control. But for 2 player, discarding each dupe is fine.
         let characters = player.filterCardsInPlay(card => card.dupes.size() > 0);
-        _.each(characters, character => {
-            while(character.dupes.size() > 0) {
-                player.removeDuplicate(character, true);
-            }
-        });
+        let dupes = characters.reduce((dupes, card) => dupes.concat(card.dupes.toArray()), []);
+        player.discardCards(dupes, false);
     }
 }
 

--- a/server/game/cards/07-WotW/NowMyWatchBegins.js
+++ b/server/game/cards/07-WotW/NowMyWatchBegins.js
@@ -4,7 +4,7 @@ class NowMyWatchBegins extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onCardPlaced: event => event.location === 'discard pile' &&
+                onCardPlaced: event => event.card.location === 'discard pile' &&
                                        event.player !== this.controller &&
                                        event.card.getType() === 'character' &&
                                        event.card.getCost() <= 5 &&

--- a/server/game/cards/08.1-TAK/NaggasRibs.js
+++ b/server/game/cards/08.1-TAK/NaggasRibs.js
@@ -9,7 +9,7 @@ class NaggasRibs extends DrawCard {
 
         this.reaction({
             when: {
-                onCardPlaced: event => event.card.getType() === 'character' && event.location === 'discard pile' &&
+                onCardPlaced: event => event.card.getType() === 'character' && event.card.location === 'discard pile' &&
                                        event.card.owner === this.controller
             },
             handler: context => {

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -93,7 +93,7 @@ class DrawCard extends BaseCard {
         }
 
         this.dupes.push(card);
-        card.moveTo('duplicate');
+        card.moveTo('duplicate', this);
     }
 
     removeDuplicate(force = false) {
@@ -356,13 +356,13 @@ class DrawCard extends BaseCard {
         return card && this.getType() === 'attachment';
     }
 
-    removeAttachment(attachment) {
-        if(!attachment || !this.attachments.includes(attachment)) {
+    removeChildCard(card) {
+        if(!card) {
             return;
         }
 
-        this.attachments = _(this.attachments.reject(a => a === attachment));
-        attachment.parent = undefined;
+        this.attachments = _(this.attachments.reject(a => a === card));
+        this.dupes = _(this.dupes.reject(a => a === card));
     }
 
     getPlayActions() {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -766,7 +766,9 @@ class Game extends EventEmitter {
 
     saveWithDupe(card) {
         let player = card.controller;
-        if(card.canBeSaved() && player.removeDuplicate(card)) {
+        let dupe = card.dupes.find(dupe => dupe.owner === card.controller);
+        if(card.canBeSaved() && dupe) {
+            dupe.owner.discardCard(dupe, false);
             card.markAsSaved();
             this.addMessage('{0} discards a duplicate to save {1}', player, card);
             this.raiseEvent('onCardSaved', { card: card });

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -1021,8 +1021,8 @@ class Player extends Spectator {
                 this.removeAttachment(attachment, false);
             });
 
-            while(card.dupes.size() > 0 && targetLocation !== 'play area') {
-                this.removeDuplicate(card, true);
+            if(!card.dupes.isEmpty()) {
+                this.discardCards(card.dupes.toArray(), false);
             }
         }
 
@@ -1073,22 +1073,6 @@ class Player extends Spectator {
         });
     }
 
-    removeDuplicate(card, force = false) {
-        if(card.dupes.isEmpty()) {
-            return false;
-        }
-
-        var dupe = card.removeDuplicate(force);
-        if(!dupe) {
-            return false;
-        }
-
-        dupe.moveTo('discard pile');
-        dupe.owner.discardPile.push(dupe);
-
-        return true;
-    }
-
     removeCardFromPile(card) {
         if(card.controller !== this) {
             card.controller.removeCardFromPile(card);
@@ -1097,7 +1081,8 @@ class Player extends Spectator {
         }
 
         if(card.parent) {
-            card.parent.removeAttachment(card);
+            card.parent.removeChildCard(card);
+            card.parent = undefined;
         }
 
         var originalLocation = card.location;

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -686,12 +686,8 @@ class Player extends Spectator {
         }
 
         let originalLocation = attachment.location;
-        let originalParent = attachment.parent;
 
         attachment.owner.removeCardFromPile(attachment);
-        if(originalParent) {
-            originalParent.removeAttachment(attachment);
-        }
         attachment.moveTo('play area', card);
         attachment.controller = player;
         card.attachments.push(attachment);
@@ -1028,10 +1024,6 @@ class Player extends Spectator {
             while(card.dupes.size() > 0 && targetLocation !== 'play area') {
                 this.removeDuplicate(card, true);
             }
-
-            if(card.parent) {
-                card.parent.removeAttachment(card);
-            }
         }
 
         if(['play area', 'active plot'].includes(card.location)) {
@@ -1040,10 +1032,6 @@ class Player extends Spectator {
 
         if(card.location === 'active plot') {
             this.game.raiseEvent('onCardLeftPlay', { player: this, card: card });
-        }
-
-        if(card.parent) {
-            card.parent.removeAttachment(card);
         }
 
         card.moveTo(targetLocation);
@@ -1106,6 +1094,10 @@ class Player extends Spectator {
             card.controller.removeCardFromPile(card);
             card.controller = card.owner;
             return;
+        }
+
+        if(card.parent) {
+            card.parent.removeAttachment(card);
         }
 
         var originalLocation = card.location;

--- a/test/server/cards/08.1-TAK/NaggasRibs.spec.js
+++ b/test/server/cards/08.1-TAK/NaggasRibs.spec.js
@@ -1,0 +1,107 @@
+describe('Nagga\'s Ribs', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck1 = this.buildDeck('greyjoy', [
+                'Marched to the Wall', 'A Noble Cause',
+                'Theon Greyjoy (Core)', 'Theon Greyjoy (Core)', 'Nagga\'s Ribs'
+            ]);
+
+            const deck2 = this.buildDeck('thenightswatch', [
+                'A Noble Cause',
+                'Hedge Knight', 'Now My Watch Begins', 'Mutiny At Craster\'s Keep'
+            ]);
+
+            this.player1.selectDeck(deck1);
+            this.player2.selectDeck(deck2);
+            this.startGame();
+            this.keepStartingHands();
+
+            [this.character1, this.character2] = this.player1.filterCardsByName('Theon Greyjoy', 'hand');
+
+            this.player1.clickCard(this.character1);
+            this.player1.clickCard('Nagga\'s Ribs', 'hand');
+
+            this.player2.clickCard('Hedge Knight', 'hand');
+            this.completeSetup();
+        });
+
+        describe('when a character is discarded', function() {
+            beforeEach(function() {
+                this.player1.selectPlot('Marched to the Wall');
+                this.player2.selectPlot('A Noble Cause');
+                this.selectFirstPlayer(this.player1);
+
+                this.player1.clickCard('Theon Greyjoy', 'play area');
+                this.player2.clickCard('Hedge Knight', 'play area');
+
+                this.player1.clickPrompt('Nagga\'s Ribs');
+            });
+
+            it('should move the card to the dead pile', function() {
+                expect(this.character1.location).toBe('dead pile');
+            });
+        });
+
+        describe('when a dupe is discarded', function() {
+            beforeEach(function() {
+                this.player2.togglePromptedActionWindow('dominance', true);
+
+                this.player1.selectPlot('A Noble Cause');
+                this.player2.selectPlot('A Noble Cause');
+                this.selectFirstPlayer(this.player1);
+
+                this.player1.clickCard(this.character2);
+                this.completeMarshalPhase();
+                this.completeChallengesPhase();
+
+                this.player2.clickCard('Mutiny At Craster\'s Keep', 'hand');
+                this.player2.clickCard('Hedge Knight', 'play area');
+                this.player2.clickCard(this.character1);
+
+                this.player1.clickPrompt('Nagga\'s Ribs');
+            });
+
+            it('should move the dupe to the dead pile', function() {
+                expect(this.character2.location).toBe('dead pile');
+            });
+        });
+
+        describe('vs Now My Watch Begins', function() {
+            beforeEach(function() {
+                this.player2.togglePromptedActionWindow('dominance', true);
+
+                this.player1.selectPlot('A Noble Cause');
+                this.player2.selectPlot('A Noble Cause');
+                this.selectFirstPlayer(this.player1);
+
+                this.completeMarshalPhase();
+                this.completeChallengesPhase();
+
+                this.player2.clickCard('Mutiny At Craster\'s Keep', 'hand');
+                this.player2.clickCard('Hedge Knight', 'play area');
+                this.player2.clickCard(this.character1);
+            });
+
+            describe('when Now My Watch Begins is triggered first', function() {
+                beforeEach(function() {
+                    this.player1.clickPrompt('Pass');
+                    this.player2.clickPrompt('Now My Watch Begins');
+                });
+
+                it('should not prompt for Nagga\'s Ribs', function() {
+                    expect(this.player1).not.toHavePromptButton('Nagga\'s Ribs');
+                });
+            });
+
+            describe('when Now My Watch Begins is triggered first', function() {
+                beforeEach(function() {
+                    this.player1.clickPrompt('Nagga\'s Ribs');
+                });
+
+                it('should not prompt for Now My Watch Begins', function() {
+                    expect(this.player2).not.toHavePromptButton('Now My Watch Begins');
+                });
+            });
+        });
+    });
+});

--- a/test/server/player/movecard.spec.js
+++ b/test/server/player/movecard.spec.js
@@ -132,12 +132,13 @@ describe('Player', function() {
                     this.dupe = new DrawCard(this.player, {});
                     this.card.addDuplicate(this.dupe);
 
+                    spyOn(this.player, 'discardCards');
+
                     this.player.moveCard(this.card, 'hand');
                 });
 
                 it('should discard the dupes', function() {
-                    expect(this.player.discardPile).toContain(this.dupe);
-                    expect(this.dupe.location).toBe('discard pile');
+                    expect(this.player.discardCards).toHaveBeenCalledWith([this.dupe], false);
                 });
             });
         });


### PR DESCRIPTION
Previously, duplicates were manually removed and placed in the discard pile without generating the events normally associated with discard. Now, when they're attached they record their parent card, allowing them to be discarded directly using the normal `discardCards` method.

Also fixes related card abilities that interact / move cards that are placed in discard - if the card is moved out discard before the ability is triggered (e.g. Now My Watch Begins vs Nagga's Ribs), the prompt for that ability will go away.

Fixes #1610 
Fixes #1623
Fixes #1639

Provides the groundwork for #1521 but additional effect engine changes seem to be required (effects applied to cards with location 'duplicate' instead of 'play area').