### PR TITLE
Fix double prompt for cancels

### DIFF
--- a/server/game/gamesteps/triggeredabilitywindow.js
+++ b/server/game/gamesteps/triggeredabilitywindow.js
@@ -76,7 +76,7 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
         };
 
         return this.isTimerEnabled(player) && _.any(this.event.getConcurrentEvents(), event => {
-            return event.player !== player && cancellableEvents[event.name] && cancellableEvents[event.name] === this.abilityType && this.isWindowEnabledForEvent(player, event);
+            return !event.cancelled && event.player !== player && cancellableEvents[event.name] && cancellableEvents[event.name] === this.abilityType && this.isWindowEnabledForEvent(player, event);
         });
     }
 

--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -46,7 +46,7 @@ class TriggeredAbility extends BaseAbility {
     isTriggeredByEvent(event) {
         let listener = this.when[event.name];
 
-        if(!listener) {
+        if(!listener || event.cancelled) {
             return false;
         }
 

--- a/test/server/card/cardreaction.spec.js
+++ b/test/server/card/cardreaction.spec.js
@@ -113,8 +113,8 @@ describe('CardReaction', function () {
 
     describe('meetsRequirements()', function() {
         beforeEach(function() {
+            this.event = new Event('onSomething', {});
             this.meetsRequirements = () => {
-                this.event = new Event('onSomething', {});
                 this.reaction = new CardReaction(this.gameSpy, this.cardSpy, this.properties);
                 this.context = this.reaction.createContext(this.event);
                 return this.reaction.meetsRequirements(this.context);
@@ -149,6 +149,16 @@ describe('CardReaction', function () {
         describe('when the when condition returns false', function() {
             beforeEach(function() {
                 this.properties.when.onSomething.and.returnValue(false);
+            });
+
+            it('should return false', function() {
+                expect(this.meetsRequirements()).toBe(false);
+            });
+        });
+
+        describe('when the event has already been cancelled', function() {
+            beforeEach(function() {
+                this.event.cancel();
             });
 
             it('should return false', function() {

--- a/test/server/integration/playingevents.spec.js
+++ b/test/server/integration/playingevents.spec.js
@@ -7,7 +7,7 @@ describe('playing events', function() {
             ]);
             const deck2 = this.buildDeck('martell', [
                 'Trading with the Pentoshi',
-                'The Hand\'s Judgment', 'Hedge Knight', 'Tower of the Sun', 'The Prince\'s Plan'
+                'The Hand\'s Judgment', 'The Hand\'s Judgment', 'Hedge Knight', 'Tower of the Sun', 'The Prince\'s Plan'
             ]);
             this.player1.selectDeck(deck1);
             this.player2.selectDeck(deck2);
@@ -57,6 +57,12 @@ describe('playing events', function() {
 
                 // Pass on Tower of the Sun
                 this.player2.clickPrompt('Pass');
+            });
+
+            it('should not prompt to cancel the event again', function() {
+                // The second copy of Hand's Judgment should not prompt for the
+                // already cancelled event.
+                expect(this.player2).not.toHavePromptButton('The Hand\'s Judgment');
             });
 
             it('should still count as having played the event', function() {


### PR DESCRIPTION
* Removes prompt choices for already cancelled events (e.g. two copies of a cancel in hand)
* Remove timed prompt for already cancelled event (e.g. use a cancel, should not get a blank timed prompt afterward)

Fixes #1636 