### PR TITLE
Implement Martell cards for Journey to Oldtown

### DIFF
--- a/server/game/cards/08.2-JtO/ArianneMartell.js
+++ b/server/game/cards/08.2-JtO/ArianneMartell.js
@@ -4,10 +4,15 @@ class ArianneMartell extends DrawCard {
     setupCardAbilities(ability) {
         this.action({
             title: 'Return character to hand',
+            //TODO: This should ideally use the snapshot functionality instead
+            condition: () => {
+                this.strengthWhenInitiated = this.getStrength();
+                return true;
+            },
             cost: ability.costs.returnSelfToHand(),
             target: {
                 cardCondition: card => card.location === 'play area' && card.getType() === 'character' &&
-                                       card.getStrength() < this.getStrength()
+                                       card.getStrength() < this.strengthWhenInitiated
             },
             handler: context => {
                 context.target.owner.returnCardToHand(context.target);

--- a/server/game/cards/08.2-JtO/ArianneMartell.js
+++ b/server/game/cards/08.2-JtO/ArianneMartell.js
@@ -1,0 +1,23 @@
+const DrawCard = require('../../drawcard.js');
+
+class ArianneMartell extends DrawCard {
+    setupCardAbilities(ability) {
+        this.action({
+            title: 'Return character to hand',
+            cost: ability.costs.returnSelfToHand(),
+            target: {
+                cardCondition: card => card.location === 'play area' && card.getType() === 'character' &&
+                                       card.getStrength() < this.getStrength()
+            },
+            handler: context => {
+                context.target.owner.returnCardToHand(context.target);
+                this.game.addMessage('{0} returns {1} to their hand to return {2} to {3}\'s hand',
+                    context.player, this, context.target, context.target.owner);
+            }
+        });
+    }
+}
+
+ArianneMartell.code = '08035';
+
+module.exports = ArianneMartell;

--- a/server/game/cards/08.2-JtO/ChangeOfPlans.js
+++ b/server/game/cards/08.2-JtO/ChangeOfPlans.js
@@ -1,0 +1,25 @@
+const DrawCard = require('../../drawcard.js');
+
+class ChangeOfPlans extends DrawCard {
+    setupCardAbilities() {
+        this.reaction({
+            when: {
+                afterChallenge: event => event.challenge.loser === this.controller && this.controller.getNumberOfUsedPlots() < 5
+            },
+            target: {
+                activePromptTitle: 'Select a plot',
+                cardCondition: card => ['plot deck', 'scheme plots'].includes(card.location) && card.controller === this.controller,
+                cardType: 'plot'
+            },
+            handler: context => {
+                context.player.moveCard(context.target, 'revealed plots', { bottom: true });
+                this.game.addMessage('{0} plays {1} to move {2} to the bottom of their used pile',
+                    context.player, this, context.target);
+            }
+        });
+    }
+}
+
+ChangeOfPlans.code = '08036';
+
+module.exports = ChangeOfPlans;

--- a/server/game/cards/agendas/TheRainsOfCastamere.js
+++ b/server/game/cards/agendas/TheRainsOfCastamere.js
@@ -7,7 +7,7 @@ class TheRainsOfCastamere extends AgendaCard {
     constructor(owner, cardData) {
         super(owner, cardData);
 
-        this.registerEvents(['onDecksPrepared', 'onPlotDiscarded']);
+        this.registerEvents(['onDecksPrepared', 'onPlotDiscarded', 'onPlotsRecycled']);
     }
 
     setupCardAbilities(ability) {
@@ -47,6 +47,12 @@ class TheRainsOfCastamere extends AgendaCard {
         _.each(this.schemes, scheme => {
             this.owner.moveCard(scheme, 'scheme plots');
         });
+    }
+
+    onPlotsRecycled(event) {
+        if(event.player === this.controller) {
+            this.onDecksPrepared();
+        }
     }
 
     onPlotDiscarded(event) {

--- a/server/game/cards/agendas/TheRainsOfCastamere.js
+++ b/server/game/cards/agendas/TheRainsOfCastamere.js
@@ -41,17 +41,21 @@ class TheRainsOfCastamere extends AgendaCard {
     }
 
     onDecksPrepared() {
-        var schemePartition = this.owner.plotDeck.partition(card => card.hasTrait('Scheme'));
-        this.schemes = schemePartition[0];
-        this.owner.plotDeck = _(schemePartition[1]);
-        _.each(this.schemes, scheme => {
-            this.owner.moveCard(scheme, 'scheme plots');
-        });
+        this.separateSchemePlots();
     }
 
     onPlotsRecycled(event) {
         if(event.player === this.controller) {
-            this.onDecksPrepared();
+            this.separateSchemePlots();
+        }
+    }
+
+    separateSchemePlots() {
+        let schemePartition = this.owner.plotDeck.partition(card => card.hasTrait('Scheme'));
+        let schemes = schemePartition[0];
+        this.owner.plotDeck = _(schemePartition[1]);
+        for(let scheme of schemes) {
+            this.owner.moveCard(scheme, 'scheme plots');
         }
     }
 
@@ -62,7 +66,7 @@ class TheRainsOfCastamere extends AgendaCard {
     }
 
     menuButtons() {
-        var buttons = _.map(this.schemes, scheme => {
+        let buttons = this.owner.schemePlots.map(scheme => {
             return { method: 'revealScheme', card: scheme };
         });
 
@@ -71,7 +75,7 @@ class TheRainsOfCastamere extends AgendaCard {
     }
 
     revealScheme(player, schemeId) {
-        var scheme = _.find(this.schemes, card => card.uuid === schemeId);
+        let scheme = this.owner.schemePlots.find(card => card.uuid === schemeId);
 
         if(!scheme) {
             return false;

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -238,12 +238,12 @@ class Game extends EventEmitter {
             return;
         }
 
-        if(card.location === 'plot deck') {
-            this.selectPlot(player, cardId);
+        if(this.pipeline.handleCardClicked(player, card)) {
             return;
         }
 
-        if(this.pipeline.handleCardClicked(player, card)) {
+        if(card.location === 'plot deck') {
+            this.selectPlot(player, cardId);
             return;
         }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -628,12 +628,10 @@ class Player extends Spectator {
     recyclePlots() {
         if(this.plotDeck.isEmpty()) {
             this.plotDiscard.each(plot => {
-                if(this.agenda && this.agenda.code === '05045' && plot.hasTrait('Scheme')) {
-                    this.moveCard(plot, 'scheme plots');
-                } else {
-                    this.moveCard(plot, 'plot deck');
-                }
+                this.moveCard(plot, 'plot deck');
             });
+
+            this.game.raiseEvent('onPlotsRecycled', { player: this });
         }
     }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -628,7 +628,11 @@ class Player extends Spectator {
     recyclePlots() {
         if(this.plotDeck.isEmpty()) {
             this.plotDiscard.each(plot => {
-                this.moveCard(plot, 'plot deck');
+                if(this.agenda && this.agenda.code === '05045' && plot.hasTrait('Scheme')) {
+                    this.moveCard(plot, 'scheme plots');
+                } else {
+                    this.moveCard(plot, 'plot deck');
+                }
             });
         }
     }

--- a/test/server/cards/agendas/TheRainsOfCastamere.spec.js
+++ b/test/server/cards/agendas/TheRainsOfCastamere.spec.js
@@ -45,8 +45,9 @@ describe('The Rains of Castamere', function() {
             expect(this.player.plotDeck.toArray()).toEqual([this.plot1, this.plot2]);
         });
 
-        it('should save the schemes for later use', function() {
-            expect(this.agenda.schemes).toEqual([this.scheme1, this.scheme2]);
+        it('should move the schemes to the scheme plot pile', function() {
+            expect(this.player.moveCard).toHaveBeenCalledWith(this.scheme1, 'scheme plots');
+            expect(this.player.moveCard).toHaveBeenCalledWith(this.scheme2, 'scheme plots');
         });
     });
 
@@ -154,7 +155,7 @@ describe('The Rains of Castamere', function() {
 
     describe('revealScheme()', function() {
         beforeEach(function() {
-            this.agenda.schemes = [this.scheme1, this.scheme2];
+            this.player.schemePlots = _([this.scheme1, this.scheme2]);
         });
 
         describe('when the argument is not one of the schemes', function() {


### PR DESCRIPTION
Mostly this fixes the problem w/ Change of Plans inappropriately wiping out the schemes pile after plots got recycled.

I'm inclined to leave the ugliness on Arianne (setting the strength in a condition) w/ a TODO as-is in the interest of getting a working implementation out. 

The proper fix (taking a snapshot the moment the `AbilityContext` object is created for the ability) currently generates a somewhat hard to diagnose infinite loop in the effects engine related to the `onCardTraitChanged` and `onCardFactionChanged` events being raised when constructing a brand new `DrawCard` for the snapshot. 

The alternative suggestion of checking to see if the snapshot exists and using the current strength otherwise isn't a pattern I'd like to encourage. (Neither is this TBH but this looks obviously wrong while checking snapshot existence could look more like "just the way you do it")

I can take the time to do the proper fix for this prior to merging but if we want the full pack released before the holidays, this may have to be Good Enough :tm: Will circle back at some point regardless.