### PR TITLE
Introduce attachment restrictions

### DIFF
--- a/docs/implementing-cards.md
+++ b/docs/implementing-cards.md
@@ -75,6 +75,40 @@ this.plotModifiers({
 });
 ```
 
+### Attachment restrictions
+
+Attachments often have restrictions on what cards they can be used on. For example, Bodyguard can only be attached to a character with a **Lord** or **Lady** trait. These restrictions can be defined using the `attachmentRestriction` method and passing the appropriate target specification object. By default, it's assumed that the attachment target is a character. Some examples:
+
+```javascript
+// Bodyguard - has either a 'Lord' or 'Lady' trait.
+this.attachmentRestriction({ trait: ['Lord', 'Lady'] });
+// Attainted - opponent character only
+this.attachmentRestriction({ controller: 'opponent' });
+// Breaker of Chains - unique Targaryen characters
+this.attachmentRestriction({ faction: 'targaryen', unique: true });
+// Improved Foritifications - locations instead of characters
+this.attachmentRestriction({ type: 'location' });
+```
+
+If an attachment has two mutually exclusive restrictions, you can pass multiple objects into the method.
+
+```javascript
+// The Silver Steed
+this.attachmentRestriction(
+    // Has trait 'Dothraki'
+    { trait: 'Dothraki' },
+    // OR is named Daenerys Targaryen
+    { name: 'Daenerys Targaryen' }
+);
+```
+
+For more complicated restrictions or restrictions that can't be checked with the target specification object, you can pass a function into `attachmentRestriction` instead. **Note** - if you do this, you need to explicitly check card type:
+
+```javascript
+// Ward - character with cost 4 or less
+this.attachmentRestriction(card => card.getType() === 'character' && card.getCost() <= 4);
+```
+
 ### Persistent effects
 
 Many cards provide continuous bonuses to other cards you control or detrimental effects to opponents cards in certain situations. These can be defined using the `persistentEffect` method. Cards that enter play while the persistent effect is in play will automatically have the effect applied, and cards that leave play will have the effect removed. If the card providing the effect becomes blank, the effect is automatically removed from all previously applied cards.

--- a/server/game/CardMatcher.js
+++ b/server/game/CardMatcher.js
@@ -1,0 +1,45 @@
+const Matcher = require('./Matcher.js');
+
+class CardMatcher {
+    static isMatch(card, properties) {
+        return (
+            Matcher.containsValue(properties.type, card.getType()) &&
+            Matcher.anyValue(properties.faction, faction => card.isFaction(faction)) &&
+            Matcher.containsValue(properties.kneeled, card.kneeled) &&
+            Matcher.containsValue(properties.location, card.location) &&
+            Matcher.containsValue(properties.name, card.name) &&
+            Matcher.anyValue(properties.trait, trait => card.hasTrait(trait)) &&
+            Matcher.containsValue(properties.unique, card.isUnique())
+        );
+    }
+
+    /**
+     * Creates a matcher function to determine whether an attachment can be
+     * attached to a particular card based on the properties passed. It defaults
+     * to only allowing attachments on characters.
+     */
+    static createAttachmentMatcher(properties) {
+        let defaultedProperties = Object.assign({ type: 'character' }, properties);
+        return function(card, context) {
+            return (
+                CardMatcher.isMatch(card, defaultedProperties) &&
+                Matcher.anyValue(properties.controller, controller => card.controller === controller || CardMatcher.attachmentControllerMatches(controller, card, context))
+            );
+        };
+    }
+
+    static attachmentControllerMatches(controllerProp, card, context) {
+        switch(controllerProp) {
+            case 'any':
+                return true;
+            case 'current':
+                return card.controller === context.player;
+            case 'opponent':
+                return card.controller !== context.player;
+        }
+
+        return false;
+    }
+}
+
+module.exports = CardMatcher;

--- a/server/game/Matcher.js
+++ b/server/game/Matcher.js
@@ -1,0 +1,37 @@
+class Matcher {
+    /**
+     * Returns true if the expected value exists and equals the actual value. If
+     * the expected value is an array, it returns true if the actual value is
+     * contained in that array.
+     */
+    static containsValue(expected, actual) {
+        if(expected === undefined) {
+            return true;
+        }
+
+        if(Array.isArray(expected)) {
+            return expected.includes(actual);
+        }
+
+        return expected === actual;
+    }
+
+    /**
+     * Returns true if the expected value exists and matches the passed
+     * predicate function. If the expected value is an array, it returns true if
+     * at least one value in the array matches the passed predicate function.
+     */
+    static anyValue(expected, predicate) {
+        if(expected === undefined) {
+            return true;
+        }
+
+        if(Array.isArray(expected)) {
+            return expected.some(value => predicate(value));
+        }
+
+        return predicate(expected);
+    }
+}
+
+module.exports = Matcher;

--- a/server/game/cards/00-VDS/SupportOfSaltcliffe.js
+++ b/server/game/cards/00-VDS/SupportOfSaltcliffe.js
@@ -2,6 +2,8 @@ const DrawCard = require('../../drawcard.js');
 
 class SupportOfSaltcliffe extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ faction: 'greyjoy' });
+
         this.whileAttached({
             effect: ability.effects.addKeyword('stealth')
         });
@@ -16,14 +18,6 @@ class SupportOfSaltcliffe extends DrawCard {
                 this.game.addMessage('{0} uses {1} to stand {2}', this.controller, this, this.parent);
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.isFaction('greyjoy')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/01-Core/BodyGuard.js
+++ b/server/game/cards/01-Core/BodyGuard.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class BodyGuard extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ trait: ['Lord', 'Lady'] });
         this.interrupt({
             canCancel: true,
             when: {
@@ -15,14 +16,6 @@ class BodyGuard extends DrawCard {
                 this.game.addMessage('{0} sacrifices {1} to save {2}', this.controller, this, parent);
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.hasTrait('Lady') && !card.hasTrait('Lord')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/01-Core/Dawn.js
+++ b/server/game/cards/01-Core/Dawn.js
@@ -11,14 +11,6 @@ class Dawn extends DrawCard {
             effect: ability.effects.addKeyword('Intimidate')
         });
     }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character') {
-            return false;
-        }
-
-        return super.canAttach(player, card);
-    }
 }
 
 Dawn.code = '01115';

--- a/server/game/cards/01-Core/DrogosArakh.js
+++ b/server/game/cards/01-Core/DrogosArakh.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class DrogosArakh extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ trait: 'Dothraki' });
         this.whileAttached({
             effect: ability.effects.modifyStrength(2)
         });
@@ -14,14 +15,6 @@ class DrogosArakh extends DrawCard {
             match: card => card.name === 'Khal Drogo',
             effect: ability.effects.doesNotKneelAsAttacker()
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.hasTrait('dothraki')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/01-Core/Heartsbane.js
+++ b/server/game/cards/01-Core/Heartsbane.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class Heartsbane extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ faction: 'tyrell' });
         this.action({
             title: 'Give attached character +3 STR',
             condition: () => this.parent && this.game.currentChallenge && this.game.currentChallenge.isParticipating(this.parent),
@@ -14,14 +15,6 @@ class Heartsbane extends DrawCard {
                 this.game.addMessage('{0} kneels {1} to give {2} +3 STR until the end of the challenge', this.controller, this, this.parent);
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.isFaction('tyrell')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/01-Core/Ice.js
+++ b/server/game/cards/01-Core/Ice.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class Ice extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ faction: 'stark' });
         this.whileAttached({
             effect: ability.effects.modifyStrength(2)
         });
@@ -23,14 +24,6 @@ class Ice extends DrawCard {
                 this.game.addMessage('{0} sacrifices {1} to kill {2}', context.player, this, context.target);
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.isFaction('stark')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/01-Core/Lightbringer.js
+++ b/server/game/cards/01-Core/Lightbringer.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class Lightbringer extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ faction: 'baratheon' });
         this.whileAttached({
             match: card => card.name === 'Stannis Baratheon',
             effect: ability.effects.addKeyword('Renown')
@@ -17,14 +18,6 @@ class Lightbringer extends DrawCard {
                 this.game.addMessage('{0} uses {1} to stand {2}', this.controller, this, this.parent);
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.isFaction('baratheon')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/01-Core/LittleBird.js
+++ b/server/game/cards/01-Core/LittleBird.js
@@ -6,14 +6,6 @@ class LittleBird extends DrawCard {
             effect: ability.effects.addIcon('intrigue')
         });
     }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character') {
-            return false;
-        }
-
-        return super.canAttach(player, card);
-    }
 }
 
 LittleBird.code = '01034';

--- a/server/game/cards/01-Core/Longclaw.js
+++ b/server/game/cards/01-Core/Longclaw.js
@@ -2,20 +2,13 @@ const DrawCard = require('../../drawcard.js');
 
 class Longclaw extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ faction: 'thenightswatch' });
         this.whileAttached({
             effect: [
                 ability.effects.modifyStrength(1),
                 ability.effects.addKeyword('Renown')
             ]
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.isFaction('thenightswatch')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/01-Core/MilkOfThePoppy.js
+++ b/server/game/cards/01-Core/MilkOfThePoppy.js
@@ -6,14 +6,6 @@ class MilkOfThePoppy extends DrawCard {
             effect: ability.effects.blank
         });
     }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character') {
-            return false;
-        }
-
-        return super.canAttach(player, card);
-    }
 }
 
 MilkOfThePoppy.code = '01035';

--- a/server/game/cards/01-Core/NobleLineage.js
+++ b/server/game/cards/01-Core/NobleLineage.js
@@ -6,14 +6,6 @@ class NobleLineage extends DrawCard {
             effect: ability.effects.addIcon('power')
         });
     }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character') {
-            return false;
-        }
-
-        return super.canAttach(player, card);
-    }
 }
 
 NobleLineage.code = '01036';

--- a/server/game/cards/01-Core/RisenFromTheSea.js
+++ b/server/game/cards/01-Core/RisenFromTheSea.js
@@ -48,6 +48,7 @@ class RisenFromTheSea extends DrawCard {
         return context.event.isBurn && card.controller.canAttach(this, card) && card.getBoostedStrength(1 + card.burnValue) > 0;
     }
 
+    // Explicitly override since it has printed type 'event'.
     canAttach(player, card) {
         return card.getType() === 'character';
     }

--- a/server/game/cards/01-Core/SealOfTheHand.js
+++ b/server/game/cards/01-Core/SealOfTheHand.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class SealOfTheHand extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ trait: ['Lord', 'Lady'] });
         this.action({
             title: 'Stand attached character',
             condition: () => this.parent.kneeled,
@@ -11,14 +12,6 @@ class SealOfTheHand extends DrawCard {
                 this.game.addMessage('{0} kneels {1} to stand {2}', this.controller, this, this.parent);
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.hasTrait('Lady') && !card.hasTrait('Lord')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/01-Core/SyriosTraining.js
+++ b/server/game/cards/01-Core/SyriosTraining.js
@@ -6,14 +6,6 @@ class SyriosTraining extends DrawCard {
             effect: ability.effects.addIcon('military')
         });
     }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character') {
-            return false;
-        }
-
-        return super.canAttach(player, card);
-    }
 }
 
 SyriosTraining.code = '01037';

--- a/server/game/cards/01-Core/ThrowingAxe.js
+++ b/server/game/cards/01-Core/ThrowingAxe.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class ThrowingAxe extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ trait: 'Ironborn' });
         this.reaction({
             when: {
                 afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isAttacking(this.parent)
@@ -18,14 +19,6 @@ class ThrowingAxe extends DrawCard {
                 this.game.addMessage('{0} sacrifices {1} to kill {2}', this.controller, this, context.target);
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.hasTrait('ironborn')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/01-Core/WidowsWail.js
+++ b/server/game/cards/01-Core/WidowsWail.js
@@ -10,14 +10,6 @@ class WidowsWail extends DrawCard {
             effect: ability.effects.addIcon('military')
         });
     }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character') {
-            return false;
-        }
-
-        return super.canAttach(player, card);
-    }
 }
 
 WidowsWail.code = '01096';

--- a/server/game/cards/02.1-TtB/KingRobertsWarhammer.js
+++ b/server/game/cards/02.1-TtB/KingRobertsWarhammer.js
@@ -30,14 +30,6 @@ class KingRobertsWarhammer extends DrawCard {
             }
         });
     }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character') {
-            return false;
-        }
-
-        return super.canAttach(player, card);
-    }
 }
 
 KingRobertsWarhammer.code = '02008';

--- a/server/game/cards/02.1-TtB/Lady.js
+++ b/server/game/cards/02.1-TtB/Lady.js
@@ -3,6 +3,7 @@ const DrawCard = require('../../drawcard.js');
 class Lady extends DrawCard {
 
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ faction: 'stark' });
         this.whileAttached({
             effect: ability.effects.modifyStrength(2)
         });
@@ -27,14 +28,6 @@ class Lady extends DrawCard {
                 this.game.addMessage(message, this.controller, this, context.target);
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.isFaction('stark')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/02.2-TRtW/CrownOfGold.js
+++ b/server/game/cards/02.2-TRtW/CrownOfGold.js
@@ -9,14 +9,6 @@ class CrownOfGold extends DrawCard {
             ]
         });
     }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character') {
-            return false;
-        }
-
-        return super.canAttach(player, card);
-    }
 }
 
 CrownOfGold.code = '02034';

--- a/server/game/cards/02.3-TKP/Attainted.js
+++ b/server/game/cards/02.3-TKP/Attainted.js
@@ -2,17 +2,10 @@ const DrawCard = require('../../drawcard.js');
 
 class Attainted extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ controller: 'opponent' });
         this.whileAttached({
             effect: ability.effects.removeIcon('intrigue')
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || card.controller === this.controller) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/02.3-TKP/FishingNet.js
+++ b/server/game/cards/02.3-TKP/FishingNet.js
@@ -2,15 +2,10 @@ const DrawCard = require('../../drawcard.js');
 
 class FishingNet extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ controller: 'opponent' });
         this.whileAttached({
             effect: ability.effects.cannotBeDeclaredAsDefender()
         });
-    }
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || card.controller === this.controller) {
-            return false;
-        }
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/02.3-TKP/Knighted.js
+++ b/server/game/cards/02.3-TKP/Knighted.js
@@ -9,14 +9,6 @@ class Knighted extends DrawCard {
             ]
         });
     }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character') {
-            return false;
-        }
-
-        return super.canAttach(player, card);
-    }
 }
 
 Knighted.code = '02058';

--- a/server/game/cards/02.3-TKP/MareInHeat.js
+++ b/server/game/cards/02.3-TKP/MareInHeat.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class MareInHeat extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ trait: 'Knight' });
         this.action({
             title: 'Remove character from challenge',
             condition: () => this.game.currentChallenge && this.game.currentChallenge.isParticipating(this.parent) &&
@@ -25,14 +26,6 @@ class MareInHeat extends DrawCard {
             return this.game.currentChallenge.attackers.length === 1;
         }
         return this.game.currentChallenge.defenders.length === 1;
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.hasTrait('Knight')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/02.3-TKP/PracticeBlade.js
+++ b/server/game/cards/02.3-TKP/PracticeBlade.js
@@ -2,20 +2,13 @@ const DrawCard = require('../../drawcard.js');
 
 class PracticeBlade extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ faction: 'thenightswatch' });
         this.whileAttached({
             effect: [
                 ability.effects.modifyStrength(1),
                 ability.effects.addIcon('military')
             ]
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.isFaction('thenightswatch')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/02.3-TKP/TheSilverSteed.js
+++ b/server/game/cards/02.3-TKP/TheSilverSteed.js
@@ -2,6 +2,10 @@ const DrawCard = require('../../drawcard.js');
 
 class TheSilverSteed extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction(
+            { trait: 'Dothraki' },
+            { name: 'Daenerys Targaryen' }
+        );
         this.whileAttached({
             condition: () => (
                 this.game.currentChallenge &&
@@ -27,14 +31,6 @@ class TheSilverSteed extends DrawCard {
                 this.game.addMessage('{0} sacrifices {1} and is able to initiate an additional {2} challenge this phase', this.controller, this, 'power');
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || (!card.hasTrait('Dothraki') && card.name !== 'Daenerys Targaryen')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/02.4-NMG/Condemned.js
+++ b/server/game/cards/02.4-NMG/Condemned.js
@@ -2,17 +2,10 @@ const DrawCard = require('../../drawcard.js');
 
 class Condemned extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ controller: 'opponent' });
         this.whileAttached({
             effect: ability.effects.removeIcon('power')
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || card.controller === this.controller) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/02.4-NMG/PaidOff.js
+++ b/server/game/cards/02.4-NMG/PaidOff.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class PaidOff extends DrawCard {
     setupCardAbilities() {
+        this.attachmentRestriction({ controller: 'opponent' });
         this.reaction({
             when: {
                 afterChallenge: ({challenge}) => challenge.challengeType === 'intrigue' && !this.parent.kneeled && challenge.winner === this.controller
@@ -48,14 +49,6 @@ class PaidOff extends DrawCard {
             player, this, this.parent);
 
         return true;
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || card.controller === this.controller) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/02.5-COW/BloodMagicRitual.js
+++ b/server/game/cards/02.5-COW/BloodMagicRitual.js
@@ -34,6 +34,7 @@ class BloodMagicRitual extends DrawCard {
         });
     }
 
+    // Explicitly override since it has printed type 'event'.
     canAttach(player, card) {
         return card.getType() === 'character';
     }

--- a/server/game/cards/02.5-COW/StinkingDrunk.js
+++ b/server/game/cards/02.5-COW/StinkingDrunk.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class StinkingDrunk extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ controller: 'opponent' });
         this.reaction({
             when: {
                 onCardStood: event => event.card === this.parent
@@ -12,14 +13,6 @@ class StinkingDrunk extends DrawCard {
                 context.event.card.controller.kneelCard(context.event.card);
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || card.controller === this.controller) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/02.6-TS/DrownedGodsBlessing.js
+++ b/server/game/cards/02.6-TS/DrownedGodsBlessing.js
@@ -3,20 +3,13 @@ const DrawCard = require('../../drawcard.js');
 class DrownedGodsBlessing extends DrawCard {
     // TODO: Cannot be chosen as the only target of opponent events
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ faction: 'greyjoy' });
         this.whileAttached({
             effect: ability.effects.addTrait('Drowned God')
         });
         this.plotModifiers({
             initiative: 1
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.isFaction('greyjoy')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/02.6-TS/Imprisoned.js
+++ b/server/game/cards/02.6-TS/Imprisoned.js
@@ -2,17 +2,10 @@ const DrawCard = require('../../drawcard.js');
 
 class Imprisoned extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ controller: 'opponent' });
         this.whileAttached({
             effect: ability.effects.removeIcon('military')
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || card.controller === this.controller) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/02.6-TS/MaestersChain.js
+++ b/server/game/cards/02.6-TS/MaestersChain.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class MaestersChain extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ trait: 'Maester' });
         this.action({
             title: 'Discard condition attachment',
             phase: 'dominance',
@@ -15,13 +16,6 @@ class MaestersChain extends DrawCard {
                 this.game.addMessage('{0} kneels {1} to discard {2}', this.controller, this, context.target);
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.hasTrait('maester')) {
-            return false;
-        }
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/02.6-TS/OldBearsRaven.js
+++ b/server/game/cards/02.6-TS/OldBearsRaven.js
@@ -10,13 +10,6 @@ class OldBearsRaven extends DrawCard {
             effect: ability.effects.addKeyword('stealth')
         });
     }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character') {
-            return false;
-        }
-        return super.canAttach(player, card);
-    }
 }
 
 OldBearsRaven.code = '02106';

--- a/server/game/cards/02.6-TS/Ward.js
+++ b/server/game/cards/02.6-TS/Ward.js
@@ -2,20 +2,13 @@ const DrawCard = require('../../drawcard.js');
 
 class Ward extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction(card => card.getType() === 'character' && card.getCost() <= 4);
         this.whileAttached({
             effect: [
                 ability.effects.addFaction('stark'),
                 ability.effects.takeControl(this.controller)
             ]
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || card.getCost() > 4) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/03-WotN/FrozenSolid.js
+++ b/server/game/cards/03-WotN/FrozenSolid.js
@@ -2,17 +2,10 @@ const DrawCard = require('../../drawcard.js');
 
 class FrozenSolid extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction(card => card.getType() === 'location' && !card.isLimited() && card.getCost() <= 3);
         this.whileAttached({
             effect: ability.effects.blank
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'location' || card.isLimited() || card.getCost() > 3) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/03-WotN/GreenDreams.js
+++ b/server/game/cards/03-WotN/GreenDreams.js
@@ -35,14 +35,6 @@ class GreenDreams extends DrawCard {
 
         return true;
     }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character') {
-            return false;
-        }
-
-        return super.canAttach(player, card);
-    }
 }
 
 GreenDreams.code = '03043';

--- a/server/game/cards/03-WotN/Motley.js
+++ b/server/game/cards/03-WotN/Motley.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class Motley extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ controller: 'opponent' });
         this.whileAttached({
             effect: ability.effects.addTrait('Fool')
         });
@@ -16,14 +17,6 @@ class Motley extends DrawCard {
                     this.controller, this, this.parent.controller);
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || card.controller === this.controller) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/03-WotN/Needle.js
+++ b/server/game/cards/03-WotN/Needle.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class Needle extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ faction: 'stark' });
         this.whileAttached({
             effect: ability.effects.modifyStrength(2)
         });
@@ -19,14 +20,6 @@ class Needle extends DrawCard {
                 });
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.isFaction('stark')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/03-WotN/Nymeria.js
+++ b/server/game/cards/03-WotN/Nymeria.js
@@ -3,6 +3,7 @@ const DrawCard = require('../../drawcard.js');
 class Nymeria extends DrawCard {
 
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ faction: 'stark', unique: true });
         this.whileAttached({
             effect: ability.effects.addKeyword('Intimidate')
         });
@@ -20,14 +21,6 @@ class Nymeria extends DrawCard {
                 this.game.addMessage('{0} pays 1 gold to attach {1} to {2}', this.controller, this, context.target);
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.isFaction('stark') || !card.isUnique()) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/04.2-CtA/BeggarKing.js
+++ b/server/game/cards/04.2-CtA/BeggarKing.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class BeggarKing extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ faction: 'targaryen' });
         this.whileAttached({
             effect: ability.effects.addTrait('King')
         });
@@ -27,14 +28,6 @@ class BeggarKing extends DrawCard {
 
     opponentHasKing() {
         return this.game.anyCardsInPlay(card => card.controller !== this.controller && card.getType() === 'character' && card.hasTrait('King'));
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.isFaction('targaryen')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/04.2-CtA/Craven.js
+++ b/server/game/cards/04.2-CtA/Craven.js
@@ -6,14 +6,6 @@ class Craven extends DrawCard {
             effect: ability.effects.cannotBeDeclaredAsAttacker()
         });
     }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character') {
-            return false;
-        }
-
-        return super.canAttach(player, card);
-    }
 }
 
 Craven.code = '04026';

--- a/server/game/cards/04.2-CtA/TheBoyKing.js
+++ b/server/game/cards/04.2-CtA/TheBoyKing.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class TheBoyKing extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ trait: 'Lord' });
         this.whileAttached({
             effect: ability.effects.addTrait('King')
         });
@@ -15,14 +16,6 @@ class TheBoyKing extends DrawCard {
                 this.game.addMessage('{0} kneels {1} to have {2} gain 1 power', this.controller, this, this.parent);
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.hasTrait('Lord')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/04.2-CtA/VenomousBlade.js
+++ b/server/game/cards/04.2-CtA/VenomousBlade.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class VenomousBlade extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ faction: 'martell', controller: 'current' });
         this.whileAttached({
             effect: ability.effects.modifyStrength(1)
         });
@@ -21,14 +22,6 @@ class VenomousBlade extends DrawCard {
                 }));
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.isFaction('martell') || card.controller !== this.controller) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/04.3-FFH/crownofgoldenroses.js
+++ b/server/game/cards/04.3-FFH/crownofgoldenroses.js
@@ -2,6 +2,8 @@ const DrawCard = require('../../drawcard.js');
 
 class CrownOfGoldenRoses extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ trait: 'Lord' });
+
         this.whileAttached({
             effect: ability.effects.addTrait('King')
         });
@@ -24,14 +26,6 @@ class CrownOfGoldenRoses extends DrawCard {
             }
         });
 
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.hasTrait('Lord')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/04.3-FFH/kingofsaltandrock.js
+++ b/server/game/cards/04.3-FFH/kingofsaltandrock.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class KingOfSaltAndRock extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ trait: 'Ironborn' });
         this.whileAttached({
             effect: [
                 ability.effects.addTrait('King'),
@@ -17,14 +18,6 @@ class KingOfSaltAndRock extends DrawCard {
                 this.game.addMessage('{0} uses {1} to have {2} gain 1 power', this.controller, this, this.parent);
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.hasTrait('Ironborn')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/04.3-FFH/visitedbyshadows.js
+++ b/server/game/cards/04.3-FFH/visitedbyshadows.js
@@ -2,16 +2,10 @@ const DrawCard = require('../../drawcard.js');
 
 class VisitedByShadows extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ controller: 'opponent' });
         this.whileAttached({
             effect: ability.effects.modifyStrength(-1)
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || card.controller === this.controller) {
-            return false;
-        }
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/04.4-TIMC/KingBeyondTheWall.js
+++ b/server/game/cards/04.4-TIMC/KingBeyondTheWall.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class KingBeyondTheWall extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ trait: 'Wildling' });
         this.whileAttached({
             effect: ability.effects.addTrait('King')
         });
@@ -11,14 +12,6 @@ class KingBeyondTheWall extends DrawCard {
             match: (card) => card === this.controller.activePlot,
             effect: ability.effects.modifyClaim(1)
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.hasTrait('Wildling')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 
     hasLessTotalPower(opponent) {

--- a/server/game/cards/04.4-TIMC/RedGodsBlessing.js
+++ b/server/game/cards/04.4-TIMC/RedGodsBlessing.js
@@ -13,14 +13,6 @@ class RedGodsBlessing extends DrawCard {
     getNumberOfCardsWithRhllor() {
         return this.controller.getNumberOfCardsInPlay(c => c.hasTrait('R\'hllor') && c.getType() === 'character');
     }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character') {
-            return false;
-        }
-
-        return super.canAttach(player, card);
-    }
 }
 
 RedGodsBlessing.code = '04068';

--- a/server/game/cards/04.4-TIMC/TheWolfKing.js
+++ b/server/game/cards/04.4-TIMC/TheWolfKing.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class TheWolfKing extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ faction: 'stark' });
         this.whileAttached({
             effect: ability.effects.addTrait('King')
         });
@@ -12,14 +13,6 @@ class TheWolfKing extends DrawCard {
             ),
             effect: ability.effects.doesNotKneelAsAttacker()
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.isFaction('stark')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/04.5-GoH/DragonglassDagger.js
+++ b/server/game/cards/04.5-GoH/DragonglassDagger.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class DragonglassDagger extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ faction: 'thenightswatch' });
         this.whileAttached({
             condition: () => this.game.currentChallenge && this.game.currentChallenge.isParticipating(this.parent),
             effect: [
@@ -9,14 +10,6 @@ class DragonglassDagger extends DrawCard {
                 ability.effects.immuneTo(card => card.controller !== this.controller && card.getType() === 'character')
             ]
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.isFaction('thenightswatch')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/04.5-GoH/MotherOfDragons.js
+++ b/server/game/cards/04.5-GoH/MotherOfDragons.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class MotherOfDragons extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ trait: 'Stormborn' });
         this.action({
             title: 'Add attached character to the challenge',
             condition: () => this.game.currentChallenge && this.parent.canParticipateInChallenge() &&
@@ -18,14 +19,6 @@ class MotherOfDragons extends DrawCard {
                 this.game.addMessage('{0} kneels {1} to have {2} participate in the challenge on their side', this.controller, this, this.parent);
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.hasTrait('Stormborn')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/05-LoCR/Appointed.js
+++ b/server/game/cards/05-LoCR/Appointed.js
@@ -2,20 +2,13 @@ const DrawCard = require('../../drawcard.js');
 
 class Appointed extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ unique: true });
         this.whileAttached({
             effect: [
                 ability.effects.addIcon('intrigue'),
                 ability.effects.addTrait('Small Council')
             ]
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.isUnique()) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/05-LoCR/DaenerysFavor.js
+++ b/server/game/cards/05-LoCR/DaenerysFavor.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class DaenerysFavor extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ faction: 'targaryen' });
         this.persistentEffect({
             condition: () => (
                 this.game.currentChallenge &&
@@ -12,13 +13,6 @@ class DaenerysFavor extends DrawCard {
             effect: ability.effects.modifyStrength(-1),
             recalculateWhen: ['onAttackersDeclared', 'onDefendersDeclared']
         });
-    }
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.isFaction('targaryen')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/05-LoCR/DisputedClaim.js
+++ b/server/game/cards/05-LoCR/DisputedClaim.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class DisputedClaim extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ trait: ['Bastard', 'Lord', 'Lady'] });
         this.whileAttached({
             condition: () => this.hasMostFactionPower(),
             effect: [
@@ -9,13 +10,6 @@ class DisputedClaim extends DrawCard {
                 ability.effects.addKeyword('Renown')
             ]
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !(card.hasTrait('Bastard') || card.hasTrait('Lord') || card.hasTrait('Lady'))) {
-            return false;
-        }
-        return super.canAttach(player, card);
     }
 
     hasMostFactionPower() {

--- a/server/game/cards/05-LoCR/ShieldOfLannisport.js
+++ b/server/game/cards/05-LoCR/ShieldOfLannisport.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class ShieldOfLannisport extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ faction: 'lannister', trait: ['Lord', 'Lady'] });
         this.whileAttached({
             condition: () => this.noOtherLordsOrLadies(),
             effect: [
@@ -20,14 +21,6 @@ class ShieldOfLannisport extends DrawCard {
             (card.hasTrait('Lord') || card.hasTrait('Lady')) &&
             card.getCost() >= 4
         ));
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.isFaction('lannister') || (!card.hasTrait('Lord') && !card.hasTrait('Lady'))) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/05-LoCR/ValyrianSteelDagger.js
+++ b/server/game/cards/05-LoCR/ValyrianSteelDagger.js
@@ -13,13 +13,6 @@ class ValyrianSteelDagger extends DrawCard {
             ]
         });
     }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character') {
-            return false;
-        }
-        return super.canAttach(player, card);
-    }
 }
 
 ValyrianSteelDagger.code = '05021';

--- a/server/game/cards/06.2-GtR/LightOfTheLord.js
+++ b/server/game/cards/06.2-GtR/LightOfTheLord.js
@@ -2,6 +2,10 @@ const DrawCard = require('../../drawcard.js');
 
 class LightOfTheLord extends DrawCard {
     setupCardAbilities() {
+        this.attachmentRestriction(
+            { faction: 'baratheon' },
+            { trait: 'R\'hllor' }
+        );
         this.reaction({
             when: {
                 onPhaseStarted: event => event.phase === 'dominance'
@@ -12,14 +16,6 @@ class LightOfTheLord extends DrawCard {
                 this.game.addMessage('{0} uses {1} to stand {2} and gain 1 gold', this.controller, this, this.parent);
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !(card.isFaction('baratheon') || card.hasTrait('R\'hllor'))) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/06.2-GtR/MarriagePact.js
+++ b/server/game/cards/06.2-GtR/MarriagePact.js
@@ -23,14 +23,6 @@ class MarriagePact extends DrawCard {
             }
         });
     }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character') {
-            return false;
-        }
-
-        return super.canAttach(player, card);
-    }
 }
 
 MarriagePact.code = '06022';

--- a/server/game/cards/06.3-TFoA/CorsairsDirk.js
+++ b/server/game/cards/06.3-TFoA/CorsairsDirk.js
@@ -2,6 +2,8 @@ const DrawCard = require('../../drawcard.js');
 
 class CorsairsDirk extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ trait: 'Ironborn' });
+
         this.whileAttached({
             effect: ability.effects.modifyStrength(2)
         });
@@ -20,14 +22,6 @@ class CorsairsDirk extends DrawCard {
                     this.controller, this, opponent);
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.hasTrait('ironborn')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/06.3-TFoA/FeverDreams.js
+++ b/server/game/cards/06.3-TFoA/FeverDreams.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class FeverDreams extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ controller: 'opponent' });
         this.reaction({
             when: {
                 onCardKneeled: event => event.card === this.parent
@@ -12,13 +13,6 @@ class FeverDreams extends DrawCard {
                 this.game.addMessage('{0} discards a gold from {1} to draw 2 cards', this.controller, this);
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || card.controller === this.controller) {
-            return false;
-        }
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/06.3-TFoA/SilverHairNet.js
+++ b/server/game/cards/06.3-TFoA/SilverHairNet.js
@@ -2,6 +2,8 @@ const DrawCard = require('../../drawcard.js');
 
 class SilverHairNet extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ trait: 'Lady' });
+
         this.whileAttached({
             effect: ability.effects.addKeyword('stealth')
         });
@@ -19,13 +21,6 @@ class SilverHairNet extends DrawCard {
                 match: card => card.getType() === 'event'
             })
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.hasTrait('Lady')) {
-            return false;
-        }
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/06.4-TRW/BreakerOfChains.js
+++ b/server/game/cards/06.4-TRW/BreakerOfChains.js
@@ -2,6 +2,8 @@ const DrawCard = require('../../drawcard.js');
 
 class BreakerOfChains extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ faction: 'targaryen', unique: true });
+
         this.whileAttached({
             effect: ability.effects.dynamicStrength(() => this.getSTRBoost())
         });
@@ -27,14 +29,6 @@ class BreakerOfChains extends DrawCard {
 
     getSTRBoost() {
         return this.controller.getNumberOfCardsInPlay(card => card.getType() === 'character' && card.getCost() <= 2);
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.isFaction('targaryen') || !card.isUnique()) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/06.4-TRW/ImprovedFortifications.js
+++ b/server/game/cards/06.4-TRW/ImprovedFortifications.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class ImprovedFortifications extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ type: 'location' });
         this.interrupt({
             canCancel: true,
             when: {
@@ -13,14 +14,6 @@ class ImprovedFortifications extends DrawCard {
                 this.game.addMessage('{0} sacrifices {1} to save {2}', this.controller, this, this.parent);
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'location') {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/06.6-TBWB/KingsBlood.js
+++ b/server/game/cards/06.6-TBWB/KingsBlood.js
@@ -4,6 +4,7 @@ const DrawCard = require('../../drawcard.js');
 
 class KingsBlood extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ trait: ['Bastard', 'King'], controller: 'current' });
         this.action({
             title: 'Discard power from opponent\'s faction',
             condition: () => this.hasToken('gold'),
@@ -23,13 +24,6 @@ class KingsBlood extends DrawCard {
                     context.player, context.cardStateWhenInitiated.parent, this, gold);
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !(card.hasTrait('Bastard') || card.hasTrait('King')) || card.controller !== this.controller) {
-            return false;
-        }
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/06.6-TBWB/RangersBow.js
+++ b/server/game/cards/06.6-TBWB/RangersBow.js
@@ -2,6 +2,8 @@ const DrawCard = require('../../drawcard.js');
 
 class RangersBow extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ faction: 'thenightswatch' });
+
         this.whileAttached({
             effect: ability.effects.modifyStrength(1)
         });
@@ -22,14 +24,6 @@ class RangersBow extends DrawCard {
                 this.game.addMessage('{0} kneels {1} to give {2} +2 STR until the end of the challenge', this.controller, this, context.target);
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.isFaction('thenightswatch')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/06.6-TBWB/WarriorsBraid.js
+++ b/server/game/cards/06.6-TBWB/WarriorsBraid.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class WarriorsBraid extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ faction: 'targaryen' });
         this.whileAttached({
             effect: [
                 ability.effects.addKeyword('renown'),
@@ -18,14 +19,6 @@ class WarriorsBraid extends DrawCard {
                 this.game.addMessage('{0} places 1 bell token on {1}', this.controller, this);
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.isFaction('targaryen')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/07-WotW/CatapultOnTheWall.js
+++ b/server/game/cards/07-WotW/CatapultOnTheWall.js
@@ -24,14 +24,6 @@ class CatapultOnTheWall extends DrawCard {
             }
         });
     }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character') {
-            return false;
-        }
-
-        return super.canAttach(player, card);
-    }
 }
 
 CatapultOnTheWall.code = '07020';

--- a/server/game/cards/07-WotW/Ghost.js
+++ b/server/game/cards/07-WotW/Ghost.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class Ghost extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ faction: ['thenightswatch', 'stark'] });
         this.interrupt({
             when: {
                 onCharactersKilled: event => {
@@ -19,14 +20,6 @@ class Ghost extends DrawCard {
                 this.game.addMessage('{0} returns {1} to their hand to save {2}', this.controller, this, this.parentCard);
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.isFaction('thenightswatch') && !card.isFaction('stark')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/07-WotW/LingeringVenom.js
+++ b/server/game/cards/07-WotW/LingeringVenom.js
@@ -17,14 +17,6 @@ class LingeringVenom extends DrawCard {
             }
         });
     }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character') {
-            return false;
-        }
-
-        return super.canAttach(player, card);
-    }
 }
 
 LingeringVenom.code = '07032';

--- a/server/game/cards/07-WotW/Summer.js
+++ b/server/game/cards/07-WotW/Summer.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class Summer extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ faction: 'stark', unique: true });
         this.action({
             title: 'Add attached character to the challenge',
             condition: () => this.game.currentChallenge && this.game.currentChallenge.challengeType === 'military',
@@ -32,14 +33,6 @@ class Summer extends DrawCard {
                     this.controller, this, this.parent);
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.isFaction('stark') || !card.isUnique()) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/07-WotW/SwornToTheWatch.js
+++ b/server/game/cards/07-WotW/SwornToTheWatch.js
@@ -18,14 +18,6 @@ class SwornToTheWatch extends DrawCard {
             effect: ability.effects.addTrait('Builder')
         });
     }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character') {
-            return false;
-        }
-
-        return super.canAttach(player, card);
-    }
 }
 
 SwornToTheWatch.code = '07022';

--- a/server/game/cards/07-WotW/WeirwoodBow.js
+++ b/server/game/cards/07-WotW/WeirwoodBow.js
@@ -2,6 +2,10 @@ const DrawCard = require('../../drawcard.js');
 
 class WeirwoodBow extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction(
+            { faction: 'thenightswatch' },
+            { trait: 'Wildling' }
+        );
         this.action({
             title: 'Give defending character -2 STR',
             cost: ability.costs.kneelSelf(),
@@ -23,14 +27,6 @@ class WeirwoodBow extends DrawCard {
                     context.player, this, context.target);
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !(card.isFaction('thenightswatch') || card.hasTrait('Wildling'))) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/08.1-TAK/BloodyArakh.js
+++ b/server/game/cards/08.1-TAK/BloodyArakh.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class BloodyArakh extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ trait: 'Dothraki' });
         this.reaction({
             max: ability.limit.perPhase(1),
             when: {
@@ -20,14 +21,6 @@ class BloodyArakh extends DrawCard {
                     context.player, this, 'military');
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.hasTrait('dothraki')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/08.1-TAK/Oathkeeper.js
+++ b/server/game/cards/08.1-TAK/Oathkeeper.js
@@ -34,14 +34,6 @@ class Oathkeeper extends DrawCard {
         this.game.addMessage('{0} sacrifices {1} to search their deck, but does not add any card to their hand',
             player, this);
     }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character') {
-            return false;
-        }
-
-        return super.canAttach(player, card);
-    }
 }
 
 Oathkeeper.code = '08005';

--- a/server/game/cards/08.1-TAK/TraitorToTheCrown.js
+++ b/server/game/cards/08.1-TAK/TraitorToTheCrown.js
@@ -2,6 +2,8 @@ const DrawCard = require('../../drawcard.js');
 
 class TraitorToTheCrown extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ controller: 'opponent' });
+
         this.whileAttached({
             effect: ability.effects.doesNotContributeToDominance()
         });
@@ -10,14 +12,6 @@ class TraitorToTheCrown extends DrawCard {
             condition: () => this.game.currentChallenge && this.game.currentChallenge.challengeType === 'power',
             effect: ability.effects.doesNotContributeStrength()
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || card.controller === this.controller) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/08.2-JtO/Kingslayer.js
+++ b/server/game/cards/08.2-JtO/Kingslayer.js
@@ -2,6 +2,8 @@ const DrawCard = require('../../drawcard.js');
 
 class Kingslayer extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ trait: 'Kingsguard' });
+
         this.action({
             title: 'Kill character',
             limit: ability.limit.perGame(1),
@@ -33,14 +35,6 @@ class Kingslayer extends DrawCard {
                     context.player, this);
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.hasTrait('Kingsguard')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/09-HoT/LionsTooth.js
+++ b/server/game/cards/09-HoT/LionsTooth.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class LionsTooth extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ faction: 'lannister', unique: true });
         this.whileAttached({
             effect: ability.effects.modifyStrength(1)
         });
@@ -20,14 +21,6 @@ class LionsTooth extends DrawCard {
                 context.target.owner.returnCardToHand(context.target);
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.isFaction('lannister') || !card.isUnique()) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/09-HoT/QueenOfTheSevenKingdoms.js
+++ b/server/game/cards/09-HoT/QueenOfTheSevenKingdoms.js
@@ -2,6 +2,8 @@ const DrawCard = require('../../drawcard.js');
 
 class QueenOfTheSevenKingdoms extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ trait: 'Lady' });
+
         this.whileAttached({
             effect: ability.effects.addTrait('Queen')
         });
@@ -23,14 +25,6 @@ class QueenOfTheSevenKingdoms extends DrawCard {
                     context.player, this, this.parent, context.target);
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.hasTrait('Lady')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/09-HoT/Strangler.js
+++ b/server/game/cards/09-HoT/Strangler.js
@@ -7,14 +7,6 @@ class Strangler extends DrawCard {
             effect: ability.effects.setStrength(1)
         });
     }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character') {
-            return false;
-        }
-
-        return super.canAttach(player, card);
-    }
 }
 
 Strangler.code = '09043';

--- a/server/game/cards/09-HoT/Tokar.js
+++ b/server/game/cards/09-HoT/Tokar.js
@@ -2,6 +2,8 @@ const DrawCard = require('../../drawcard.js');
 
 class Tokar extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ faction: 'targaryen' });
+
         this.whileAttached({
             effect: ability.effects.dynamicStrength(() => this.parent.attachments.size())
         });
@@ -12,14 +14,6 @@ class Tokar extends DrawCard {
             targetController: 'any',
             effect: ability.effects.cannotGainPower()
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.isFaction('targaryen')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/09-HoT/TourneyLance.js
+++ b/server/game/cards/09-HoT/TourneyLance.js
@@ -2,6 +2,8 @@ const DrawCard = require('../../drawcard.js');
 
 class TourneyLance extends DrawCard {
     setupCardAbilities(ability) {
+        this.attachmentRestriction({ trait: 'Knight' });
+
         this.whileAttached({
             effect: ability.effects.modifyStrength(1)
         });
@@ -13,14 +15,6 @@ class TourneyLance extends DrawCard {
             targetController: 'opponent',
             effect: ability.effects.setDefenderMaximum(1)
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || !card.hasTrait('Knight')) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/server/game/cards/10-SoD/Patience.js
+++ b/server/game/cards/10-SoD/Patience.js
@@ -2,6 +2,7 @@ const DrawCard = require('../../drawcard.js');
 
 class Patience extends DrawCard {
     setupCardAbilities() {
+        this.attachmentRestriction({ controller: 'current' });
         this.action({
             title: 'Return parent to hand',
             phase: 'challenge',
@@ -11,14 +12,6 @@ class Patience extends DrawCard {
                     context.player, this, this.parent, this.parent.owner);
             }
         });
-    }
-
-    canAttach(player, card) {
-        if(card.getType() !== 'character' || card.controller !== this.controller) {
-            return false;
-        }
-
-        return super.canAttach(player, card);
     }
 }
 

--- a/test/server/CardMatcher.spec.js
+++ b/test/server/CardMatcher.spec.js
@@ -1,0 +1,82 @@
+const CardMatcher = require('../../server/game/CardMatcher.js');
+
+describe('CardMatcher', function() {
+    beforeEach(function() {
+        this.cardSpy = jasmine.createSpyObj('card', ['getType', 'isUnique']);
+    });
+
+    describe('createAttachmentMatcher', function() {
+        beforeEach(function() {
+            let controller = { controller: 1 };
+            this.context = { player: controller };
+            this.cardSpy.controller = controller;
+            this.cardSpy.getType.and.returnValue('character');
+        });
+
+        describe('defaults', function() {
+            beforeEach(function() {
+                this.matcher = CardMatcher.createAttachmentMatcher({});
+            });
+
+            it('should match characters', function() {
+                expect(this.matcher(this.cardSpy, this.context)).toBe(true);
+            });
+
+            it('should not match non-characters', function() {
+                this.cardSpy.getType.and.returnValue('location');
+                expect(this.matcher(this.cardSpy, this.context)).toBe(false);
+            });
+        });
+
+        describe('controller', function() {
+            describe('when a specific value', function() {
+                beforeEach(function() {
+                    this.controller = { controller: 1 };
+                    this.matcher = CardMatcher.createAttachmentMatcher({ controller: this.controller });
+                });
+
+                it('should return true when it matches', function() {
+                    this.cardSpy.controller = this.controller;
+                    expect(this.matcher(this.cardSpy, this.context)).toBe(true);
+                });
+
+                it('should return false when it does not match', function() {
+                    this.cardSpy.controller = { controller: 2 };
+                    expect(this.matcher(this.cardSpy, this.context)).toBe(false);
+                });
+            });
+
+            describe('when the value is \'current\'', function() {
+                beforeEach(function() {
+                    this.matcher = CardMatcher.createAttachmentMatcher({ controller: 'current' });
+                });
+
+                it('should return true when the controller is the same as the context player', function() {
+                    this.cardSpy.controller = this.context.player;
+                    expect(this.matcher(this.cardSpy, this.context)).toBe(true);
+                });
+
+                it('should return false when the controller is different from the context player', function() {
+                    this.cardSpy.controller = { controller: 2 };
+                    expect(this.matcher(this.cardSpy, this.context)).toBe(false);
+                });
+            });
+
+            describe('when the value is \'opponent\'', function() {
+                beforeEach(function() {
+                    this.matcher = CardMatcher.createAttachmentMatcher({ controller: 'opponent' });
+                });
+
+                it('should return false when the controller is the same as the context player', function() {
+                    this.cardSpy.controller = this.context.player;
+                    expect(this.matcher(this.cardSpy, this.context)).toBe(false);
+                });
+
+                it('should return true when the controller is different from the context player', function() {
+                    this.cardSpy.controller = { controller: 2 };
+                    expect(this.matcher(this.cardSpy, this.context)).toBe(true);
+                });
+            });
+        });
+    });
+});

--- a/test/server/Matcher.spec.js
+++ b/test/server/Matcher.spec.js
@@ -1,0 +1,62 @@
+const Matcher = require('../../server/game/Matcher.js');
+
+describe('Matcher', function() {
+    describe('containsValue', function() {
+        it('should return true when the expected value is undefined', function() {
+            expect(Matcher.containsValue(undefined, 1)).toBe(true);
+        });
+
+        it('should return true when the values match', function() {
+            expect(Matcher.containsValue(1, 1)).toBe(true);
+        });
+
+        it('should return false when the values do not match', function() {
+            expect(Matcher.containsValue(2, 1)).toBe(false);
+        });
+
+        describe('when the expected value is an array', function() {
+            it('should return true if the actual value is contained in the array', function() {
+                expect(Matcher.containsValue([1, 2, 3], 2)).toBe(true);
+            });
+        });
+    });
+
+    describe('anyValue', function() {
+        beforeEach(function() {
+            this.predicateSpy = jasmine.createSpy('predicate');
+        });
+
+        it('should return true when the expected value is undefined', function() {
+            expect(Matcher.anyValue(undefined, this.predicateSpy)).toBe(true);
+        });
+
+        it('should call the predicate using the expected value', function() {
+            Matcher.anyValue(1, this.predicateSpy);
+            expect(this.predicateSpy).toHaveBeenCalledWith(1);
+        });
+
+        it('should return true when the predicate returns true', function() {
+            this.predicateSpy.and.returnValue(true);
+            expect(Matcher.anyValue(1, this.predicateSpy)).toBe(true);
+        });
+
+        it('should return false when the predicate returns false', function() {
+            this.predicateSpy.and.returnValue(false);
+            expect(Matcher.anyValue(1, this.predicateSpy)).toBe(false);
+        });
+
+        describe('when the expected value is an array', function() {
+            it('should call the predicate with values in the array', function() {
+                Matcher.anyValue([1, 2, 3], this.predicateSpy);
+                expect(this.predicateSpy).toHaveBeenCalledWith(1);
+                expect(this.predicateSpy).toHaveBeenCalledWith(2);
+                expect(this.predicateSpy).toHaveBeenCalledWith(3);
+            });
+
+            it('should return true if the predicate returns true for at least 1 value in the array', function() {
+                this.predicateSpy.and.callFake(i => i % 2 === 0);
+                expect(Matcher.anyValue([1, 2, 3], this.predicateSpy)).toBe(true);
+            });
+        });
+    });
+});

--- a/test/server/card/drawcard.canAttach.spec.js
+++ b/test/server/card/drawcard.canAttach.spec.js
@@ -10,12 +10,42 @@ describe('DrawCard', function() {
     describe('canAttach()', function() {
         describe('when the card is an attachment', function() {
             beforeEach(function() {
-                this.targetCard = new DrawCard(this.owner, { text: '' });
+                this.targetCard = new DrawCard(this.owner, { type_code: 'character' });
+                this.targetCard.location = 'play area';
                 this.attachment = new DrawCard(this.owner, { type_code: 'attachment' });
             });
 
             it('should return true', function() {
                 expect(this.attachment.canAttach(this.player, this.targetCard)).toBe(true);
+            });
+
+            describe('when the target card is not a character', function() {
+                beforeEach(function() {
+                    spyOn(this.targetCard, 'getType').and.returnValue('location');
+                });
+
+                it('should return false', function() {
+                    expect(this.attachment.canAttach(this.player, this.targetCard)).toBe(false);
+                });
+            });
+
+            describe('when custom restrictions are added', function() {
+                beforeEach(function() {
+                    this.matcherSpy = jasmine.createSpy('matcher');
+                    this.attachment.attachmentRestriction(this.matcherSpy);
+                });
+
+                it('should call the matcher', function() {
+                    let controller = { controller: true };
+                    this.attachment.controller = controller;
+                    this.attachment.canAttach(this.player, this.targetCard);
+                    expect(this.matcherSpy).toHaveBeenCalledWith(this.targetCard, jasmine.objectContaining({ player: controller }));
+                });
+
+                it('should return the result of the matcher', function() {
+                    this.matcherSpy.and.returnValue(true);
+                    expect(this.attachment.canAttach(this.player, this.targetCard)).toBe(true);
+                });
             });
         });
 


### PR DESCRIPTION
* Instead of overriding `canAttach`, attachment requirements can be defined in the `setupCardAbilities` method.
* Introduces a card matcher syntax that may later be used in the target API.
* Converts all existing attachments to the new syntax.