### PR TITLE
Remove gameAction property from Political Disaster prompt

### DIFF
--- a/server/game/cards/02.2-TRtW/PoliticalDisaster.js
+++ b/server/game/cards/02.2-TRtW/PoliticalDisaster.js
@@ -64,7 +64,6 @@ class PoliticalDisaster extends PlotCard {
                     card.controller === currentPlayer
                     && card.getType() === 'location'
                     && card.location === 'play area',
-                gameAction: 'discard',
                 onSelect: (player, cards) => this.onSelect(player, cards),
                 onCancel: (player) => this.cancelSelection(player)
             });


### PR DESCRIPTION
The Political Disaster prompt selects locations to preclude from discarding, so the gameAction property preventing selection of cards that are immune/cannot be discarded doesn't fit here.