### PR TITLE
Fix data format for new decks

### DIFF
--- a/client/reducers/cards.js
+++ b/client/reducers/cards.js
@@ -156,8 +156,8 @@ export default function(state = {}, action) {
 
             return newState;
         case 'ADD_DECK':
-            var newDeck = { name: 'New Deck' };
-            
+            var newDeck = { name: 'New Deck', drawCards: [], plotCards: [] };
+
             newState = Object.assign({}, state, {
                 selectedDeck: newDeck,
                 deckSaved: false


### PR DESCRIPTION
The client-side deck processing that occurs now assumes the deck data
already has arrays for `plotCards` and `drawCards`. This caused crashes
when creating a new deck because it was missing these fields.

Fixes THRONETEKI-1QX
Fixes THRONETEKI-1QW