### PR TITLE
Show character being returned on button prompt for SpearsOTMK

### DIFF
--- a/server/game/cards/06.3-TFoA/SpearsOfTheMerlingKing.js
+++ b/server/game/cards/06.3-TFoA/SpearsOfTheMerlingKing.js
@@ -3,6 +3,7 @@ const DrawCard = require('../../drawcard.js');
 class SpearsOfTheMerlingKing extends DrawCard {
     setupCardAbilities(ability) {
         this.interrupt({
+            title: context => context.event.card.name,
             when: {
                 onCharacterKilled: event => event.card.controller === this.controller
             },


### PR DESCRIPTION
Fixes a bug where when multiple characters were dying at the same time, players had to guess which button corresponded to which character.