### PR TITLE
Fixes to attachment styling

### DIFF
--- a/less/cards.less
+++ b/less/cards.less
@@ -249,7 +249,7 @@
   .generate-attachments(@n, (@i + 1));
 }
 
-.generate-attachments(5, 1);
+.generate-attachments(10, 1);
 
 .card-dupe {
   margin-bottom: @attachment-offset;

--- a/less/cards.less
+++ b/less/cards.less
@@ -234,11 +234,11 @@
   }
 
   &.large {
-    margin-top: @attachment-offset - @card-lg-height;    
+    margin-top: @attachment-offset-lg - @card-lg-height;
   }
 
   &.x-large {
-    margin-top: @attachment-offset - @card-xl-height;    
+    margin-top: @attachment-offset-xl - @card-xl-height;
   }
 }
 
@@ -260,11 +260,11 @@
   }
 
   &.large {
-    margin-top: -(@attachment-offset + @card-lg-height);
+    margin-top: -(@attachment-offset-lg + @card-lg-height);
   }
 
   &.x-large {
-    margin-top: -(@attachment-offset + @card-xl-height);
+    margin-top: -(@attachment-offset-xl + @card-xl-height);
   }
 }
 

--- a/less/gameboard.less
+++ b/less/gameboard.less
@@ -660,6 +660,18 @@ span.down-arrow {
 
 .card-row .card.horizontal {
   margin-bottom: @card-height - @card-width;
+
+  &.small {
+    margin-bottom: @card-sm-height - @card-sm-width;
+  }
+
+  &.large {
+    margin-bottom: @card-lg-height - @card-lg-width;
+  }
+
+  &.x-large {
+    margin-bottom: @card-xl-height - @card-xl-width;
+  }
 }
 
 .player-board .card-wrapper {

--- a/less/variables.less
+++ b/less/variables.less
@@ -33,6 +33,8 @@
 @card-sm-height: @card-height * 0.8;
 
 @attachment-offset: 10px;
+@attachment-offset-lg: @attachment-offset * 1.4;
+@attachment-offset-xl: @attachment-offset * 2;
 
 @btn-default-bg: @brand-primary;
 @btn-default-border: darken(@btn-default-bg, 5%);

--- a/server/game/gamesteps/plotphase.js
+++ b/server/game/gamesteps/plotphase.js
@@ -10,6 +10,7 @@ class PlotPhase extends Phase {
     constructor(game) {
         super(game, 'plot');
         this.initialise([
+            new SimpleStep(game, () => this.clearNewCards()),
             new SimpleStep(game, () => this.startPlotPhase()),
             new SelectPlotPrompt(game),
             new SimpleStep(game, () => this.removeActivePlots()),
@@ -19,6 +20,12 @@ class PlotPhase extends Phase {
             () => new ChooseTitlePrompt(game, game.titlePool),
             new ActionWindow(this.game, 'After plots revealed', 'plot')
         ]);
+    }
+
+    clearNewCards() {
+        this.game.allCards.each(card => {
+            card.new = false;
+        });
     }
 
     startPlotPhase() {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -613,10 +613,6 @@ class Player extends Spectator {
         this.challenges.reset();
 
         this.drawPhaseCards = DrawPhaseCards;
-
-        this.cardsInPlay.each(card => {
-            card.new = false;
-        });
     }
 
     flipPlotFaceup() {


### PR DESCRIPTION
* Increases the display offset for attachments when the card size is above the default
* Fixes spacing issues for kneeled attachments when the card size is not the default
* Increases the styling limit for attachments up to 10 attachments on a single card (previously 5)
* Properly clear "new" status from attachments.

Also offsets attachments to the right as suggested in lobby chat. This should make clicking on attachments a bit easier overall. 
![screen shot 2018-01-09 at 7 03 00 pm](https://user-images.githubusercontent.com/145077/34754327-f0e5750e-f571-11e7-85c9-93f2aee027d4.png)

If we don't want the offset (or want to think about it more), it's easy enough to drop the specific commit.