### PR TITLE
Add a 'singleController'-flag to the target API

### DIFF
--- a/server/game/CardSelector.js
+++ b/server/game/CardSelector.js
@@ -9,7 +9,8 @@ const defaultProperties = {
     cardCondition: () => true,
     cardType: ['attachment', 'character', 'event', 'location'],
     gameAction: 'target',
-    multiSelect: false
+    multiSelect: false,
+    singleController: false
 };
 
 const ModeToSelector = {

--- a/server/game/CardSelectors/BaseCardSelector.js
+++ b/server/game/CardSelectors/BaseCardSelector.js
@@ -1,8 +1,11 @@
+const _ = require('underscore');
+
 class BaseCardSelector {
     constructor(properties) {
         this.cardCondition = properties.cardCondition;
         this.cardType = properties.cardType;
         this.gameAction = properties.gameAction;
+        this.singleController = properties.singleController;
 
         if(!Array.isArray(properties.cardType)) {
             this.cardType = [properties.cardType];
@@ -15,6 +18,14 @@ class BaseCardSelector {
             this.cardCondition(card, context) &&
             card.allowGameAction(this.gameAction)
         );
+    }
+
+    checkForSingleController(selectedCards, card) {
+        if(!this.singleController || _.isEmpty(selectedCards)) {
+            return true;
+        }
+
+        return card.controller === selectedCards[0].controller;
     }
 
     getEligibleTargets(context) {

--- a/server/game/cards/01-Core/ConsolidationOfPower.js
+++ b/server/game/cards/01-Core/ConsolidationOfPower.js
@@ -11,6 +11,7 @@ class ConsolidationOfPower extends DrawCard {
                 activePromptTitle: 'Select character(s)',
                 maxStat: () => 4,
                 cardStat: card => card.getStrength(),
+                singleController: true,
                 cardCondition: card => card.location === 'play area' && card.getType() === 'character' && !card.kneeled,
                 gameAction: 'kneel'
             },

--- a/server/game/gamesteps/selectcardprompt.js
+++ b/server/game/gamesteps/selectcardprompt.js
@@ -135,6 +135,7 @@ class SelectCardPrompt extends UiPrompt {
 
         return (
             this.selector.canTarget(card, this.context) &&
+            this.selector.checkForSingleController(this.selectedCards, card) &&
             !this.selector.wouldExceedLimit(this.selectedCards, card)
         );
     }


### PR DESCRIPTION
This flag restricts SelectCardPrompt targets to a single controller. Fixes a bug where Consolidation of Power could be used to select characters from either player.

Fixes #1669.