### PR TITLE
Set claim minimum to 0

### DIFF
--- a/server/game/plotcard.js
+++ b/server/game/plotcard.js
@@ -59,7 +59,7 @@ class PlotCard extends BaseCard {
             return this.claimSet;
         }
 
-        return baseClaim + this.claimModifier;
+        return Math.max(baseClaim + this.claimModifier, 0);
     }
 
     flipFaceup() {


### PR DESCRIPTION
Fixes a bug where for example Calm over Westeros vs. Valar Morghulis could result in a -1 claim value.