### PR TITLE
Raise onCardPlayed event for attaching events

### DIFF
--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -152,7 +152,7 @@ class CardAction extends BaseAbility {
     }
 
     isPlayableEventAbility() {
-        return this.card.getType() === 'event' && this.location === 'hand';
+        return this.card.getPrintedType() === 'event' && this.location === 'hand';
     }
 
     hasMax() {

--- a/server/game/gamesteps/abilityresolver.js
+++ b/server/game/gamesteps/abilityresolver.js
@@ -178,7 +178,9 @@ class AbilityResolver extends BaseStep {
         // then this event will need to wrap the execution of the entire
         // ability instead.
         if(this.ability.isPlayableEventAbility()) {
-            this.context.source.owner.moveCard(this.context.source, this.context.source.eventPlacementLocation);
+            if(this.context.source.location === 'being played') {
+                this.context.source.owner.moveCard(this.context.source, this.context.source.eventPlacementLocation);
+            }
             this.game.raiseEvent('onCardPlayed', { player: this.context.player, card: this.context.source });
         }
     }

--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -108,7 +108,7 @@ class TriggeredAbility extends BaseAbility {
     }
 
     isPlayableEventAbility() {
-        return this.card.getType() === 'event' && this.location === 'hand';
+        return this.card.getPrintedType() === 'event' && this.location === 'hand';
     }
 
     hasMax() {

--- a/test/server/card/cardforcedreaction.spec.js
+++ b/test/server/card/cardforcedreaction.spec.js
@@ -4,7 +4,7 @@ const Event = require('../../../server/game/event.js');
 describe('CardForcedReaction', function () {
     beforeEach(function () {
         this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener', 'registerAbility']);
-        this.cardSpy = jasmine.createSpyObj('card', ['getType', 'isBlank']);
+        this.cardSpy = jasmine.createSpyObj('card', ['getPrintedType', 'getType', 'isBlank']);
         this.cardSpy.location = 'play area';
         this.limitSpy = jasmine.createSpyObj('limit', ['increment', 'isAtMax', 'registerEvents', 'unregisterEvents']);
 

--- a/test/server/card/cardreaction.spec.js
+++ b/test/server/card/cardreaction.spec.js
@@ -4,7 +4,7 @@ const Event = require('../../../server/game/event.js');
 describe('CardReaction', function () {
     beforeEach(function () {
         this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener', 'registerAbility']);
-        this.cardSpy = jasmine.createSpyObj('card', ['getType', 'isBlank']);
+        this.cardSpy = jasmine.createSpyObj('card', ['getPrintedType', 'getType', 'isBlank']);
         this.cardSpy.location = 'play area';
         this.limitSpy = jasmine.createSpyObj('limit', ['increment', 'isAtMax', 'registerEvents', 'unregisterEvents']);
 

--- a/test/server/gamesteps/abilityresolver.spec.js
+++ b/test/server/gamesteps/abilityresolver.spec.js
@@ -83,17 +83,31 @@ describe('AbilityResolver', function() {
         describe('when the ability is an event being played', function() {
             beforeEach(function() {
                 this.source.eventPlacementLocation = 'event placement location';
+                this.source.location = 'being played';
                 this.ability.resolveCosts.and.returnValue([{ resolved: true, value: true }, { resolved: true, value: true }]);
                 this.ability.isPlayableEventAbility.and.returnValue(true);
-                this.resolver.continue();
             });
 
             it('should move the card to the specified event location', function() {
+                this.resolver.continue();
                 expect(this.player.moveCard).toHaveBeenCalledWith(this.source, 'event placement location');
             });
 
             it('should raise the onCardPlayed event', function() {
+                this.resolver.continue();
                 expect(this.game.raiseEvent).toHaveBeenCalledWith('onCardPlayed', jasmine.any(Object));
+            });
+
+            describe('and the event is no longer in the "being played" state', function() {
+                beforeEach(function() {
+                    // Example: Risen from the Sea attached to character after playing it
+                    this.source.location = 'play area';
+                    this.resolver.continue();
+                });
+
+                it('should not move the card', function() {
+                    expect(this.player.moveCard).not.toHaveBeenCalled();
+                });
             });
         });
 

--- a/test/server/integration/playingevents.spec.js
+++ b/test/server/integration/playingevents.spec.js
@@ -3,7 +3,7 @@ describe('playing events', function() {
         beforeEach(function() {
             const deck1 = this.buildDeck('baratheon', [
                 'Trading with the Pentoshi',
-                'Melisandre (Core)', 'Seen In Flames'
+                'Melisandre (Core)', 'Seen In Flames', 'Theon Greyjoy (Core)', 'Risen from the Sea'
             ]);
             const deck2 = this.buildDeck('martell', [
                 'Trading with the Pentoshi',
@@ -94,6 +94,26 @@ describe('playing events', function() {
 
             it('should not count as playing an event', function() {
                 expect(this.player2).not.toHavePromptButton('Tower of the Sun');
+            });
+        });
+
+        describe('when an event becomes an attachment', function() {
+            beforeEach(function() {
+                let character = this.player1.findCardByName('Theon Greyjoy', 'hand');
+                this.player1.dragCard(character, 'play area');
+
+                this.game.killCharacter(character, { allowSave: true });
+                this.game.continue();
+
+                this.player1.clickPrompt('Risen from the Sea');
+                this.player1.clickCard(character);
+
+                // Pass on Hand's Judgment to allow the save
+                this.player2.clickPrompt('Pass');
+            });
+
+            it('should count as playing an event', function() {
+                expect(this.player2).toHavePromptButton('Tower of the Sun');
             });
         });
     });


### PR DESCRIPTION
Previously, playing Risen from the Sea and Blood Magic Ritual did not
properly count as playing events because they change their card type to
'attachment' after resolving. Now, this check looks at the printed card
type and makes sure the event is still "being played" before placing in
discard.

Fixes #1675 