### PR TITLE
Allow effects to be applied before Bestow prompt

### DIFF
--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -138,7 +138,7 @@ class DrawCard extends BaseCard {
     }
 
     isBestow() {
-        return !_.isUndefined(this.bestowMax);
+        return !this.isBlank() && !_.isUndefined(this.bestowMax);
     }
 
     isRenown() {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -536,11 +536,6 @@ class Player extends Spectator {
         if(card.getType() === 'attachment' && playingType !== 'setup' && !dupeCard) {
             card.controller = this;
             this.promptForAttachment(card, playingType);
-
-            if(this.game.currentPhase !== 'setup' && card.isBestow()) {
-                this.game.queueStep(new BestowPrompt(this.game, this, card));
-            }
-
             return;
         }
 
@@ -564,9 +559,11 @@ class Player extends Spectator {
                 card.applyPersistentEffects();
             }
 
-            if(this.game.currentPhase !== 'setup' && card.isBestow()) {
-                this.game.queueStep(new BestowPrompt(this.game, this, card));
-            }
+            this.game.queueSimpleStep(() => {
+                if(this.game.currentPhase !== 'setup' && card.isBestow()) {
+                    this.game.queueStep(new BestowPrompt(this.game, this, card));
+                }
+            });
 
             this.game.raiseEvent('onCardEntersPlay', { card: card, playingType: playingType, originalLocation: originalLocation });
         }
@@ -692,6 +689,12 @@ class Player extends Spectator {
 
         this.game.queueSimpleStep(() => {
             attachment.applyPersistentEffects();
+        });
+
+        this.game.queueSimpleStep(() => {
+            if(this.game.currentPhase !== 'setup' && attachment.isBestow()) {
+                this.game.queueStep(new BestowPrompt(this.game, player, attachment));
+            }
         });
 
         if(originalLocation !== 'play area') {

--- a/test/server/integration/Bestow.spec.js
+++ b/test/server/integration/Bestow.spec.js
@@ -1,0 +1,89 @@
+describe('Bestow keyword', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck = this.buildDeck('stark', [
+                'A Noble Cause', 'Fortified Position',
+                'Fickle Bannerman', 'Hedge Knight', 'Fever Dreams'
+            ]);
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.bestowCharacter = this.player1.findCardByName('Fickle Bannerman', 'hand');
+            this.bestowAttachment = this.player1.findCardByName('Fever Dreams', 'hand');
+            this.opponentCharacter = this.player2.findCardByName('Hedge Knight', 'hand');
+
+            this.player2.clickCard(this.opponentCharacter);
+            this.completeSetup();
+        });
+
+        describe('when putting a bestow character into play', function() {
+            beforeEach(function() {
+                this.player1.selectPlot('A Noble Cause');
+                this.player2.selectPlot('A Noble Cause');
+                this.selectFirstPlayer(this.player1);
+
+                this.player1.clickCard(this.bestowCharacter);
+            });
+
+            it('should prompt for the amount of gold', function() {
+                expect(this.player1).toHavePrompt('Select bestow amount for Fickle Bannerman');
+                expect(this.player1).toHavePromptButton('Done');
+                expect(this.player1).toHavePromptButton('1');
+                expect(this.player1).toHavePromptButton('2');
+                expect(this.player1).not.toHavePromptButton('3');
+            });
+
+            it('should move the selected amount of gold onto the card', function() {
+                this.player1.clickPrompt('1');
+
+                expect(this.bestowCharacter.tokens.gold).toBe(1);
+                expect(this.player1Object.gold).toBe(1); // 5 from plot - 3 from character - 1 from bestow
+            });
+        });
+
+        describe('when putting a bestow attachment into play', function() {
+            beforeEach(function() {
+                this.player1.selectPlot('A Noble Cause');
+                this.player2.selectPlot('A Noble Cause');
+                this.selectFirstPlayer(this.player1);
+
+                this.player1.clickCard(this.bestowAttachment);
+            });
+
+            it('should prompt for the amount of gold after selecting target character', function() {
+                this.player1.clickCard(this.opponentCharacter);
+
+                expect(this.player1).toHavePrompt('Select bestow amount for Fever Dreams');
+                expect(this.player1).toHavePromptButton('Done');
+                expect(this.player1).toHavePromptButton('1');
+                expect(this.player1).toHavePromptButton('2');
+                expect(this.player1).toHavePromptButton('3');
+                expect(this.player1).not.toHavePromptButton('4');
+            });
+
+            it('should move the selected amount of gold onto the card', function() {
+                this.player1.clickCard(this.opponentCharacter);
+                this.player1.clickPrompt('3');
+
+                expect(this.bestowAttachment.tokens.gold).toBe(3);
+                expect(this.player1Object.gold).toBe(1); // 5 from plot - 1 from character - 3 from bestow
+            });
+        });
+
+        describe('when Fortified Position is in play', function() {
+            beforeEach(function() {
+                this.player1.selectPlot('A Noble Cause');
+                this.player2.selectPlot('Fortified Position');
+                this.selectFirstPlayer(this.player1);
+
+                this.player1.clickCard(this.bestowCharacter);
+            });
+
+            it('should not prompt for bestow', function() {
+                expect(this.player1).not.toHavePrompt('Select bestow amount for Fickle Bannerman');
+            });
+        });
+    });
+});

--- a/test/server/player/putintoplay.spec.js
+++ b/test/server/player/putintoplay.spec.js
@@ -4,13 +4,15 @@ const Player = require('../../../server/game/player.js');
 
 describe('Player', function() {
     beforeEach(function() {
-        this.gameSpy = jasmine.createSpyObj('game', ['queueStep', 'raiseEvent', 'playerDecked']);
+        this.gameSpy = jasmine.createSpyObj('game', ['queueSimpleStep', 'queueStep', 'raiseEvent', 'playerDecked']);
         this.player = new Player('1', {username: 'Player 1', settings: {}}, true, this.gameSpy);
         this.player.initialise();
 
         spyOn(this.player, 'getDuplicateInPlay');
         spyOn(this.player, 'isCharacterDead');
         spyOn(this.player, 'canResurrect');
+
+        this.gameSpy.queueSimpleStep.and.callFake(func => func());
 
         this.cardSpy = jasmine.createSpyObj('card', ['getType', 'getCost', 'isBestow', 'isUnique', 'applyPersistentEffects', 'moveTo']);
         this.cardSpy.controller = this.player;


### PR DESCRIPTION
Previously, if a character with Bestow came out during Fortified
Position, the player would be prompted for the bestow amount even though
Bestow keyword would be blanked. Now the prompt is delayed until after
the effects engine has a chance to apply effects to the card.

Fixes #1462 