### PR TITLE
Filter out stealth characters without targets

### DIFF
--- a/server/game/gamesteps/challenge/choosestealthtargets.js
+++ b/server/game/gamesteps/challenge/choosestealthtargets.js
@@ -6,16 +6,16 @@ class ChooseStealthTargets extends BaseStep {
     constructor(game, challenge, stealthCharacters) {
         super(game);
         this.challenge = challenge;
-        this.stealthCharacters = stealthCharacters;
+        this.stealthCharacters = stealthCharacters.filter(character => this.hasStealthTargets(character));
+    }
+
+    hasStealthTargets(character) {
+        return this.challenge.defendingPlayer.anyCardsInPlay(card => this.canStealth(card, this.challenge, character));
     }
 
     continue() {
         if(this.stealthCharacters.length > 0) {
             let character = this.stealthCharacters.shift();
-
-            if(!this.challenge.defendingPlayer.anyCardsInPlay(card => this.canStealth(card, this.challenge, character))) {
-                return false;
-            }
 
             let title = character.stealthLimit === 1 ? 'Select stealth target for ' + character.name : 'Select up to ' + character.stealthLimit + ' stealth targets for ' + character.name;
             this.game.promptForSelect(character.controller, {


### PR DESCRIPTION
Previously, the game step that prompted for stealth targets during a
challenge would check each character individually and pause the step if
they had no valid targets. This lead to a bug where if two or more
stealth characters were declared and the defender had no valid targets,
the pipeline would pause indefinitely.

Now, stealth characters that don't have valid targets are immediately
filtered out, allowing the game step to prompt without improperly
pausing.