### PR TITLE
Fix "does not kneel when declared as attacker"

### DIFF
--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -14,6 +14,7 @@ class ChallengeFlow extends BaseStep {
         this.pipeline = new GamePipeline();
         this.pipeline.initialise([
             new SimpleStep(this.game, () => this.resetCards()),
+            new SimpleStep(this.game, () => this.recalculateEffects()),
             new SimpleStep(this.game, () => this.announceChallenge()),
             new SimpleStep(this.game, () => this.promptForAttackers()),
             new SimpleStep(this.game, () => this.chooseStealthTargets()),
@@ -32,6 +33,14 @@ class ChallengeFlow extends BaseStep {
 
     resetCards() {
         this.challenge.resetCards();
+    }
+
+    recalculateEffects() {
+        // Explicit effect recalculation is needed here since conditions that
+        // watch the currentChallenge property need recalculation before
+        // attackers are chosen, but the challenge initiation event isn't fired
+        // until after attackers have been chosen.
+        this.game.effectEngine.reapplyStateDependentEffects();
     }
 
     announceChallenge() {

--- a/test/server/effects/doesNotKneelAsAttacker.spec.js
+++ b/test/server/effects/doesNotKneelAsAttacker.spec.js
@@ -1,0 +1,36 @@
+describe('doesNotKneelAsAttacker', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck = this.buildDeck('stark', [
+                'A Noble Cause',
+                'Ser Jaime Lannister (Core)'
+            ]);
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.character = this.player1.findCardByName('Ser Jaime Lannister');
+            this.player1.clickCard(this.character);
+
+            this.completeSetup();
+            this.player1.selectPlot('A Noble Cause');
+            this.player2.selectPlot('A Noble Cause');
+            this.selectFirstPlayer(this.player1);
+            this.completeMarshalPhase();
+        });
+
+        describe('when the character is declared as an attacker', function() {
+            beforeEach(function() {
+                this.player1.clickPrompt('Military');
+                this.player1.clickCard(this.character);
+                this.player1.clickPrompt('Done');
+            });
+
+            it('should not kneel the character', function() {
+                expect(this.game.currentChallenge.isAttacking(this.character));
+                expect(this.character.kneeled).toBe(false);
+            });
+        });
+    });
+});

--- a/test/server/effects/doesNotKneelAsDefender.spec.js
+++ b/test/server/effects/doesNotKneelAsDefender.spec.js
@@ -1,0 +1,43 @@
+describe('doesNotKneelAsDefender', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck = this.buildDeck('stark', [
+                'A Noble Cause',
+                'Littlefinger', 'Myrcella Baratheon'
+            ]);
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.attacker = this.player1.findCardByName('Littlefinger');
+            this.character = this.player2.findCardByName('Myrcella Baratheon');
+            this.player1.clickCard(this.attacker);
+            this.player2.clickCard(this.character);
+
+            this.completeSetup();
+            this.player1.selectPlot('A Noble Cause');
+            this.player2.selectPlot('A Noble Cause');
+            this.selectFirstPlayer(this.player1);
+            this.completeMarshalPhase();
+        });
+
+        describe('when the character is declared as a defender', function() {
+            beforeEach(function() {
+                this.player1.clickPrompt('Power');
+                this.player1.clickCard(this.attacker);
+                this.player1.clickPrompt('Done');
+
+                this.skipActionWindow();
+
+                this.player2.clickCard(this.character);
+                this.player2.clickPrompt('Done');
+            });
+
+            it('should not kneel the character', function() {
+                expect(this.game.currentChallenge.isDefending(this.character));
+                expect(this.character.kneeled).toBe(false);
+            });
+        });
+    });
+});


### PR DESCRIPTION
The previous change to the effects engine where effects are recalculated
only after a game event has occurred caused the "does not kneel when
declared as an attacker" cards to stop working. This is because the
event for attackers being declared and being knelt happens
simultaneously, so the engine had no opportunity to see that the cards
shouldn't be knelt until after kneeling them.