### PR TITLE
Do not discard attachments that are being removed

### DIFF
--- a/server/game/AttachmentValidityCheck.js
+++ b/server/game/AttachmentValidityCheck.js
@@ -28,7 +28,7 @@ class AttachmentValidityCheck {
     }
 
     filterInvalidAttachments() {
-        let attachmentsInPlay = this.game.filterCardsInPlay(card => card.parent && card.getType() === 'attachment');
+        let attachmentsInPlay = this.game.filterCardsInPlay(card => card.parent && card.getType() === 'attachment' && !card.isBeingRemoved);
         return attachmentsInPlay.filter(card => !card.controller.canAttach(card, card.parent));
     }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -958,10 +958,15 @@ class Player extends Spectator {
     }
 
     removeAttachment(attachment, allowSave = true) {
+        attachment.isBeingRemoved = true;
         if(attachment.isTerminal()) {
-            attachment.owner.moveCard(attachment, 'discard pile', { allowSave: allowSave });
+            attachment.owner.moveCard(attachment, 'discard pile', { allowSave: allowSave }, () => {
+                attachment.isBeingRemoved = false;
+            });
         } else {
-            attachment.owner.moveCard(attachment, 'hand', { allowSave: allowSave });
+            attachment.owner.moveCard(attachment, 'hand', { allowSave: allowSave }, () => {
+                attachment.isBeingRemoved = false;
+            });
         }
     }
 

--- a/test/server/integration/Attachments.spec.js
+++ b/test/server/integration/Attachments.spec.js
@@ -114,5 +114,57 @@ describe('attachments', function() {
                 expect(this.character.attachments).not.toContain(this.attachment);
             });
         });
+
+        describe('when the character an attachment is placed on leaves play', function() {
+            beforeEach(function() {
+                const deck1 = this.buildDeck('stark', [
+                    'A Noble Cause',
+                    'Winterfell Steward', 'Little Bird'
+                ]);
+                const deck2 = this.buildDeck('stark', [
+                    'A Noble Cause',
+                    'Milk of the Poppy'
+                ]);
+                this.player1.selectDeck(deck1);
+                this.player2.selectDeck(deck2);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.character = this.player1.findCardByName('Winterfell Steward', 'hand');
+                this.nonTerminalAttachment = this.player1.findCardByName('Little Bird', 'hand');
+                this.terminalAttachment = this.player2.findCardByName('Milk of the Poppy', 'hand');
+
+                this.player1.clickCard(this.character);
+                this.player1.clickCard(this.nonTerminalAttachment);
+                this.completeSetup();
+
+                // Attach the non-terminal attachment
+                this.player1.clickCard(this.nonTerminalAttachment);
+                this.player1.clickCard(this.character);
+
+                this.player1.selectPlot('A Noble Cause');
+                this.player2.selectPlot('A Noble Cause');
+                this.selectFirstPlayer(this.player2);
+
+                // Attach the terminal attachment
+                this.player2.clickCard(this.terminalAttachment);
+                this.player2.clickCard(this.character);
+
+                expect(this.character.attachments).toContain(this.nonTerminalAttachment);
+                expect(this.character.attachments).toContain(this.terminalAttachment);
+
+                this.player1.dragCard(this.character, 'dead pile');
+            });
+
+            it('should return the non-terminal attachment back to hand', function() {
+                expect(this.nonTerminalAttachment.location).toBe('hand');
+                expect(this.player1Object.hand).toContain(this.nonTerminalAttachment);
+            });
+
+            it('should place the terminal attachment in discard', function() {
+                expect(this.terminalAttachment.location).toBe('discard pile');
+                expect(this.player2Object.discardPile).toContain(this.terminalAttachment);
+            });
+        });
     });
 });


### PR DESCRIPTION
The addition of the attachment validity check lead to a bug where
non-terminal attachments did not return to hand properly. This was due
to the fact that by the time the asynchronous return to hand call
occurs, the parent of the attachment is already out of the play area,
which then triggers the attachment validity check to discard it instead.

Fixes #1719 