### PR TITLE
Do not recalculate effects that have expired

### DIFF
--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -50,7 +50,9 @@ class EffectEngine {
             this.effectsBeingRecalculated = this.effectsBeingRecalculated.concat(needsRecalc);
 
             for(let effect of needsRecalc) {
-                effect.reapply(this.getTargets());
+                if(this.effects.includes(effect)) {
+                    effect.reapply(this.getTargets());
+                }
             }
         });
 

--- a/test/server/integration/plotphase.spec.js
+++ b/test/server/integration/plotphase.spec.js
@@ -26,5 +26,40 @@ describe('plot phase', function() {
                 expect(this.chud.location).toBe('play area');
             });
         });
+
+        describe('when a new plot is revealed', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('targaryen', [
+                    'A Song of Summer', 'A Noble Cause', 'A Noble Cause',
+                    'Targaryen Loyalist'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.character = this.player1.findCardByName('Targaryen Loyalist', 'hand');
+                this.player1.clickCard(this.character);
+
+                this.completeSetup();
+
+                this.player1.selectPlot('A Song of Summer');
+                this.player2.selectPlot('A Noble Cause');
+                this.selectFirstPlayer(this.player1);
+
+                expect(this.character.getStrength()).toBe(2);
+
+                this.completeMarshalPhase();
+                this.completeChallengesPhase();
+
+                this.player1.selectPlot('A Noble Cause');
+                this.player2.selectPlot('A Noble Cause');
+                this.selectFirstPlayer(this.player1);
+            });
+
+            it('should unapply the effects of the plot', function() {
+                expect(this.character.getStrength()).toBe(1);
+            });
+        });
     });
 });


### PR DESCRIPTION
With the previous change to the effects engine, conditional and state
dependent effects are queued up to be recalculated after each event.
However, certain events around revealing new plots cause those effects
to be removed. Since the effects were already queued, though, the engine
ended up reapplying the effect after it expired.

Now, the engine makes sure the effect is still in the list of active
effects before reapplying it.

Fixes #1722 
Fixes #1724 