### PR TITLE
Automatically recalculate player-matched effects

### DIFF
--- a/server/game/cards/05-LoCR/TommenBaratheon.js
+++ b/server/game/cards/05-LoCR/TommenBaratheon.js
@@ -5,8 +5,6 @@ class TommenBaratheon extends DrawCard {
         this.persistentEffect({
             targetType: 'player',
             targetController: 'any',
-            //This forces a recalculate for player level effects
-            condition: () => true,
             match: player => player.hand.size() === 0,
             effect: ability.effects.cannotGainChallengeBonus()
         });

--- a/server/game/cards/08.4-FotOG/TheKingInTheNorth.js
+++ b/server/game/cards/08.4-FotOG/TheKingInTheNorth.js
@@ -5,8 +5,6 @@ class TheKingInTheNorth extends PlotCard {
         this.persistentEffect({
             targetType: 'player',
             targetController: 'any',
-            //This forces a recalculate for player level effects
-            condition: () => true,
             match: player => !player.anyCardsInPlay(card => card.getType() === 'character' && card.hasTrait('King')),
             effect: ability.effects.cannotTriggerCardAbilities(card => ['character', 'location', 'attachment'].includes(card.getType()))
         });

--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -55,7 +55,7 @@ class Effect {
         this.targets = [];
         this.context = { game: game, source: source };
         this.active = !source.facedown;
-        this.isConditional = !!properties.condition;
+        this.isConditional = !!properties.condition || this.targetType === 'player' && _.isFunction(properties.match);
         this.isStateDependent = this.isConditional || this.effect.isStateDependent;
     }
 

--- a/test/server/cards/01-Core/AGameOfThrones.spec.js
+++ b/test/server/cards/01-Core/AGameOfThrones.spec.js
@@ -1,0 +1,66 @@
+describe('A Game Of Thrones', function() {
+    integration(function() {
+        describe('when dupes are put out in the setup phase', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('baratheon', [
+                    'A Noble Cause', 'A Game of Thrones',
+                    'Wildling Scout', 'Stannis Baratheon (Core)'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.wildlingScout = this.player1.findCardByName('Wildling Scout', 'hand');
+                this.character = this.player1.findCardByName('Stannis Baratheon', 'hand');
+
+                this.player1.clickCard(this.wildlingScout);
+                this.player1.clickCard(this.character);
+
+                this.completeSetup();
+                this.player1.selectPlot('A Game of Thrones');
+                this.player2.selectPlot('A Noble Cause');
+                this.selectFirstPlayer(this.player1);
+
+                this.completeMarshalPhase();
+            });
+
+            describe('when the player has not won an intrigue challenge', function() {
+                it('should not allow military challenges to be declared', function() {
+                    this.player1.clickPrompt('Military');
+
+                    expect(this.player1).not.toHavePrompt('Select challenge attackers');
+                    expect(this.player1).toHavePromptButton('Military');
+                });
+
+                it('should not allow power challenges to be declared', function() {
+                    this.player1.clickPrompt('Power');
+
+                    expect(this.player1).not.toHavePrompt('Select challenge attackers');
+                    expect(this.player1).toHavePromptButton('Power');
+                });
+            });
+
+            describe('when the player has won an intrigue challenge', function() {
+                beforeEach(function() {
+                    this.unopposedChallenge(this.player1, 'Intrigue', this.wildlingScout);
+                    this.player1.clickPrompt('Apply Claim');
+                });
+
+                it('should allow military challenges to be declared', function() {
+                    this.player1.clickPrompt('Military');
+
+                    expect(this.player1).toHavePrompt('Select challenge attackers');
+                    expect(this.player1).not.toHavePromptButton('Military');
+                });
+
+                it('should allow power challenges to be declared', function() {
+                    this.player1.clickPrompt('Power');
+
+                    expect(this.player1).toHavePrompt('Select challenge attackers');
+                    expect(this.player1).not.toHavePromptButton('Power');
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Previously, when an effect was applied only to players that met a
matching condition (e.g. Tommen, The King in the North, A Game of
Thrones), an explicit recalculate was needed. The change to the way
effects are recalculated didn't take this into account, requiring an
always-true condition be added to such effects to ensure they were
recalculated. If that condition was missing, the effect would never be
reapplied properly.

This led to a bug where A Game of Thrones would not allow players
initiate military or power challenges, even after winning intrigue
challenges, because the effect wasn't removed from the player.

Now, all effects that target a player that also have a matching function
will automatically be considered a conditional effect and be
recalculated at the proper interval.

Fixes #1733 