### PR TITLE
Convert "enters play knelt" to effect + option

### DIFF
--- a/server/game/cards/01-Core/SansaStark.js
+++ b/server/game/cards/01-Core/SansaStark.js
@@ -1,21 +1,13 @@
 const DrawCard = require('../../drawcard.js');
 
 class SansaStark extends DrawCard {
-    constructor(owner, cardData) {
-        super(owner, cardData);
-
-        this.registerEvents(['onCardEntersPlay']);
-    }
-
-    onCardEntersPlay(event) {
-        if(event.card !== this || this.controller.phase === 'setup') {
-            return;
-        }
-
-        this.controller.kneelCard(this);
-    }
-
     setupCardAbilities(ability) {
+        this.persistentEffect({
+            location: 'any',
+            targetLocation: 'any',
+            match: this,
+            effect: ability.effects.entersPlayKneeled()
+        });
         this.reaction({
             when: {
                 onCardStood: event => event.card === this

--- a/server/game/cards/04.2-CtA/DolorousEdd.js
+++ b/server/game/cards/04.2-CtA/DolorousEdd.js
@@ -14,9 +14,7 @@ class DolorousEdd extends DrawCard {
             cost: ability.costs.kneelFactionCard(),
             handler: () => {
                 this.game.addMessage('{0} kneels their faction card to put {1} into play as a defender', this.controller, this);
-                this.controller.putIntoPlay(this);
-                // Manually kneel Edd, since he enters play that way - should not fire a kneeling event.
-                this.kneeled = true;
+                this.controller.putIntoPlay(this, 'play', { kneeled: true });
                 this.game.currentChallenge.addDefender(this);
                 this.game.once('afterChallenge', event => this.promptOnWin(event.challenge));
             }

--- a/server/game/cards/05-LoCR/OldWyk.js
+++ b/server/game/cards/05-LoCR/OldWyk.js
@@ -14,9 +14,7 @@ class OldWyk extends DrawCard {
             handler: () => {
                 let card = _.last(this.controller.deadPile.filter(c => c.hasTrait('Drowned God')));
 
-                this.controller.putIntoPlay(card);
-                //Manually kneel instead of firing kneel event as character is put into play knelt
-                card.kneeled = true;
+                this.controller.putIntoPlay(card, 'play', { kneeled: true });
                 this.game.currentChallenge.addAttacker(card);
 
                 this.game.addMessage('{0} kneels {1} to put {2} into play from their dead pile knelt as an attacker',

--- a/server/game/cards/10-SoD/Val.js
+++ b/server/game/cards/10-SoD/Val.js
@@ -11,8 +11,7 @@ class Val extends DrawCard {
                                        card.getType() === 'character' && card.hasTrait('Wildling') && card.getPrintedCost() <= 4
             },
             handler: context => {
-                context.player.putIntoPlay(context.target);
-                context.target.kneeled = true;
+                context.player.putIntoPlay(context.target, 'play', { kneeled: true });
                 this.game.currentChallenge.addAttacker(context.target);
 
                 this.game.addMessage('{0} uses {1} to put {2} into play from their hand knelt, participating as an attacker',

--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -33,7 +33,7 @@ class EffectEngine {
     }
 
     getTargets() {
-        const validLocations = ['active plot', 'being played', 'discard pile', 'hand', 'play area', 'duplicate'];
+        const validLocations = ['active plot', 'being played', 'dead pile', 'discard pile', 'draw deck', 'hand', 'play area', 'duplicate'];
         let validTargets = this.game.allCards.filter(card => validLocations.includes(card.location));
         return validTargets.concat(this.game.getPlayers()).concat([this.game]);
     }

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -55,6 +55,16 @@ const Effects = {
             }
         };
     },
+    entersPlayKneeled: function() {
+        return {
+            apply: function(card) {
+                card.entersPlayKneeled = true;
+            },
+            unapply: function(card) {
+                card.entersPlayKneeled = false;
+            }
+        };
+    },
     cannotBeDeclaredAsAttacker: cannotEffect('declareAsAttacker'),
     cannotBeDeclaredAsDefender: cannotEffect('declareAsDefender'),
     cannotParticipate: cannotEffect('participateInChallenge'),

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -556,6 +556,7 @@ class Player extends Spectator {
             card.new = true;
             this.moveCard(card, 'play area', { isDupe: !!dupeCard });
             card.controller = this;
+            card.kneeled = playingType !== 'setup' && !!card.entersPlayKneeled || !!options.kneeled;
             card.wasAmbush = (playingType === 'ambush');
 
             if(!dupeCard && !isSetupAttachment) {

--- a/test/server/effectengine.spec.js
+++ b/test/server/effectengine.spec.js
@@ -8,11 +8,17 @@ describe('EffectEngine', function () {
         this.handCard = { location: 'hand' };
         this.discardedCard = { location: 'discard pile' };
         this.drawCard = { location: 'draw deck' };
+        this.deadCard = { location: 'dead pile' };
+        this.activePlot = { location: 'active plot' };
+        this.plotCard = { location: 'plot deck' };
+        this.revealedPlot = { location: 'revealed plot' };
+        this.agendaCard = { location: 'agenda' };
+        this.factionCard = { location: 'faction card' };
 
         this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener', 'getPlayers', 'queueSimpleStep']);
         this.gameSpy.getPlayers.and.returnValue([]);
         this.gameSpy.queueSimpleStep.and.callFake(func => func());
-        this.gameSpy.allCards = _([this.handCard, this.playAreaCard, this.discardedCard, this.drawCard]);
+        this.gameSpy.allCards = _([this.handCard, this.playAreaCard, this.discardedCard, this.drawCard, this.deadCard, this.activePlot, this.plotCard, this.revealedPlot, this.agendaCard, this.factionCard]);
 
         this.effectSpy = jasmine.createSpyObj('effect', ['addTargets', 'isInActiveLocation', 'reapply', 'removeTarget', 'cancel', 'setActive']);
         this.effectSpy.isInActiveLocation.and.returnValue(true);
@@ -31,7 +37,7 @@ describe('EffectEngine', function () {
         });
 
         it('should add existing valid targets to the effect', function() {
-            expect(this.effectSpy.addTargets).toHaveBeenCalledWith([this.handCard, this.playAreaCard, this.discardedCard, this.gameSpy]);
+            expect(this.effectSpy.addTargets).toHaveBeenCalledWith(jasmine.arrayContaining([this.handCard, this.playAreaCard, this.discardedCard, this.gameSpy]));
         });
 
         describe('when the effect has custom duration', function() {
@@ -57,8 +63,28 @@ describe('EffectEngine', function () {
             this.gameSpy.getPlayers.and.returnValue([this.player]);
         });
 
-        it('should return all play area cards, discarded cards, players and the game object', function() {
-            expect(this.engine.getTargets()).toEqual([this.handCard, this.playAreaCard, this.discardedCard, this.player, this.gameSpy]);
+        it('should not include cards in the plot deck', function() {
+            expect(this.engine.getTargets()).not.toContain(this.plotCard);
+        });
+
+        it('should not include cards in the revealed plots pile', function() {
+            expect(this.engine.getTargets()).not.toContain(this.revealedPlot);
+        });
+
+        it('should not include agenda cards', function() {
+            expect(this.engine.getTargets()).not.toContain(this.agendaCard);
+        });
+
+        it('should not include faction cards', function() {
+            expect(this.engine.getTargets()).not.toContain(this.factionCard);
+        });
+
+        it('should include player objects', function() {
+            expect(this.engine.getTargets()).toContain(this.player);
+        });
+
+        it('should include the game object', function() {
+            expect(this.engine.getTargets()).toContain(this.gameSpy);
         });
     });
 
@@ -74,7 +100,7 @@ describe('EffectEngine', function () {
             });
 
             it('should reapply valid targets', function() {
-                expect(this.effectSpy.reapply).toHaveBeenCalledWith([this.handCard, this.playAreaCard, this.discardedCard, this.gameSpy]);
+                expect(this.effectSpy.reapply).toHaveBeenCalledWith(jasmine.arrayContaining([this.handCard, this.playAreaCard, this.discardedCard, this.gameSpy]));
             });
         });
 
@@ -273,7 +299,7 @@ describe('EffectEngine', function () {
                 });
 
                 it('should set the active value for the effect along with cards to target', function() {
-                    expect(this.effectSpy.setActive).toHaveBeenCalledWith(true, [this.handCard, this.playAreaCard, this.discardedCard, this.gameSpy]);
+                    expect(this.effectSpy.setActive).toHaveBeenCalledWith(true, jasmine.arrayContaining([this.handCard, this.playAreaCard, this.discardedCard, this.gameSpy]));
                 });
             });
 


### PR DESCRIPTION
Now cards that enter play knelt (such as Core Sansa or Dolorous Edd's
ability) can be done directly by either applying an effect to the card,
or by passing a `kneeled` option into the `Player.putIntoPlay` method.
Note that the effect must be applied no matter where the card is
currently, because the act of entering play knelt completes before any
effects for in-play cards can be applied. For example, Sansa comes into
play knelt before the effects of Fortified Position can blank her card
text.