### PR TITLE
Don't show warning message for Nothing Burns when no valid locations

### DIFF
--- a/server/game/cards/09-HoT/NothingBurnsLikeTheCold.js
+++ b/server/game/cards/09-HoT/NothingBurnsLikeTheCold.js
@@ -62,7 +62,7 @@ class NothingBurnsLikeTheCold extends PlotCard {
     }
 
     hasValidLocations(player) {
-        return this.game.anyCardsInPlay(card => card.controller === player && card.getType() === 'location' && !card.isLimited());
+        return this.game.anyCardsInPlay(card => card.controller === player && card.getType() === 'location' && !card.isLimited() && card.canBeDiscarded());
     }
 
     onSelectLocation(player, attachment, location) {

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -436,6 +436,10 @@ class DrawCard extends BaseCard {
         return this.allowGameAction('kill');
     }
 
+    canBeDiscarded() {
+        return this.allowGameAction('discard');
+    }
+
     canBeSaved() {
         return this.allowGameAction('save');
     }


### PR DESCRIPTION
Previously, the target prompt for Nothing Burns Like the Cold precluded selecting locations that can't be discarded, but the hasValidLocations() check did not. This could lead to players being presented with a prompt with all targets greyed out, but after cancelling getting a message warning players they did have valid targets. This PR fixes that.