### PR TITLE
refactoring: do not deconstruct event with ({challenge})

### DIFF
--- a/server/game/cards/01-Core/AClashOfKings.js
+++ b/server/game/cards/01-Core/AClashOfKings.js
@@ -4,10 +4,10 @@ class AClashOfKings extends PlotCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.winner === this.controller &&
-                    challenge.challengeType === 'power' &&
-                    challenge.loser.faction.power > 0
+                afterChallenge: event => (
+                    event.challenge.winner === this.controller &&
+                    event.challenge.challengeType === 'power' &&
+                    event.challenge.loser.faction.power > 0
                 )
             },
             handler: () => {

--- a/server/game/cards/01-Core/AshaGreyjoy.js
+++ b/server/game/cards/01-Core/AshaGreyjoy.js
@@ -4,7 +4,7 @@ class AshaGreyjoy extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => this.controller === challenge.winner && challenge.isParticipating(this) && challenge.isUnopposed()
+                afterChallenge: event => this.controller === event.challenge.winner && event.challenge.isParticipating(this) && event.challenge.isUnopposed()
             },
             handler: () => {
                 this.controller.standCard(this);

--- a/server/game/cards/01-Core/DothrakiSea.js
+++ b/server/game/cards/01-Core/DothrakiSea.js
@@ -4,7 +4,7 @@ class DothrakiSea extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.challengeType === 'power'
+                afterChallenge: event => event.challenge.winner === this.controller && event.challenge.challengeType === 'power'
             },
             cost: ability.costs.sacrificeSelf(),
             target: {

--- a/server/game/cards/01-Core/GreatKraken.js
+++ b/server/game/cards/01-Core/GreatKraken.js
@@ -8,7 +8,7 @@ class GreatKraken extends DrawCard {
         });
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => this.controller === challenge.winner && challenge.isUnopposed()
+                afterChallenge: event => this.controller === event.challenge.winner && event.challenge.isUnopposed()
             },
             limit: ability.limit.perRound(2),
             choices: {

--- a/server/game/cards/01-Core/Ice.js
+++ b/server/game/cards/01-Core/Ice.js
@@ -8,10 +8,10 @@ class Ice extends DrawCard {
         });
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.winner === this.controller &&
-                    challenge.challengeType === 'military' &&
-                    challenge.isParticipating(this.parent)
+                afterChallenge: event => (
+                    event.challenge.winner === this.controller &&
+                    event.challenge.challengeType === 'military' &&
+                    event.challenge.isParticipating(this.parent)
                 )
             },
             cost: ability.costs.sacrificeSelf(),

--- a/server/game/cards/01-Core/Lannisport.js
+++ b/server/game/cards/01-Core/Lannisport.js
@@ -4,7 +4,7 @@ class Lannisport extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.challengeType === 'intrigue' && challenge.winner === this.controller
+                afterChallenge: event => event.challenge.challengeType === 'intrigue' && event.challenge.winner === this.controller
             },
             handler: () => {
                 this.controller.drawCardsToHand(1);

--- a/server/game/cards/01-Core/MaesterCaleotte.js
+++ b/server/game/cards/01-Core/MaesterCaleotte.js
@@ -4,7 +4,7 @@ class MaesterCaleotte extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.loser === this.controller && challenge.isParticipating(this)
+                afterChallenge: event => event.challenge.loser === this.controller && event.challenge.isParticipating(this)
             },
             target: {
                 cardCondition: card => card.location === 'play area' && card.getType() === 'character'

--- a/server/game/cards/01-Core/MaesterLomys.js
+++ b/server/game/cards/01-Core/MaesterLomys.js
@@ -4,7 +4,7 @@ class MaesterLomys extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.defendingPlayer === this.controller && challenge.challengeType === 'intrigue'
+                afterChallenge: event => event.challenge.winner === this.controller && event.challenge.defendingPlayer === this.controller && event.challenge.challengeType === 'intrigue'
             },
             handler: () => {
                 this.game.currentChallenge.loser.discardAtRandom(1);

--- a/server/game/cards/01-Core/PlazaOfPunishment.js
+++ b/server/game/cards/01-Core/PlazaOfPunishment.js
@@ -4,7 +4,7 @@ class PlazaOfPunishment extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.challengeType === 'power'
+                afterChallenge: event => event.challenge.winner === this.controller && event.challenge.challengeType === 'power'
             },
             cost: ability.costs.kneelSelf(),
             target: {

--- a/server/game/cards/01-Core/Rhaegal.js
+++ b/server/game/cards/01-Core/Rhaegal.js
@@ -6,9 +6,9 @@ class Rhaegal extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.winner === this.controller &&
-                    _.any(challenge.getWinnerCards(), card => card.hasTrait('Stormborn'))
+                afterChallenge: event => (
+                    event.challenge.winner === this.controller &&
+                    _.any(event.challenge.getWinnerCards(), card => card.hasTrait('Stormborn'))
                 )
             },
             limit: ability.limit.perPhase(1),

--- a/server/game/cards/01-Core/SerJorahMormont.js
+++ b/server/game/cards/01-Core/SerJorahMormont.js
@@ -4,7 +4,7 @@ class SerJorahMormont extends DrawCard {
     setupCardAbilities() {
         this.forcedReaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isParticipating(this)
+                afterChallenge: event => event.challenge.winner === this.controller && event.challenge.isParticipating(this)
             },
             handler: () => {
                 this.modifyToken('betrayal', 1);

--- a/server/game/cards/01-Core/Sunspear.js
+++ b/server/game/cards/01-Core/Sunspear.js
@@ -4,7 +4,7 @@ class Sunspear extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.loser === this.controller && challenge.defendingPlayer === this.controller
+                afterChallenge: event => event.challenge.loser === this.controller && event.challenge.defendingPlayer === this.controller
             },
             cost: ability.costs.kneelSelf(),
             handler: () => {

--- a/server/game/cards/01-Core/TheMander.js
+++ b/server/game/cards/01-Core/TheMander.js
@@ -4,9 +4,9 @@ class TheMander extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.winner === this.controller &&
-                    challenge.strengthDifference >= 5)
+                afterChallenge: event => (
+                    event.challenge.winner === this.controller &&
+                    event.challenge.strengthDifference >= 5)
             },
             cost: ability.costs.kneelSelf(),
             handler: () => {

--- a/server/game/cards/01-Core/TheQueenOfThorns.js
+++ b/server/game/cards/01-Core/TheQueenOfThorns.js
@@ -4,7 +4,7 @@ class TheQueenOfThorns extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isParticipating(this) && challenge.challengeType === 'intrigue'
+                afterChallenge: event => event.challenge.winner === this.controller && event.challenge.isParticipating(this) && event.challenge.challengeType === 'intrigue'
             },
             target: {
                 cardCondition: card => card.location === 'hand' && card.controller === this.controller &&

--- a/server/game/cards/01-Core/TheRedViper.js
+++ b/server/game/cards/01-Core/TheRedViper.js
@@ -4,7 +4,7 @@ class TheRedViper extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isAttacking(this) && challenge.strengthDifference >= 5
+                afterChallenge: event => event.challenge.winner === this.controller && event.challenge.isAttacking(this) && event.challenge.strengthDifference >= 5
             },
             handler: () => {
                 var power = Math.trunc(this.game.currentChallenge.strengthDifference / 5);

--- a/server/game/cards/01-Core/TheWall.js
+++ b/server/game/cards/01-Core/TheWall.js
@@ -4,7 +4,7 @@ class TheWall extends DrawCard {
     setupCardAbilities(ability) {
         this.forcedReaction({
             when: {
-                afterChallenge: ({challenge}) => this.controller === challenge.loser && !this.kneeled && challenge.isUnopposed()
+                afterChallenge: event => this.controller === event.challenge.loser && !this.kneeled && event.challenge.isUnopposed()
             },
             handler: () => {
                 this.game.addMessage('{0} is forced to kneel {1}', this.controller, this);

--- a/server/game/cards/01-Core/TheonGreyjoy.js
+++ b/server/game/cards/01-Core/TheonGreyjoy.js
@@ -4,7 +4,7 @@ class TheonGreyjoy extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isParticipating(this) && challenge.isUnopposed()
+                afterChallenge: event => event.challenge.winner === this.controller && event.challenge.isParticipating(this) && event.challenge.isUnopposed()
             },
             handler: () => {
                 this.modifyPower(1);

--- a/server/game/cards/01-Core/ThrowingAxe.js
+++ b/server/game/cards/01-Core/ThrowingAxe.js
@@ -5,7 +5,7 @@ class ThrowingAxe extends DrawCard {
         this.attachmentRestriction({ trait: 'Ironborn' });
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isAttacking(this.parent)
+                afterChallenge: event => event.challenge.winner === this.controller && event.challenge.isAttacking(this.parent)
             },
             limit: ability.limit.perPhase(1),
             cost: ability.costs.sacrificeSelf(),

--- a/server/game/cards/02.1-TtB/KingRobertsWarhammer.js
+++ b/server/game/cards/02.1-TtB/KingRobertsWarhammer.js
@@ -9,7 +9,7 @@ class KingRobertsWarhammer extends DrawCard {
         });
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isAttacking(this.parent)
+                afterChallenge: event => event.challenge.winner === this.controller && event.challenge.isAttacking(this.parent)
             },
             target: {
                 activePromptTitle: 'Select character(s)',

--- a/server/game/cards/02.1-TtB/StreetOfTheSisters.js
+++ b/server/game/cards/02.1-TtB/StreetOfTheSisters.js
@@ -4,8 +4,10 @@ class StreetOfTheSisters extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.challengeType === 'power' &&
-                                                 challenge.strengthDifference >= 5
+                afterChallenge: event =>
+                    event.challenge.winner === this.controller &&
+                    event.challenge.challengeType === 'power' &&
+                    event.challenge.strengthDifference >= 5
             },
             cost: ability.costs.kneelFactionCard(),
             handler: () => {

--- a/server/game/cards/02.1-TtB/SupportOfThePeople.js
+++ b/server/game/cards/02.1-TtB/SupportOfThePeople.js
@@ -4,10 +4,10 @@ class SupportOfThePeople extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.challengeType === 'power' &&
-                    challenge.winner === this.controller &&
-                    challenge.strengthDifference >= 5
+                afterChallenge: event => (
+                    event.challenge.challengeType === 'power' &&
+                    event.challenge.winner === this.controller &&
+                    event.challenge.strengthDifference >= 5
                 )
             },
             handler: () => {

--- a/server/game/cards/02.1-TtB/TheHound.js
+++ b/server/game/cards/02.1-TtB/TheHound.js
@@ -4,7 +4,7 @@ class TheHound extends DrawCard {
     setupCardAbilities() {
         this.forcedReaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isParticipating(this)
+                afterChallenge: event => event.challenge.winner === this.controller && event.challenge.isParticipating(this)
             },
             handler: () => {
                 if(this.controller.hand.size() < 1) {

--- a/server/game/cards/02.1-TtB/TheLongPlan.js
+++ b/server/game/cards/02.1-TtB/TheLongPlan.js
@@ -4,7 +4,7 @@ class TheLongPlan extends PlotCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.loser === this.controller
+                afterChallenge: event => event.challenge.loser === this.controller
             },
             handler: () => {
                 this.game.addMessage('{0} uses {1} to gain 1 gold from losing a challenge', this.controller, this);

--- a/server/game/cards/02.1-TtB/Will.js
+++ b/server/game/cards/02.1-TtB/Will.js
@@ -4,7 +4,7 @@ class Will extends DrawCard {
     setupCardAbilities() {
         this.forcedReaction({
             when: {
-                afterChallenge: ({challenge}) => this.controller === challenge.loser && challenge.isUnopposed()
+                afterChallenge: event => this.controller === event.challenge.loser && event.challenge.isUnopposed()
             },
             target: {
                 cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.hasTrait('Ranger') && card.controller === this.controller

--- a/server/game/cards/02.2-TRtW/LadySansasRose.js
+++ b/server/game/cards/02.2-TRtW/LadySansasRose.js
@@ -4,10 +4,10 @@ class LadySansasRose extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.winner === this.controller &&
+                afterChallenge: event =>
+                    event.challenge.winner === this.controller &&
                     this.hasSingleParticipatingChar() &&
-                    this.hasParticipatingKnight())
+                    this.hasParticipatingKnight()
             },
             max: ability.limit.perChallenge(1),
             handler: (context) => {

--- a/server/game/cards/02.2-TRtW/RoyalEntourage.js
+++ b/server/game/cards/02.2-TRtW/RoyalEntourage.js
@@ -5,7 +5,7 @@ class RoyalEntourage extends DrawCard {
     setupCardAbilities() {
         this.forcedReaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.loser === this.controller && challenge.challengeType === 'intrigue'
+                afterChallenge: event => event.challenge.loser === this.controller && event.challenge.challengeType === 'intrigue'
             },
             handler: () => {
                 this.controller.kneelCard(this);

--- a/server/game/cards/02.2-TRtW/ShadowblackLane.js
+++ b/server/game/cards/02.2-TRtW/ShadowblackLane.js
@@ -4,7 +4,7 @@ class ShadowblackLane extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.challengeType === 'intrigue'
+                afterChallenge:event => event.challenge.winner === this.controller && event.challenge.challengeType === 'intrigue'
             },
             cost: ability.costs.kneelFactionCard(),
             handler: () => {

--- a/server/game/cards/02.2-TRtW/TheReader.js
+++ b/server/game/cards/02.2-TRtW/TheReader.js
@@ -6,11 +6,10 @@ class TheReader extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.winner === this.controller &&
-                    challenge.isUnopposed() &&
-                    _.any(challenge.getWinnerCards(), card => card.isFaction('greyjoy') && card.isUnique())
-                )
+                afterChallenge: event =>
+                    event.challenge.winner === this.controller &&
+                    event.challenge.isUnopposed() &&
+                    _.any(event.challenge.getWinnerCards(), card => card.isFaction('greyjoy') && card.isUnique())
             },
             limit: ability.limit.perPhase(1),
             choices: {

--- a/server/game/cards/02.2-TRtW/WardensOfTheWest.js
+++ b/server/game/cards/02.2-TRtW/WardensOfTheWest.js
@@ -4,9 +4,10 @@ class WardensOfTheWest extends PlotCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => {
-                    return challenge.winner === this.controller && challenge.challengeType === 'intrigue' && this.controller.gold >= 2;
-                }
+                afterChallenge: event =>
+                    event.challenge.winner === this.controller &&
+                    event.challenge.challengeType === 'intrigue' &&
+                    this.controller.gold >= 2
             },
             cost: ability.costs.payGold(2),
             handler: () => {

--- a/server/game/cards/02.3-TKP/MoonBoy.js
+++ b/server/game/cards/02.3-TKP/MoonBoy.js
@@ -4,7 +4,7 @@ class MoonBoy extends DrawCard {
     setupCardAbilities() {
         this.forcedReaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.loser === this.controller && challenge.isParticipating(this)
+                afterChallenge: event => event.challenge.loser === this.controller && event.challenge.isParticipating(this)
             },
             handler: () => {
                 this.game.addMessage('{0} is forced to discard 1 card at random after losing a challenge in which {1} was participating', this.controller, this);

--- a/server/game/cards/02.3-TKP/TheBoneway.js
+++ b/server/game/cards/02.3-TKP/TheBoneway.js
@@ -4,7 +4,7 @@ class TheBoneway extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.loser === this.controller
+                afterChallenge: event => event.challenge.loser === this.controller
             },
             handler: () => {
                 this.modifyToken('vengeance', 1);

--- a/server/game/cards/02.4-NMG/PaidOff.js
+++ b/server/game/cards/02.4-NMG/PaidOff.js
@@ -5,7 +5,10 @@ class PaidOff extends DrawCard {
         this.attachmentRestriction({ controller: 'opponent' });
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.challengeType === 'intrigue' && !this.parent.kneeled && challenge.winner === this.controller
+                afterChallenge: event =>
+                    event.challenge.challengeType === 'intrigue' &&
+                    !this.parent.kneeled &&
+                    event.challenge.winner === this.controller
             },
             handler: () => {
                 this.parent.controller.kneelCard(this.parent);

--- a/server/game/cards/02.5-COW/Kingswood.js
+++ b/server/game/cards/02.5-COW/Kingswood.js
@@ -14,7 +14,7 @@ class Kingswood extends DrawCard {
 
         this.forcedReaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.loser === this.controller && challenge.challengeType === 'power'
+                afterChallenge: event => event.challenge.loser === this.controller && event.challenge.challengeType === 'power'
             },
             handler: () => {
                 this.game.addMessage('{0} is forced to sacrifice {1}', this.controller, this);

--- a/server/game/cards/02.5-COW/StreetOfSteel.js
+++ b/server/game/cards/02.5-COW/StreetOfSteel.js
@@ -4,7 +4,7 @@ class StreetOfSteel extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.challengeType === 'military'
+                afterChallenge: event => event.challenge.winner === this.controller && event.challenge.challengeType === 'military'
             },
             cost: ability.costs.kneelFactionCard(),
             handler: () => {

--- a/server/game/cards/02.6-TS/Butterbumps.js
+++ b/server/game/cards/02.6-TS/Butterbumps.js
@@ -4,7 +4,7 @@ class Butterbumps extends DrawCard {
     setupCardAbilities() {
         this.forcedReaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.loser === this.controller && challenge.isParticipating(this)
+                afterChallenge: event => event.challenge.loser === this.controller && event.challenge.isParticipating(this)
             },
             handler: () => {
                 this.controller.discardAtRandom(1);

--- a/server/game/cards/02.6-TS/SmallCouncilChamber.js
+++ b/server/game/cards/02.6-TS/SmallCouncilChamber.js
@@ -8,7 +8,7 @@ class SmallCouncilChamber extends DrawCard {
         });
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.challengeType === 'intrigue'
+                afterChallenge: event => event.challenge.winner === this.controller && event.challenge.challengeType === 'intrigue'
             },
             handler: () => {
                 this.game.addMessage('{0} gains 1 power on {1}', this.controller, this);

--- a/server/game/cards/02.6-TS/StreetOfSilk.js
+++ b/server/game/cards/02.6-TS/StreetOfSilk.js
@@ -6,7 +6,7 @@ class StreetOfSilk extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller && this.hasParticipatingLordOrLady()
+                afterChallenge: event => event.challenge.winner === this.controller && this.hasParticipatingLordOrLady()
             },
             cost: ability.costs.kneelFactionCard(),
             handler: () => {

--- a/server/game/cards/02.6-TS/TyeneSand.js
+++ b/server/game/cards/02.6-TS/TyeneSand.js
@@ -4,10 +4,10 @@ class TyeneSand extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.challengeType === 'intrigue' &&
-                    challenge.winner === this.controller &&
-                    challenge.isAttacking(this)
+                afterChallenge: event => (
+                    event.challenge.challengeType === 'intrigue' &&
+                    event.challenge.winner === this.controller &&
+                    event.challenge.isAttacking(this)
                 )
             },
             target: {

--- a/server/game/cards/03-WotN/HisViperEyes.js
+++ b/server/game/cards/03-WotN/HisViperEyes.js
@@ -4,12 +4,11 @@ class HisViperEyes extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.defendingPlayer === this.controller &&
-                    challenge.loser === this.controller &&
-                    ['military', 'power'].includes(challenge.challengeType) &&
-                    challenge.winner.hand.size() >= 1
-                )
+                afterChallenge: event =>
+                    event.challenge.defendingPlayer === this.controller &&
+                    event.challenge.loser === this.controller &&
+                    ['military', 'power'].includes(event.challenge.challengeType) &&
+                    event.challenge.winner.hand.size() >= 1
             },
             handler: () => {
                 this.challengeWinner = this.game.currentChallenge.winner;

--- a/server/game/cards/03-WotN/KingRobbsHost.js
+++ b/server/game/cards/03-WotN/KingRobbsHost.js
@@ -4,11 +4,11 @@ class KingRobbsHost extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.challengeType === 'military' &&
-                    challenge.winner === this.controller &&
-                    challenge.isParticipating(this) &&
-                    challenge.loser.faction.power >= 1)
+                afterChallenge: event =>
+                    event.challenge.challengeType === 'military' &&
+                    event.challenge.winner === this.controller &&
+                    event.challenge.isParticipating(this) &&
+                    event.challenge.loser.faction.power >= 1
             },
             handler: () => {
                 this.game.promptForSelect(this.controller, {

--- a/server/game/cards/03-WotN/TheBlackfish.js
+++ b/server/game/cards/03-WotN/TheBlackfish.js
@@ -10,11 +10,10 @@ class TheBlackfish extends DrawCard {
 
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.winner === this.controller &&
-                    challenge.challengeType === 'military' &&
-                    challenge.isAttackerTheWinner()
-                )
+                afterChallenge: event =>
+                    event.challenge.winner === this.controller &&
+                    event.challenge.challengeType === 'military' &&
+                    event.challenge.isAttackerTheWinner()
             },
             handler: () => {
                 this.controller.drawCardsToHand(1);

--- a/server/game/cards/03-WotN/TheShadowTower.js
+++ b/server/game/cards/03-WotN/TheShadowTower.js
@@ -4,7 +4,7 @@ class TheShadowTower extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.defendingPlayer === this.controller
+                afterChallenge: event => event.challenge.winner === this.controller && event.challenge.defendingPlayer === this.controller
             },
             cost: ability.costs.kneelSelf(),
             target: {

--- a/server/game/cards/03-WotN/TowerOfTheHand.js
+++ b/server/game/cards/03-WotN/TowerOfTheHand.js
@@ -4,7 +4,7 @@ class TowerOfTheHand extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.challengeType === 'intrigue' && challenge.winner === this.controller
+                afterChallenge: event => event.challenge.challengeType === 'intrigue' && event.challenge.winner === this.controller
             },
             cost: [
                 ability.costs.kneelSelf(),

--- a/server/game/cards/04.1-AtSK/ShierakQiya.js
+++ b/server/game/cards/04.1-AtSK/ShierakQiya.js
@@ -4,11 +4,10 @@ class ShierakQiya extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.challengeType === 'power' &&
-                    challenge.winner === this.controller &&
-                    challenge.strengthDifference >= 5
-                )
+                afterChallenge: event =>
+                    event.challenge.challengeType === 'power' &&
+                    event.challenge.winner === this.controller &&
+                    event.challenge.strengthDifference >= 5
             },
             cost: ability.costs.kneelFactionCard(),
             target: {

--- a/server/game/cards/04.1-AtSK/WhiteRaven.js
+++ b/server/game/cards/04.1-AtSK/WhiteRaven.js
@@ -4,7 +4,7 @@ class WhiteRaven extends DrawCard {
     setupCardAbilities() {
         this.forcedReaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.loser === this.controller && challenge.challengeType === 'power'
+                afterChallenge: event => event.challenge.loser === this.controller && event.challenge.challengeType === 'power'
             },
             handler: () => {
                 this.game.addMessage('{0} is forced by {1} to sacrifice {1}', this.controller, this);

--- a/server/game/cards/04.3-FFH/TheScorpionsSting.js
+++ b/server/game/cards/04.3-FFH/TheScorpionsSting.js
@@ -4,8 +4,8 @@ class TheScorpionsSting extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.loser === this.controller &&
+                afterChallenge: event => (
+                    event.challenge.loser === this.controller &&
                     this.controller.getNumberOfUsedPlots() >= 1 &&
                     this.hasMartellCharacter())
             },

--- a/server/game/cards/04.3-FFH/ThorenSmallwood.js
+++ b/server/game/cards/04.3-FFH/ThorenSmallwood.js
@@ -4,7 +4,7 @@ class ThorenSmallwood extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller && !challenge.isAttackerTheWinner()
+                afterChallenge: event => event.challenge.winner === this.controller && !event.challenge.isAttackerTheWinner()
             },
             handler: () => {
                 this.game.addPower(this.controller, 1);

--- a/server/game/cards/04.4-TIMC/EliaSand.js
+++ b/server/game/cards/04.4-TIMC/EliaSand.js
@@ -4,7 +4,7 @@ class EliaSand extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => this.controller === challenge.loser
+                afterChallenge: event => this.controller === event.challenge.loser
             },
             limit: ability.limit.perPhase(2),
             target: {

--- a/server/game/cards/04.4-TIMC/JaqenHGhar.js
+++ b/server/game/cards/04.4-TIMC/JaqenHGhar.js
@@ -31,10 +31,10 @@ class JaqenHGhar extends DrawCard {
         });
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.winner === this.controller &&
-                    challenge.isAttacking(this) &&
-                    challenge.attackers.length === 1
+                afterChallenge: event => (
+                    event.challenge.winner === this.controller &&
+                    event.challenge.isAttacking(this) &&
+                    event.challenge.attackers.length === 1
                 )
             },
             target: {

--- a/server/game/cards/04.4-TIMC/PyatPree.js
+++ b/server/game/cards/04.4-TIMC/PyatPree.js
@@ -4,7 +4,7 @@ class PyatPree extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isParticipating(this)
+                afterChallenge: event => event.challenge.winner === this.controller && event.challenge.isParticipating(this)
             },
             handler: () => {
                 this.game.promptForDeckSearch(this.controller, {

--- a/server/game/cards/04.4-TIMC/TheHauntedForest.js
+++ b/server/game/cards/04.4-TIMC/TheHauntedForest.js
@@ -14,7 +14,7 @@ class TheHauntedForest extends DrawCard {
         });
         this.forcedReaction({
             when: {
-                afterChallenge: ({challenge}) => this.controller === challenge.loser && !this.kneeled
+                afterChallenge: event => this.controller === event.challenge.loser && !this.kneeled
             },
             handler: () => {
                 this.game.addMessage('{0} is forced to kneel {1}', this.controller, this);

--- a/server/game/cards/04.5-GoH/ThePrincesPass.js
+++ b/server/game/cards/04.5-GoH/ThePrincesPass.js
@@ -4,7 +4,7 @@ class ThePrincesPass extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.loser === this.controller && challenge.defendingPlayer === this.controller
+                afterChallenge: event => event.challenge.loser === this.controller && event.challenge.defendingPlayer === this.controller
             },
             cost: ability.costs.kneelSelf(),
             target: {

--- a/server/game/cards/04.6-TC/QhorinHalfhand.js
+++ b/server/game/cards/04.6-TC/QhorinHalfhand.js
@@ -4,10 +4,10 @@ class QhorinHalfhand extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.challengeType === 'military' &&
-                    challenge.winner === this.controller &&
-                    challenge.isParticipating(this)
+                afterChallenge: event => (
+                    event.challenge.challengeType === 'military' &&
+                    event.challenge.winner === this.controller &&
+                    event.challenge.isParticipating(this)
                 )
             },
             target: {

--- a/server/game/cards/04.6-TC/RelentlessAssault.js
+++ b/server/game/cards/04.6-TC/RelentlessAssault.js
@@ -4,10 +4,10 @@ class RelentlessAssault extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.winner === this.controller &&
-                    challenge.attackingPlayer === this.controller &&
-                    challenge.strengthDifference >= 5
+                afterChallenge: event => (
+                    event.challenge.winner === this.controller &&
+                    event.challenge.attackingPlayer === this.controller &&
+                    event.challenge.strengthDifference >= 5
                 )
             },
             cost: ability.costs.kneelFactionCard(),

--- a/server/game/cards/04.6-TC/SalladhorSaan.js
+++ b/server/game/cards/04.6-TC/SalladhorSaan.js
@@ -4,9 +4,9 @@ class SalladhorSaan extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.winner === this.controller &&
-                    challenge.isParticipating(this))
+                afterChallenge: event => (
+                    event.challenge.winner === this.controller &&
+                    event.challenge.isParticipating(this))
             },
             target: {
                 activePromptTitle: 'Select a card',

--- a/server/game/cards/04.6-TC/TyrionsChain.js
+++ b/server/game/cards/04.6-TC/TyrionsChain.js
@@ -5,8 +5,8 @@ class TyrionsChain extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.winner === this.controller &&
+                afterChallenge: event => (
+                    event.challenge.winner === this.controller &&
                     this.hasParticipatingUniqueLannister() &&
                     this.game.anyPlotHasTrait('War')
                 )

--- a/server/game/cards/05-LoCR/TheCouncilConsents.js
+++ b/server/game/cards/05-LoCR/TheCouncilConsents.js
@@ -4,10 +4,10 @@ class TheCouncilConsents extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.challengeType === 'intrigue' &&
-                    challenge.strengthDifference >= 5 &&
-                    this.anySmallCouncilCharacterInPlay())
+                afterChallenge: event =>
+                    event.challenge.challengeType === 'intrigue' &&
+                    event.challenge.strengthDifference >= 5 &&
+                    this.anySmallCouncilCharacterInPlay()
             },
             handler: () => {
                 let smallCouncilChars = this.game.filterCardsInPlay(card => card.hasTrait('Small Council') && card.getType() === 'character');

--- a/server/game/cards/05-LoCR/TimettSonOfTimett.js
+++ b/server/game/cards/05-LoCR/TimettSonOfTimett.js
@@ -4,9 +4,7 @@ class TimettSonOfTimett extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.winner === this.controller &&
-                    challenge.isAttacking(this))
+                afterChallenge: event => event.challenge.winner === this.controller && event.challenge.isAttacking(this)
             },
             target: {
                 activePromptTitle: 'Select character to kill',

--- a/server/game/cards/05-LoCR/TrystaneMartell.js
+++ b/server/game/cards/05-LoCR/TrystaneMartell.js
@@ -4,7 +4,7 @@ class TrystaneMartell extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => this.controller === challenge.loser && challenge.isParticipating(this)
+                afterChallenge: event => this.controller === event.challenge.loser && event.challenge.isParticipating(this)
             },
             target: {
                 cardCondition: card => (

--- a/server/game/cards/05-LoCR/TyrionLannister.js
+++ b/server/game/cards/05-LoCR/TyrionLannister.js
@@ -4,7 +4,7 @@ class TyrionLannister extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller
+                afterChallenge: event => event.challenge.winner === this.controller
             },
             cost: ability.costs.returnToHand(card => this.isAttackingClansman(card)),
             limit: ability.limit.perPhase(2),

--- a/server/game/cards/06.1-AMAF/AllMenAreFools.js
+++ b/server/game/cards/06.1-AMAF/AllMenAreFools.js
@@ -7,9 +7,9 @@ class AllMenAreFools extends DrawCard {
         this.reaction({
             max: ability.limit.perChallenge(1),
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.winner === this.controller &&
-                    challenge.strengthDifference >= 5 &&
+                afterChallenge: event => (
+                    event.challenge.winner === this.controller &&
+                    event.challenge.strengthDifference >= 5 &&
                     this.hasLady())
             },
             handler: () => {

--- a/server/game/cards/06.1-AMAF/AttackFromTheMountains.js
+++ b/server/game/cards/06.1-AMAF/AttackFromTheMountains.js
@@ -4,7 +4,7 @@ class AttackFromTheMountains extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller && this.hasAttackingClansman()
+                afterChallenge: event => event.challenge.winner === this.controller && this.hasAttackingClansman()
             },
             target: {
                 cardCondition: card => (

--- a/server/game/cards/06.1-AMAF/ThePrincesPlan.js
+++ b/server/game/cards/06.1-AMAF/ThePrincesPlan.js
@@ -26,7 +26,7 @@ class ThePrincesPlan extends DrawCard {
         this.reaction({
             location: 'discard pile',
             when: {
-                afterChallenge: ({challenge}) => challenge.loser === this.controller
+                afterChallenge: event => event.challenge.loser === this.controller
             },
             ignoreEventCosts: true,
             cost: ability.costs.payGold(1),

--- a/server/game/cards/06.2-GtR/ADragonIsNoSlave.js
+++ b/server/game/cards/06.2-GtR/ADragonIsNoSlave.js
@@ -22,7 +22,7 @@ class ADragonIsNoSlave extends DrawCard {
         this.reaction({
             location: 'discard pile',
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller && this.hasParticipatingDragonOrDany()
+                afterChallenge: event => event.challenge.winner === this.controller && this.hasParticipatingDragonOrDany()
             },
             ignoreEventCosts: true,
             cost: ability.costs.payGold(1),

--- a/server/game/cards/06.2-GtR/GuardingTheRealm.js
+++ b/server/game/cards/06.2-GtR/GuardingTheRealm.js
@@ -19,7 +19,7 @@ class GuardingTheRealm extends DrawCard {
         this.reaction({
             location: 'discard pile',
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller && !challenge.isAttackerTheWinner()
+                afterChallenge: event => event.challenge.winner === this.controller && !event.challenge.isAttackerTheWinner()
             },
             ignoreEventCosts: true,
             cost: ability.costs.payGold(1),

--- a/server/game/cards/06.2-GtR/KnightOfTheReach.js
+++ b/server/game/cards/06.2-GtR/KnightOfTheReach.js
@@ -4,9 +4,9 @@ class KnightOfTheReach extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.winner === this.controller &&
-                    challenge.isParticipating(this) &&
+                afterChallenge: event => (
+                    event.challenge.winner === this.controller &&
+                    event.challenge.isParticipating(this) &&
                     this.hasSingleParticipatingChar())
             },
             target: {

--- a/server/game/cards/06.3-TFoA/MaesterOfSunspear.js
+++ b/server/game/cards/06.3-TFoA/MaesterOfSunspear.js
@@ -4,7 +4,7 @@ class MaesterOfSunspear extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => this.controller === challenge.loser && challenge.isParticipating(this)
+                afterChallenge: event => this.controller === event.challenge.loser && event.challenge.isParticipating(this)
             },
             target: {
                 activePromptTitle: 'Select an attachment',

--- a/server/game/cards/06.4-TRW/EllariaSand.js
+++ b/server/game/cards/06.4-TRW/EllariaSand.js
@@ -6,7 +6,7 @@ class EllariaSand extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => this.controller === challenge.loser && challenge.isParticipating(this)
+                afterChallenge: event => this.controller === event.challenge.loser && event.challenge.isParticipating(this)
             },
             cost: ability.costs.discardGold(),
             handler: () => {

--- a/server/game/cards/06.4-TRW/FreyBastard.js
+++ b/server/game/cards/06.4-TRW/FreyBastard.js
@@ -4,7 +4,7 @@ class FreyBastard extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller && this.getNumberOfAttackingFreys() >= 2
+                afterChallenge: event => event.challenge.winner === this.controller && this.getNumberOfAttackingFreys() >= 2
             },
             cost: ability.costs.discardGold(),
             handler: () => {

--- a/server/game/cards/06.4-TRW/FreyHospitality.js
+++ b/server/game/cards/06.4-TRW/FreyHospitality.js
@@ -4,9 +4,10 @@ class FreyHospitality extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller &&
-                                                 challenge.number === 3 &&
-                                                 this.hasAttackingFrey()
+                afterChallenge: event =>
+                    event.challenge.winner === this.controller &&
+                    event.challenge.number === 3 &&
+                    this.hasAttackingFrey()
             },
             handler: () => {
                 let numTargets = this.game.currentChallenge.strengthDifference >= 20 ? 3 : 1;

--- a/server/game/cards/06.4-TRW/SerAxellFlorent.js
+++ b/server/game/cards/06.4-TRW/SerAxellFlorent.js
@@ -4,7 +4,7 @@ class SerAxellFlorent extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isParticipating(this)
+                afterChallenge: event => event.challenge.winner === this.controller && event.challenge.isParticipating(this)
             },
             cost: ability.costs.discardGold(),
             target: {

--- a/server/game/cards/06.4-TRW/TheRedWedding.js
+++ b/server/game/cards/06.4-TRW/TheRedWedding.js
@@ -4,7 +4,7 @@ class TheRedWedding extends PlotCard {
     setupCardAbilities() {
         this.interrupt({
             when: {
-                afterChallenge: ({challenge}) => challenge.attackingPlayer === challenge.winner
+                afterChallenge: event => event.challenge.attackingPlayer === event.challenge.winner
             },
             player: () => this.game.currentChallenge.winner,
             target: {

--- a/server/game/cards/06.5-OR/OlennasMachinations.js
+++ b/server/game/cards/06.5-OR/OlennasMachinations.js
@@ -19,8 +19,10 @@ class OlennasMachinations extends DrawCard {
         this.reaction({
             location: 'discard pile',
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.challengeType === 'intrigue' &&
-                                                      challenge.strengthDifference >= 5
+                afterChallenge: event =>
+                    event.challenge.winner === this.controller &&
+                    event.challenge.challengeType === 'intrigue' &&
+                    event.challenge.strengthDifference >= 5
             },
             ignoreEventCosts: true,
             cost: ability.costs.payGold(1),

--- a/server/game/cards/06.6-TBWB/PayTheIronPrice.js
+++ b/server/game/cards/06.6-TBWB/PayTheIronPrice.js
@@ -19,7 +19,7 @@ class PayTheIronPrice extends DrawCard {
         this.reaction({
             location: 'discard pile',
             when: {
-                afterChallenge: ({challenge}) => this.controller === challenge.winner && challenge.isUnopposed()
+                afterChallenge: event => this.controller === event.challenge.winner && event.challenge.isUnopposed()
             },
             ignoreEventCosts: true,
             cost: ability.costs.payGold(1),

--- a/server/game/cards/07-WotW/JonSnow.js
+++ b/server/game/cards/07-WotW/JonSnow.js
@@ -6,7 +6,7 @@ class JonSnow extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isParticipating(this)
+                afterChallenge: event => event.challenge.winner === this.controller && event.challenge.isParticipating(this)
             },
             limit: ability.limit.perPhase(1),
             handler: () => {

--- a/server/game/cards/07-WotW/LingeringVenom.js
+++ b/server/game/cards/07-WotW/LingeringVenom.js
@@ -4,7 +4,7 @@ class LingeringVenom extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.loser === this.controller
+                afterChallenge: event => event.challenge.loser === this.controller
             },
             handler: () => {
                 this.modifyToken('venom', 1);

--- a/server/game/cards/07-WotW/NameDayTourney.js
+++ b/server/game/cards/07-WotW/NameDayTourney.js
@@ -4,10 +4,10 @@ class NameDayTourney extends PlotCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.winner === this.controller &&
+                afterChallenge: event =>
+                    event.challenge.winner === this.controller &&
                     this.hasParticipatingKnight() &&
-                    this.hasSingleParticipatingChar())
+                    this.hasSingleParticipatingChar()
             },
             target: {
                 activePromptTitle: 'Select Lord or Lady',

--- a/server/game/cards/07-WotW/Pyp.js
+++ b/server/game/cards/07-WotW/Pyp.js
@@ -4,7 +4,7 @@ class Pyp extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.isAttacking(this)
+                afterChallenge: event => event.challenge.winner === this.controller && event.challenge.isAttacking(this)
             },
             target: {
                 cardCondition: card => (

--- a/server/game/cards/07-WotW/TheFrozenShore.js
+++ b/server/game/cards/07-WotW/TheFrozenShore.js
@@ -6,11 +6,10 @@ class TheFrozenShore extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.winner === this.controller &&
-                    this.getNumOfAttackingWildlings(challenge) > 0 &&
+                afterChallenge: event =>
+                    event.challenge.winner === this.controller &&
+                    this.getNumOfAttackingWildlings(event.challenge) > 0 &&
                     this.getNumOfWinterPlots() > 0
-                )
             },
             cost: ability.costs.kneelSelf(),
             handler: () => {

--- a/server/game/cards/07-WotW/TheHoneywine.js
+++ b/server/game/cards/07-WotW/TheHoneywine.js
@@ -4,10 +4,10 @@ class TheHoneywine extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
-                    challenge.winner === this.controller &&
-                    challenge.attackingPlayer === this.controller &&
-                    challenge.strengthDifference >= 5)
+                afterChallenge: event => (
+                    event.challenge.winner === this.controller &&
+                    event.challenge.attackingPlayer === this.controller &&
+                    event.challenge.strengthDifference >= 5)
             },
             handler: () => {
                 this.modifyPower(1);

--- a/server/game/cards/08.1-TAK/Oathkeeper.js
+++ b/server/game/cards/08.1-TAK/Oathkeeper.js
@@ -8,8 +8,10 @@ class Oathkeeper extends DrawCard {
 
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller && challenge.strengthDifference >= 5 &&
-                                                 challenge.isParticipating(this.parent)
+                afterChallenge: event =>
+                    event.challenge.winner === this.controller &&
+                    event.challenge.strengthDifference >= 5 &&
+                    event.challenge.isParticipating(this.parent)
             },
             cost: ability.costs.sacrificeSelf(),
             handler: () => {

--- a/server/game/cards/08.3-Km/Jhiqui.js
+++ b/server/game/cards/08.3-Km/Jhiqui.js
@@ -4,7 +4,7 @@ class Jhiqui extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller
+                afterChallenge: event => event.challenge.winner === this.controller
             },
             cost: ability.costs.discardFromHand(),
             target: {

--- a/server/game/cards/agendas/TheConclave.js
+++ b/server/game/cards/agendas/TheConclave.js
@@ -12,7 +12,7 @@ class TheConclave extends AgendaCard {
     setupCardAbilities() {
         this.reaction({
             when : {
-                afterChallenge: ({challenge}) => challenge.winner === this.controller && this.hasParticipatingMaester(challenge)
+                afterChallenge: event => event.challenge.winner === this.controller && this.hasParticipatingMaester(event.challenge)
             },
             target: {
                 activePromptTitle: 'Choose Conclave card to swap with top of deck',

--- a/server/game/cards/agendas/TheRainsOfCastamere.js
+++ b/server/game/cards/agendas/TheRainsOfCastamere.js
@@ -13,11 +13,11 @@ class TheRainsOfCastamere extends AgendaCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: ({challenge}) => (
+                afterChallenge: event => (
                     !this.owner.faction.kneeled &&
-                    challenge.challengeType === 'intrigue' &&
-                    challenge.winner === this.owner &&
-                    challenge.strengthDifference >= 5
+                    event.challenge.challengeType === 'intrigue' &&
+                    event.challenge.winner === this.owner &&
+                    event.challenge.strengthDifference >= 5
                 )
             },
             handler: this.trigger.bind(this)


### PR DESCRIPTION
As observed in the conversation of #1754, we no longer deconstruct event in
when hooks to get to containing fields. This change migrate deconstructors used
to access challenge to use regular .challenge accessor instead.