### PR TITLE
Implement 'Each Player' targeting mode

### DIFF
--- a/server/game/CardSelector.js
+++ b/server/game/CardSelector.js
@@ -1,3 +1,4 @@
+const EachPlayerCardSelector = require('./CardSelectors/EachPlayerCardSelector');
 const ExactlyXCardSelector = require('./CardSelectors/ExactlyXCardSelector');
 const MaxStatCardSelector = require('./CardSelectors/MaxStatCardSelector');
 const OptionalCardSelector = require('./CardSelectors/OptionalCardSelector');
@@ -15,6 +16,7 @@ const defaultProperties = {
 };
 
 const ModeToSelector = {
+    eachPlayer: p => new EachPlayerCardSelector(p),
     exactly: p => new ExactlyXCardSelector(p.numCards, p),
     maxStat: p => new MaxStatCardSelector(p),
     optional: p => new OptionalCardSelector(p),

--- a/server/game/CardSelectors/BaseCardSelector.js
+++ b/server/game/CardSelectors/BaseCardSelector.js
@@ -32,7 +32,7 @@ class BaseCardSelector {
         return context.game.allCards.filter(card => this.canTarget(card, context));
     }
 
-    hasEnoughSelected(selectedCards) {
+    hasEnoughSelected(selectedCards, numPlayers) { // eslint-disable-line no-unused-vars
         return selectedCards.length > 0;
     }
 
@@ -52,7 +52,7 @@ class BaseCardSelector {
         return false;
     }
 
-    hasReachedLimit(selectedCards) { // eslint-disable-line no-unused-vars
+    hasReachedLimit(selectedCards, numPlayers) { // eslint-disable-line no-unused-vars
         return false;
     }
 

--- a/server/game/CardSelectors/EachPlayerCardSelector.js
+++ b/server/game/CardSelectors/EachPlayerCardSelector.js
@@ -1,0 +1,41 @@
+const _ = require('underscore');
+const BaseCardSelector = require('./BaseCardSelector.js');
+
+class EachPlayerCardSelector extends BaseCardSelector {
+    constructor(properties) {
+        super(properties);
+        this.numCardsPerPlayer = properties.numCards;
+    }
+
+    canTarget(card, context, selectedCards) {
+        return super.canTarget(card, context) && !this.isPlayerSatisfied(card, selectedCards);
+    }
+
+    isPlayerSatisfied(card, selectedCards) {
+        let count = _.filter(selectedCards, selectedCard => selectedCard.controller === card.controller).length;
+        return count >= this.numCardsPerPlayer;
+    }
+
+    defaultActivePromptTitle() {
+        return this.numCardsPerPlayer === 1 ? 'Select a character controlled by each player' : 
+            `Select ${this.numCardsPerPlayer} characters controlled by each player`;
+    }
+
+    hasEnoughSelected(selectedCards, numPlayers) {
+        return selectedCards.length === (numPlayers * this.numCardsPerPlayer);
+    }
+
+    hasEnoughTargets(context) {
+        return _.every(context.game.getPlayers(), player => {
+            let playerCards = context.game.allCards.filter(card => card.controller === player);
+            let matchingCards = _.filter(playerCards, card => super.canTarget(card, context));
+            return matchingCards.length >= this.numCardsPerPlayer;
+        });
+    }
+
+    hasReachedLimit(selectedCards, numPlayers) {
+        return selectedCards.length >= (numPlayers * this.numCardsPerPlayer);
+    }
+}
+
+module.exports = EachPlayerCardSelector;

--- a/server/game/cards/03-WotN/EvenHandedJustice.js
+++ b/server/game/cards/03-WotN/EvenHandedJustice.js
@@ -6,33 +6,14 @@ class EvenHandedJustice extends DrawCard {
     setupCardAbilities() {
         this.action({
             title: 'Kneel a character for each player',
-            // TODO: Rework for Melee
-            targets: {
-                yourCard: {
-                    activePromptTitle: 'Select a character of yours',
-                    cardCondition: card =>
-                        !card.kneeled
-                        && card.location === 'play area'
-                        && card.getType() === 'character'
-                        && card.controller === this.controller, // event controller
-                    gameAction: 'kneel'
-                },
-                opponentCard: {
-                    activePromptTitle: 'Select a character controlled by your opponent',
-                    cardCondition: card =>
-                        !card.kneeled
-                        && card.location === 'play area'
-                        && card.getType() === 'character'
-                        && card.controller !== this.controller, // not event controller
-                    gameAction: 'kneel'
-                }
+            target: {
+                cardCondition: card => card.location === 'play area' && card.getType() === 'character' && !card.kneeled,
+                mode: 'eachPlayer',
+                gameAction: 'kneel'
             },
             handler: context => {
-                let kneeledCards = [context.targets.yourCard, context.targets.opponentCard];
-
-                _.each(kneeledCards, card => card.controller.kneelCard(card));
-                this.game.addMessage('{0} uses {1} to kneel {2}',
-                    this.controller, this, kneeledCards);
+                _.each(context.target, card => card.controller.kneelCard(card));
+                this.game.addMessage('{0} plays {1} to kneel {2}', this.controller, this, context.target);
             }
         });
     }

--- a/server/game/cards/06.4-TRW/TywinsStratagem.js
+++ b/server/game/cards/06.4-TRW/TywinsStratagem.js
@@ -7,26 +7,15 @@ class TywinsStratagem extends DrawCard {
         this.action({
             title: 'Return characters to hand',
             phase: 'challenge',
-            // TODO: Rework for Melee
-            targets: {
-                ownToReturn: {
-                    activePromptTitle: 'Select a character of yours',
-                    cardCondition: card => card.controller === this.controller && this.cardCondition(card)
-                },
-                opponentToReturn: {
-                    activePromptTitle: 'Select a character controlled by your opponent',
-                    cardCondition: card => card.controller !== this.controller && this.cardCondition(card)
-                }
+            target: {
+                cardCondition: card => card.location === 'play area' && card.getType() === 'character' && card.getCost() <= 2,
+                mode: 'eachPlayer',
+                gameAction: 'returnToHand'
             },
             handler: context => {
-                let characters = [context.targets.ownToReturn, context.targets.opponentToReturn];
-
-                _.each(characters, card => {
-                    card.owner.returnCardToHand(card);
-                });
-
-                this.game.addMessage('{0} plays {1} to return {2} to {3}\'s hand and {4} to {5}\'s hand',
-                    this.controller, this, characters[0], characters[0].owner, characters[1], characters[1].owner);
+                _.each(context.target, card => card.owner.returnCardToHand(card));
+                this.game.addMessage('{0} plays {1} to return {2} to its owner\'s hands',
+                    this.controller, this, context.target);
             }
         });
 
@@ -44,10 +33,6 @@ class TywinsStratagem extends DrawCard {
                 this.controller.moveCard(this, 'hand');
             }
         });
-    }
-
-    cardCondition(card) {
-        return card.location === 'play area' && card.getType() === 'character' && card.getCost() <= 2;
     }
 }
 

--- a/server/game/cards/08.5-TFM/Coldhands.js
+++ b/server/game/cards/08.5-TFM/Coldhands.js
@@ -11,35 +11,25 @@ class Coldhands extends DrawCard {
             when: {
                 onCardEntersPlay: event => event.card === this && event.playingType === 'marshal'
             },
-            //TODO Melee: needs a target controlled by each player
-            targets: {
-                ownCharacter: {
-                    cardCondition: card => this.nonArmyCharacterInPlay(card) && card.controller === this.controller
-                },
-                opponentCharacter: {
-                    cardCondition: card => this.nonArmyCharacterInPlay(card) && card.controller !== this.controller
-                }
+            target: {
+                cardCondition: card => card.location === 'play area' && card.getType() === 'character' &&
+                                       !card.hasTrait('Army') && card !== this,
+                mode: 'eachPlayer'
             },
             handler: context => {
-                let targets = [context.targets.ownCharacter, context.targets.opponentCharacter];
-
                 this.lastingEffect(ability => ({
                     until: {
                         onCardLeftPlay: event => event.card === this
                     },
                     targetController: 'any',
-                    match: card => targets.includes(card),
+                    match: card => context.target.includes(card),
                     effect: ability.effects.removeFromGame()
                 }));
 
                 this.game.addMessage('{0} uses {1} to remove {2} from the game until {1} leaves play',
-                    context.player, this, targets);
+                    context.player, this, context.target);
             }
         });
-    }
-
-    nonArmyCharacterInPlay(card) {
-        return card.location === 'play area' && card.getType() === 'character' && !card.hasTrait('Army') && card !== this;
     }
 }
 

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -113,6 +113,10 @@ class Game extends EventEmitter {
         return Object.values(this.playersAndSpectators).filter(player => !this.isSpectator(player));
     }
 
+    getNumberOfPlayers() {
+        return this.getPlayers().length;
+    }
+
     getPlayerByName(playerName) {
         let player = this.playersAndSpectators[playerName];
 

--- a/server/game/gamesteps/selectcardprompt.js
+++ b/server/game/gamesteps/selectcardprompt.js
@@ -47,6 +47,7 @@ class SelectCardPrompt extends UiPrompt {
     constructor(game, choosingPlayer, properties) {
         super(game);
 
+        this.numPlayers = this.game.getNumberOfPlayers();
         this.choosingPlayer = choosingPlayer;
         if(properties.source && !properties.waitingPromptTitle) {
             properties.waitingPromptTitle = 'Waiting for opponent to use ' + properties.source.name;
@@ -122,7 +123,7 @@ class SelectCardPrompt extends UiPrompt {
             return false;
         }
 
-        if(this.selector.automaticFireOnSelect() && this.selector.hasReachedLimit(this.selectedCards)) {
+        if(this.selector.automaticFireOnSelect() && this.selector.hasReachedLimit(this.selectedCards, this.numPlayers)) {
             this.fireOnSelect();
         }
     }
@@ -134,14 +135,14 @@ class SelectCardPrompt extends UiPrompt {
         }
 
         return (
-            this.selector.canTarget(card, this.context) &&
+            this.selector.canTarget(card, this.context, this.selectedCards) &&
             this.selector.checkForSingleController(this.selectedCards, card) &&
             !this.selector.wouldExceedLimit(this.selectedCards, card)
         );
     }
 
     selectCard(card) {
-        if(this.selector.hasReachedLimit(this.selectedCards) && !this.selectedCards.includes(card)) {
+        if(this.selector.hasReachedLimit(this.selectedCards, this.numPlayers) && !this.selectedCards.includes(card)) {
             return false;
         }
 
@@ -180,7 +181,7 @@ class SelectCardPrompt extends UiPrompt {
             return;
         }
 
-        if(this.selector.hasEnoughSelected(this.selectedCards)) {
+        if(this.selector.hasEnoughSelected(this.selectedCards, this.numPlayers)) {
             this.fireOnSelect();
         } else if(this.selectedCards.length === 0) {
             this.properties.onCancel(player);

--- a/test/server/gamesteps/selectcardprompt.spec.js
+++ b/test/server/gamesteps/selectcardprompt.spec.js
@@ -11,7 +11,7 @@ describe('the SelectCardPrompt', function() {
     }
 
     beforeEach(function() {
-        this.game = jasmine.createSpyObj('game', ['getPlayers']);
+        this.game = jasmine.createSpyObj('game', ['getPlayers', 'getNumberOfPlayers']);
 
         this.player = jasmine.createSpyObj('player1', ['setPrompt', 'cancelPrompt', 'clearSelectableCards', 'clearSelectedCards', 'setSelectableCards', 'setSelectedCards']);
         this.player.cardsInPlay = _([]);


### PR DESCRIPTION
- Adds a target mode that satisfies a target for each player, making such cards compatible with upcoming melee functionality and single-player.
- Instead of sequentially prompting for each separate player, all targets are selected in a single prompt.