### PR TITLE
Use ability contexts directly for immunity

### DIFF
--- a/server/game/AbilityContext.js
+++ b/server/game/AbilityContext.js
@@ -9,6 +9,7 @@ class AbilityContext {
         this.costs = {};
         this.costValues = {};
         this.targets = new ResolvedTargets();
+        this.resolutionStage = 'effect';
     }
 
     addCost(name, value) {

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -440,7 +440,7 @@ class BaseCard {
     }
 
     allowEffectFrom(sourceCard) {
-        let currentAbilityContext = { source: 'card', card: sourceCard, stage: 'effect' };
+        let currentAbilityContext = { source: sourceCard, resolutionStage: 'effect' };
         return !_.any(this.abilityRestrictions, restriction => restriction.isMatch('applyEffect', currentAbilityContext));
     }
 

--- a/server/game/cards/06.1-AMAF/Ygritte.js
+++ b/server/game/cards/06.1-AMAF/Ygritte.js
@@ -4,7 +4,7 @@ class Ygritte extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             match: this,
-            effect: ability.effects.cannotBeKneeled(context => context.stage === 'effect')
+            effect: ability.effects.cannotBeKneeled(context => context.resolutionStage === 'effect')
         });
         this.persistentEffect({
             condition: () => this.controlsAnotherWildling(),

--- a/server/game/cards/agendas/TheHouseWithTheRedDoor.js
+++ b/server/game/cards/agendas/TheHouseWithTheRedDoor.js
@@ -32,7 +32,7 @@ class TheHouseWithTheRedDoor extends AgendaCard {
                 onCardLeftPlay: event => event.card === this.startLocation
             },
             match: card => card === this.startLocation,
-            effect: ability.effects.cannotBeDiscarded(context => context.stage === 'effect')
+            effect: ability.effects.cannotBeDiscarded(context => context.resolutionStage === 'effect')
         }));
     }
 

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -56,7 +56,7 @@ class Game extends EventEmitter {
         this.createdAt = new Date();
         this.savedGameId = details.savedGameId;
         this.gameType = details.gameType;
-        this.abilityCardStack = [];
+        this.abilityContextStack = [];
         this.abilityWindowStack = [];
         this.password = details.password;
         this.cancelPromptUsed = false;
@@ -82,7 +82,7 @@ class Game extends EventEmitter {
 
         this.router = options.router;
 
-        this.pushAbilityContext('framework', null, 'framework');
+        this.pushAbilityContext({ resolutionStage: 'framework' });
     }
 
     reportError(e) {
@@ -700,15 +700,15 @@ class Game extends EventEmitter {
     }
 
     get currentAbilityContext() {
-        return _.last(this.abilityCardStack);
+        return _.last(this.abilityContextStack);
     }
 
-    pushAbilityContext(source, card, stage) {
-        this.abilityCardStack.push({ source: source, card: card, stage: stage });
+    pushAbilityContext(context) {
+        this.abilityContextStack.push(context);
     }
 
     popAbilityContext() {
-        this.abilityCardStack.pop();
+        this.abilityContextStack.pop();
     }
 
     resolveAbility(ability, context) {

--- a/server/game/gamesteps/abilityresolver.js
+++ b/server/game/gamesteps/abilityresolver.js
@@ -14,12 +14,12 @@ class AbilityResolver extends BaseStep {
         this.pipeline.initialise([
             new SimpleStep(game, () => this.createSnapshot()),
             new SimpleStep(game, () => this.markActionAsTaken()),
-            new SimpleStep(game, () => this.game.pushAbilityContext('card', context.source, 'cost')),
+            new SimpleStep(game, () => this.game.pushAbilityContext(this.context)),
+            new SimpleStep(game, () => this.context.resolutionStage = 'cost'),
             new SimpleStep(game, () => this.resolveCosts()),
             new SimpleStep(game, () => this.waitForCostResolution()),
             new SimpleStep(game, () => this.payCosts()),
-            new SimpleStep(game, () => this.game.popAbilityContext()),
-            new SimpleStep(game, () => this.game.pushAbilityContext('card', context.source, 'effect')),
+            new SimpleStep(game, () => this.context.resolutionStage = 'effect'),
             new SimpleStep(game, () => this.chooseOpponents()),
             new SimpleStep(game, () => this.resolveTargets()),
             new SimpleStep(game, () => this.waitForTargetResolution()),
@@ -58,7 +58,7 @@ class AbilityResolver extends BaseStep {
             this.game.reportError(e);
 
             let currentAbilityContext = this.game.currentAbilityContext;
-            if(currentAbilityContext && currentAbilityContext.source === 'card' && currentAbilityContext.card === this.context.source) {
+            if(currentAbilityContext === this.context) {
                 this.game.popAbilityContext();
             }
 

--- a/server/game/immunityrestriction.js
+++ b/server/game/immunityrestriction.js
@@ -5,9 +5,9 @@ class ImmunityRestriction {
 
     isMatch(type, abilityContext) {
         return (
-            abilityContext.stage === 'effect' &&
-            abilityContext.card &&
-            this.cardCondition(abilityContext.card)
+            abilityContext.resolutionStage === 'effect' &&
+            abilityContext.source &&
+            this.cardCondition(abilityContext.source, abilityContext)
         );
     }
 }

--- a/test/server/card/baseability.spec.js
+++ b/test/server/card/baseability.spec.js
@@ -5,6 +5,7 @@ const _ = require('underscore');
 describe('BaseAbility', function () {
     beforeEach(function () {
         this.properties = {};
+        this.gameSpy = jasmine.createSpyObj('game', ['popAbilityContext', 'pushAbilityContext']);
     });
 
     describe('constructor', function() {
@@ -92,7 +93,7 @@ describe('BaseAbility', function () {
             this.cost2 = jasmine.createSpyObj('cost1', ['canPay']);
             this.ability = new BaseAbility(this.properties);
             this.ability.cost = [this.cost1, this.cost2];
-            this.context = { context: 1 };
+            this.context = { context: 1, game: this.gameSpy };
         });
 
         describe('when all costs can be paid', function() {
@@ -200,8 +201,8 @@ describe('BaseAbility', function () {
             this.card2 = jasmine.createSpyObj('card', ['allowGameAction', 'getType']);
             this.card2.allowGameAction.and.returnValue(true);
             this.card2.getType.and.returnValue('location');
-            let game = { allCards: _([this.card1, this.card2]) };
-            this.context = { game: game };
+            this.gameSpy.allCards = _([this.card1, this.card2]);
+            this.context = { game: this.gameSpy };
         });
 
         describe('when there is a non-draw card', function() {

--- a/test/server/card/cardaction.spec.js
+++ b/test/server/card/cardaction.spec.js
@@ -2,7 +2,7 @@ const CardAction = require('../../../server/game/cardaction.js');
 
 describe('CardAction', function () {
     beforeEach(function () {
-        this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener', 'raiseEvent', 'resolveAbility']);
+        this.gameSpy = jasmine.createSpyObj('game', ['on', 'popAbilityContext', 'pushAbilityContext', 'removeListener', 'raiseEvent', 'resolveAbility']);
         this.gameSpy.currentPhase = 'marshal';
 
         this.playerSpy = jasmine.createSpyObj('player', ['canTrigger']);

--- a/test/server/card/cardforcedreaction.spec.js
+++ b/test/server/card/cardforcedreaction.spec.js
@@ -3,7 +3,7 @@ const Event = require('../../../server/game/event.js');
 
 describe('CardForcedReaction', function () {
     beforeEach(function () {
-        this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener', 'registerAbility']);
+        this.gameSpy = jasmine.createSpyObj('game', ['on', 'popAbilityContext', 'pushAbilityContext', 'removeListener', 'registerAbility']);
         this.cardSpy = jasmine.createSpyObj('card', ['getPrintedType', 'getType', 'isBlank']);
         this.cardSpy.location = 'play area';
         this.limitSpy = jasmine.createSpyObj('limit', ['increment', 'isAtMax', 'registerEvents', 'unregisterEvents']);

--- a/test/server/card/cardreaction.spec.js
+++ b/test/server/card/cardreaction.spec.js
@@ -3,7 +3,7 @@ const Event = require('../../../server/game/event.js');
 
 describe('CardReaction', function () {
     beforeEach(function () {
-        this.gameSpy = jasmine.createSpyObj('game', ['on', 'removeListener', 'registerAbility']);
+        this.gameSpy = jasmine.createSpyObj('game', ['on', 'popAbilityContext', 'pushAbilityContext', 'removeListener', 'registerAbility']);
         this.cardSpy = jasmine.createSpyObj('card', ['getPrintedType', 'getType', 'isBlank']);
         this.cardSpy.location = 'play area';
         this.limitSpy = jasmine.createSpyObj('limit', ['increment', 'isAtMax', 'registerEvents', 'unregisterEvents']);

--- a/test/server/gamesteps/abilityresolver.spec.js
+++ b/test/server/gamesteps/abilityresolver.spec.js
@@ -286,7 +286,7 @@ describe('AbilityResolver', function() {
 
             describe('when the current ability context is for this ability', function() {
                 beforeEach(function() {
-                    this.game.currentAbilityContext = { source: 'card', card: this.context.source };
+                    this.game.currentAbilityContext = this.context;
                 });
 
                 it('should pop the current context', function() {


### PR DESCRIPTION
Previously, immunity / cannot restrictions looked at an object that
contained the card and the current stage of resolution for the ability.
This was referred to as a "ability context" which overlapped with the
name given to the context that tracks the player using the ability and
cost / target resolution.

To reduce confusion and gain access to this additional information, the
actual AbilityContext object is tracked directly and used within the
immunity system.