### PR TITLE
Fully implement Iron Bank and Sweet Cersei

### DIFF
--- a/server/game/GoldSource.js
+++ b/server/game/GoldSource.js
@@ -1,0 +1,28 @@
+class GoldSource {
+    constructor(playerOrCard, allowSpendingFunc = () => true) {
+        this.playerOrCard = playerOrCard;
+        this.allowSpendingFunc = allowSpendingFunc;
+    }
+
+    get gold() {
+        return this.playerOrCard.gold;
+    }
+
+    get name() {
+        if(this.playerOrCard.getGameElementType() === 'player') {
+            return `${this.playerOrCard.name}'s gold pool`;
+        }
+
+        return this.playerOrCard.name;
+    }
+
+    allowSpendingFor(spendParams) {
+        return this.allowSpendingFunc(spendParams);
+    }
+
+    modifyGold(amount) {
+        this.playerOrCard.modifyGold(amount);
+    }
+}
+
+module.exports = GoldSource;

--- a/server/game/cards/01-Core/TheThingsIDoForLove.js
+++ b/server/game/cards/01-Core/TheThingsIDoForLove.js
@@ -15,7 +15,7 @@ class TheThingsIDoForLove extends DrawCard {
             ],
             target: {
                 cardCondition: (card, context) => card.location === 'play area' && card.controller !== this.controller && card.getType() === 'character' &&
-                                                  (context.xValue ? (card.getCost() <= context.xValue) : (card.getCost() <= this.controller.gold))
+                                                  (context.xValue ? (card.getCost() <= context.xValue) : (card.getCost() <= this.controller.getSpendableGold()))
             },
             handler: context => {
                 context.target.controller.returnCardToHand(context.target);

--- a/server/game/cards/02.2-TRtW/BrothelMadame.js
+++ b/server/game/cards/02.2-TRtW/BrothelMadame.js
@@ -33,7 +33,7 @@ class BrothelMadame extends DrawCard {
                     effect: ability.effects.cannotInitiateChallengeType('military', opponent => opponent === this.controller)
                 }));
 
-                if(context.opponent.gold >= 1) {
+                if(context.opponent.getSpendableGold({ activePlayer: context.opponent }) >= 1) {
                     this.game.promptWithMenu(context.opponent, this, {
                         activePrompt: {
                             menuTitle: 'Pay 1 gold to initiate military challenges this phase?',
@@ -65,11 +65,11 @@ class BrothelMadame extends DrawCard {
     }
 
     payOneGold(player) {
-        if(player.gold < 1) {
+        if(player.getSpendableGold({ activePlayer: player }) < 1) {
             return false;
         }
 
-        this.game.transferGold({ from: player, to: this.controller, amount: 1 });
+        this.game.transferGold({ from: player, to: this.controller, amount: 1, activePlayer: player });
 
         this.game.addMessage('{0} uses {1} to make {2} pay 1 gold', this.controller, this, player);
 

--- a/server/game/cards/02.4-NMG/PaidOff.js
+++ b/server/game/cards/02.4-NMG/PaidOff.js
@@ -15,7 +15,7 @@ class PaidOff extends DrawCard {
                 this.game.addMessage('{0} uses {1} to kneel {2}', this.controller, this, this.parent);
 
                 let player = this.parent.controller;
-                if(player.gold < 1) {
+                if(player.getSpendableGold({ activePlayer: player }) < 1) {
                     this.cancel(player);
                     return false;
                 }
@@ -35,7 +35,7 @@ class PaidOff extends DrawCard {
     }
 
     stand(player) {
-        if(player.gold < 1) {
+        if(player.getSpendableGold({ activePlayer: player }) < 1) {
             return false;
         }
 

--- a/server/game/cards/02.4-NMG/RedCloaks.js
+++ b/server/game/cards/02.4-NMG/RedCloaks.js
@@ -5,7 +5,7 @@ class RedCloaks extends DrawCard {
         this.action({
             title: 'Move 1 gold from your gold pool to this card',
             limit: ability.limit.perPhase(1),
-            condition: () => this.controller.hasEnoughGold(1),
+            condition: () => this.controller.getSpendableGold() >= 1,
             handler: () => {
                 this.game.transferGold({ from: this.controller, to: this, amount: 1 });
                 this.game.addMessage('{0} moves 1 gold from their gold pool to {1}', this.controller, this);

--- a/server/game/cards/04.6-TC/PodrickPayne.js
+++ b/server/game/cards/04.6-TC/PodrickPayne.js
@@ -20,7 +20,7 @@ class PodrickPayne extends DrawCard {
                 this.game.addMessage('{0} puts {1} into play and pays 2 gold to save {2}',
                     this.controller, this, context.target);
 
-                if(context.target.name === 'Tyrion Lannister' && this.controller.hasEnoughGold(2) &&
+                if(context.target.name === 'Tyrion Lannister' && this.controller.getSpendableGold() >= 2 &&
                    this.game.currentChallenge && this.game.currentChallenge.attackers.length >= 1) {
                     this.game.promptWithMenu(this.controller, this, {
                         activePrompt: {

--- a/server/game/cards/05-LoCR/LannisportTreasury.js
+++ b/server/game/cards/05-LoCR/LannisportTreasury.js
@@ -6,7 +6,7 @@ class LannisportTreasury extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onPhaseStarted: event => event.phase === 'taxation' && this.controller.gold >= 1
+                onPhaseStarted: event => event.phase === 'taxation' && this.controller.getSpendableGold() >= 1
             },
             handler: () => {
                 this.game.transferGold({ from: this.controller, to: this, amount: 1 });

--- a/server/game/cards/06.2-GtR/WexPyke.js
+++ b/server/game/cards/06.2-GtR/WexPyke.js
@@ -11,7 +11,7 @@ class WexPyke extends DrawCard {
 
         this.action({
             title: 'Move gold to ' + this.name,
-            condition: () => this.controller.gold >= 1,
+            condition: () => this.controller.getSpendableGold() >= 1,
             phase: 'dominance',
             limit: ability.limit.perPhase(2),
             handler: context => {

--- a/server/game/cards/06.5-OR/StannissCavalry.js
+++ b/server/game/cards/06.5-OR/StannissCavalry.js
@@ -11,7 +11,7 @@ class StannissCavalry extends DrawCard {
 
         this.action({
             title: 'Move gold to ' + this.name,
-            condition: () => this.controller.gold >= 1,
+            condition: () => this.controller.getSpendableGold() >= 1,
             phase: 'standing',
             limit: ability.limit.perPhase(2),
             handler: context => {

--- a/server/game/cards/08.1-TAK/TheIronBank.js
+++ b/server/game/cards/08.1-TAK/TheIronBank.js
@@ -1,20 +1,27 @@
 const DrawCard = require('../../drawcard.js');
 
 class TheIronBank extends DrawCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            condition: () => this.game.currentPhase === 'marshal',
+            match: this,
+            effect: ability.effects.canSpendGold((amount, spendParams) => {
+                return spendParams.activePlayer === this.controller ? amount : 0;
+            })
+        });
         this.reaction({
             when: {
-                onIncomeCollected: event => event.player === this.controller
+                onIncomeCollected: event => event.player === this.controller && this.hasToken('gold')
             },
             handler: () => {
                 let interest = this.tokens['gold'];
-                this.modifyToken('gold', interest);
+                this.modifyGold(interest);
                 this.game.addMessage('{0} uses {1} to place {2} gold from the treasury on {1}', this.controller, this, interest);
             }
         });
     }
 }
 
-TheIronBank.code = '08019'; 
+TheIronBank.code = '08019';
 
 module.exports = TheIronBank;

--- a/server/game/cards/08.1-TAK/TheIronBank.js
+++ b/server/game/cards/08.1-TAK/TheIronBank.js
@@ -5,9 +5,7 @@ class TheIronBank extends DrawCard {
         this.persistentEffect({
             condition: () => this.game.currentPhase === 'marshal',
             match: this,
-            effect: ability.effects.canSpendGold((amount, spendParams) => {
-                return spendParams.activePlayer === this.controller ? amount : 0;
-            })
+            effect: ability.effects.canSpendGold(spendParams => spendParams.activePlayer === this.controller)
         });
         this.reaction({
             when: {

--- a/server/game/cards/08.2-JtO/TheHouseOfBlackAndWhite.js
+++ b/server/game/cards/08.2-JtO/TheHouseOfBlackAndWhite.js
@@ -19,15 +19,15 @@ class TheHouseOfBlackAndWhite extends DrawCard {
                 this.game.killCharacter(context.target);
                 this.game.addMessage('{0} kneels and discards {1} gold from {2} to kill {3}',
                     context.player, context.xValue, this, context.target);
-                
-                if(context.player.gold > 0) {
-                    let range = _.range(1, context.player.gold + 1).reverse();
-            
+
+                if(context.player.getSpendableGold() > 0) {
+                    let range = _.range(1, context.player.getSpendableGold() + 1).reverse();
+
                     let buttons = _.map(range, gold => {
                         return { text: gold.toString(), method: 'moveGold', arg: gold };
                     });
                     buttons.push({ text: 'Done', method: 'moveGold', arg: 0 });
-            
+
                     this.game.promptWithMenu(context.player, this, {
                         activePrompt: {
                             menuTitle: 'Select gold amount to move to ' + this.name,

--- a/server/game/cards/08.4-FotOG/SweetCersei.js
+++ b/server/game/cards/08.4-FotOG/SweetCersei.js
@@ -5,9 +5,7 @@ class SweetCersei extends DrawCard {
         this.persistentEffect({
             condition: () => this.game.currentPhase === 'challenge',
             match: this,
-            effect: ability.effects.canSpendGold((amount, spendParams) => {
-                return spendParams.activePlayer === this.controller ? amount : 0;
-            })
+            effect: ability.effects.canSpendGold(spendParams => spendParams.activePlayer === this.controller)
         });
         this.reaction({
             when: {

--- a/server/game/cards/08.4-FotOG/SweetCersei.js
+++ b/server/game/cards/08.4-FotOG/SweetCersei.js
@@ -1,7 +1,14 @@
 const DrawCard = require('../../drawcard.js');
 
 class SweetCersei extends DrawCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            condition: () => this.game.currentPhase === 'challenge',
+            match: this,
+            effect: ability.effects.canSpendGold((amount, spendParams) => {
+                return spendParams.activePlayer === this.controller ? amount : 0;
+            })
+        });
         this.reaction({
             when: {
                 afterChallenge: event => event.challenge.winner === this.controller && event.challenge.challengeType === 'intrigue'

--- a/server/game/chatcommands.js
+++ b/server/game/chatcommands.js
@@ -335,7 +335,7 @@ class ChatCommands {
     bestow(player, args) {
         var num = this.getNumberOrDefault(args[1], 1);
 
-        if(player.gold < num) {
+        if(player.getSpendableGold({ activePlayer: player }) < num) {
             return false;
         }
 

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -297,7 +297,7 @@ const Costs = {
             resolve: function(context, result = { resolved: false }) {
                 let reduction = context.player.getCostReduction('play', context.source);
                 let opponentObj = opponentFunc && opponentFunc(context);
-                let gold = opponentObj ? opponentObj.gold : context.player.gold;
+                let gold = opponentObj ? opponentObj.getSpendableGold({ playingType: 'play' }) : context.player.getSpendableGold({ playingType: 'play' });
                 let max = _.min([maxFunc(context), gold + reduction]);
 
                 context.game.queueStep(new XValuePrompt(minFunc(context), max, context, reduction));

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -224,7 +224,7 @@ const Costs = {
                     return true;
                 }
 
-                return context.player.hasEnoughGold(context.source.getCost());
+                return context.player.getSpendableGold() >= context.source.getCost();
             },
             pay: function(context) {
                 var hasDupe = context.player.getDuplicateInPlay(context.source);
@@ -250,7 +250,7 @@ const Costs = {
                 }
 
                 let reducedCost = context.player.getReducedCost(playingType, context.source);
-                return context.player.hasEnoughGold(reducedCost, { playingType: playingType });
+                return context.player.getSpendableGold({ playingType: playingType }) >= reducedCost;
             },
             pay: function(context) {
                 var hasDupe = context.player.getDuplicateInPlay(context.source);
@@ -271,7 +271,7 @@ const Costs = {
     payGold: function(amount) {
         return {
             canPay: function(context) {
-                return context.player.hasEnoughGold(amount, { player: context.player, playingType: 'ability' });
+                return context.player.getSpendableGold({ player: context.player, playingType: 'ability' }) >= amount;
             },
             pay: function(context) {
                 context.game.spendGold({ amount: amount, player: context.player });
@@ -290,9 +290,9 @@ const Costs = {
                 let opponentObj = opponentFunc && opponentFunc(context);
 
                 if(!opponentObj) {
-                    return context.player.hasEnoughGold(minFunc(context) - reduction);
+                    return context.player.getSpendableGold() >= (minFunc(context) - reduction);
                 }
-                return opponentObj.hasEnoughGold(minFunc(context) - reduction);
+                return opponentObj.getSpendableGold() >= (minFunc(context) - reduction);
             },
             resolve: function(context, result = { resolved: false }) {
                 let reduction = context.player.getCostReduction('play', context.source);

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -6,6 +6,7 @@ const PlayableLocation = require('./playablelocation.js');
 const CannotRestriction = require('./cannotrestriction.js');
 const ChallengeRestriction = require('./ChallengeRestriction.js');
 const ImmunityRestriction = require('./immunityrestriction.js');
+const GoldSource = require('./GoldSource.js');
 
 function cannotEffect(type) {
     return function(predicate) {
@@ -782,6 +783,21 @@ const Effects = {
             },
             unapply: function(player) {
                 player.removeChallengeRestriction(restriction);
+            }
+        };
+    },
+    canSpendGold: function(allowSpendingFunc) {
+        return {
+            apply: function(card, context) {
+                let goldSource = new GoldSource(card, allowSpendingFunc);
+                context.canSpendGold = context.canSpendGold || {};
+                context.canSpendGold[card.uuid] = goldSource;
+                card.controller.addGoldSource(goldSource);
+            },
+            unapply: function(card, context) {
+                let goldSource = context.canSpendGold[card.uuid];
+                card.controller.removeGoldSource(goldSource);
+                delete context.canSpendGold[card.uuid];
             }
         };
     },

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -459,6 +459,7 @@ class Game extends EventEmitter {
 
         if(from.getGameElementType() === 'player') {
             let activePlayer = transferParams.activePlayer || this.currentAbilityContext && this.currentAbilityContext.player;
+            appliedGold = Math.min(from.getSpendableGold({ player: from, activePlayer: activePlayer }), amount);
             this.spendGold({ amount: appliedGold, player: from, activePlayer: activePlayer }, () => {
                 to.modifyGold(appliedGold);
                 this.raiseEvent('onGoldTransferred', { source: from, target: to, amount: appliedGold });

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -33,6 +33,7 @@ const TitlePool = require('./TitlePool.js');
 const Event = require('./event.js');
 const AtomicEvent = require('./AtomicEvent.js');
 const GroupedCardEvent = require('./GroupedCardEvent.js');
+const ChooseGoldSourceAmounts = require('./gamesteps/ChooseGoldSourceAmounts.js');
 
 class Game extends EventEmitter {
     constructor(details, options = {}) {
@@ -434,10 +435,10 @@ class Game extends EventEmitter {
      * Optional callback that will be called after the gold has been spent
      */
     spendGold(spendParams, callback = () => true) {
-        let {player, amount} = spendParams;
+        let activePlayer = spendParams.activePlayer || this.currentAbilityContext && this.currentAbilityContext.player;
+        spendParams = Object.assign({ playingType: 'ability', activePlayer: activePlayer }, spendParams);
 
-        player.modifyGold(-amount);
-        callback();
+        this.queueStep(new ChooseGoldSourceAmounts(this, spendParams, callback));
     }
 
     /**
@@ -457,7 +458,8 @@ class Game extends EventEmitter {
         let appliedGold = Math.min(from.gold, amount);
 
         if(from.getGameElementType() === 'player') {
-            this.spendGold({ amount: appliedGold, player: from }, () => {
+            let activePlayer = transferParams.activePlayer || this.currentAbilityContext && this.currentAbilityContext.player;
+            this.spendGold({ amount: appliedGold, player: from, activePlayer: activePlayer }, () => {
                 to.modifyGold(appliedGold);
                 this.raiseEvent('onGoldTransferred', { source: from, target: to, amount: appliedGold });
             });

--- a/server/game/gamesteps/ChooseGoldSourceAmounts.js
+++ b/server/game/gamesteps/ChooseGoldSourceAmounts.js
@@ -1,0 +1,60 @@
+const _ = require('underscore');
+
+const BaseStep = require('./basestep');
+
+class ChooseGoldSourceAmounts extends BaseStep {
+    constructor(game, spendParams, callback) {
+        super(game);
+
+        this.remainingAmount = spendParams.amount;
+        this.player = spendParams.player;
+        this.sources = this.player.getSpendableGoldSources(spendParams);
+        this.spendParams = spendParams;
+        this.callback = callback;
+    }
+
+    continue() {
+        while(this.sources.length > 0) {
+            if(this.remainingAmount === 0) {
+                return;
+            }
+
+            this.currentSource = this.sources.shift();
+            let currentAvailable = this.currentSource.gold;
+            let maxAmount = Math.min(this.remainingAmount, currentAvailable);
+            let minAmount = Math.max(0, this.remainingAmount - this.getMaxRemainingAvailable());
+
+            if(this.sources.length > 0 && minAmount !== maxAmount) {
+                let buttons = _.range(minAmount, maxAmount + 1).reverse().map(amount => {
+                    return { text: amount.toString(), method: 'payGold', arg: amount };
+                });
+                this.game.promptWithMenu(this.player, this, {
+                    activePrompt: {
+                        menuTitle: `Select amount from ${this.currentSource.name}`,
+                        buttons: buttons
+                    }
+                });
+                return false;
+            }
+
+            this.payGold(this.player, maxAmount);
+        }
+    }
+
+    getMaxRemainingAvailable() {
+        return this.sources.reduce((sum, source) => sum + source.gold, 0);
+    }
+
+    payGold(player, amount) {
+        this.remainingAmount -= amount;
+        this.currentSource.modifyGold(-amount);
+
+        if(this.remainingAmount === 0) {
+            this.callback();
+        }
+
+        return true;
+    }
+}
+
+module.exports = ChooseGoldSourceAmounts;

--- a/server/game/gamesteps/bestowprompt.js
+++ b/server/game/gamesteps/bestowprompt.js
@@ -11,7 +11,7 @@ class BestowPrompt extends BaseStep {
     }
 
     continue() {
-        let limit = Math.min(this.player.gold, this.card.bestowMax);
+        let limit = Math.min(this.player.getSpendableGold({ activePlayer: this.player }), this.card.bestowMax);
         let range = _.range(1, limit + 1).reverse();
 
         if(limit === 0) {
@@ -37,11 +37,11 @@ class BestowPrompt extends BaseStep {
             return true;
         }
 
-        if(gold > this.player.gold) {
+        if(gold > this.player.getSpendableGold({ activePlayer: this.player })) {
             return false;
         }
 
-        this.game.transferGold({ from: player, to: this.card, amount: gold });
+        this.game.transferGold({ from: player, to: this.card, amount: gold, activePlayer: this.player });
         this.game.addMessage('{0} bestows {1} gold on {2}', this.player, gold, this.card);
 
         return true;

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -216,10 +216,6 @@ class Player extends Spectator {
         return validSources.reduce((sum, source) => sum + source.gold, 0);
     }
 
-    hasEnoughGold(gold, options = {}) {
-        return this.getSpendableGold(options) >= gold;
-    }
-
     modifyGold(amount) {
         this.gold += amount;
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -11,6 +11,7 @@ const PlayableLocation = require('./playablelocation.js');
 const PlayActionPrompt = require('./gamesteps/playactionprompt.js');
 const PlayerPromptState = require('./playerpromptstate.js');
 const MinMaxProperty = require('./MinMaxProperty.js');
+const GoldSource = require('./GoldSource.js');
 
 const logger = require('../log.js');
 
@@ -64,6 +65,7 @@ class Player extends Spectator {
         this.timerSettings = user.settings.timerSettings || {};
         this.timerSettings.windowTimer = user.settings.windowTimer;
         this.keywordSettings = user.settings.keywordSettings;
+        this.goldSources = [new GoldSource(this)];
 
         this.promptState = new PlayerPromptState();
     }
@@ -195,8 +197,27 @@ class Player extends Spectator {
         return this.plotDiscard.size() + this.usedPlotsModifier;
     }
 
-    hasEnoughGold(gold) {
-        return this.gold >= gold;
+    addGoldSource(source) {
+        this.goldSources.unshift(source);
+    }
+
+    removeGoldSource(source) {
+        this.goldSources = this.goldSources.filter(s => s !== source);
+    }
+
+    getSpendableGoldSources(spendParams) {
+        let activePlayer = spendParams.activePlayer || this.game.currentAbilityContext && this.game.currentAbilityContext.player || this;
+        let defaultedSpendParams = Object.assign({ activePlayer: activePlayer, playingType: 'ability' }, spendParams);
+        return this.goldSources.filter(source => source.allowSpendingFor(defaultedSpendParams));
+    }
+
+    getSpendableGold(spendParams = {}) {
+        let validSources = this.getSpendableGoldSources(spendParams);
+        return validSources.reduce((sum, source) => sum + source.gold, 0);
+    }
+
+    hasEnoughGold(gold, options = {}) {
+        return this.getSpendableGold(options) >= gold;
     }
 
     modifyGold(amount) {

--- a/test/server/cards/08.1-TAK/TheIronBank.spec.js
+++ b/test/server/cards/08.1-TAK/TheIronBank.spec.js
@@ -87,7 +87,9 @@ describe('The Iron Bank', function() {
                 });
 
                 it('should allow gold to be bestowed', function() {
-                    this.player1.clickCard('Stone Crows', 'hand');
+                    let stoneCrows = this.player1.findCardByName('Stone Crows', 'hand');
+
+                    this.player1.clickCard(stoneCrows);
                     // No gold from Iron Bank to marshal Stone Crows
                     this.player1.clickPrompt('0');
                     // Bestow 2 gold on Stone Crows
@@ -95,8 +97,28 @@ describe('The Iron Bank', function() {
                     // Choose the amount to use from the Iron Bank
                     this.player1.clickPrompt('2');
 
+                    expect(stoneCrows.gold).toBe(2);
                     expect(this.ironBank.gold).toBe(8); // 10 - 2 from Bestow
                     expect(this.player1Object.gold).toBe(2); // 5 - 3 from marshal
+                });
+
+                it('should allow gold to be bestowed solely from Iron Bank', function() {
+                    let stoneCrows = this.player1.findCardByName('Stone Crows', 'hand');
+
+                    this.player1Object.gold = 3;
+
+                    this.player1.clickCard(stoneCrows);
+                    // No gold from Iron Bank to marshal Stone Crows
+                    this.player1.clickPrompt('0');
+                    // Bestow 2 gold on Stone Crows
+                    this.player1.clickPrompt('2');
+
+                    // Automatically spend from Iron Bank without prompting
+                    expect(this.player1).not.toHavePromptButton('2');
+
+                    expect(stoneCrows.gold).toBe(2);
+                    expect(this.ironBank.gold).toBe(8); // 10 - 2 from Bestow
+                    expect(this.player1Object.gold).toBe(0); // 3 - 3 from marshal
                 });
 
                 it('should allow gold to be moved', function() {

--- a/test/server/cards/08.1-TAK/TheIronBank.spec.js
+++ b/test/server/cards/08.1-TAK/TheIronBank.spec.js
@@ -1,0 +1,172 @@
+describe('The Iron Bank', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck1 = this.buildDeck('lannister', [
+                'A Noble Cause',
+                'The Iron Bank', 'Cersei Lannister (LoCR)', 'Stone Crows', 'Janos Slynt', 'Red Cloaks', 'Nightmares', 'The Hand\'s Judgment'
+            ]);
+            const deck2 = this.buildDeck('thenightswatch', [
+                'A Noble Cause',
+                'A Meager Contribution', 'Steward at the Wall', 'Nightmares'
+            ]);
+            this.player1.selectDeck(deck1);
+            this.player2.selectDeck(deck2);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.ironBank = this.player1.findCardByName('The Iron Bank');
+            this.opponentChar = this.player2.findCardByName('Steward at the Wall', 'hand');
+
+            this.player1.clickCard(this.ironBank);
+            this.player2.clickCard(this.opponentChar);
+
+            this.completeSetup();
+
+            this.ironBank.modifyToken('gold', 10);
+
+            this.player1.selectPlot('A Noble Cause');
+            this.player2.selectPlot('A Noble Cause');
+        });
+
+        describe('when the player collects income', function() {
+            it('should double the gold on the Iron Bank', function() {
+                this.selectFirstPlayer(this.player1);
+                this.player1.clickPrompt('The Iron Bank');
+
+                expect(this.ironBank.gold).toBe(20);
+            });
+
+            it('should not prompt when there is no gold on the Iron Bank', function() {
+                delete this.ironBank.tokens.gold;
+                this.selectFirstPlayer(this.player1);
+
+                expect(this.player1).not.toHavePromptButton('The Iron Bank');
+            });
+        });
+
+        describe('when the player has gold in their gold pool', function() {
+            beforeEach(function() {
+                this.selectFirstPlayer(this.player1);
+
+                // Pass on Iron Bank
+                this.player1.clickPrompt('Pass');
+            });
+
+            it('should not allow gold to be stolen from the card', function() {
+                this.player2.clickPrompt('A Meager Contribution');
+                // Pass on Hand's Judgment
+                this.player1.clickPrompt('Pass');
+
+                expect(this.ironBank.gold).toBe(10);
+                expect(this.player1Object.gold).toBe(4);
+                expect(this.player2Object.gold).toBe(1);
+            });
+
+            describe('', function() {
+                beforeEach(function() {
+                    // Pass on A Meager Contribution
+                    this.player2.clickPrompt('Pass');
+                });
+
+                it('should allow cards to be marshalled', function() {
+                    this.player1.clickCard('Cersei Lannister', 'hand');
+                    this.player1.clickPrompt('2');
+
+                    expect(this.ironBank.gold).toBe(8);
+                    expect(this.player1Object.gold).toBe(2);
+                });
+
+                it('should allow events to be played', function() {
+                    this.player1.clickCard('Nightmares', 'hand');
+                    this.player1.clickPrompt('1');
+                    this.player1.clickCard(this.opponentChar);
+
+                    expect(this.opponentChar.isBlank()).toBe(true);
+                    expect(this.ironBank.gold).toBe(9);
+                    expect(this.player1Object.gold).toBe(5);
+                });
+
+                it('should allow gold to be bestowed', function() {
+                    this.player1.clickCard('Stone Crows', 'hand');
+                    // No gold from Iron Bank to marshal Stone Crows
+                    this.player1.clickPrompt('0');
+                    // Bestow 2 gold on Stone Crows
+                    this.player1.clickPrompt('2');
+                    // Choose the amount to use from the Iron Bank
+                    this.player1.clickPrompt('2');
+
+                    expect(this.ironBank.gold).toBe(8); // 10 - 2 from Bestow
+                    expect(this.player1Object.gold).toBe(2); // 5 - 3 from marshal
+                });
+
+                it('should allow gold to be moved', function() {
+                    let redCloaks = this.player1.findCardByName('Red Cloaks', 'hand');
+                    this.player1.clickCard(redCloaks);
+                    // No gold from Iron Bank to marshal Red Cloaks
+                    this.player1.clickPrompt('0');
+
+                    this.player1.clickMenu(redCloaks, 'Move 1 gold from your gold pool to this card');
+                    // Move 1 gold from Iron Bank onto Red Cloaks
+                    this.player1.clickPrompt('1');
+
+                    expect(redCloaks.gold).toBe(1);
+                    expect(this.ironBank.gold).toBe(9);
+                    expect(this.player1Object.gold).toBe(3);
+                });
+
+                it('should allow gold to be paid for abilities', function() {
+                    let janos = this.player1.findCardByName('Janos Slynt', 'hand');
+                    this.player1.clickCard(janos);
+                    // No gold from Iron Bank to marshal Janos Slynt
+                    this.player1.clickPrompt('0');
+
+                    this.player1.clickMenu(janos, 'Pay 1 gold to give Janos Slynt +2 strength');
+                    // Automatically take it off the Iron Bank without prompting
+                    // since 0 gold left in the actual pool
+                    expect(this.player1).not.toHavePromptButton('1');
+
+                    expect(janos.getStrength()).toBe(4);
+                    expect(this.ironBank.gold).toBe(9);
+                    expect(this.player1Object.gold).toBe(0);
+                });
+            });
+        });
+
+        describe('when the player has no gold in their gold pool', function() {
+            beforeEach(function() {
+                this.selectFirstPlayer(this.player2);
+            });
+
+            it('should allow actions to be paid for using gold on the Iron Bank', function() {
+                this.player1.clickCard('Nightmares', 'hand');
+                this.player1.clickCard(this.opponentChar);
+
+                // Automatically take it off the Iron Bank without prompting
+                expect(this.player1).not.toHavePromptButton('1');
+
+                expect(this.opponentChar.isBlank()).toBe(true);
+                expect(this.ironBank.gold).toBe(9);
+                expect(this.player1Object.gold).toBe(0);
+            });
+
+            it('should allow them to play interrupts / reactions using gold on the Iron Bank', function() {
+                let cersei = this.player1.findCardByName('Cersei Lannister', 'hand');
+                this.player1.dragCard(cersei, 'play area');
+                this.player2.clickCard('Nightmares', 'hand');
+                this.player2.clickCard(cersei);
+
+                expect(this.player1).toHavePromptButton('The Hand\'s Judgment');
+                expect(cersei.isBlank()).toBe(false);
+
+                this.player1.clickPrompt('The Hand\'s Judgment');
+
+                // Automatically take it off the Iron Bank without prompting
+                expect(this.player1).not.toHavePromptButton('1');
+
+                expect(cersei.isBlank()).toBe(false);
+                expect(this.ironBank.gold).toBe(9);
+                expect(this.player1Object.gold).toBe(0);
+            });
+        });
+    });
+});

--- a/test/server/costs/payreduceablegoldcost.spec.js
+++ b/test/server/costs/payreduceablegoldcost.spec.js
@@ -3,7 +3,7 @@ const Costs = require('../../../server/game/costs.js');
 describe('Costs.payReduceableGoldCost', function() {
     beforeEach(function() {
         this.gameSpy = jasmine.createSpyObj('game', ['addMessage', 'spendGold']);
-        this.playerSpy = jasmine.createSpyObj('player', ['hasEnoughGold', 'getDuplicateInPlay', 'getReducedCost', 'markUsedReducers']);
+        this.playerSpy = jasmine.createSpyObj('player', ['getDuplicateInPlay', 'getReducedCost', 'getSpendableGold', 'markUsedReducers']);
         this.cardSpy = { card: 1 };
         this.context = {
             costs: {},
@@ -16,13 +16,13 @@ describe('Costs.payReduceableGoldCost', function() {
 
     describe('canPay()', function() {
         beforeEach(function() {
-            this.playerSpy.hasEnoughGold.and.returnValue(true);
+            this.playerSpy.getSpendableGold.and.returnValue(6);
             this.playerSpy.getReducedCost.and.returnValue(4);
         });
 
         it('should check that the player can spend the amount of gold', function() {
             this.cost.canPay(this.context);
-            expect(this.playerSpy.hasEnoughGold).toHaveBeenCalledWith(4, jasmine.objectContaining({ playingType: 'playing-type' }));
+            expect(this.playerSpy.getSpendableGold).toHaveBeenCalledWith(jasmine.objectContaining({ playingType: 'playing-type' }));
         });
 
         it('should return true when all criteria are met', function() {
@@ -45,7 +45,7 @@ describe('Costs.payReduceableGoldCost', function() {
                 });
 
                 it('should return true regardless of gold', function() {
-                    this.playerSpy.hasEnoughGold.and.returnValue(false);
+                    this.playerSpy.getSpendableGold.and.returnValue(0);
                     expect(this.cost.canPay(this.context)).toBe(true);
                 });
             });
@@ -56,12 +56,12 @@ describe('Costs.payReduceableGoldCost', function() {
                 });
 
                 it('should return true if there is enough gold gold', function() {
-                    this.playerSpy.hasEnoughGold.and.returnValue(true);
+                    this.playerSpy.getSpendableGold.and.returnValue(6);
                     expect(this.cost.canPay(this.context)).toBe(true);
                 });
 
                 it('should return false if there is not enough gold gold', function() {
-                    this.playerSpy.hasEnoughGold.and.returnValue(false);
+                    this.playerSpy.getSpendableGold.and.returnValue(3);
                     expect(this.cost.canPay(this.context)).toBe(false);
                 });
             });
@@ -69,7 +69,7 @@ describe('Costs.payReduceableGoldCost', function() {
 
         describe('when there is not enough gold', function() {
             beforeEach(function() {
-                this.playerSpy.hasEnoughGold.and.returnValue(false);
+                this.playerSpy.getSpendableGold.and.returnValue(3);
             });
 
             it('should return false', function() {
@@ -80,7 +80,7 @@ describe('Costs.payReduceableGoldCost', function() {
 
     describe('pay()', function() {
         beforeEach(function() {
-            this.playerSpy.hasEnoughGold.and.returnValue(true);
+            this.playerSpy.getSpendableGold.and.returnValue(6);
             this.playerSpy.getReducedCost.and.returnValue(3);
         });
 


### PR DESCRIPTION
~**DO NOT MERGE until #1806 and #1807 are merged**~

For review purposes until the other 2 PRs are merged, you can look at https://github.com/ystros/throneteki/compare/b630c5f...ystros:iron-bank-final?expand=1

This works by explicitly prompting the user when they want to spend gold during the eligible phase. If there aren't multiple ways to combine the gold in their pool and the gold on the card, then the gold will be spent automatically without prompting. Examples:

* 4 gold in pool, 1 on Iron Bank. Marshal a 5 cost character. All gold spent automatically, no prompting.
* 1 gold in pool, 4 on Iron Bank. Marshal a 5 cost character. All gold spent automatically, no prompting.
* 4 gold in pool, 2 on Iron Bank. Marshal a 5 cost character. Player is prompted whether they want to spend 1 or 2 gold from the Iron Bank. The remainder is spent from their pool.
* 5 gold in pool, 5 on Iron Bank. Marshal a 5 cost character. Player is prompted whether they want to spend 0 to 5 gold from the Iron Bank. The remainder (if any) is spent from their pool.
* 0 gold in pool, 1 gold on Iron Bank. Play a 1 cost event. Gold spent automatically from Iron Bank, no prompting.

I'm sure there are still bugs (anywhere checking player.gold directly is suspect), and there's probably some quality of life things we can add (like saying "I don't want to spend from Iron Bank this round" to reduce prompting while you let gold build up), but this should get us 99% there.

Fixes #1628 