### PR TITLE
Allow select card prompts to reveal facedown targets & Implement False Spring

### DIFF
--- a/client/GameBoard.jsx
+++ b/client/GameBoard.jsx
@@ -326,6 +326,7 @@ export class GameBoard extends React.Component {
                                 onMouseOver={ this.onMouseOver }
                                 onMouseOut={ this.onMouseOut }
                                 outOfGamePile={ otherPlayer.cardPiles.outOfGamePile }
+                                username={ this.props.user.username }
                                 showHand={ this.props.currentGame.showHand }
                                 spectating={ this.state.spectating }
                                 title={ otherPlayer.title }

--- a/client/GameComponents/PlayerHand.jsx
+++ b/client/GameComponents/PlayerHand.jsx
@@ -51,15 +51,20 @@ class PlayerHand extends React.Component {
     }
 
     getCards(needsSquish) {
+        let cards = this.props.cards;
         let cardIndex = 0;
-        let handLength = this.props.cards ? this.props.cards.length : 0;
+        let handLength = cards ? cards.length : 0;
         let cardWidth = this.getCardWidth();
 
         let requiredWidth = handLength * cardWidth;
         let overflow = requiredWidth - (cardWidth * 5);
         let offset = overflow / (handLength - 1);
 
-        let hand = _.map(this.props.cards, card => {
+        if(!this.props.isMe) {
+            cards = _.sortBy(this.props.cards, card => card.revealWhenHiddenTo);
+        }
+
+        let hand = _.map(cards, card => {
             let left = (cardWidth - offset) * cardIndex++;
 
             let style = {};

--- a/client/GameComponents/PlayerHand.jsx
+++ b/client/GameComponents/PlayerHand.jsx
@@ -38,8 +38,12 @@ class PlayerHand extends React.Component {
         }
     }
 
-    disableMouseOver() {
+    disableMouseOver(revealWhenHiddenTo) {
         if(this.props.spectating && this.props.showHand) {
+            return false;
+        }
+
+        if(revealWhenHiddenTo === this.props.username) {
             return false;
         }
 
@@ -65,7 +69,7 @@ class PlayerHand extends React.Component {
                 };
             }
 
-            return (<Card key={ card.uuid } card={ card } style={ style } disableMouseOver={ this.disableMouseOver() } source='hand'
+            return (<Card key={ card.uuid } card={ card } style={ style } disableMouseOver={ this.disableMouseOver(card.revealWhenHiddenTo) } source='hand'
                 onMouseOver={ this.props.onMouseOver }
                 onMouseOut={ this.props.onMouseOut }
                 onClick={ this.props.onCardClick }
@@ -131,7 +135,8 @@ PlayerHand.propTypes = {
     onMouseOut: PropTypes.func,
     onMouseOver: PropTypes.func,
     showHand: PropTypes.bool,
-    spectating: PropTypes.bool
+    spectating: PropTypes.bool,
+    username: PropTypes.string
 };
 
 export default PlayerHand;

--- a/client/GameComponents/PlayerRow.jsx
+++ b/client/GameComponents/PlayerRow.jsx
@@ -153,6 +153,7 @@ class PlayerRow extends React.Component {
                 <PlayerHand
                     cards={ this.props.hand }
                     isMe={ this.props.isMe }
+                    username={ this.props.username }
                     onCardClick={ this.props.onCardClick }
                     onDragDrop={ this.props.onDragDrop }
                     onMouseOut={ this.props.onMouseOut }
@@ -208,7 +209,8 @@ PlayerRow.propTypes = {
     showDrawDeck: PropTypes.bool,
     showHand: PropTypes.bool,
     spectating: PropTypes.bool,
-    title: PropTypes.object
+    title: PropTypes.object,
+    username: PropTypes.string
 };
 
 export default PlayerRow;

--- a/server/game/CardSelector.js
+++ b/server/game/CardSelector.js
@@ -12,7 +12,8 @@ const defaultProperties = {
     cardType: ['attachment', 'character', 'event', 'location'],
     gameAction: 'target',
     multiSelect: false,
-    singleController: false
+    singleController: false,
+    revealTargets: false
 };
 
 const ModeToSelector = {

--- a/server/game/CardSelectors/BaseCardSelector.js
+++ b/server/game/CardSelectors/BaseCardSelector.js
@@ -17,12 +17,16 @@ class BaseCardSelector {
      * the game action checked for immunity purposes on potential target cards.
      * @param {boolean} properties.singleController
      * indicates that all cards selected must belong to the same controller.
+     * @param {boolean} properties.revealTargets
+     * indicates that all selectable facedown cards are flipped faceup for
+     * the selecting player.
      */
     constructor(properties) {
         this.cardCondition = properties.cardCondition;
         this.cardType = properties.cardType;
         this.gameAction = properties.gameAction;
         this.singleController = properties.singleController;
+        this.revealTargets = properties.revealTargets;
 
         if(!Array.isArray(properties.cardType)) {
             this.cardType = [properties.cardType];
@@ -41,14 +45,6 @@ class BaseCardSelector {
             this.cardCondition(card, context) &&
             card.allowGameAction(this.gameAction)
         );
-    }
-
-    checkForSingleController(selectedCards, card) {
-        if(!this.singleController || _.isEmpty(selectedCards)) {
-            return true;
-        }
-
-        return card.controller === selectedCards[0].controller;
     }
 
     /**
@@ -133,6 +129,33 @@ class BaseCardSelector {
      */
     formatSelectParam(cards) {
         return cards;
+    }
+
+    /**
+     * Returns whether the specified card can be targeted if the singleController
+     * flag is set.
+     * @param {BaseCard[]} selectedcards
+     * @param {BaseCard} card
+     * @returns {boolean}
+     */
+    checkForSingleController(selectedCards, card) {
+        if(!this.singleController || _.isEmpty(selectedCards)) {
+            return true;
+        }
+
+        return card.controller === selectedCards[0].controller;
+    }
+
+    /**
+     * Flips the specified (facedown) card faceup to the selecting player if the
+     * revealTargets flag is set.
+     * @param {BaseCard} card 
+     * @param {Player} player 
+     */
+    showFacedownTargetTo(card, player) {
+        if(this.revealTargets) {
+            card.showFacedownTargetTo(player);
+        }
     }
 }
 

--- a/server/game/cards/01-Core/SeenInFlames.js
+++ b/server/game/cards/01-Core/SeenInFlames.js
@@ -3,37 +3,27 @@ const DrawCard = require('../../drawcard.js');
 class SeenInFlames extends DrawCard {
     setupCardAbilities() {
         this.action({
-            title: 'Discard from opponent\'s hand',
+            title: 'Look at opponent\'s hand',
             phase: 'challenge',
             condition: () => this.controller.anyCardsInPlay(card => card.hasTrait('R\'hllor') && card.getType() === 'character'),
             chooseOpponent: opponent => !opponent.hand.isEmpty(),
             handler: context => {
-                let buttons = context.opponent.hand.map(card => {
-                    return { method: 'cardSelected', card: card };
-                });
-
-                this.game.promptWithMenu(this.controller, this, {
-                    activePrompt: {
-                        menuTitle: 'Select a card',
-                        buttons: buttons
-                    },
-                    source: this
+                this.game.addMessage('{0} plays {1} to look at {2}\'s hand', context.player, this, context.opponent);
+                this.game.promptForSelect(context.player, {
+                    activePromptTitle: 'Select a card',
+                    source: this,
+                    revealTargets: true,
+                    cardCondition: card => card.location === 'hand' && card.controller === context.opponent,
+                    onSelect: (player, card) => this.onCardSelected(player, card)
                 });
             }
         });
     }
 
-    cardSelected(player, cardId) {
-        let card = this.game.findAnyCardInAnyList(cardId);
-        if(!card) {
-            return false;
-        }
-
+    onCardSelected(player, card) {
         let otherPlayer = card.controller;
-
         otherPlayer.discardCard(card);
-
-        this.game.addMessage('{0} plays {1} to discard {2} from {3}\'s hand', player, this, card, otherPlayer);
+        this.game.addMessage('{0} then uses {1} to discard {2} from {3}\'s hand', player, this, card, otherPlayer);
 
         return true;
     }

--- a/server/game/cards/03-WotN/HisViperEyes.js
+++ b/server/game/cards/03-WotN/HisViperEyes.js
@@ -8,37 +8,25 @@ class HisViperEyes extends DrawCard {
                     event.challenge.defendingPlayer === this.controller &&
                     event.challenge.loser === this.controller &&
                     ['military', 'power'].includes(event.challenge.challengeType) &&
-                    event.challenge.winner.hand.size() >= 1
+                    !event.challenge.winner.hand.isEmpty()
             },
-            handler: () => {
-                this.challengeWinner = this.game.currentChallenge.winner;
-
-                let buttons = this.challengeWinner.hand.map(card => {
-                    return { method: 'cardSelected', card: card };
-                });
-
-                this.game.promptWithMenu(this.controller, this, {
-                    activePrompt: {
-                        menuTitle: 'Select a card',
-                        buttons: buttons
-                    },
-                    source: this
+            handler: context => {
+                this.game.addMessage('{0} plays {1} to look at {2}\'s hand', context.player, this, context.event.challenge.winner);
+                this.game.promptForSelect(context.player, {
+                    activePromptTitle: 'Select a card',
+                    source: this,
+                    revealTargets: true,
+                    cardCondition: card => card.location === 'hand' && card.controller === context.event.challenge.winner,
+                    onSelect: (player, card) => this.onCardSelected(player, card)
                 });
             }
         });
     }
 
-    cardSelected(player, cardId) {
-        let otherPlayer = this.challengeWinner;
-
-        let card = otherPlayer.findCardByUuid(otherPlayer.hand, cardId);
-        if(!card) {
-            return false;
-        }
-
+    onCardSelected(player, card) {
+        let otherPlayer = card.controller;
         otherPlayer.discardCard(card);
-
-        this.game.addMessage('{0} uses {1} to discard {2} from {3}\'s hand', player, this, card, otherPlayer);
+        this.game.addMessage('{0} then uses {1} to discard {2} from {3}\'s hand', player, this, card, otherPlayer);
 
         return true;
     }

--- a/server/game/cards/06.2-GtR/Melisandre.js
+++ b/server/game/cards/06.2-GtR/Melisandre.js
@@ -6,31 +6,21 @@ class Melisandre extends DrawCard {
             when: {
                 onDominanceDetermined: event => this.controller === event.winner
             },
-            chooseOpponent: opponent => opponent.hand.size() >= 1,
+            chooseOpponent: opponent => !opponent.hand.isEmpty(),
             handler: context => {
-                let otherPlayer = context.opponent;
-                let buttons = otherPlayer.hand.map(card => {
-                    return { method: 'cardSelected', card: card };
-                });
-
-                this.game.promptWithMenu(this.controller, this, {
-                    activePrompt: {
-                        menuTitle: 'Select a card',
-                        buttons: buttons
-                    },
-                    source: this
+                this.game.addMessage('{0} uses {1} to look at {2}\'s hand', context.player, this, context.opponent);
+                this.game.promptForSelect(context.player, {
+                    activePromptTitle: 'Select a card',
+                    source: this,
+                    revealTargets: true,
+                    cardCondition: card => card.location === 'hand' && card.controller === context.opponent,
+                    onSelect: (player, card) => this.onCardSelected(player, card)
                 });
             }
         });
     }
 
-    cardSelected(player, cardId) {
-        let card = this.game.findAnyCardInAnyList(cardId);
-
-        if(!card) {
-            return false;
-        }
-
+    onCardSelected(player, card) {
         let otherPlayer = card.controller;
 
         otherPlayer.discardCards([card], true, () => {
@@ -41,7 +31,7 @@ class Melisandre extends DrawCard {
                 otherPlayer.moveCard(card, 'dead pile');
             }
 
-            this.game.addMessage('{0} uses {1} to discard {2} from {3}\'s hand{4}',
+            this.game.addMessage('{0} then uses {1} to discard {2} from {3}\'s hand{4}',
                 player, this, card, otherPlayer, charMessage);
         });
 

--- a/server/game/cards/10-SoD/FalseSpring.js
+++ b/server/game/cards/10-SoD/FalseSpring.js
@@ -1,0 +1,67 @@
+const _ = require('underscore');
+
+const PlotCard = require('../../plotcard.js');
+
+class FalseSpring extends PlotCard {
+    setupCardAbilities() {
+        this.whenRevealed({
+            handler: () => {
+                this.remainingOpponents = _.filter(this.game.getPlayers(), player => player !== this.controller);
+                this.selections = [];
+                this.proceedToNextStep();
+            }
+        });
+    }
+
+    proceedToNextStep() {
+        if(this.remainingOpponents.length > 0) {
+            let currentOpponent = this.remainingOpponents.shift();
+            let numToReveal = Math.min(currentOpponent.hand.size(), 3);
+
+            this.game.promptForSelect(currentOpponent, {
+                activePromptTitle: `Select ${numToReveal} card(s)`,
+                source: this,
+                numCards: numToReveal,
+                multiSelect: true,
+                mode: 'exactly',
+                cardCondition: card => card.location === 'hand' && card.controller === currentOpponent,
+                onSelect: (player, cards) => this.onToRevealSelected(player, cards)
+            });
+        } else {
+            this.doReveal();
+        }
+    }
+
+    onToRevealSelected(player, cards) {
+        this.selections = this.selections.concat(cards);
+        this.game.addMessage('{0} reveals {1} for {2}', player, cards, this);
+        this.proceedToNextStep();
+        return true;
+    }
+
+    doReveal() {
+        let numToDiscard = this.game.getNumberOfPlayers() - 1;
+
+        //TODO Melee: This prompt should work in Melee with well-meaning players but can be abused as well
+        this.game.promptForSelect(this.controller, {
+            activePromptTitle: `Select up to ${numToDiscard} card(s)`,
+            mode: 'upTo',
+            source: this,
+            revealTargets: true,
+            multiSelect: true,
+            numCards: numToDiscard,
+            cardCondition: card => this.selections.includes(card),
+            onSelect: (player, cards) => this.onToDiscardardSelected(player, cards)
+        });
+    }
+
+    onToDiscardardSelected(player, cards) {
+        _.each(cards, card => card.controller.discardCard(card));
+        this.game.addMessage('{0} uses {1} to discard {2}', player, this, cards);
+        return true;
+    }
+}
+
+FalseSpring.code = '10052';
+
+module.exports = FalseSpring;

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -507,6 +507,7 @@ class DrawCard extends BaseCard {
             inDanger: this.inDanger,
             kneeled: this.kneeled,
             power: this.power,
+            revealWhenHiddenTo: this.revealWhenHiddenTo,
             saved: this.saved,
             strength: this.getStrength(),
             stealth: this.stealth

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -40,6 +40,7 @@ class DrawCard extends BaseCard {
             }
         }
 
+        this.revealWhenHiddenTo = undefined;
         this.power = 0;
         this.burnValue = 0;
         this.strengthModifier = 0;
@@ -472,7 +473,19 @@ class DrawCard extends BaseCard {
         this.saved = false;
     }
 
+    showFacedownTargetTo(player) {
+        this.revealWhenHiddenTo = player.name;
+    }
+
+    hideFacedownTarget() {
+        this.revealWhenHiddenTo = undefined;
+    }
+
     getSummary(activePlayer, hideWhenFaceup) {
+        if(this.revealWhenHiddenTo === activePlayer.name) {
+            hideWhenFaceup = false;
+        }
+
         let baseSummary = super.getSummary(activePlayer, hideWhenFaceup);
 
         return _.extend(baseSummary, {

--- a/server/game/gamesteps/selectcardprompt.js
+++ b/server/game/gamesteps/selectcardprompt.js
@@ -87,6 +87,7 @@ class SelectCardPrompt extends UiPrompt {
         let selectableCards = this.game.allCards.filter(card => {
             return this.checkCardCondition(card);
         });
+        _.each(selectableCards, card => this.selector.showFacedownTargetTo(card, this.choosingPlayer));
         this.choosingPlayer.setSelectableCards(selectableCards);
     }
 

--- a/server/game/playerpromptstate.js
+++ b/server/game/playerpromptstate.js
@@ -26,6 +26,7 @@ class PlayerPromptState {
     }
 
     clearSelectableCards() {
+        _.each(this.selectableCards, card => card.hideFacedownTarget());
         this.selectableCards = [];
     }
 

--- a/test/server/card/drawcard.getsummary.spec.js
+++ b/test/server/card/drawcard.getsummary.spec.js
@@ -4,6 +4,8 @@ describe('DrawCard', function () {
     beforeEach(function () {
         this.testCard = { code: '111', label: 'test 1(some pack)', name: 'test 1' };
         this.card = new DrawCard({}, this.testCard);
+        this.activePlayer = {};
+        this.activePlayer.name = 'bla';
     });
 
     describe('getSummary', function() {
@@ -11,7 +13,7 @@ describe('DrawCard', function () {
             describe('when the card has non-zero strength', function() {
                 beforeEach(function() {
                     this.testCard.strength = 5;
-                    this.summary = this.card.getSummary(true, true);
+                    this.summary = this.card.getSummary(this.activePlayer, true);
                 });
 
                 it('should include the strength', function() {
@@ -22,7 +24,7 @@ describe('DrawCard', function () {
             describe('when the card has a zero strength', function() {
                 beforeEach(function() {
                     this.testCard.strength = 0;
-                    this.summary = this.card.getSummary(true, true);
+                    this.summary = this.card.getSummary(this.activePlayer, true);
                 });
 
                 it('should include the strength', function() {

--- a/test/server/integration/playingevents.spec.js
+++ b/test/server/integration/playingevents.spec.js
@@ -16,6 +16,7 @@ describe('playing events', function() {
 
             this.knight = this.player2.findCardByName('Hedge Knight', 'hand');
             this.plan = this.player2.findCardByName('The Prince\'s Plan', 'hand');
+            this.event = this.player2.findCardByName('The Hand\'s Judgment', 'hand');
 
             this.player1.clickCard('Melisandre', 'hand');
             this.player2.clickCard(this.knight);
@@ -37,7 +38,7 @@ describe('playing events', function() {
                 this.player2.clickPrompt('Pass');
 
                 // Discard Hand's Judgment from the opponent's hand
-                this.player1.clickPrompt('The Hand\'s Judgment');
+                this.player1.clickCard(this.event);
             });
 
             it('should count as having played the event', function() {


### PR DESCRIPTION
- Adds a flag to select card prompts that reveals selectable cards that are otherwise facedown, for example cards in an opponent's hand.
- Allows cards like Seen in Flames and His Viper Eyes to use a select card prompt, instead of menu buttons.
- This mirrors earlier changes that converted cards targeting the faction card to switch from menu buttons to target prompts.