### PR TITLE
Distinguish between gaining and discarding power

### DIFF
--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -308,7 +308,8 @@ class DrawCard extends BaseCard {
     }
 
     modifyPower(power) {
-        this.game.applyGameAction('gainPower', this, card => {
+        let action = power < 0 ? 'discardPower' : 'gainPower';
+        this.game.applyGameAction(action, this, card => {
             let oldPower = card.power;
 
             card.power += power;

--- a/test/server/card/drawcard.modifyPower.spec.js
+++ b/test/server/card/drawcard.modifyPower.spec.js
@@ -37,5 +37,30 @@ describe('DrawCard', function () {
                 expect(this.gameSpy.raiseEvent).not.toHaveBeenCalled();
             });
         });
+
+        describe('when a card cannot gain power', function() {
+            beforeEach(function() {
+                this.gameSpy.applyGameAction.and.callFake((action, card, fn) => {
+                    if(action === 'gainPower') {
+                        return;
+                    }
+
+                    fn(card);
+                });
+            });
+
+            it('should not gain power', function() {
+                this.card.modifyPower(2);
+
+                expect(this.card.power).toBe(0);
+            });
+
+            it('should still lose power', function() {
+                this.card.power = 2;
+                this.card.modifyPower(-1);
+
+                expect(this.card.power).toBe(1);
+            });
+        });
     });
 });


### PR DESCRIPTION
Previously, `DrawCard.modifyPower` always applied a 'gain power' action
to the card, regardless of whether power was being gained or lost. This
lead to a bug where Your King Commands It would prevent not only power
from being gained but also power being discarded from cards.