### PR TITLE
Reliably recalculate effects after state change

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -446,10 +446,12 @@ class BaseCard {
 
     addAbilityRestriction(restriction) {
         this.abilityRestrictions.push(restriction);
+        this.markAsDirty();
     }
 
     removeAbilityRestriction(restriction) {
         this.abilityRestrictions = _.reject(this.abilityRestrictions, r => r === restriction);
+        this.markAsDirty();
     }
 
     addKeyword(keyword) {

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -471,7 +471,7 @@ class BaseCard {
             this.traits[lowerCaseTrait]++;
         }
 
-        this.game.raiseEvent('onCardTraitChanged', { card: this });
+        this.markAsDirty();
     }
 
     getTraits() {
@@ -487,7 +487,7 @@ class BaseCard {
         this.factions[lowerCaseFaction] = this.factions[lowerCaseFaction] || 0;
         this.factions[lowerCaseFaction]++;
 
-        this.game.raiseEvent('onCardFactionChanged', { card: this });
+        this.markAsDirty();
     }
 
     removeKeyword(keyword) {
@@ -498,12 +498,12 @@ class BaseCard {
 
     removeTrait(trait) {
         this.traits[trait.toLowerCase()]--;
-        this.game.raiseEvent('onCardTraitChanged', { card: this });
+        this.markAsDirty();
     }
 
     removeFaction(faction) {
         this.factions[faction.toLowerCase()]--;
-        this.game.raiseEvent('onCardFactionChanged', { card: this });
+        this.markAsDirty();
     }
 
     clearBlank() {
@@ -541,6 +541,14 @@ class BaseCard {
         if(this.tokens[type] === 0) {
             delete this.tokens[type];
         }
+    }
+
+    markAsDirty() {
+        this.isDirty = true;
+    }
+
+    clearDirty() {
+        this.isDirty = false;
     }
 
     onClick(player) {

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -81,6 +81,7 @@ class Challenge {
     markAsParticipating(cards) {
         _.each(cards, card => {
             card.inChallenge = true;
+            card.markAsDirty();
         });
     }
 

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -836,6 +836,7 @@ class Game extends EventEmitter {
      * checks, such as state dependent effects, attachment validity, and others.
      */
     postEventCalculations() {
+        this.effectEngine.recalculateDirtyTargets();
         this.effectEngine.reapplyStateDependentEffects();
         this.attachmentValidityCheck.enforceValidity();
     }

--- a/test/server/cards/04.5-GoH/DragonglassDagger.spec.js
+++ b/test/server/cards/04.5-GoH/DragonglassDagger.spec.js
@@ -1,0 +1,63 @@
+describe('Dragonglass Dagger', function() {
+    integration(function() {
+        describe('vs Theon Greyjoy (TFoA)', function() {
+            beforeEach(function() {
+                const deck1 = this.buildDeck('thenightswatch', [
+                    'A Noble Cause',
+                    'Stonesnake', 'Dragonglass Dagger'
+                ]);
+                const deck2 = this.buildDeck('greyjoy', [
+                    'A Noble Cause',
+                    'Theon Greyjoy (TFoA)'
+                ]);
+
+                this.player1.selectDeck(deck1);
+                this.player2.selectDeck(deck2);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.character = this.player1.findCardByName('Stonesnake', 'hand');
+                this.attachment = this.player1.findCardByName('Dragonglass Dagger', 'hand');
+
+                this.player1.clickCard(this.character);
+                this.player1.clickCard(this.attachment);
+
+                this.theon = this.player2.findCardByName('Theon Greyjoy', 'hand');
+                this.player2.clickCard(this.theon);
+
+                this.completeSetup();
+
+                // Attach the dagger
+                this.player1.clickCard(this.attachment);
+                this.player1.clickCard(this.character);
+
+                this.player1.selectPlot('A Noble Cause');
+                this.player2.selectPlot('A Noble Cause');
+                this.selectFirstPlayer(this.player2);
+
+                this.completeMarshalPhase();
+            });
+
+            describe('when Theon is attacking alone', function() {
+                beforeEach(function() {
+                    this.player2.clickPrompt('Military');
+                    this.player2.clickCard(this.theon);
+                    this.player2.clickPrompt('Done');
+
+                    this.skipActionWindow();
+
+                    this.player1.clickCard(this.character);
+                    this.player1.clickPrompt('Done');
+
+                    this.skipActionWindow();
+                });
+
+                it('should immunize the charcter with the dagger from Theon\'s effect', function() {
+                    expect(this.player2).not.toHavePromptButton('Apply Claim');
+                    // Challenge completed, kicked back to challenge declaration
+                    expect(this.player2).toHavePromptButton('Intrigue');
+                });
+            });
+        });
+    });
+});

--- a/test/server/cards/agendas/TheLordOfTheCrossing.spec.js
+++ b/test/server/cards/agendas/TheLordOfTheCrossing.spec.js
@@ -190,4 +190,46 @@ describe('The Lord of the Crossing', function() {
             });
         });
     });
+
+    integration(function() {
+        describe('vs Jon Snow (Core)', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('thenightswatch', [
+                    'The Lord of the Crossing',
+                    'A Noble Cause',
+                    'Jon Snow (Core)', 'Steward at the Wall'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.jon = this.player1.findCardByName('Jon Snow', 'hand');
+                this.steward = this.player1.findCardByName('Steward at the Wall', 'hand');
+
+                this.player1.clickCard(this.jon);
+                this.player1.clickCard(this.steward);
+
+                this.completeSetup();
+            });
+
+            describe('when Jon Snow becomes an attacker through his ability', function() {
+                beforeEach(function() {
+                    this.player1.selectPlot('A Noble Cause');
+                    this.player2.selectPlot('A Noble Cause');
+                    this.selectFirstPlayer(this.player1);
+
+                    this.completeMarshalPhase();
+
+                    this.player1.clickPrompt('Intrigue');
+                    this.player1.clickCard(this.steward);
+                    this.player1.clickPrompt('Done');
+                });
+
+                it('should reduce Jon Snow\'s strength', function() {
+                    expect(this.jon.getStrength()).toBe(3);
+                });
+            });
+        });
+    });
 });


### PR DESCRIPTION
Adds an `isDirty` flag to cards whose state has changed that might require recalculation of existing effects that target them. Examples:
* [Theon (TFoA)](https://thronesdb.com/card/06051) is attacking alone. No one with STR greater than him can contribute strength to defense. A character with greater STR that has [Dragonglass Dagger](https://thronesdb.com/card/04086) attached is declared as a defender. As soon as they become a defender, the ability for Dragonglass Dagger kicks in, making them immune to opponent abilities. Thus, the "does not contribute strength" effect from Theon needs to be deactivated for that character.
* A player with [Lord of the Crossing](https://thronesdb.com/card/02060) initiates their first challenge with a Night's Watch character while [Jon Snow (Core)](https://thronesdb.com/card/01124) is out. The -1 STR effect is immediately put on the declared character. Then, Jon Snow's ability makes him come in as a attacker. Crossing needs to then add the -1 STR to Jon as well.

Fixes #1782 
Fixes #1826 