### PR TITLE
Disallow triggering action abilities when no valid opponents

### DIFF
--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -130,7 +130,7 @@ class CardAction extends BaseAbility {
             return false;
         }
 
-        return this.canPayCosts(context) && this.canResolveTargets(context);
+        return this.canResolveOpponents(context) && this.canPayCosts(context) && this.canResolveTargets(context);
     }
 
     execute(player, arg) {


### PR DESCRIPTION
Fixes a bug where Seen in Flames could be played when no opponents had cards in hand to trigger Melisandre.

Fixes #1497.
Fixes #1791.