### PR TITLE
Handle players without plot cards

### DIFF
--- a/server/game/gamesteps/plotphase.js
+++ b/server/game/gamesteps/plotphase.js
@@ -16,7 +16,7 @@ class PlotPhase extends Phase {
             new SelectPlotPrompt(game),
             new SimpleStep(game, () => this.removeActivePlots()),
             new SimpleStep(game, () => this.flipPlotsFaceup()),
-            () => new RevealPlots(game, _.map(this.game.getPlayers(), player => player.activePlot)),
+            () => new RevealPlots(game, this.getActivePlots()),
             new SimpleStep(game, () => this.recyclePlots()),
             () => new ChooseTitlePrompt(game, game.titlePool),
             new ActionWindow(this.game, 'After plots revealed', 'plot')
@@ -59,6 +59,10 @@ class PlotPhase extends Phase {
         _.each(this.game.getPlayers(), player => {
             player.recyclePlots();
         });
+    }
+
+    getActivePlots() {
+        return this.game.getPlayers().filter(player => !!player.activePlot).map(player => player.activePlot);
     }
 }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -672,6 +672,10 @@ class Player extends Spectator {
     }
 
     flipPlotFaceup() {
+        if(!this.selectedPlot) {
+            return;
+        }
+
         this.selectedPlot.flipFaceup();
         this.moveCard(this.selectedPlot, 'active plot');
         this.selectedPlot = undefined;


### PR DESCRIPTION
Previously, if a player used /cancel-prompt to skip the plot selection
step, the game would enter an unplayable state that continually threw
errors. Now if they have no plot card selected and cancel the prompt,
the game will continue as best it can with the other players that have
selected their plot.

Fixes THRONETEKI-1J9
Fixes THRONETEKI-1M9