### PR TITLE
Fix ability limit when card leaves play as cost

### DIFF
--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -167,6 +167,14 @@ class CardAction extends BaseAbility {
         return this.card.getPrintedType() === 'event' && this.location === 'hand';
     }
 
+    incrementLimit() {
+        if(this.location !== this.card.location) {
+            return;
+        }
+
+        super.incrementLimit();
+    }
+
     hasMax() {
         return !!this.max;
     }

--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -121,6 +121,14 @@ class TriggeredAbility extends BaseAbility {
         return this.card.getPrintedType() === 'event' && this.location.includes('hand');
     }
 
+    incrementLimit() {
+        if(!this.location.includes(this.card.location)) {
+            return;
+        }
+
+        super.incrementLimit();
+    }
+
     hasMax() {
         return !!this.max;
     }

--- a/test/server/cards/10-SoD/ObaraSand.spec.js
+++ b/test/server/cards/10-SoD/ObaraSand.spec.js
@@ -1,0 +1,59 @@
+describe('Obara Sand (SoD)', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck1 = this.buildDeck('martell', [
+                'A Noble Cause',
+                'Obara Sand (SoD)', 'Arianne Martell (Core)', 'Bastard Daughter', 'Southron Messenger'
+            ]);
+            const deck2 = this.buildDeck('martell', [
+                'A Noble Cause',
+                'House Dayne Knight'
+            ]);
+
+            this.player1.selectDeck(deck1);
+            this.player2.selectDeck(deck2);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.obara = this.player1.findCardByName('Obara Sand', 'hand');
+            this.arianne = this.player1.findCardByName('Arianne Martell', 'hand');
+            this.character1 = this.player1.findCardByName('Bastard Daughter', 'hand');
+            this.character2 = this.player1.findCardByName('Southron Messenger', 'hand');
+
+            this.player1.clickCard(this.obara);
+
+            this.completeSetup();
+
+            this.player1.selectPlot('A Noble Cause');
+            this.player2.selectPlot('A Noble Cause');
+            this.selectFirstPlayer(this.player1);
+
+            this.player1.clickCard(this.arianne);
+            this.completeMarshalPhase();
+        });
+
+        describe('when Obara is used multiple times', function() {
+            beforeEach(function() {
+                // Return Obara to hand to bring in a character
+                this.player1.clickMenu(this.obara, 'Put character into play');
+                this.player1.clickCard(this.obara);
+                this.player1.clickCard(this.character1);
+
+                expect(this.character1.location).toBe('play area');
+
+                // Bring Obara back
+                this.player1.clickMenu(this.arianne, 'Put character into play');
+                this.player1.clickCard(this.obara);
+
+                // Return Obara back to hand to bring in another character
+                this.player1.clickMenu(this.obara, 'Put character into play');
+                this.player1.clickCard(this.obara);
+                this.player1.clickCard(this.character2);
+            });
+
+            it('should put the second character into play', function() {
+                expect(this.character2.location).toBe('play area');
+            });
+        });
+    });
+});


### PR DESCRIPTION
Previously, if an ability had both a cost that caused the card to leave
and a limit, the limit would be improperly incremented after the card
left play. This could cause cards like Obara Sand (SoD) to only be
usable once per phase, despite the rules saying the limit should reset
when they leave / re-enter play.

Fixes #1850 