### PR TITLE
Do not reveal strength / icons for facedown cards

### DIFF
--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -436,12 +436,11 @@ class DrawCard extends BaseCard {
 
         let baseSummary = super.getSummary(activePlayer, hideWhenFaceup);
 
-        return _.extend(baseSummary, {
+        let publicSummary = {
             attached: !!this.parent,
             attachments: this.attachments.map(attachment => {
                 return attachment.getSummary(activePlayer, hideWhenFaceup);
             }),
-            baseStrength: this.getPrintedStrength(),
             dupes: this.dupes.map(dupe => {
                 if(dupe.dupes.size() !== 0) {
                     throw new Error('A dupe should not have dupes! ' + dupe.name);
@@ -449,13 +448,21 @@ class DrawCard extends BaseCard {
 
                 return dupe.getSummary(activePlayer, hideWhenFaceup);
             }),
+            kneeled: this.kneeled,
+            power: this.power,
+            revealWhenHiddenTo: this.revealWhenHiddenTo
+        };
+
+        if(baseSummary.facedown) {
+            return Object.assign(baseSummary, publicSummary);
+        }
+
+        return Object.assign(baseSummary, publicSummary, {
+            baseStrength: this.getPrintedStrength(),
             iconsAdded: this.getIconsAdded(),
             iconsRemoved: this.getIconsRemoved(),
             inChallenge: this.inChallenge,
             inDanger: this.inDanger,
-            kneeled: this.kneeled,
-            power: this.power,
-            revealWhenHiddenTo: this.revealWhenHiddenTo,
             saved: this.saved,
             strength: this.getStrength(),
             stealth: this.stealth

--- a/test/server/card/drawcard.getsummary.spec.js
+++ b/test/server/card/drawcard.getsummary.spec.js
@@ -1,11 +1,17 @@
 const DrawCard = require('../../../server/game/drawcard.js');
 
 describe('DrawCard', function () {
+    function createPlayerSpy(name) {
+        let player = jasmine.createSpyObj('player', ['getCardSelectionState']);
+        player.name = name;
+        return player;
+    }
+
     beforeEach(function () {
         this.testCard = { code: '111', label: 'test 1(some pack)', name: 'test 1' };
         this.card = new DrawCard({}, this.testCard);
-        this.activePlayer = {};
-        this.activePlayer.name = 'bla';
+        this.activePlayer = createPlayerSpy('player1');
+        this.card.owner = this.activePlayer;
     });
 
     describe('getSummary', function() {
@@ -13,7 +19,7 @@ describe('DrawCard', function () {
             describe('when the card has non-zero strength', function() {
                 beforeEach(function() {
                     this.testCard.strength = 5;
-                    this.summary = this.card.getSummary(this.activePlayer, true);
+                    this.summary = this.card.getSummary(this.activePlayer, false);
                 });
 
                 it('should include the strength', function() {
@@ -24,12 +30,36 @@ describe('DrawCard', function () {
             describe('when the card has a zero strength', function() {
                 beforeEach(function() {
                     this.testCard.strength = 0;
-                    this.summary = this.card.getSummary(this.activePlayer, true);
+                    this.summary = this.card.getSummary(this.activePlayer, false);
                 });
 
                 it('should include the strength', function() {
                     expect(this.summary.strength).toBe(0);
                 });
+            });
+        });
+
+        describe('when a card is facedown', function() {
+            beforeEach(function() {
+                this.testCard.strength = 5;
+                let anotherPlayer = createPlayerSpy('player2');
+                this.summary = this.card.getSummary(anotherPlayer, true);
+            });
+
+            it('should not include baseStrength', function() {
+                expect(this.summary.baseStrength).toBeUndefined();
+            });
+
+            it('should not include iconsAdded', function() {
+                expect(this.summary.iconsAdded).toBeUndefined();
+            });
+
+            it('should not include iconsRemoved', function() {
+                expect(this.summary.iconsRemoved).toBeUndefined();
+            });
+
+            it('should not include strength', function() {
+                expect(this.summary.strength).toBeUndefined();
             });
         });
     });


### PR DESCRIPTION
Returning information about a card's strength and the icons while it's
facedown can make it guessable what card it may be. This is a potential
problem during setup, for cards in hand, and cards in the upcoming
Shadow zone.