### PR TITLE
Only allow Forced March to initiate twice

### DIFF
--- a/server/game/cards/10-SoD/ForcedMarch.js
+++ b/server/game/cards/10-SoD/ForcedMarch.js
@@ -6,6 +6,7 @@ class ForcedMarch extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
             handler: () => {
+                this.initiatedPostThen = false;
                 this.initiate();
             }
         });
@@ -51,7 +52,7 @@ class ForcedMarch extends PlotCard {
             card.controller.kneelCard(card);
         }
 
-        if(this.hasStandingMilIcon(this.controller) && !_.isEmpty(this.filterForOpponents())) {
+        if(this.hasStandingMilIcon(this.controller) && !_.isEmpty(this.filterForOpponents()) && !this.initiatedPostThen) {
             this.game.promptForSelect(this.controller, {
                 source: this,
                 gameAction: 'kneel',
@@ -66,6 +67,7 @@ class ForcedMarch extends PlotCard {
         player.kneelCard(card);
         this.game.addMessage('{0} then kneels {1} to initiate the effect of {2} again', player, card, this);
         this.initiate();
+        this.initiatedPostThen = true;
         return true;
     }
 


### PR DESCRIPTION
The post-then effect of Forced March reads as "initiate this effect
again." The "this effect" refers to the pre-then effect, not to the
ability as a whole. This means initiating the post-then effect does not
lead to another instance of the "then", and thus you can only initiate
the effect a total of two times.

See: https://thronesdb.com/card/10048#review-441