### PR TITLE
Remove the scheme plots pile

### DIFF
--- a/client/Components/GameBoard/Card.jsx
+++ b/client/Components/GameBoard/Card.jsx
@@ -308,7 +308,7 @@ class Card extends React.Component {
 
     render() {
         if(this.props.wrapped) {
-            return this.props.connectDragSource(
+            return (
                 <div className='card-wrapper' style={ this.props.style }>
                     { this.getCard() }
                     { this.getDupes() }
@@ -362,7 +362,7 @@ Card.propTypes = {
     orientation: PropTypes.oneOf(['horizontal', 'kneeled', 'vertical']),
     size: PropTypes.string,
     source: PropTypes.oneOf(['hand', 'discard pile', 'play area', 'dead pile', 'draw deck', 'plot deck', 'revealed plots', 'selected plot', 'attachment', 'agenda', 'faction',
-        'additional', 'scheme plots', 'conclave']).isRequired,
+        'additional', 'conclave']).isRequired,
     style: PropTypes.object,
     wrapped: PropTypes.bool
 };

--- a/client/Components/GameBoard/CardPile.jsx
+++ b/client/Components/GameBoard/CardPile.jsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import _ from 'underscore';
 
 import Card from './Card';
+import CardTiledList from './CardTiledList';
 import Droppable from './Droppable';
 
 class CardPile extends React.Component {
@@ -95,45 +96,32 @@ class CardPile extends React.Component {
         }
     }
 
-    getCardList(cards) {
-        let cardIndex = 0;
-
-        if(!cards) {
-            return null;
-        }
-
-        let cardList = cards.map(card => {
-            let cardKey = card.uuid || cardIndex++;
-            return (<Card key={ cardKey } card={ card } source={ this.props.source }
-                disableMouseOver={ this.props.disableMouseOver }
-                onMouseOver={ this.props.onMouseOver }
-                onMouseOut={ this.props.onMouseOut }
-                onTouchMove={ this.props.onTouchMove }
-                onClick={ this.onCardClick.bind(this, card) }
-                orientation={ this.props.orientation === 'kneeled' ? 'vertical' : this.props.orientation }
-                size={ this.props.size } />);
-        });
-
-        return cardList;
-    }
-
     getPopup() {
         let popup = null;
 
         let cardList = [];
 
+        let listProps = {
+            disableMouseOver: this.props.disableMouseOver,
+            onCardClick: this.onCardClick.bind(this),
+            onCardMouseOut: this.props.onMouseOut,
+            onCardMouseOver: this.props.onMouseOver,
+            onTouchMove: this.props.onTouchMove,
+            orientation: this.props.orientation,
+            size: this.props.size,
+            source: this.props.source
+        };
+
         if(this.props.cards && this.props.cards.some(card => card.group)) {
             let cardGroup = _.groupBy(this.props.cards, card => card.group);
             for(const [type, cards] of Object.entries(cardGroup)) {
                 cardList.push(
-                    <div key={ type }>
-                        <div className='group-title'>{ `${type} (${cards.length})` }</div>
-                        { this.getCardList(cards) }
-                    </div>
+                    <CardTiledList cards={ cards } key={ type } title={ type } { ...listProps } />
                 );
             }
         } else {
-            cardList = this.getCardList(this.props.cards);
+            cardList = (
+                <CardTiledList cards={ this.props.cards } { ...listProps } />);
         }
 
         if(this.props.disablePopup || !this.state.showPopup) {
@@ -148,6 +136,7 @@ class CardPile extends React.Component {
             'up': this.props.popupLocation !== 'top' && this.props.orientation !== 'horizontal',
             'left': this.props.orientation === 'horizontal'
         });
+        let innerClass = classNames('inner', this.props.size);
 
         let linkIndex = 0;
 
@@ -166,7 +155,7 @@ class CardPile extends React.Component {
                 <Droppable onDragDrop={ this.props.onDragDrop } source={ this.props.source }>
                     <div className={ popupClass } onClick={ event => event.stopPropagation() }>
                         { popupMenu }
-                        <div className='inner'>
+                        <div className={ innerClass }>
                             { cardList }
                         </div>
                         <div className={ arrowClass } />

--- a/client/Components/GameBoard/CardTiledList.jsx
+++ b/client/Components/GameBoard/CardTiledList.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Card from './Card';
+
+function CardTiledList(props) {
+    let cardList = props.cards && props.cards.map((card, index) => {
+        return (<Card
+            card={ card }
+            disableMouseOver={ props.disableMouseOver }
+            key={ index }
+            onClick={ props.onCardClick }
+            onMouseOut={ props.onCardMouseOut }
+            onMouseOver={ props.onCardMouseOver }
+            onTouchMove={ props.onTouchMove }
+            orientation={ props.orientation }
+            size={ props.size }
+            source={ props.source } />);
+    });
+
+    let title = props.title && props.cards ? `${props.title} (${props.cards.length})` : props.title;
+
+    return (
+        <div className='card-list'>
+            { title &&
+                <div className='card-list-title'>{ title }</div>
+            }
+            <div className='card-list-cards'>
+                { cardList }
+            </div>
+        </div>);
+}
+
+CardTiledList.propTypes = {
+    cards: PropTypes.array,
+    disableMouseOver: PropTypes.bool,
+    onCardClick: PropTypes.func,
+    onCardMouseOut: PropTypes.func,
+    onCardMouseOver: PropTypes.func,
+    onTouchMove: PropTypes.func,
+    orientation: PropTypes.string,
+    size: PropTypes.string,
+    source: PropTypes.string,
+    title: PropTypes.string
+};
+
+export default CardTiledList;

--- a/client/Components/GameBoard/Droppable.jsx
+++ b/client/Components/GameBoard/Droppable.jsx
@@ -48,18 +48,15 @@ const validTargets = {
     ],
     'plot deck': [
         'revealed plots',
-        'scheme plots',
         'out of game'
     ],
     'revealed plots': [
         'plot deck',
-        'scheme plots',
         'out of game'
     ],
     'out of game': [
         'plot deck',
         'revealed plots',
-        'scheme plots',
         'draw deck',
         'play area',
         'discard pile',

--- a/client/Components/GameBoard/GameBoard.jsx
+++ b/client/Components/GameBoard/GameBoard.jsx
@@ -7,6 +7,7 @@ import { toastr } from 'react-redux-toastr';
 import { bindActionCreators } from 'redux';
 import { DragDropContext } from 'react-dnd';
 import { default as TouchBackend } from 'react-dnd-touch-backend';
+import classNames from 'classnames';
 
 import PlayerStats from './PlayerStats';
 import PlayerRow from './PlayerRow';
@@ -86,12 +87,6 @@ export class GameBoard extends React.Component {
             this.setState({ spectating: false });
         } else {
             this.setState({ spectating: true });
-        }
-
-        if(thisPlayer && thisPlayer.selectCard) {
-            $('body').addClass('select-cursor');
-        } else {
-            $('body').removeClass('select-cursor');
         }
 
         let menuOptions = [
@@ -226,8 +221,7 @@ export class GameBoard extends React.Component {
                 isMe={ false }
                 plotDeck={ otherPlayer.cardPiles.plotDeck }
                 plotDiscard={ otherPlayer.cardPiles.plotDiscard }
-                plotSelected={ otherPlayer.plotSelected }
-                schemePlots={ otherPlayer.cardPiles.schemePlots } />
+                plotSelected={ otherPlayer.plotSelected } />
             <PlayerPlots
                 { ...commonProps }
                 activePlot={ thisPlayer.activePlot }
@@ -236,8 +230,7 @@ export class GameBoard extends React.Component {
                 isMe
                 plotDeck={ thisPlayer.cardPiles.plotDeck }
                 plotDiscard={ thisPlayer.cardPiles.plotDiscard }
-                plotSelected={ thisPlayer.plotSelected }
-                schemePlots={ thisPlayer.cardPiles.schemePlots } />
+                plotSelected={ thisPlayer.plotSelected } />
         </div>);
     }
 
@@ -296,8 +289,12 @@ export class GameBoard extends React.Component {
 
         let boundActionCreators = bindActionCreators(actions, this.props.dispatch);
 
+        let boardClass = classNames('game-board', {
+            'select-cursor': thisPlayer && thisPlayer.selectCard
+        });
+
         return (
-            <div className='game-board'>
+            <div className={ boardClass }>
                 <GameConfigurationModal
                     id='settings-modal'
                     keywordSettings={ thisPlayer.keywordSettings }

--- a/client/Components/GameBoard/PlayerPlots.jsx
+++ b/client/Components/GameBoard/PlayerPlots.jsx
@@ -6,38 +6,6 @@ import CardPile from './CardPile';
 import Droppable from './Droppable';
 
 class PlayerPlots extends React.Component {
-    renderSchemePile() {
-        if(!this.props.agenda || this.props.agenda.code !== '05045') {
-            return;
-        }
-
-        let schemePlots = (<CardPile
-            cards={ this.props.schemePlots }
-            className='plot'
-            closeOnClick={ this.props.isMe }
-            hiddenTopCard
-            onDragDrop={ this.props.onDragDrop }
-            disablePopup={ !this.props.isMe }
-            onCardClick={ this.props.onCardClick }
-            onMenuItemClick={ this.props.onMenuItemClick }
-            onMouseOut={ this.props.onCardMouseOut }
-            onMouseOver={ this.props.onCardMouseOver }
-            orientation='horizontal'
-            source='scheme plots'
-            title='Schemes'
-            topCard={ { facedown: true, kneeled: true } }
-            size={ this.props.cardSize } />);
-
-        if(this.props.isMe) {
-            return (<Droppable onDragDrop={ this.props.onDragDrop } source='scheme plots'>
-                { schemePlots }
-            </Droppable>);
-
-        }
-
-        return schemePlots;
-    }
-
     renderPlotPiles() {
         let revealedPlots = (<CardPile
             key='activeplot'
@@ -79,8 +47,7 @@ class PlayerPlots extends React.Component {
             this.props.isMe ?
                 <Droppable key='plotdeck' onDragDrop={ this.props.onDragDrop } source='plot deck'>
                     { plotDeck }
-                </Droppable> : plotDeck,
-            this.renderSchemePile()
+                </Droppable> : plotDeck
         ];
 
         if(this.props.direction === 'reverse') {
@@ -116,8 +83,7 @@ PlayerPlots.propTypes = {
     onMenuItemClick: PropTypes.func,
     plotDeck: PropTypes.array,
     plotDiscard: PropTypes.array,
-    plotSelected: PropTypes.bool,
-    schemePlots: PropTypes.array
+    plotSelected: PropTypes.bool
 };
 
 export default PlayerPlots;

--- a/client/Components/GameBoard/PlayerRow.jsx
+++ b/client/Components/GameBoard/PlayerRow.jsx
@@ -109,7 +109,9 @@ class PlayerRow extends React.Component {
 
         disablePopup = disablePopup || !cards || cards.length === 0;
 
-        let pile = (<CardPile className='agenda'
+        let pileClass = classNames('agenda', `agenda-${this.props.agenda.code}`);
+
+        let pile = (<CardPile className={ pileClass }
             cards={ cards }
             disablePopup={ disablePopup }
             onCardClick={ this.props.onCardClick }

--- a/less/gameboard.less
+++ b/less/gameboard.less
@@ -296,10 +296,63 @@
   }
 }
 
-.inner {
-  .card-wrapper {
-    margin: 5px 5px 0 0;
+/**
+ * Generates the specified property based on the calculation of:
+ * property: numCards * (cardSize + cardSpacing) + additionalOffset
+ *
+ * for the various different card sizes. Example, mixing in
+ * .calculate-tiled-card-prop(min-height, 2, height, 3px) will generate CSS for:
+ * min-height: 2 * (@card-height + 5px) + 3px
+ * &.small {
+ *   min-height: 2 * (@card-sm-height + 5px) + 3px
+ * }
+ * ... etc ...
+ */
+ .calculate-tiled-card-prop(@property, @numCards, @cardMeasurement, @additionalOffset: 0px) {
+  @cardMeasurementNm: "card-@{cardMeasurement}";
+  @cardMeasurementSm: "card-sm-@{cardMeasurement}";
+  @cardMeasurementLg: "card-lg-@{cardMeasurement}";
+  @cardMeasurementXl: "card-xl-@{cardMeasurement}";
+
+
+  @{property}: @numCards * (@@cardMeasurementNm + 5px) + @additionalOffset;
+
+  &.small {
+    @{property}: @numCards * (@@cardMeasurementSm + 5px) + @additionalOffset;
   }
+
+  &.large {
+    @{property}: @numCards * (@@cardMeasurementLg + 5px) + @additionalOffset;
+  };
+
+  &.x-large {
+    @{property}: @numCards * (@@cardMeasurementXl + 5px) + @additionalOffset;
+  };
+}
+
+.inner {
+  .calculate-tiled-card-prop(max-height, 4, height);
+  overflow-y: auto;
+}
+
+.card-list {
+  .card-wrapper {
+    margin: 0 5px 5px 0;
+  }
+}
+
+.card-list-title {
+  background-color: @brand-primary;
+  color: white;
+  margin-bottom: 5px;
+  text-align: center;
+}
+
+.card-list-cards {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start;
 }
 
 .our-side {
@@ -373,8 +426,8 @@
     left: 20px;
 
     .inner {
-      min-width: @card-height * 2 + (2 * 5px);
-      min-height: @card-width * 2 + (2 * 5px);
+      .calculate-tiled-card-prop(min-height, 2, width);
+      .calculate-tiled-card-prop(min-width, 2, height, @scrollbar-width);
     }
 
     .arrow {
@@ -395,12 +448,8 @@
     top: -75px;
 
     .inner {
-      columns: 3;
-      min-height: 128px;
-
-      .card-wrapper {
-        margin: 5px 0 0 0;
-      }
+      .calculate-tiled-card-prop(min-height, 1, width);
+      .calculate-tiled-card-prop(width, 4, height);
     }
 
     .arrow {
@@ -419,10 +468,8 @@
     top: 95px;
 
     .inner {
-      min-height: @card-height;
-      width: @card-width * 5 + (5 * 5px) + @scrollbar-width;
-      max-height: @card-height * 4 + (4 * 5px);
-      overflow-y: auto;
+      .calculate-tiled-card-prop(min-height, 1, height);
+      .calculate-tiled-card-prop(width, 5, width, @scrollbar-width);
     }
 
     .arrow {
@@ -440,10 +487,8 @@
     left: 0;
 
     .inner {
-      min-height: @card-height;
-      width: @card-width * 5 + (5 * 5px) + @scrollbar-width;
-      max-height: @card-height * 4 + (4 * 5px);
-      overflow-y: auto;
+      .calculate-tiled-card-prop(min-height, 1, height);
+      .calculate-tiled-card-prop(width, 5, width, @scrollbar-width);
     }
 
     .arrow {
@@ -467,11 +512,8 @@
     bottom: 95px;
 
     .inner {
-      width: @card-width * 7 + (7 * 5px) + @scrollbar-width;
-      min-height: @card-height;
-      max-height: @card-height * 4 + (4 * 5px);
-
-      overflow-y: auto;
+      .calculate-tiled-card-prop(min-height, 1, height);
+      .calculate-tiled-card-prop(width, 7, width, @scrollbar-width);
     }
   }
 
@@ -487,17 +529,25 @@
     top: 95px;
     left: 0;
 
-    .inner {
-      min-width: @card-width * 2 + (2 * 5px);
-      max-height: @card-height + 10px;
-      display: flex;
-    }
-
     .arrow {
       bottom: initial;
       top: -60px;
       left: 10px;
     }
+  }
+}
+
+// Alliance agenda
+.agenda-06018 {
+  .inner {
+    .calculate-tiled-card-prop(width, 2, width);
+  }
+}
+
+// Conclave agenda
+.agenda-09045 {
+  .inner {
+    .calculate-tiled-card-prop(width, 7, width);
   }
 }
 
@@ -799,10 +849,4 @@ span.down-arrow {
     margin-top: 10px;
     margin-bottom: 10px;
   }
-}
-
-.group-title {
-  background-color: @brand-primary;
-  text-align: center;
-  color: white;
 }

--- a/less/gameboard.less
+++ b/less/gameboard.less
@@ -9,6 +9,10 @@
   justify-content: space-between;
   flex-direction: column;
 
+  &.select-cursor {
+    cursor: url(/img/crosshairs.cur), default;
+  }
+
   .panel {
     position: relative;
     margin: 5px;
@@ -141,10 +145,6 @@
   .panel-title {
     margin: 5px 5px;
   }
-}
-
-.select-cursor {
-  cursor: url(/img/crosshairs.cur), default;
 }
 
 .prompt-area {
@@ -395,7 +395,7 @@
     top: -75px;
 
     .inner {
-      columns: 2;
+      columns: 3;
       min-height: 128px;
 
       .card-wrapper {
@@ -629,7 +629,7 @@ span.down-arrow {
   .drop-target {
     flex: 1;
   }
-  
+
   display: flex;
   flex: 1;
   flex-direction: column;
@@ -799,4 +799,10 @@ span.down-arrow {
     margin-top: 10px;
     margin-bottom: 10px;
   }
+}
+
+.group-title {
+  background-color: @brand-primary;
+  text-align: center;
+  color: white;
 }

--- a/server/game/cards/08.2-JtO/ChangeOfPlans.js
+++ b/server/game/cards/08.2-JtO/ChangeOfPlans.js
@@ -9,7 +9,7 @@ class ChangeOfPlans extends DrawCard {
             target: {
                 type: 'select',
                 activePromptTitle: 'Select a plot',
-                cardCondition: card => ['plot deck', 'scheme plots'].includes(card.location) && card.controller === this.controller,
+                cardCondition: card => card.location === 'plot deck' && card.controller === this.controller,
                 cardType: 'plot'
             },
             handler: context => {

--- a/server/game/cards/08.6-SAT/TheCrowIsATricksyBird.js
+++ b/server/game/cards/08.6-SAT/TheCrowIsATricksyBird.js
@@ -11,7 +11,7 @@ class TheCrowIsATricksyBird extends DrawCard {
                 this.context = context;
                 this.game.addMessage('{0} plays {1} and kneels their faction card to look at {2}\'s plot deck',
                     context.player, this, context.opponent);
-                
+
                 let buttons = context.opponent.plotDeck.map(card => {
                     return { method: 'cardSelected', card: card };
                 });
@@ -40,10 +40,10 @@ class TheCrowIsATricksyBird extends DrawCard {
             },
             targetType: player,
             match: this.context.opponent,
-            effect: ability.effects.mustRevealPlot(card)
+            effect: ability.effects.cannotRevealPlot(plot => plot !== card)
         }));
- 
-        //TODO Melee: The choice should not be revealed to anyone other than the chosen opponent, 
+
+        //TODO Melee: The choice should not be revealed to anyone other than the chosen opponent,
         //so this message, as well as the announcement message in the plot phase will have to be whispered.
         this.game.addMessage('{0} uses {1} to force {2} to reveal {3} the next time they reveal a plot, if able',
             player, this, this.context.opponent, card);

--- a/server/game/cards/08.6-SAT/TheCrowIsATricksyBird.js
+++ b/server/game/cards/08.6-SAT/TheCrowIsATricksyBird.js
@@ -12,7 +12,8 @@ class TheCrowIsATricksyBird extends DrawCard {
                 this.game.addMessage('{0} plays {1} and kneels their faction card to look at {2}\'s plot deck',
                     context.player, this, context.opponent);
 
-                let buttons = context.opponent.plotDeck.map(card => {
+                let validPlots = context.opponent.plotDeck.filter(plot => !plot.notConsideredToBeInPlotDeck);
+                let buttons = validPlots.map(card => {
                     return { method: 'cardSelected', card: card };
                 });
 
@@ -40,7 +41,7 @@ class TheCrowIsATricksyBird extends DrawCard {
             },
             targetType: player,
             match: this.context.opponent,
-            effect: ability.effects.cannotRevealPlot(plot => plot !== card)
+            effect: ability.effects.mustRevealPlot(card)
         }));
 
         //TODO Melee: The choice should not be revealed to anyone other than the chosen opponent,

--- a/server/game/cards/10-SoD/AtPrinceDoransBehest.js
+++ b/server/game/cards/10-SoD/AtPrinceDoransBehest.js
@@ -10,7 +10,7 @@ class AtPrinceDoransBehest extends PlotCard {
             cannotBeCanceled: true,
             target: {
                 activePromptTitle: 'Select a plot',
-                cardCondition: card => card.controller === this.controller,
+                cardCondition: card => card.controller === this.controller && !card.notConsideredToBeInPlotDeck,
                 cardType: 'plot'
             },
             handler: context => {

--- a/server/game/cards/10-SoD/AtPrinceDoransBehest.js
+++ b/server/game/cards/10-SoD/AtPrinceDoransBehest.js
@@ -15,7 +15,7 @@ class AtPrinceDoransBehest extends PlotCard {
             },
             handler: context => {
                 this.game.addMessage('{0} uses {1} to reveal {2}', context.player, this, context.target);
-        
+
                 context.player.selectedPlot = context.target;
                 context.player.removeActivePlot();
                 context.player.flipPlotFaceup();
@@ -25,7 +25,8 @@ class AtPrinceDoransBehest extends PlotCard {
     }
 
     getPlotSourceForPhase(card) {
-        return (this.game.currentPhase !== 'plot') ? 
+        /// XXX needs to be updated to use cannot select schemes flag
+        return (this.game.currentPhase !== 'plot') ?
             ['plot deck', 'scheme plots'].includes(card.location) :
             card.location === 'plot deck';
     }

--- a/server/game/cards/10-SoD/AtPrinceDoransBehest.js
+++ b/server/game/cards/10-SoD/AtPrinceDoransBehest.js
@@ -10,7 +10,7 @@ class AtPrinceDoransBehest extends PlotCard {
             cannotBeCanceled: true,
             target: {
                 activePromptTitle: 'Select a plot',
-                cardCondition: card => card.controller === this.controller && this.checkPlotForPhase(card),
+                cardCondition: card => card.controller === this.controller,
                 cardType: 'plot'
             },
             handler: context => {
@@ -22,12 +22,6 @@ class AtPrinceDoransBehest extends PlotCard {
                 this.game.queueStep(new RevealPlots(this.game, [context.target]));
             }
         });
-    }
-
-    checkPlotForPhase(card) {
-        return (this.game.currentPhase !== 'plot') ?
-            card.location === 'plot deck' :
-            card.location === 'plot deck' && !card.hasTrait('scheme');
     }
 }
 

--- a/server/game/cards/10-SoD/AtPrinceDoransBehest.js
+++ b/server/game/cards/10-SoD/AtPrinceDoransBehest.js
@@ -10,7 +10,7 @@ class AtPrinceDoransBehest extends PlotCard {
             cannotBeCanceled: true,
             target: {
                 activePromptTitle: 'Select a plot',
-                cardCondition: card => card.controller === this.controller && this.getPlotSourceForPhase(card),
+                cardCondition: card => card.controller === this.controller && this.checkPlotForPhase(card),
                 cardType: 'plot'
             },
             handler: context => {
@@ -24,11 +24,10 @@ class AtPrinceDoransBehest extends PlotCard {
         });
     }
 
-    getPlotSourceForPhase(card) {
-        /// XXX needs to be updated to use cannot select schemes flag
+    checkPlotForPhase(card) {
         return (this.game.currentPhase !== 'plot') ?
-            ['plot deck', 'scheme plots'].includes(card.location) :
-            card.location === 'plot deck';
+            card.location === 'plot deck' :
+            card.location === 'plot deck' && !card.hasTrait('scheme');
     }
 }
 

--- a/server/game/cards/agendas/TheRainsOfCastamere.js
+++ b/server/game/cards/agendas/TheRainsOfCastamere.js
@@ -2,6 +2,12 @@ const AgendaCard = require('../../agendacard');
 const RevealPlots = require('../../gamesteps/revealplots');
 
 class TheRainsOfCastamere extends AgendaCard {
+    constructor(owner, cardData) {
+        super(owner, cardData);
+
+        this.registerEvents(['onPlotDiscarded']);
+    }
+
     setupCardAbilities(ability) {
         this.reaction({
             when: {
@@ -49,6 +55,12 @@ class TheRainsOfCastamere extends AgendaCard {
         context.player.removeActivePlot();
         context.player.flipPlotFaceup();
         this.game.queueStep(new RevealPlots(this.game, [context.target]));
+    }
+
+    onPlotDiscarded(event) {
+        if(event.card.controller === this.controller && event.card.hasTrait('Scheme')) {
+            this.owner.moveCard(event.card, 'out of game');
+        }
     }
 }
 

--- a/server/game/cards/agendas/TheRainsOfCastamere.js
+++ b/server/game/cards/agendas/TheRainsOfCastamere.js
@@ -40,8 +40,9 @@ class TheRainsOfCastamere extends AgendaCard {
         this.persistentEffect({
             targetType: 'player',
             targetController: 'current',
+            condition: () => this.game.currentPhase === 'plot',
             effect: [
-                ability.effects.cannotSelectSchemes(),
+                ability.effects.cannotRevealPlot(plot => plot.hasTrait('Scheme')),
                 ability.effects.groupCardPile('plot deck')
             ]
         });

--- a/server/game/cards/agendas/TheRainsOfCastamere.js
+++ b/server/game/cards/agendas/TheRainsOfCastamere.js
@@ -12,8 +12,8 @@ class TheRainsOfCastamere extends AgendaCard {
         this.reaction({
             when: {
                 afterChallenge: event => event.challenge.challengeType === 'intrigue' &&
-                                         event.challenge.winner === this.owner &&
-                                         event.challenge.strengthDifference >= 5
+                    event.challenge.winner === this.owner &&
+                    event.challenge.strengthDifference >= 5
             },
             cost: ability.costs.kneelFactionCard(),
             target: {
@@ -38,13 +38,11 @@ class TheRainsOfCastamere extends AgendaCard {
         });
 
         this.persistentEffect({
-            targetType: 'player',
-            targetController: 'current',
             condition: () => this.game.currentPhase === 'plot',
-            effect: [
-                ability.effects.cannotRevealPlot(plot => plot.hasTrait('Scheme')),
-                ability.effects.groupCardPile('plot deck')
-            ]
+            match: card => card.getType() === 'plot' && card.hasTrait('Scheme'),
+            targetController: 'current',
+            targetLocation: 'plot deck',
+            effect: ability.effects.notConsideredToBeInPlotDeck()
         });
     }
 

--- a/server/game/effectengine.js
+++ b/server/game/effectengine.js
@@ -33,7 +33,7 @@ class EffectEngine {
     }
 
     getTargets() {
-        const validLocations = ['active plot', 'being played', 'dead pile', 'discard pile', 'draw deck', 'hand', 'play area', 'duplicate'];
+        const validLocations = ['active plot', 'being played', 'dead pile', 'discard pile', 'draw deck', 'hand', 'play area', 'duplicate', 'plot deck'];
         let validTargets = this.game.allCards.filter(card => validLocations.includes(card.location));
         return validTargets.concat(this.game.getPlayers()).concat([this.game]);
     }
@@ -132,7 +132,7 @@ class EffectEngine {
     }
 
     onCardBlankToggled(event) {
-        let {card, isBlank} = event;
+        let { card, isBlank } = event;
         let targets = this.getTargets();
         let matchingEffects = _.filter(this.effects, effect => effect.duration === 'persistent' && effect.source === card);
         _.each(matchingEffects, effect => {

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -1141,6 +1141,26 @@ const Effects = {
                 game.skipPhase[name] = false;
             }
         };
+    },
+    cannotSelectSchemes: function() {
+        return {
+            apply: function(player) {
+                player.cannotSelectSchemes = true;
+            },
+            unapply: function(player) {
+                player.cannotSelectSchemes = false;
+            }
+        };
+    },
+    groupCardPile: function(pile) {
+        return {
+            apply: function(player) {
+                player.groupedPiles[pile] = true;
+            },
+            unapply: function(player) {
+                player.groupedPiles[pile] = false;
+            }
+        };
     }
 };
 

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -1132,23 +1132,23 @@ const Effects = {
             }
         };
     },
-    cannotRevealPlot: function(restriction = () => true) {
+    notConsideredToBeInPlotDeck: function() {
         return {
-            apply: function(player) {
-                player.plotRevealRestrictions.push(restriction);
+            apply: function(card) {
+                card.notConsideredToBeInPlotDeck = true;
             },
-            unapply: function(player) {
-                player.plotRevealRestrictions = _.reject(player.plotRevealRestrictions, r => r === restriction);
+            unapply: function(card) {
+                card.notConsideredToBeInPlotDeck = false;
             }
         };
     },
-    groupCardPile: function(pile) {
+    mustRevealPlot: function(card) {
         return {
             apply: function(player) {
-                player.groupedPiles[pile] = true;
+                player.mustRevealPlot = card;
             },
             unapply: function(player) {
-                player.groupedPiles[pile] = false;
+                player.mustRevealPlot = undefined;
             }
         };
     }

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -1122,16 +1122,6 @@ const Effects = {
             }
         };
     },
-    mustRevealPlot: function(card) {
-        return {
-            apply: function(player) {
-                player.mustRevealPlot = card;
-            },
-            unapply: function(player) {
-                player.mustRevealPlot = undefined;
-            }
-        };
-    },
     skipPhase: function(name) {
         return {
             apply: function(game) {
@@ -1142,13 +1132,13 @@ const Effects = {
             }
         };
     },
-    cannotSelectSchemes: function() {
+    cannotRevealPlot: function(restriction = () => true) {
         return {
             apply: function(player) {
-                player.cannotSelectSchemes = true;
+                player.plotRevealRestrictions.push(restriction);
             },
             unapply: function(player) {
-                player.cannotSelectSchemes = false;
+                player.plotRevealRestrictions = _.reject(player.plotRevealRestrictions, r => r === restriction);
             }
         };
     },

--- a/server/game/gamesteps/plot/selectplotprompt.js
+++ b/server/game/gamesteps/plot/selectplotprompt.js
@@ -2,9 +2,13 @@ const AllPlayerPrompt = require('../allplayerprompt.js');
 
 class SelectPlotPrompt extends AllPlayerPrompt {
     completionCondition(player) {
-        let selectableCards = player.getSelectableCards();
-        if(selectableCards.length === 1) {
-            player.selectedPlot = selectableCards[0];
+        if(player.mustRevealPlot) {
+            player.selectedPlot = player.mustRevealPlot;
+        } else {
+            let selectableCards = player.getSelectableCards();
+            if(selectableCards.length === 1) {
+                player.selectedPlot = selectableCards[0];
+            }
         }
 
         return !!player.selectedPlot;
@@ -59,9 +63,9 @@ class SelectPlotPrompt extends AllPlayerPrompt {
 
     highlightSelectableCards(player) {
         let selectableCards = this.game.allCards.filter(card => card.getType() === 'plot' &&
-                                                                card.location === 'plot deck' &&
-                                                                card.controller === player &&
-                                                                !player.plotRevealRestrictions.some(restriction => restriction(card)));
+            card.location === 'plot deck' &&
+            card.controller === player &&
+            !card.notConsideredToBeInPlotDeck);
 
         player.selectCard = true;
         player.setSelectableCards(selectableCards);

--- a/server/game/gamesteps/plot/selectplotprompt.js
+++ b/server/game/gamesteps/plot/selectplotprompt.js
@@ -2,8 +2,9 @@ const AllPlayerPrompt = require('../allplayerprompt.js');
 
 class SelectPlotPrompt extends AllPlayerPrompt {
     completionCondition(player) {
-        if(player.mustRevealPlot) {
-            player.selectedPlot = player.mustRevealPlot;
+        let selectableCards = player.getSelectableCards();
+        if(selectableCards.length === 1) {
+            player.selectedPlot = selectableCards[0];
         }
 
         return !!player.selectedPlot;
@@ -60,7 +61,7 @@ class SelectPlotPrompt extends AllPlayerPrompt {
         let selectableCards = this.game.allCards.filter(card => card.getType() === 'plot' &&
                                                                 card.location === 'plot deck' &&
                                                                 card.controller === player &&
-                                                                (player.cannotSelectSchemes && !card.hasTrait('scheme')));
+                                                                !player.plotRevealRestrictions.some(restriction => restriction(card)));
 
         player.selectCard = true;
         player.setSelectableCards(selectableCards);

--- a/server/game/gamesteps/plot/selectplotprompt.js
+++ b/server/game/gamesteps/plot/selectplotprompt.js
@@ -14,7 +14,8 @@ class SelectPlotPrompt extends AllPlayerPrompt {
             menuTitle: 'Select a plot',
             buttons: [
                 { arg: 'plotselected', text: 'Done' }
-            ]
+            ],
+            selectCard: true
         };
     }
 
@@ -50,8 +51,29 @@ class SelectPlotPrompt extends AllPlayerPrompt {
         }
 
         player.selectedPlot = plot;
+        player.clearSelectableCards();
 
         this.game.addMessage('{0} has selected a plot', player);
+    }
+
+    highlightSelectableCards(player) {
+        let selectableCards = this.game.allCards.filter(card => card.getType() === 'plot' &&
+                                                                card.location === 'plot deck' &&
+                                                                card.controller === player &&
+                                                                (player.cannotSelectSchemes && !card.hasTrait('scheme')));
+
+        player.selectCard = true;
+        player.setSelectableCards(selectableCards);
+    }
+
+    continue() {
+        for(let player of this.game.getPlayers()) {
+            if(!this.completionCondition(player)) {
+                this.highlightSelectableCards(player);
+            }
+        }
+
+        return super.continue();
     }
 }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -62,6 +62,7 @@ class Player extends Spectator {
         this.abilityMaxByTitle = {};
         this.standPhaseRestrictions = [];
         this.mustChooseAsClaim = [];
+        this.plotRevealRestrictions = [];
         this.mustRevealPlot = undefined;
         this.promptedActionWindows = user.promptedActionWindows;
         this.timerSettings = user.settings.timerSettings || {};
@@ -682,7 +683,7 @@ class Player extends Spectator {
     }
 
     recyclePlots() {
-        if(this.plotDeck.isEmpty()) {
+        if(this.plotDeck.isEmpty() || (this.groupedPiles['plot deck'] && this.plotDeck.all(plot => plot.hasTrait('Scheme')))) {
             this.plotDiscard.each(plot => {
                 this.moveCard(plot, 'plot deck');
             });
@@ -1228,6 +1229,10 @@ class Player extends Spectator {
 
     clearSelectedCards() {
         this.promptState.clearSelectedCards();
+    }
+
+    getSelectableCards() {
+        return this.promptState.selectableCards;
     }
 
     setSelectableCards(cards) {

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -683,7 +683,8 @@ class Player extends Spectator {
     }
 
     recyclePlots() {
-        if(this.plotDeck.isEmpty() || (this.groupedPiles['plot deck'] && this.plotDeck.all(plot => plot.hasTrait('Scheme')))) {
+        const plots = this.plotDeck.filter(plot => !plot.notConsideredToBeInPlotDeck);
+        if(plots.length === 0) {
             this.plotDiscard.each(plot => {
                 this.moveCard(plot, 'plot deck');
             });
@@ -1289,7 +1290,8 @@ class Player extends Spectator {
 
         let plots = [];
 
-        if(this.groupedPiles['plot deck']) {
+        // Rains
+        if(this.agenda && this.agenda.code === '05045') {
             for(const plot of this.plotDeck.value()) {
                 let plotSummary = plot.getSummary(activePlayer, true);
                 if(plot.hasTrait('scheme')) {

--- a/test/server/cards/01-Core/AryaStark.spec.js
+++ b/test/server/cards/01-Core/AryaStark.spec.js
@@ -10,8 +10,7 @@ describe('Arya Stark (Core)', function() {
             this.startGame();
             this.keepStartingHands();
             this.completeSetup();
-            this.player1.selectPlot('Trading with the Pentoshi');
-            this.player2.selectPlot('Trading with the Pentoshi');
+
             this.selectFirstPlayer(this.player1);
             this.selectPlotOrder(this.player1);
 

--- a/test/server/cards/01-Core/BenjenStark.spec.js
+++ b/test/server/cards/01-Core/BenjenStark.spec.js
@@ -16,8 +16,6 @@ describe('Benjen Stark', function() {
             this.player1.clickCard('Benjen Stark', 'hand');
             this.player2.clickCard('Summer', 'hand');
             this.completeSetup();
-            this.player1.selectPlot('A Feast for Crows');
-            this.player2.selectPlot('A Feast for Crows');
             this.selectFirstPlayer(this.player2);
 
             this.benjen = this.player1.findCardByName('Benjen Stark', 'play area');

--- a/test/server/cards/01-Core/BranStark.spec.js
+++ b/test/server/cards/01-Core/BranStark.spec.js
@@ -18,8 +18,6 @@ describe('Bran Stark (Core)', function() {
             this.player1.clickCard('Bran Stark', 'hand');
             this.player2.clickCard('Melisandre (Core)', 'hand');
             this.completeSetup();
-            this.player1.selectPlot('Sneak Attack');
-            this.player2.selectPlot('A Feast for Crows');
             this.selectFirstPlayer(this.player2);
 
             this.bran = this.player1.findCardByName('Bran Stark', 'play area');
@@ -41,14 +39,14 @@ describe('Bran Stark (Core)', function() {
 
             it('should sacrifice bran', function() {
                 this.player1.clickPrompt('Bran Stark');
-                
+
                 expect(this.bran.location).toBe('discard pile');
             });
 
             it('should still discard the event', function() {
                 this.player1.clickPrompt('Bran Stark');
-                
-                expect(this.seenInFlames.location).toBe('discard pile');                
+
+                expect(this.seenInFlames.location).toBe('discard pile');
             });
         });
     });

--- a/test/server/cards/01-Core/CatelynStark.spec.js
+++ b/test/server/cards/01-Core/CatelynStark.spec.js
@@ -17,8 +17,6 @@ describe('Catelyn Stark', function() {
             this.player1.clickCard('Catelyn Stark (Core)', 'hand');
             this.player2.clickCard('Tyrion Lannister (Core)', 'hand');
             this.completeSetup();
-            this.player1.selectPlot('Sneak Attack');
-            this.player2.selectPlot('Sneak Attack');
             this.selectFirstPlayer(this.player1);
 
             this.player1.clickCard('Septa Mordane', 'hand');

--- a/test/server/cards/01-Core/EuronCrowsEye.spec.js
+++ b/test/server/cards/01-Core/EuronCrowsEye.spec.js
@@ -15,8 +15,6 @@ describe('Euron Crow\'s Eye', function() {
             this.keepStartingHands();
             this.player1.clickCard('Euron Crow\'s Eye', 'hand');
             this.completeSetup();
-            this.player1.selectPlot('Sneak Attack');
-            this.player2.selectPlot('Sneak Attack');
             this.selectFirstPlayer(this.player1);
 
             this.ourArbor = this.player1.findCardByName('The Arbor', 'hand');

--- a/test/server/cards/01-Core/HeadsOnSpikes.spec.js
+++ b/test/server/cards/01-Core/HeadsOnSpikes.spec.js
@@ -25,8 +25,6 @@ describe('Heads on Spikes', function() {
                     }
                 });
 
-                this.player1.selectPlot('Heads on Spikes');
-                this.player2.selectPlot('Sneak Attack');
                 this.selectFirstPlayer(this.player1);
 
                 this.completeMarshalPhase();
@@ -56,8 +54,6 @@ describe('Heads on Spikes', function() {
                     }
                 });
 
-                this.player1.selectPlot('Heads on Spikes');
-                this.player2.selectPlot('Sneak Attack');
                 this.selectFirstPlayer(this.player1);
 
                 this.completeMarshalPhase();

--- a/test/server/cards/01-Core/PowerBehindTheThrone.spec.js
+++ b/test/server/cards/01-Core/PowerBehindTheThrone.spec.js
@@ -16,8 +16,6 @@ describe('Power Behind the Throne', function() {
             this.player1.clickCard(this.cersei);
             this.completeSetup();
 
-            this.player1.selectPlot('Power Behind the Throne');
-            this.player2.selectPlot('Power Behind the Throne');
             this.selectFirstPlayer(this.player1);
 
             // Resolve plot order

--- a/test/server/cards/01-Core/RandyllTarly.spec.js
+++ b/test/server/cards/01-Core/RandyllTarly.spec.js
@@ -26,7 +26,6 @@ describe('Randyll Tarly', function() {
                 this.player1.clickCard(this.randyll);
 
                 this.player1.selectPlot('A Feast for Crows');
-                this.player2.selectPlot('A Feast for Crows');
                 this.selectFirstPlayer(this.player1);
 
                 let margaery = this.player1.findCardByName('Margaery Tyrell', 'hand');
@@ -54,7 +53,6 @@ describe('Randyll Tarly', function() {
                 this.player1.clickCard(this.randyll);
 
                 this.player1.selectPlot('A Song of Summer');
-                this.player2.selectPlot('A Feast for Crows');
 
                 // A Song of Summer takes effect immediately
                 this.player1.clickPrompt('Randyll Tarly');
@@ -69,7 +67,6 @@ describe('Randyll Tarly', function() {
         describe('when strength is decreased', function() {
             beforeEach(function() {
                 this.player1.selectPlot('A Feast for Crows');
-                this.player2.selectPlot('A Feast for Crows');
                 this.selectFirstPlayer(this.player1);
 
                 this.completeMarshalPhase();

--- a/test/server/cards/01-Core/RisenFromTheSea.spec.js
+++ b/test/server/cards/01-Core/RisenFromTheSea.spec.js
@@ -25,8 +25,6 @@ describe('Risen from the Sea', function() {
             this.player2.clickCard('Viserion', 'hand');
             this.completeSetup();
 
-            this.player1.selectPlot('A Noble Cause');
-            this.player2.selectPlot('A Noble Cause');
             this.selectFirstPlayer(this.player2);
 
             this.completeMarshalPhase();

--- a/test/server/cards/01-Core/SelyseBaratheon.spec.js
+++ b/test/server/cards/01-Core/SelyseBaratheon.spec.js
@@ -16,8 +16,6 @@ describe('Selyse Baratheon (Core)', function() {
             this.player1.clickCard('Selyse Baratheon', 'hand');
             this.player2.clickCard('Nymeria Sand', 'hand');
             this.completeSetup();
-            this.player1.selectPlot('Sneak Attack');
-            this.player2.selectPlot('Sneak Attack');
             this.selectFirstPlayer(this.player1);
 
             this.completeMarshalPhase();

--- a/test/server/cards/01-Core/StannisBaratheon.spec.js
+++ b/test/server/cards/01-Core/StannisBaratheon.spec.js
@@ -26,8 +26,6 @@ describe('Stannis Baratheon', function() {
             this.player1.clickCard(this.attachment);
             this.player1.clickCard(this.character1);
 
-            this.player1.selectPlot('Trading with the Pentoshi');
-            this.player2.selectPlot('Trading with the Pentoshi');
             this.selectFirstPlayer(this.player1);
             this.selectPlotOrder(this.player1);
 

--- a/test/server/cards/01-Core/TakeTheBlack.spec.js
+++ b/test/server/cards/01-Core/TakeTheBlack.spec.js
@@ -18,8 +18,6 @@ describe('Take the Black', function() {
 
             this.player2.clickCard(this.tooExpensive);
             this.completeSetup();
-            this.player1.selectPlot('Trading with the Pentoshi');
-            this.player2.selectPlot('Trading with the Pentoshi');
             this.selectFirstPlayer(this.player1);
             this.selectPlotOrder(this.player1);
 

--- a/test/server/cards/01-Core/TheHandsJudgment.spec.js
+++ b/test/server/cards/01-Core/TheHandsJudgment.spec.js
@@ -14,8 +14,6 @@ describe('The Hand\'s Judgment', function() {
 
             this.character = this.player1.findCardByName('Ser Jaime Lannister', 'hand');
 
-            this.player1.selectPlot('A Noble Cause');
-            this.player2.selectPlot('A Noble Cause');
             this.selectFirstPlayer(this.player1);
 
             this.completeMarshalPhase();

--- a/test/server/cards/01-Core/TheRedKeep.spec.js
+++ b/test/server/cards/01-Core/TheRedKeep.spec.js
@@ -17,8 +17,6 @@ describe('The Red Keep', function() {
             this.player1.clickCard(this.redKeep);
             this.completeSetup();
 
-            this.player1.selectPlot('Trading with the Pentoshi');
-            this.player2.selectPlot('Trading with the Pentoshi');
             this.selectFirstPlayer(this.player1);
             this.selectPlotOrder(this.player1);
 

--- a/test/server/cards/01-Core/TheTickler.spec.js
+++ b/test/server/cards/01-Core/TheTickler.spec.js
@@ -19,8 +19,6 @@ describe('The Tickler', function() {
             this.player1.clickCard('The Tickler', 'hand');
             this.player2.clickCard('The Roseroad', 'hand');
             this.completeSetup();
-            this.player1.selectPlot('Sneak Attack');
-            this.player2.selectPlot('Sneak Attack');
             this.selectFirstPlayer(this.player1);
 
             // Move remaining cards back to draw deck.

--- a/test/server/cards/01-Core/ViserysTargaryen.spec.js
+++ b/test/server/cards/01-Core/ViserysTargaryen.spec.js
@@ -17,12 +17,10 @@ describe('Viserys Targaryen', function() {
             this.player1.clickCard('Viserys Targaryen (Core)', 'hand');
             this.player2.clickCard('Tumblestone Knight', 'hand');
             this.completeSetup();
-            this.player1.selectPlot('Sneak Attack');
-            this.player2.selectPlot('A Feast for Crows');
             this.selectFirstPlayer(this.player2);
 
             this.viserys = this.player1.findCardByName('Viserys Targaryen (Core)', 'play area');
-            
+
             this.player2.clickCard('Lady');
             this.player2.clickCard('Tumblestone Knight');
 

--- a/test/server/cards/02.1-TtB/RenlyBaratheon.spec.js
+++ b/test/server/cards/02.1-TtB/RenlyBaratheon.spec.js
@@ -12,8 +12,6 @@ describe('Renly Baratheon (TtB)', function() {
 
             this.player1.clickCard('Renly Baratheon', 'hand');
             this.completeSetup();
-            this.player1.selectPlot('Sneak Attack');
-            this.player2.selectPlot('Sneak Attack');
             this.selectFirstPlayer(this.player1);
         });
 

--- a/test/server/cards/02.2-TRtW/BrothelMadame.spec.js
+++ b/test/server/cards/02.2-TRtW/BrothelMadame.spec.js
@@ -16,8 +16,6 @@ describe('Brothel Madame', function() {
             this.player2.clickCard(this.character);
             this.completeSetup();
 
-            this.player1.selectPlot('A Noble Cause');
-            this.player2.selectPlot('A Noble Cause');
             this.selectFirstPlayer(this.player1);
         });
 

--- a/test/server/cards/02.2-TRtW/LadyInWaiting.spec.js
+++ b/test/server/cards/02.2-TRtW/LadyInWaiting.spec.js
@@ -17,8 +17,6 @@ describe('Lady-in-Waiting', function() {
             this.player2.clickCard('Cersei Lannister', 'hand');
 
             this.completeSetup();
-            this.player1.selectPlot('A Noble Cause');
-            this.player2.selectPlot('A Noble Cause');
             this.selectFirstPlayer(this.player1);
 
             this.ladyInWaiting = this.player1.findCardByName('Lady-in-Waiting');

--- a/test/server/cards/02.3-TKP/CroneOfVaesDothrak.spec.js
+++ b/test/server/cards/02.3-TKP/CroneOfVaesDothrak.spec.js
@@ -17,8 +17,6 @@ describe('Crone of Vaes Dothrak', function() {
             this.player1.clickCard('Braided Warrior', 'hand');
             this.player1.clickCard('Black Wind\'s Crew', 'hand');
             this.completeSetup();
-            this.player1.selectPlot('A Noble Cause');
-            this.player2.selectPlot('Sneak Attack');
             this.selectFirstPlayer(this.player1);
         });
 

--- a/test/server/cards/02.3-TKP/SerGregorClegane.spec.js
+++ b/test/server/cards/02.3-TKP/SerGregorClegane.spec.js
@@ -17,10 +17,8 @@ describe('Ser Gregor Clegane', function() {
             this.player2.clickCard('Hedge Knight', 'hand');
             this.player2.clickCard('Shireen Baratheon', 'hand');
             this.completeSetup();
-            this.player1.selectPlot('A Noble Cause');
-            this.player2.selectPlot('Sneak Attack');
             this.selectFirstPlayer(this.player1);
-            
+
             this.completeMarshalPhase();
 
             this.shireen = this.player2.findCardByName('Shireen Baratheon', 'play area');

--- a/test/server/cards/02.4-NMG/WraithsInTheirMidst.spec.js
+++ b/test/server/cards/02.4-NMG/WraithsInTheirMidst.spec.js
@@ -84,8 +84,6 @@ describe('WraithsInTheirMidst', function() {
                 this.completeMarshalPhase();
                 this.completeChallengesPhase();
 
-                this.player1.selectPlot('A Noble Cause');
-                this.player2.selectPlot('A Feast for Crows');
                 this.selectFirstPlayer(this.player2);
 
                 this.completeMarshalPhase();

--- a/test/server/cards/02.5-COW/MirriMazDuur.spec.js
+++ b/test/server/cards/02.5-COW/MirriMazDuur.spec.js
@@ -22,8 +22,6 @@ describe('Mirri Maz Duur', function() {
             this.player2.clickCard(this.character);
             this.completeSetup();
 
-            this.player1.selectPlot('Marching Orders');
-            this.player2.selectPlot('Marching Orders');
             this.selectFirstPlayer(this.player1);
 
             this.player1.clickCard(this.hound);

--- a/test/server/cards/02.5-COW/VengeanceForElia.spec.js
+++ b/test/server/cards/02.5-COW/VengeanceForElia.spec.js
@@ -20,8 +20,6 @@ describe('Vengeance for Elia', function() {
 
             this.completeSetup();
 
-            this.player1.selectPlot('A Noble Cause');
-            this.player2.selectPlot('A Noble Cause');
             this.selectFirstPlayer(this.player1);
 
             this.completeMarshalPhase();

--- a/test/server/cards/02.5-TS/Jhogo.spec.js
+++ b/test/server/cards/02.5-TS/Jhogo.spec.js
@@ -21,8 +21,6 @@ describe('Jhogo', function() {
             this.player1.clickCard(this.jhogo);
             this.completeSetup();
 
-            this.player1.selectPlot('Marching Orders');
-            this.player2.selectPlot('Marching Orders');
             this.selectFirstPlayer(this.player1);
 
             this.player1.clickCard(this.aggo);

--- a/test/server/cards/03-WotN/AryasGift.spec.js
+++ b/test/server/cards/03-WotN/AryasGift.spec.js
@@ -21,8 +21,6 @@ describe('Arya\'s Gift', function() {
 
             this.completeSetup();
 
-            this.player1.selectPlot('A Noble Cause');
-            this.player2.selectPlot('A Noble Cause');
             this.selectFirstPlayer(this.player2);
 
             // Attach Milk to the first character.

--- a/test/server/cards/03-WotN/HouseFlorentKnight.spec.js
+++ b/test/server/cards/03-WotN/HouseFlorentKnight.spec.js
@@ -10,8 +10,6 @@ describe('House Florent Knight', function() {
             this.startGame();
             this.keepStartingHands();
             this.completeSetup();
-            this.player1.selectPlot('Trading with the Pentoshi');
-            this.player2.selectPlot('Trading with the Pentoshi');
 
             this.florentKnight = this.player2.findCardByName('House Florent Knight', 'hand');
         });

--- a/test/server/cards/04.1-AtSK/VaryssRiddle.spec.js
+++ b/test/server/cards/04.1-AtSK/VaryssRiddle.spec.js
@@ -25,8 +25,6 @@ describe('Varys\'s Riddle', function() {
 
             it('should not crash', function() {
                 expect(() => {
-                    this.player1.selectPlot('Varys\'s Riddle');
-                    this.player2.selectPlot('Wildfire Assault');
                     this.selectFirstPlayer(this.player1);
                     this.selectPlotOrder(this.player1);
                 }).not.toThrow();
@@ -46,8 +44,6 @@ describe('Varys\'s Riddle', function() {
 
                 this.varysRiddle = this.player1.findCardByName('Varys\'s Riddle');
 
-                this.player1.selectPlot('Varys\'s Riddle');
-                this.player2.selectPlot('Wraiths in Their Midst');
                 this.selectFirstPlayer(this.player1);
             });
 
@@ -80,8 +76,6 @@ describe('Varys\'s Riddle', function() {
 
                     this.powerBehindTheThrone = this.player2.findCardByName('Power Behind the Throne');
 
-                    this.player1.selectPlot('Varys\'s Riddle');
-                    this.player2.selectPlot('Calm Over Westeros');
                     this.selectFirstPlayer(this.player2);
 
                     this.selectPlotOrder(this.player1);
@@ -135,9 +129,6 @@ describe('Varys\'s Riddle', function() {
                 this.keepStartingHands();
                 this.player2.clickCard('Old Nan', 'hand');
                 this.completeSetup();
-
-                this.player1.selectPlot('Varys\'s Riddle');
-                this.player2.selectPlot('Trading with the Pentoshi');
 
                 expect(this.player2).toHavePromptButton('Old Nan');
                 this.player2.clickPrompt('Pass');

--- a/test/server/cards/04.2-CtA/DolorousEdd.spec.js
+++ b/test/server/cards/04.2-CtA/DolorousEdd.spec.js
@@ -17,8 +17,6 @@ describe('Dolorous Edd', function() {
             this.player2.clickCard('Grand Maester Pycelle', 'hand');
             this.player2.clickCard('Ser Jaime Lannister', 'hand');
             this.completeSetup();
-            this.player1.selectPlot('Sneak Attack');
-            this.player2.selectPlot('Sneak Attack');
             this.selectFirstPlayer(this.player2);
 
             this.completeMarshalPhase();

--- a/test/server/cards/04.2-CtA/FearCutsDeeperThanSwords.spec.js
+++ b/test/server/cards/04.2-CtA/FearCutsDeeperThanSwords.spec.js
@@ -24,8 +24,6 @@ describe('Fear Cuts Deeper Than Swords', function() {
 
             this.completeSetup();
 
-            this.player1.selectPlot('A Noble Cause');
-            this.player2.selectPlot('Filthy Accusations');
             this.selectFirstPlayer(this.player2);
         });
 
@@ -43,7 +41,7 @@ describe('Fear Cuts Deeper Than Swords', function() {
                 beforeEach(function() {
                     this.player1.clickPrompt('Fear Cuts Deeper Than Swords');
                 });
-    
+
                 it('should cancel the plot when revealed', function() {
                     expect(this.knight.kneeled).toBe(false);
                 });
@@ -70,7 +68,7 @@ describe('Fear Cuts Deeper Than Swords', function() {
                 beforeEach(function() {
                     this.player1.clickPrompt('Fear Cuts Deeper Than Swords');
                 });
-    
+
                 it('should cancel the intimidate keyword', function() {
                     expect(this.knight.kneeled).toBe(false);
                 });

--- a/test/server/cards/04.2-CtA/SummerHarvest.spec.js
+++ b/test/server/cards/04.2-CtA/SummerHarvest.spec.js
@@ -18,7 +18,6 @@ describe('SummerHarvest', function() {
 
         describe('when played against a normal plot', function() {
             beforeEach(function() {
-                this.player1.selectPlot(this.summerHarvest);
                 this.player2.selectPlot(this.nobleCause);
 
                 this.selectFirstPlayer(this.player1);
@@ -36,9 +35,6 @@ describe('SummerHarvest', function() {
                     // Move Summer Harvest back to the plot deck so it's eligible to be picked again.
                     this.summerHarvest.controller.moveCard(this.summerHarvest, 'plot deck');
 
-                    this.player1.selectPlot(this.summerHarvest);
-                    this.player2.selectPlot(this.nobleCause);
-
                     this.selectFirstPlayer(this.player1);
                 });
 
@@ -50,7 +46,6 @@ describe('SummerHarvest', function() {
 
         describe('when played against Varys\'s Riddle', function() {
             beforeEach(function() {
-                this.player1.selectPlot(this.summerHarvest);
                 this.player2.selectPlot(this.varysRiddle);
 
                 this.selectFirstPlayer(this.player1);

--- a/test/server/cards/04.3-FFH/NightGathers.spec.js
+++ b/test/server/cards/04.3-FFH/NightGathers.spec.js
@@ -14,8 +14,6 @@ describe('Night Gathers...', function() {
             this.player2.selectDeck(deck2);
             this.startGame();
             this.skipSetupPhase();
-            this.player1.selectPlot('A Noble Cause');
-            this.player2.selectPlot('Sneak Attack');
             this.selectFirstPlayer(this.player1);
 
             this.steward = this.player1.findCardByName('Steward at the Wall');

--- a/test/server/cards/04.4-TIMC/JaqenHghar.spec.js
+++ b/test/server/cards/04.4-TIMC/JaqenHghar.spec.js
@@ -18,8 +18,6 @@ describe('Jaqen H\'ghar', function() {
             this.player2.clickCard(this.arya);
             this.completeSetup();
 
-            this.player1.selectPlot('Trading with the Pentoshi');
-            this.player2.selectPlot('Trading with the Pentoshi');
             this.selectFirstPlayer(this.player1);
             this.selectPlotOrder(this.player1);
 

--- a/test/server/cards/04.4-TIMC/TheHauntedForest.spec.js
+++ b/test/server/cards/04.4-TIMC/TheHauntedForest.spec.js
@@ -18,8 +18,6 @@ describe('The Haunted Forest', function() {
             this.player2.clickCard('Maester Aemon', 'hand');
             this.completeSetup();
 
-            this.player1.selectPlot('Sneak Attack');
-            this.player2.selectPlot('Sneak Attack');
             this.selectFirstPlayer(this.player2);
 
             this.completeMarshalPhase();

--- a/test/server/cards/04.4-TIMC/ValarMorghulis.spec.js
+++ b/test/server/cards/04.4-TIMC/ValarMorghulis.spec.js
@@ -34,9 +34,6 @@ describe('Valar Morghulis', function() {
 
                 this.player1Object.moveCard(this.eddard, 'draw deck');
 
-                this.player1.selectPlot('Valar Morghulis');
-                this.player2.selectPlot('A Noble Cause');
-
                 this.selectFirstPlayer(this.player1);
             });
 

--- a/test/server/cards/04.5-GoH/Craster.spec.js
+++ b/test/server/cards/04.5-GoH/Craster.spec.js
@@ -33,7 +33,6 @@ describe('Craster', function() {
                 this.player2.clickCard(this.opponentCharacter);
                 this.completeSetup();
                 this.player1.selectPlot('A Noble Cause');
-                this.player2.selectPlot('Valar Morghulis');
                 this.selectFirstPlayer(this.player1);
 
                 this.player2.clickPrompt('Benjen Stark');
@@ -84,7 +83,6 @@ describe('Craster', function() {
                 this.player1Object.moveCard(this.craster, 'draw deck');
 
                 this.player1.selectPlot('Called Into Service');
-                this.player2.selectPlot('Valar Morghulis');
                 this.selectFirstPlayer(this.player1);
                 // Resolve Valar before Called Into Service.
                 this.selectPlotOrder(this.player2);

--- a/test/server/cards/04.5-GoH/DragonglassDagger.spec.js
+++ b/test/server/cards/04.5-GoH/DragonglassDagger.spec.js
@@ -31,8 +31,6 @@ describe('Dragonglass Dagger', function() {
                 this.player1.clickCard(this.attachment);
                 this.player1.clickCard(this.character);
 
-                this.player1.selectPlot('A Noble Cause');
-                this.player2.selectPlot('A Noble Cause');
                 this.selectFirstPlayer(this.player2);
 
                 this.completeMarshalPhase();

--- a/test/server/cards/04.5-GoH/Harrenhal.spec.js
+++ b/test/server/cards/04.5-GoH/Harrenhal.spec.js
@@ -15,8 +15,6 @@ describe('Harrenhal (GoH)', function() {
             this.player1.clickCard(this.harrenhal);
             this.completeSetup();
 
-            this.player1.selectPlot('Sneak Attack');
-            this.player2.selectPlot('Sneak Attack');
             this.selectFirstPlayer(this.player1);
         });
 

--- a/test/server/cards/04.6-TC/Esgred.spec.js
+++ b/test/server/cards/04.6-TC/Esgred.spec.js
@@ -22,8 +22,6 @@ describe('Esgred', function() {
             this.player2.clickCard(this.knight2);
             this.completeSetup();
 
-            this.player1.selectPlot('Trading with the Pentoshi');
-            this.player2.selectPlot('Trading with the Pentoshi');
             this.selectFirstPlayer(this.player1);
             this.selectPlotOrder(this.player1);
         });

--- a/test/server/cards/05-LoCR/CerseiLannister.spec.js
+++ b/test/server/cards/05-LoCR/CerseiLannister.spec.js
@@ -24,7 +24,6 @@ describe('Cersei Lannister (LoCR)', function() {
                     this.cersei = this.player1.findCardByName('Cersei Lannister');
 
                     this.player1.selectPlot('A Clash of Kings');
-                    this.player2.selectPlot('Sneak Attack');
                     this.selectFirstPlayer(this.player1);
 
                     this.completeMarshalPhase();
@@ -45,7 +44,6 @@ describe('Cersei Lannister (LoCR)', function() {
                     this.cersei = this.player1.findCardByName('Cersei Lannister');
 
                     this.player1.selectPlot('Sneak Attack');
-                    this.player2.selectPlot('Sneak Attack');
                     this.selectFirstPlayer(this.player1);
 
                     this.completeMarshalPhase();
@@ -67,7 +65,6 @@ describe('Cersei Lannister (LoCR)', function() {
                     this.cersei = this.player1.findCardByName('Cersei Lannister');
 
                     this.player1.selectPlot('Heads on Spikes');
-                    this.player2.selectPlot('Sneak Attack');
                     this.selectFirstPlayer(this.player1);
                 });
 

--- a/test/server/cards/05-LoCR/ChellaDaughterOfCheyk.spec.js
+++ b/test/server/cards/05-LoCR/ChellaDaughterOfCheyk.spec.js
@@ -21,8 +21,6 @@ describe('Chella Daughter of Cheyk', function() {
             this.player2.clickCard(this.chud);
             this.completeSetup();
 
-            this.player1.selectPlot('A Clash of Kings');
-            this.player2.selectPlot('A Clash of Kings');
             this.selectFirstPlayer(this.player1);
 
             this.completeMarshalPhase();

--- a/test/server/cards/05-LoCR/HighSepton.spec.js
+++ b/test/server/cards/05-LoCR/HighSepton.spec.js
@@ -24,10 +24,6 @@ describe('High Septon', function() {
             this.player2.clickCard('Mirri Maz Duur');
 
             this.completeSetup();
-
-            this.player1.selectPlot('A Noble Cause');
-            this.player2.selectPlot('A Noble Cause');
-
         });
 
         describe('vs a single target ability', function() {

--- a/test/server/cards/05-LoCR/SerLancelLannister.spec.js
+++ b/test/server/cards/05-LoCR/SerLancelLannister.spec.js
@@ -15,8 +15,6 @@ describe('Ser Lancel Lannister', function() {
             this.player1.clickCard(this.lancel);
             this.completeSetup();
 
-            this.player1.selectPlot('Trading with the Pentoshi');
-            this.player2.selectPlot('Trading with the Pentoshi');
             this.selectFirstPlayer(this.player1);
             this.selectPlotOrder(this.player1);
         });

--- a/test/server/cards/05-LoCR/ShieldOfLannisport.spec.js
+++ b/test/server/cards/05-LoCR/ShieldOfLannisport.spec.js
@@ -16,8 +16,6 @@ describe('Shield of Lannisport', function() {
             this.player1.clickCard(this.tyrion);
             this.completeSetup();
 
-            this.player1.selectPlot('A Noble Cause');
-            this.player2.selectPlot('A Noble Cause');
             this.selectFirstPlayer(this.player1);
 
             // Attach Shield to Tyrion

--- a/test/server/cards/05-LoCR/TywinLannister.spec.js
+++ b/test/server/cards/05-LoCR/TywinLannister.spec.js
@@ -18,8 +18,6 @@ describe('Tywin Lannister (LoCR)', function() {
             this.player2.clickCard('The Tickler', 'hand');
             this.player2.clickCard('The Reader', 'hand');
             this.completeSetup();
-            this.player1.selectPlot('Sneak Attack');
-            this.player2.selectPlot('Sneak Attack');
             this.selectFirstPlayer(this.player1);
 
             // Move remaining cards back to draw deck so we have something to discard

--- a/test/server/cards/05-LoCR/WildlingBandit.spec.js
+++ b/test/server/cards/05-LoCR/WildlingBandit.spec.js
@@ -17,8 +17,6 @@ describe('Wildling Bandit', function() {
             this.player1.clickCard(this.bandit);
             this.completeSetup();
 
-            this.player1.selectPlot('Sneak Attack');
-            this.player2.selectPlot('Time of Plenty');
             this.selectFirstPlayer(this.player1);
 
             this.completeMarshalPhase();

--- a/test/server/cards/06.1-AMAF/BarringTheGates.spec.js
+++ b/test/server/cards/06.1-AMAF/BarringTheGates.spec.js
@@ -22,8 +22,6 @@ describe('Barring the Gates', function() {
 
             this.completeSetup();
 
-            this.player1.selectPlot('Barring the Gates');
-            this.player2.selectPlot('A Noble Cause');
             this.selectFirstPlayer(this.player2);
         });
 

--- a/test/server/cards/06.1-AMAF/ThePrincesPlan.spec.js
+++ b/test/server/cards/06.1-AMAF/ThePrincesPlan.spec.js
@@ -15,8 +15,6 @@ describe('The Prince\'s Plan', function() {
             this.player2.clickCard('The Red Viper', 'hand');
 
             this.completeSetup();
-            this.player1.selectPlot('A Noble Cause');
-            this.player2.selectPlot('A Noble Cause');
             this.selectFirstPlayer(this.player1);
 
             this.completeMarshalPhase();

--- a/test/server/cards/06.1-AMAF/Ygritte.spec.js
+++ b/test/server/cards/06.1-AMAF/Ygritte.spec.js
@@ -16,8 +16,6 @@ describe('Ygritte', function() {
             this.player1.clickCard(this.brothel);
             this.completeSetup();
 
-            this.player1.selectPlot('Sneak Attack');
-            this.player2.selectPlot('Sneak Attack');
             this.selectFirstPlayer(this.player1);
 
             this.player1.clickPrompt('Done');

--- a/test/server/cards/06.2-GtR/MarriagePact.spec.js
+++ b/test/server/cards/06.2-GtR/MarriagePact.spec.js
@@ -19,8 +19,6 @@ describe('Marriage Pact', function() {
             this.player2.clickCard(this.opponentCharacter);
             this.completeSetup();
 
-            this.player1.selectPlot('A Noble Cause');
-            this.player2.selectPlot('A Noble Cause');
             this.selectFirstPlayer(this.player1);
 
             // Attach Marriage Pact

--- a/test/server/cards/06.2-GtR/TheAnnalsOfCastleBlack.spec.js
+++ b/test/server/cards/06.2-GtR/TheAnnalsOfCastleBlack.spec.js
@@ -93,9 +93,6 @@ describe('The Annals of Castle Black', function() {
                 this.completeMarshalPhase();
                 this.completeChallengesPhase();
 
-                this.player1.selectPlot('A Noble Cause');
-                this.player2.selectPlot('A Noble Cause');
-
                 expect(this.player1).not.toHavePromptButton('Ahead of the Tide');
             });
         });

--- a/test/server/cards/06.3-TFoA/RecruiterForTheWatch.spec.js
+++ b/test/server/cards/06.3-TFoA/RecruiterForTheWatch.spec.js
@@ -18,8 +18,6 @@ describe('Recruiter for the Watch', function() {
             this.player2.clickCard(this.character);
             this.completeSetup();
 
-            this.player1.selectPlot('Sneak Attack');
-            this.player2.selectPlot('Sneak Attack');
             this.selectFirstPlayer(this.player1);
 
             this.player1.clickMenu(this.recruiter, 'Take control of character');

--- a/test/server/cards/06.5-OR/BeggingBrother.spec.js
+++ b/test/server/cards/06.5-OR/BeggingBrother.spec.js
@@ -18,8 +18,6 @@ describe('Begging Brother', function() {
 
             this.completeSetup();
 
-            this.player1.selectPlot('Trading with the Pentoshi');
-            this.player2.selectPlot('Trading with the Pentoshi');
             this.selectFirstPlayer(this.player1);
             this.selectPlotOrder(this.player1);
 

--- a/test/server/cards/06.5-OR/FleaBottom.spec.js
+++ b/test/server/cards/06.5-OR/FleaBottom.spec.js
@@ -17,8 +17,6 @@ describe('Flea Bottom', function() {
 
             this.completeSetup();
 
-            this.player1.selectPlot('Trading with the Pentoshi');
-            this.player2.selectPlot('Trading with the Pentoshi');
             this.selectFirstPlayer(this.player1);
             this.selectPlotOrder(this.player1);
 

--- a/test/server/cards/06.6-TBWB/Patchface.spec.js
+++ b/test/server/cards/06.6-TBWB/Patchface.spec.js
@@ -21,8 +21,6 @@ describe('Patchface', function() {
 
             this.completeSetup();
 
-            this.player1.selectPlot('Trading with the Pentoshi');
-            this.player2.selectPlot('Trading with the Pentoshi');
             this.selectFirstPlayer(this.player1);
             this.selectPlotOrder(this.player1);
         });

--- a/test/server/cards/06.6-TBWB/PayTheIronPrice.spec.js
+++ b/test/server/cards/06.6-TBWB/PayTheIronPrice.spec.js
@@ -27,8 +27,6 @@ describe('Pay The Iron Price', function() {
 
             this.completeSetup();
 
-            this.player1.selectPlot('A Noble Cause');
-            this.player2.selectPlot('A Noble Cause');
             this.selectFirstPlayer(this.player1);
 
             this.completeMarshalPhase();

--- a/test/server/cards/07-WotW/MaesterAemon.spec.js
+++ b/test/server/cards/07-WotW/MaesterAemon.spec.js
@@ -18,8 +18,6 @@ describe('Maester Aemon (WotW)', function() {
 
             this.completeSetup();
 
-            this.player1.selectPlot('Sneak Attack');
-            this.player2.selectPlot('Sneak Attack');
             this.selectFirstPlayer(this.player2);
 
             this.completeMarshalPhase();

--- a/test/server/cards/08.1-TAK/NaggasRibs.spec.js
+++ b/test/server/cards/08.1-TAK/NaggasRibs.spec.js
@@ -28,7 +28,6 @@ describe('Nagga\'s Ribs', function() {
         describe('when a character is discarded', function() {
             beforeEach(function() {
                 this.player1.selectPlot('Marched to the Wall');
-                this.player2.selectPlot('A Noble Cause');
                 this.selectFirstPlayer(this.player1);
 
                 this.player1.clickCard('Theon Greyjoy', 'play area');
@@ -47,7 +46,6 @@ describe('Nagga\'s Ribs', function() {
                 this.player2.togglePromptedActionWindow('dominance', true);
 
                 this.player1.selectPlot('A Noble Cause');
-                this.player2.selectPlot('A Noble Cause');
                 this.selectFirstPlayer(this.player1);
 
                 this.player1.clickCard(this.character2);
@@ -71,7 +69,6 @@ describe('Nagga\'s Ribs', function() {
                 this.player2.togglePromptedActionWindow('dominance', true);
 
                 this.player1.selectPlot('A Noble Cause');
-                this.player2.selectPlot('A Noble Cause');
                 this.selectFirstPlayer(this.player1);
 
                 this.completeMarshalPhase();

--- a/test/server/cards/08.1-TAK/TheIronBank.spec.js
+++ b/test/server/cards/08.1-TAK/TheIronBank.spec.js
@@ -23,9 +23,6 @@ describe('The Iron Bank', function() {
             this.completeSetup();
 
             this.ironBank.modifyToken('gold', 10);
-
-            this.player1.selectPlot('A Noble Cause');
-            this.player2.selectPlot('A Noble Cause');
         });
 
         describe('when the player collects income', function() {

--- a/test/server/cards/08.4-FotOG/TheKingInTheNorth.spec.js
+++ b/test/server/cards/08.4-FotOG/TheKingInTheNorth.spec.js
@@ -24,8 +24,6 @@ describe('The King in the North', function() {
 
             this.completeSetup();
 
-            this.player1.selectPlot('The King in the North');
-            this.player2.selectPlot('The King in the North');
             this.selectFirstPlayer(this.player1);
         });
 

--- a/test/server/cards/08.5-TFM/DaenerysTargaryen.spec.js
+++ b/test/server/cards/08.5-TFM/DaenerysTargaryen.spec.js
@@ -21,7 +21,6 @@ describe('Daenerys Targaryen (TFM)', function() {
 
             this.completeSetup();
 
-            this.player1.selectPlot('Trading with the Pentoshi');
             this.selectFirstPlayer(this.player1);
 
             this.completeMarshalPhase();
@@ -70,7 +69,7 @@ describe('Daenerys Targaryen (TFM)', function() {
                 describe('and when it reaches 0', function() {
                     beforeEach(function() {
                         this.player1.clickCard(this.noSlave2);
-                        this.player1.clickCard(this.dany);                    
+                        this.player1.clickCard(this.dany);
                     });
 
                     it('should kill her', function() {

--- a/test/server/cards/09-HoT/Besieged.spec.js
+++ b/test/server/cards/09-HoT/Besieged.spec.js
@@ -34,8 +34,6 @@ describe('Besieged', function() {
                 this.completeMarshalPhase();
                 this.completeChallengesPhase();
 
-                this.player1.selectPlot('A Noble Cause');
-                this.player2.selectPlot('A Noble Cause');
                 this.selectFirstPlayer(this.player1);
             });
 

--- a/test/server/cards/09-HoT/EmissaryOfTheHightower.spec.js
+++ b/test/server/cards/09-HoT/EmissaryOfTheHightower.spec.js
@@ -23,8 +23,6 @@ describe('Hidden Thorns', function() {
 
             this.completeSetup();
 
-            this.player1.selectPlot('Trading with the Pentoshi');
-            this.player2.selectPlot('A Noble Cause');
             this.selectFirstPlayer(this.player1);
         });
 

--- a/test/server/cards/09-HoT/HiddenThorns.spec.js
+++ b/test/server/cards/09-HoT/HiddenThorns.spec.js
@@ -26,8 +26,6 @@ describe('Hidden Thorns', function() {
 
             this.completeSetup();
 
-            this.player1.selectPlot('A Noble Cause');
-            this.player2.selectPlot('A Noble Cause');
             this.selectFirstPlayer(this.player1);
         });
 

--- a/test/server/cards/09-HoT/MaceTyrell.spec.js
+++ b/test/server/cards/09-HoT/MaceTyrell.spec.js
@@ -24,7 +24,6 @@ describe('Mace Tyrell', function() {
 
         describe('when removing a character from the game', function() {
             beforeEach(function() {
-                this.player1.selectPlot('A Noble Cause');
                 this.player2.selectPlot('A Noble Cause');
                 this.selectFirstPlayer(this.player1);
 
@@ -49,7 +48,6 @@ describe('Mace Tyrell', function() {
 
         describe('when a removed character is placed in the dead pile', function() {
             beforeEach(function() {
-                this.player1.selectPlot('A Noble Cause');
                 this.player2.selectPlot('A Noble Cause');
                 this.selectFirstPlayer(this.player1);
 
@@ -78,7 +76,6 @@ describe('Mace Tyrell', function() {
             // Ruling: http://www.cardgamedb.com/forums/index.php?/topic/36886-mace-tyrell/
 
             beforeEach(function() {
-                this.player1.selectPlot('A Noble Cause');
                 this.player2.selectPlot('Barring the Gates');
                 this.selectFirstPlayer(this.player1);
 

--- a/test/server/cards/09-HoT/MeleeAtBitterbridge.spec.js
+++ b/test/server/cards/09-HoT/MeleeAtBitterbridge.spec.js
@@ -21,8 +21,6 @@ describe('Melee at Bitterbridge', function() {
 
             this.completeSetup();
 
-            this.player1.selectPlot('Trading with the Pentoshi');
-            this.player2.selectPlot('Trading with the Pentoshi');
             this.selectFirstPlayer(this.player1);
             this.selectPlotOrder(this.player1);
 

--- a/test/server/cards/10-SoD/FalsePlans.spec.js
+++ b/test/server/cards/10-SoD/FalsePlans.spec.js
@@ -26,7 +26,6 @@ describe('False Plans', function() {
 
         describe('when False Plans is discarded normally', function() {
             beforeEach(function() {
-                this.player1.selectPlot('A Noble Cause');
                 this.player2.selectPlot('Heads on Spikes');
                 this.selectFirstPlayer(this.player1);
             });
@@ -40,7 +39,6 @@ describe('False Plans', function() {
 
         describe('when False Plans is discarded by intrigue claim', function() {
             beforeEach(function() {
-                this.player1.selectPlot('A Noble Cause');
                 this.player2.selectPlot('A Noble Cause');
                 this.selectFirstPlayer(this.player2);
 
@@ -63,7 +61,6 @@ describe('False Plans', function() {
 
         describe('vs Vengeance for Elia', function() {
             beforeEach(function() {
-                this.player1.selectPlot('A Noble Cause');
                 this.player2.selectPlot('A Noble Cause');
                 this.selectFirstPlayer(this.player1);
 

--- a/test/server/cards/10-SoD/Missandei.spec.js
+++ b/test/server/cards/10-SoD/Missandei.spec.js
@@ -22,8 +22,6 @@ describe('Missandei', function() {
 
             this.completeSetup();
 
-            this.player1.selectPlot('A Noble Cause');
-            this.player2.selectPlot('A Noble Cause');
             this.selectFirstPlayer(this.player2);
 
             this.completeMarshalPhase();

--- a/test/server/cards/10-SoD/ObaraSand.spec.js
+++ b/test/server/cards/10-SoD/ObaraSand.spec.js
@@ -24,8 +24,6 @@ describe('Obara Sand (SoD)', function() {
 
             this.completeSetup();
 
-            this.player1.selectPlot('A Noble Cause');
-            this.player2.selectPlot('A Noble Cause');
             this.selectFirstPlayer(this.player1);
 
             this.player1.clickCard(this.arianne);

--- a/test/server/cards/10-SoD/ObellaSand.spec.js
+++ b/test/server/cards/10-SoD/ObellaSand.spec.js
@@ -23,8 +23,6 @@ describe('Obella Sand', function() {
 
             this.completeSetup();
 
-            this.player1.selectPlot('A Noble Cause');
-            this.player2.selectPlot('A Noble Cause');
             this.selectFirstPlayer(this.player2);
 
             this.completeMarshalPhase();

--- a/test/server/cards/agendas/Fealty.spec.js
+++ b/test/server/cards/agendas/Fealty.spec.js
@@ -11,8 +11,6 @@ describe('Fealty', function() {
             this.startGame();
             this.skipSetupPhase();
 
-            this.player1.selectPlot('Sneak Attack');
-            this.player2.selectPlot('Sneak Attack');
             this.selectFirstPlayer(this.player1);
 
             this.balon = this.player1.findCardByName('Balon Greyjoy (Core)', 'hand');

--- a/test/server/cards/agendas/TheLordOfTheCrossing.spec.js
+++ b/test/server/cards/agendas/TheLordOfTheCrossing.spec.js
@@ -215,8 +215,6 @@ describe('The Lord of the Crossing', function() {
 
             describe('when Jon Snow becomes an attacker through his ability', function() {
                 beforeEach(function() {
-                    this.player1.selectPlot('A Noble Cause');
-                    this.player2.selectPlot('A Noble Cause');
                     this.selectFirstPlayer(this.player1);
 
                     this.completeMarshalPhase();

--- a/test/server/cards/agendas/TheRainsOfCastamere.spec.js
+++ b/test/server/cards/agendas/TheRainsOfCastamere.spec.js
@@ -34,23 +34,6 @@ describe('The Rains of Castamere', function() {
         this.agenda = new TheRainsOfCastamere(this.player, {});
     });
 
-    describe('onDecksPrepared()', function() {
-        beforeEach(function() {
-            this.player.plotDeck = _([this.plot1, this.scheme1, this.plot2, this.scheme2]);
-
-            this.agenda.onDecksPrepared();
-        });
-
-        it('should remove the schemes from the players plot deck', function() {
-            expect(this.player.plotDeck.toArray()).toEqual([this.plot1, this.plot2]);
-        });
-
-        it('should move the schemes to the scheme plot pile', function() {
-            expect(this.player.moveCard).toHaveBeenCalledWith(this.scheme1, 'scheme plots');
-            expect(this.player.moveCard).toHaveBeenCalledWith(this.scheme2, 'scheme plots');
-        });
-    });
-
     describe('onPlotDiscarded()', function() {
         beforeEach(function() {
             this.plotSpy = jasmine.createSpyObj('plot', ['hasTrait']);

--- a/test/server/cards/agendas/TheRainsOfCastamere.spec.js
+++ b/test/server/cards/agendas/TheRainsOfCastamere.spec.js
@@ -212,8 +212,6 @@ describe('The Rains of Castamere', function() {
             this.keepStartingHands();
             this.player1.clickCard('Cersei Lannister', 'hand');
             this.completeSetup();
-            this.player1.selectPlot('Trading with the Pentoshi');
-            this.player2.selectPlot('Trading with the Pentoshi');
             this.selectFirstPlayer(this.player1);
             this.selectPlotOrder(this.player1);
             this.completeMarshalPhase();

--- a/test/server/effectengine.spec.js
+++ b/test/server/effectengine.spec.js
@@ -2,8 +2,8 @@ const _ = require('underscore');
 
 const EffectEngine = require('../../server/game/effectengine.js');
 
-describe('EffectEngine', function () {
-    beforeEach(function () {
+describe('EffectEngine', function() {
+    beforeEach(function() {
         this.playAreaCard = { location: 'play area' };
         this.handCard = { location: 'hand' };
         this.discardedCard = { location: 'discard pile' };
@@ -61,10 +61,6 @@ describe('EffectEngine', function () {
         beforeEach(function() {
             this.player = {};
             this.gameSpy.getPlayers.and.returnValue([this.player]);
-        });
-
-        it('should not include cards in the plot deck', function() {
-            expect(this.engine.getTargets()).not.toContain(this.plotCard);
         });
 
         it('should not include cards in the revealed plots pile', function() {
@@ -163,7 +159,7 @@ describe('EffectEngine', function () {
             });
         });
 
-        describe('when leaving play', function () {
+        describe('when leaving play', function() {
             beforeEach(function() {
                 this.cardLeavingPlay = { location: 'play area' };
             });

--- a/test/server/effects/doesNotKneelAsAttacker.spec.js
+++ b/test/server/effects/doesNotKneelAsAttacker.spec.js
@@ -14,8 +14,6 @@ describe('doesNotKneelAsAttacker', function() {
             this.player1.clickCard(this.character);
 
             this.completeSetup();
-            this.player1.selectPlot('A Noble Cause');
-            this.player2.selectPlot('A Noble Cause');
             this.selectFirstPlayer(this.player1);
             this.completeMarshalPhase();
         });

--- a/test/server/effects/doesNotKneelAsDefender.spec.js
+++ b/test/server/effects/doesNotKneelAsDefender.spec.js
@@ -16,8 +16,6 @@ describe('doesNotKneelAsDefender', function() {
             this.player2.clickCard(this.character);
 
             this.completeSetup();
-            this.player1.selectPlot('A Noble Cause');
-            this.player2.selectPlot('A Noble Cause');
             this.selectFirstPlayer(this.player1);
             this.completeMarshalPhase();
         });

--- a/test/server/integration/AbilityLimits.spec.js
+++ b/test/server/integration/AbilityLimits.spec.js
@@ -17,8 +17,6 @@ describe('ability limits', function() {
                 this.player1.clickCard(this.character1);
                 this.completeSetup();
 
-                this.player1.selectPlot('A Noble Cause');
-                this.player2.selectPlot('A Noble Cause');
                 this.selectFirstPlayer(this.player1);
 
                 this.player1.clickPrompt('Done');
@@ -63,8 +61,6 @@ describe('ability limits', function() {
                 this.player2.clickCard(this.character1);
                 this.completeSetup();
 
-                this.player1.selectPlot('A Noble Cause');
-                this.player2.selectPlot('A Noble Cause');
                 this.selectFirstPlayer(this.player1);
 
                 this.player1.clickPrompt('Done');

--- a/test/server/integration/Attachments.spec.js
+++ b/test/server/integration/Attachments.spec.js
@@ -16,8 +16,6 @@ describe('attachments', function() {
                 this.player1.clickCard(this.character);
                 this.completeSetup();
 
-                this.player1.selectPlot('A Noble Cause');
-                this.player2.selectPlot('A Noble Cause');
                 this.selectFirstPlayer(this.player2);
 
                 this.player2.clickCard('Milk of the Poppy', 'hand');
@@ -96,8 +94,6 @@ describe('attachments', function() {
 
                 expect(this.character.isFaction('thenightswatch'));
 
-                this.player1.selectPlot('A Noble Cause');
-                this.player2.selectPlot('A Noble Cause');
                 this.selectFirstPlayer(this.player1);
 
                 this.player1.clickCard(this.attachment);
@@ -142,8 +138,6 @@ describe('attachments', function() {
                 this.player1.clickCard(this.nonTerminalAttachment);
                 this.player1.clickCard(this.character);
 
-                this.player1.selectPlot('A Noble Cause');
-                this.player2.selectPlot('A Noble Cause');
                 this.selectFirstPlayer(this.player2);
 
                 // Attach the terminal attachment

--- a/test/server/integration/MeleeTitles.spec.js
+++ b/test/server/integration/MeleeTitles.spec.js
@@ -14,9 +14,6 @@ describe('melee titles', function() {
 
                 this.completeSetup();
 
-                this.player1.selectPlot('Trading with the Pentoshi');
-                this.player2.selectPlot('Trading with the Pentoshi');
-                this.player3.selectPlot('Trading with the Pentoshi');
                 this.selectFirstPlayer(this.player2);
 
                 // Resolve plot order

--- a/test/server/integration/ReplacementEffects.spec.js
+++ b/test/server/integration/ReplacementEffects.spec.js
@@ -23,8 +23,6 @@ describe('replacement effects', function() {
 
                 this.completeSetup();
 
-                this.player1.selectPlot('A Noble Cause');
-                this.player2.selectPlot('A Noble Cause');
                 this.selectFirstPlayer(this.player2);
 
                 this.completeMarshalPhase();
@@ -72,8 +70,6 @@ describe('replacement effects', function() {
 
                 this.completeSetup();
 
-                this.player1.selectPlot('A Noble Cause');
-                this.player2.selectPlot('A Noble Cause');
                 this.selectFirstPlayer(this.player1);
 
                 this.completeMarshalPhase();

--- a/test/server/integration/burneffects.spec.js
+++ b/test/server/integration/burneffects.spec.js
@@ -20,8 +20,6 @@ describe('burn effects', function() {
 
                 this.completeSetup();
 
-                this.player1.selectPlot('Blood of the Dragon');
-                this.player2.selectPlot('Trading with the Pentoshi');
                 this.selectFirstPlayer(this.player2);
 
                 this.player2.clickCard(this.wall);
@@ -58,8 +56,6 @@ describe('burn effects', function() {
 
                 this.completeSetup();
 
-                this.player1.selectPlot('Blood of the Dragon');
-                this.player2.selectPlot('Trading with the Pentoshi');
                 this.selectFirstPlayer(this.player2);
 
                 // Move character to dead pile to give Silent Sisters +1 STR.

--- a/test/server/integration/challengesphase.spec.js
+++ b/test/server/integration/challengesphase.spec.js
@@ -14,8 +14,6 @@ describe('challenges phase', function() {
                 this.player2.clickCard('Joffrey Baratheon', 'hand');
                 this.completeSetup();
 
-                this.player1.selectPlot('Sneak Attack');
-                this.player2.selectPlot('Sneak Attack');
                 this.selectFirstPlayer(this.player1);
 
                 this.completeMarshalPhase();
@@ -53,12 +51,10 @@ describe('challenges phase', function() {
                 this.player2.clickCard('The Shadow Tower', 'hand');
                 this.completeSetup();
 
-                this.player1.selectPlot('Sneak Attack');
-                this.player2.selectPlot('Sneak Attack');
                 this.selectFirstPlayer(this.player1);
 
                 this.completeMarshalPhase();
-                
+
                 this.player1.clickPrompt('Intrigue');
                 this.player1.clickCard('Steward at the Wall', 'play area');
                 this.player1.clickPrompt('Done');
@@ -103,8 +99,6 @@ describe('challenges phase', function() {
                 this.player2.clickCard(this.merchant);
                 this.completeSetup();
 
-                this.player1.selectPlot('Trading with the Pentoshi');
-                this.player2.selectPlot('Trading with the Pentoshi');
                 this.selectFirstPlayer(this.player1);
                 this.selectPlotOrder(this.player1);
 
@@ -179,8 +173,6 @@ describe('challenges phase', function() {
 
                 this.completeSetup();
 
-                this.player1.selectPlot('Sneak Attack');
-                this.player2.selectPlot('Sneak Attack');
                 this.selectFirstPlayer(this.player2);
 
                 // Put the remaining card back in draw deck for insight

--- a/test/server/integration/effects.spec.js
+++ b/test/server/integration/effects.spec.js
@@ -16,8 +16,6 @@ describe('effects', function() {
                 this.player1.clickCard(this.jhogo);
                 this.completeSetup();
 
-                this.player1.selectPlot('Sneak Attack');
-                this.player2.selectPlot('Sneak Attack');
                 this.selectFirstPlayer(this.player1);
 
                 this.completeMarshalPhase();
@@ -159,9 +157,6 @@ describe('effects', function() {
                 beforeEach(function() {
                     this.completeMarshalPhase();
                     this.completeChallengesPhase();
-
-                    this.player2.selectPlot('Famine');
-                    this.player1.selectPlot('Sneak Attack');
 
                     this.selectFirstPlayer(this.player2);
                     this.player2.clickCard('Winterfell Steward', 'hand');

--- a/test/server/integration/eventmaximums.spec.js
+++ b/test/server/integration/eventmaximums.spec.js
@@ -48,8 +48,6 @@ describe('event maximums', function() {
 
                 this.completeChallengesPhase();
 
-                this.player1.selectPlot('A Game of Thrones');
-                this.player2.selectPlot('A Game of Thrones');
                 this.selectFirstPlayer(this.player2);
             });
 

--- a/test/server/integration/factionchange.spec.js
+++ b/test/server/integration/factionchange.spec.js
@@ -76,8 +76,6 @@ describe('faction change', function() {
 
                 this.completeSetup();
 
-                this.player1.selectPlot('A Noble Cause');
-                this.player2.selectPlot('A Noble Cause');
                 this.selectFirstPlayer(this.player1);
 
                 this.player1.clickCard('Ward', 'hand');

--- a/test/server/integration/forcedreactionorder.spec.js
+++ b/test/server/integration/forcedreactionorder.spec.js
@@ -18,8 +18,6 @@ describe('forced reaction order', function() {
             this.player2.clickCard('Will', 'hand');
             this.completeSetup();
 
-            this.player1.selectPlot('Trading with the Pentoshi');
-            this.player2.selectPlot('Trading with the Pentoshi');
             this.selectFirstPlayer(this.player1);
 
             // Resolve plot order

--- a/test/server/integration/immunity.spec.js
+++ b/test/server/integration/immunity.spec.js
@@ -19,8 +19,6 @@ describe('immunity', function() {
 
                 this.completeSetup();
 
-                this.player1.selectPlot('Sneak Attack');
-                this.player2.selectPlot('Sneak Attack');
                 this.selectFirstPlayer(this.player2);
 
                 this.completeMarshalPhase();

--- a/test/server/integration/intimidate.spec.js
+++ b/test/server/integration/intimidate.spec.js
@@ -23,8 +23,6 @@ describe('intimidate', function() {
 
             this.completeSetup();
 
-            this.player1.selectPlot('Trading with the Pentoshi');
-            this.player2.selectPlot('Trading with the Pentoshi');
             this.selectFirstPlayer(this.player1);
 
             // Resolve plot order

--- a/test/server/integration/leavingplay.spec.js
+++ b/test/server/integration/leavingplay.spec.js
@@ -22,8 +22,6 @@ describe('leaving play', function() {
 
                 this.completeSetup();
 
-                this.player1.selectPlot('Trading with the Pentoshi');
-                this.player2.selectPlot('Trading with the Pentoshi');
                 this.selectFirstPlayer(this.player1);
                 this.selectPlotOrder(this.player1);
 
@@ -116,9 +114,6 @@ describe('leaving play', function() {
                 this.player2.clickCard(this.chud2);
 
                 this.completeSetup();
-
-                this.player1.selectPlot('Trading with the Pentoshi');
-                this.player2.selectPlot('Trading with the Pentoshi');
 
                 this.selectFirstPlayer(this.player1);
                 this.selectPlotOrder(this.player1);

--- a/test/server/integration/marshalphase.spec.js
+++ b/test/server/integration/marshalphase.spec.js
@@ -92,8 +92,6 @@ describe('marshal phase', function() {
                 this.player2.selectDeck(deck);
                 this.startGame();
                 this.skipSetupPhase();
-                this.player1.selectPlot('Sneak Attack');
-                this.player2.selectPlot('Sneak Attack');
                 this.selectFirstPlayer(this.player1);
 
                 this.roseroad = this.player1.findCardByName('The Roseroad');
@@ -124,8 +122,6 @@ describe('marshal phase', function() {
                 this.player2.selectDeck(deck);
                 this.startGame();
                 this.skipSetupPhase();
-                this.player1.selectPlot('Sneak Attack');
-                this.player2.selectPlot('Sneak Attack');
                 this.selectFirstPlayer(this.player1);
 
                 this.character = this.player1.findCardByName('Dragonstone Faithful');
@@ -175,8 +171,6 @@ describe('marshal phase', function() {
 
                 this.completeSetup();
 
-                this.player1.selectPlot('Trading with the Pentoshi');
-                this.player2.selectPlot('Trading with the Pentoshi');
                 this.selectFirstPlayer(this.player1);
                 this.selectPlotOrder(this.player1);
 

--- a/test/server/integration/nestedabilitysequences.spec.js
+++ b/test/server/integration/nestedabilitysequences.spec.js
@@ -25,8 +25,6 @@ describe('nested ability sequences', function() {
 
                 this.completeSetup();
 
-                this.player1.selectPlot('Trading with the Pentoshi');
-                this.player2.selectPlot('Trading with the Pentoshi');
                 this.selectFirstPlayer(this.player1);
 
                 // Resolve plot order
@@ -139,8 +137,6 @@ describe('nested ability sequences', function() {
 
                 this.completeSetup();
 
-                this.player1.selectPlot('A Song of Summer');
-                this.player2.selectPlot('A Song of Summer');
                 this.selectFirstPlayer(this.player1);
 
                 // Move the event to draw so that it can be drawn via The Blackfish.

--- a/test/server/integration/pillage.spec.js
+++ b/test/server/integration/pillage.spec.js
@@ -10,8 +10,6 @@ describe('pillage', function() {
             this.startGame();
             this.skipSetupPhase();
 
-            this.player1.selectPlot('Trading with the Pentoshi');
-            this.player2.selectPlot('Trading with the Pentoshi');
             this.selectFirstPlayer(this.player1);
 
             // Resolve plot order

--- a/test/server/integration/playingevents.spec.js
+++ b/test/server/integration/playingevents.spec.js
@@ -24,8 +24,6 @@ describe('playing events', function() {
 
             this.completeSetup();
 
-            this.player1.selectPlot('Trading with the Pentoshi');
-            this.player2.selectPlot('Trading with the Pentoshi');
             this.selectFirstPlayer(this.player1);
             this.selectPlotOrder(this.player1);
 

--- a/test/server/integration/reducers.spec.js
+++ b/test/server/integration/reducers.spec.js
@@ -17,8 +17,6 @@ describe('reducer cards', function() {
             this.player1.clickCard(this.grove);
             this.completeSetup();
 
-            this.player1.selectPlot('Power Behind the Throne');
-            this.player2.selectPlot('Power Behind the Throne');
             this.selectFirstPlayer(this.player1);
 
             // Resolve plot order

--- a/test/server/integration/setup.spec.js
+++ b/test/server/integration/setup.spec.js
@@ -158,8 +158,6 @@ describe('setup phase', function() {
 
                 it('should properly calculate the effects of the attachment', function() {
                     // Get into an intrigue challenge to check the strength boost.
-                    this.player1.selectPlot('Sneak Attack');
-                    this.player2.selectPlot('Sneak Attack');
                     this.selectFirstPlayer(this.player1);
 
                     this.completeMarshalPhase();
@@ -169,10 +167,6 @@ describe('setup phase', function() {
                     this.player1.clickPrompt('Done');
 
                     expect(this.refugee.getStrength()).toBe(3);
-                });
-
-                it('should continue to the plot phase', function() {
-                    expect(this.player1).toHavePrompt('Select a plot');
                 });
             });
         });
@@ -212,8 +206,6 @@ describe('setup phase', function() {
 
             it('should not double trigger reactions', function() {
                 this.completeSetup();
-                this.player1.selectPlot(this.sneakAttack);
-                this.player2.selectPlot(this.opponentSneakAttack);
                 this.selectFirstPlayer(this.player1);
 
                 this.completeMarshalPhase();

--- a/test/server/integration/takecontrol.spec.js
+++ b/test/server/integration/takecontrol.spec.js
@@ -44,7 +44,6 @@ describe('take control', function() {
 
                     // Select plots for round 2
                     this.player1.selectPlot('Valar Morghulis');
-                    this.player2.selectPlot('Confiscation');
 
                     this.selectFirstPlayer(this.player1);
                 });
@@ -99,7 +98,6 @@ describe('take control', function() {
 
                     // Select plots for round 2
                     this.player1.selectPlot('A Noble Cause');
-                    this.player2.selectPlot('Confiscation');
                     this.selectFirstPlayer(this.player1);
 
                     // Remove the Ward via Confiscation
@@ -177,8 +175,6 @@ describe('take control', function() {
                 this.player2.clickPrompt('Done');
 
                 // Round 2
-                this.player1.selectPlot('Sneak Attack');
-                this.player2.selectPlot('Sneak Attack');
                 this.selectFirstPlayer(this.player1);
             });
 
@@ -219,9 +215,6 @@ describe('take control', function() {
                 this.player2.clickCard(this.steward);
 
                 this.completeSetup();
-
-                this.player1.selectPlot('Trading with the Pentoshi');
-                this.player2.selectPlot('Trading with the Pentoshi');
             });
 
             describe('when it comes into play under control', function() {
@@ -339,9 +332,6 @@ describe('take control', function() {
                 this.mines = this.player2.findCardByName('Iron Mines', 'hand');
 
                 this.completeSetup();
-
-                this.player1.selectPlot('Trading with the Pentoshi');
-                this.player2.selectPlot('Trading with the Pentoshi');
 
                 this.selectFirstPlayer(this.player1);
                 this.selectPlotOrder(this.player1);
@@ -486,8 +476,6 @@ describe('take control', function() {
                     this.player1.clickCard(this.ourCharacter);
                     this.completeSetup();
 
-                    this.player1.selectPlot('Trading with the Pentoshi');
-                    this.player2.selectPlot('A Noble Cause');
                     this.selectFirstPlayer(this.player1);
 
                     expect(this.ourCharacter.location).toBe('play area');
@@ -516,8 +504,6 @@ describe('take control', function() {
                     this.player1.dragCard(this.ourCharacter, 'dead pile');
                     this.completeSetup();
 
-                    this.player1.selectPlot('Trading with the Pentoshi');
-                    this.player2.selectPlot('A Noble Cause');
                     this.selectFirstPlayer(this.player1);
                 });
 
@@ -544,8 +530,6 @@ describe('take control', function() {
                     this.player2.clickCard(this.theirCharacter);
                     this.completeSetup();
 
-                    this.player1.selectPlot('Trading with the Pentoshi');
-                    this.player2.selectPlot('A Noble Cause');
                     this.selectFirstPlayer(this.player1);
 
                     this.player1.clickCard('Ward');
@@ -574,8 +558,6 @@ describe('take control', function() {
                     this.player2.clickCard(this.theirCharacter);
                     this.completeSetup();
 
-                    this.player1.selectPlot('Trading with the Pentoshi');
-                    this.player2.selectPlot('A Noble Cause');
                     this.selectFirstPlayer(this.player1);
                 });
 
@@ -603,8 +585,6 @@ describe('take control', function() {
                     this.player2.dragCard(this.theirCharacter, 'dead pile');
                     this.completeSetup();
 
-                    this.player1.selectPlot('Trading with the Pentoshi');
-                    this.player2.selectPlot('A Noble Cause');
                     this.selectFirstPlayer(this.player1);
                 });
 
@@ -666,8 +646,6 @@ describe('take control', function() {
 
                 this.completeChallengesPhase();
 
-                this.player1.selectPlot('A Game of Thrones');
-                this.player2.selectPlot('A Game of Thrones');
                 this.selectFirstPlayer(this.player1);
 
                 // Remarshal the character
@@ -708,8 +686,6 @@ describe('take control', function() {
 
                 this.completeSetup();
 
-                this.player1.selectPlot('Snowed Under');
-                this.player2.selectPlot('A Storm of Swords');
                 this.selectFirstPlayer(this.player1);
 
                 // Drag these to discard to be available for Night Gathers

--- a/test/server/integration/traitchange.spec.js
+++ b/test/server/integration/traitchange.spec.js
@@ -21,8 +21,6 @@ describe('trait change', function() {
                     this.player1.clickCard(this.character);
                     this.completeSetup();
 
-                    this.player1.selectPlot('A Tourney for the King');
-                    this.player2.selectPlot('A Tourney for the King');
                     this.selectFirstPlayer(this.player1);
 
                     this.player1.clickCard(this.knighted);
@@ -52,8 +50,6 @@ describe('trait change', function() {
 
                     expect(this.character.hasTrait('Knight')).toBe(true);
 
-                    this.player1.selectPlot('A Tourney for the King');
-                    this.player2.selectPlot('A Tourney for the King');
                     this.selectFirstPlayer(this.player1);
 
                     this.completeMarshalPhase();

--- a/test/server/player/flipplotfaceup.spec.js
+++ b/test/server/player/flipplotfaceup.spec.js
@@ -80,7 +80,7 @@ describe('Player', function() {
     describe('recyclePlots()', function() {
         describe('when there are no plots left', function() {
             beforeEach(function() {
-                this.player.activePlot = this.selectedPlot;
+                this.player.activePlot = this.selectedPlotSpy;
                 this.player.plotDeck = _([]);
                 this.player.plotDiscard = _([this.anotherPlotSpy]);
                 this.anotherPlotSpy.location = 'revealed plots';
@@ -102,7 +102,7 @@ describe('Player', function() {
 
         describe('when there are plots left', function() {
             beforeEach(function() {
-                this.player.plotDeck = _([this.selectedPlot]);
+                this.player.plotDeck = _([this.selectedPlotSpy]);
                 this.player.plotDiscard = _([this.anotherPlotSpy]);
                 this.anotherPlotSpy.location = 'revealed plots';
 


### PR DESCRIPTION
Change rains to use effects to restrict the available plot selection
Update the plot selection to be able to show valid targets
Add the ability to tell the client to group cards and change the client to group said cards
Make the target select cursor conditional and only apply to the board element so that it doesnt stick if a game breaks