### PR TITLE
Update styling for pile popup groups

### DIFF
--- a/client/Components/GameBoard/CardPile.jsx
+++ b/client/Components/GameBoard/CardPile.jsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import _ from 'underscore';
 
 import Card from './Card';
+import CardTiledList from './CardTiledList';
 import Droppable from './Droppable';
 
 class CardPile extends React.Component {
@@ -95,45 +96,32 @@ class CardPile extends React.Component {
         }
     }
 
-    getCardList(cards) {
-        let cardIndex = 0;
-
-        if(!cards) {
-            return null;
-        }
-
-        let cardList = cards.map(card => {
-            let cardKey = card.uuid || cardIndex++;
-            return (<Card key={ cardKey } card={ card } source={ this.props.source }
-                disableMouseOver={ this.props.disableMouseOver }
-                onMouseOver={ this.props.onMouseOver }
-                onMouseOut={ this.props.onMouseOut }
-                onTouchMove={ this.props.onTouchMove }
-                onClick={ this.onCardClick.bind(this, card) }
-                orientation={ this.props.orientation === 'kneeled' ? 'vertical' : this.props.orientation }
-                size={ this.props.size } />);
-        });
-
-        return cardList;
-    }
-
     getPopup() {
         let popup = null;
 
         let cardList = [];
 
+        let listProps = {
+            disableMouseOver: this.props.disableMouseOver,
+            onCardClick: this.onCardClick.bind(this),
+            onCardMouseOut: this.props.onMouseOut,
+            onCardMouseOver: this.props.onMouseOver,
+            onTouchMove: this.props.onTouchMove,
+            orientation: this.props.orientation,
+            size: this.props.size,
+            source: this.props.source
+        };
+
         if(this.props.cards && this.props.cards.some(card => card.group)) {
             let cardGroup = _.groupBy(this.props.cards, card => card.group);
             for(const [type, cards] of Object.entries(cardGroup)) {
                 cardList.push(
-                    <div key={ type }>
-                        <div className='group-title'>{ `${type} (${cards.length})` }</div>
-                        { this.getCardList(cards) }
-                    </div>
+                    <CardTiledList cards={ cards } key={ type } title={ type } { ...listProps } />
                 );
             }
         } else {
-            cardList = this.getCardList(this.props.cards);
+            cardList = (
+                <CardTiledList cards={ this.props.cards } { ...listProps } />);
         }
 
         if(this.props.disablePopup || !this.state.showPopup) {

--- a/client/Components/GameBoard/CardPile.jsx
+++ b/client/Components/GameBoard/CardPile.jsx
@@ -148,6 +148,7 @@ class CardPile extends React.Component {
             'up': this.props.popupLocation !== 'top' && this.props.orientation !== 'horizontal',
             'left': this.props.orientation === 'horizontal'
         });
+        let innerClass = classNames('inner', this.props.size);
 
         let linkIndex = 0;
 
@@ -166,7 +167,7 @@ class CardPile extends React.Component {
                 <Droppable onDragDrop={ this.props.onDragDrop } source={ this.props.source }>
                     <div className={ popupClass } onClick={ event => event.stopPropagation() }>
                         { popupMenu }
-                        <div className='inner'>
+                        <div className={ innerClass }>
                             { cardList }
                         </div>
                         <div className={ arrowClass } />

--- a/client/Components/GameBoard/CardTiledList.jsx
+++ b/client/Components/GameBoard/CardTiledList.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Card from './Card';
+
+function CardTiledList(props) {
+    let cardList = props.cards && props.cards.map((card, index) => {
+        return (<Card
+            card={ card }
+            disableMouseOver={ props.disableMouseOver }
+            key={ index }
+            onClick={ props.onCardClick }
+            onMouseOut={ props.onCardMouseOut }
+            onMouseOver={ props.onCardMouseOver }
+            onTouchMove={ props.onTouchMove }
+            orientation={ props.orientation }
+            size={ props.size }
+            source={ props.source } />);
+    });
+
+    let title = props.title && props.cards ? `${props.title} (${props.cards.length})` : props.title;
+
+    return (
+        <div className='card-list'>
+            { title &&
+                <div className='card-list-title'>{ title }</div>
+            }
+            <div className='card-list-cards'>
+                { cardList }
+            </div>
+        </div>);
+}
+
+CardTiledList.propTypes = {
+    cards: PropTypes.array,
+    disableMouseOver: PropTypes.bool,
+    onCardClick: PropTypes.func,
+    onCardMouseOut: PropTypes.func,
+    onCardMouseOver: PropTypes.func,
+    onTouchMove: PropTypes.func,
+    orientation: PropTypes.string,
+    size: PropTypes.string,
+    source: PropTypes.string,
+    title: PropTypes.string
+};
+
+export default CardTiledList;

--- a/client/Components/GameBoard/PlayerRow.jsx
+++ b/client/Components/GameBoard/PlayerRow.jsx
@@ -109,7 +109,9 @@ class PlayerRow extends React.Component {
 
         disablePopup = disablePopup || !cards || cards.length === 0;
 
-        let pile = (<CardPile className='agenda'
+        let pileClass = classNames('agenda', `agenda-${this.props.agenda.code}`);
+
+        let pile = (<CardPile className={ pileClass }
             cards={ cards }
             disablePopup={ disablePopup }
             onCardClick={ this.props.onCardClick }

--- a/less/gameboard.less
+++ b/less/gameboard.less
@@ -529,16 +529,25 @@
     top: 95px;
     left: 0;
 
-    .inner {
-      .calculate-tiled-card-prop(max-height, 1, height);
-      .calculate-tiled-card-prop(min-width, 2, width);
-    }
-
     .arrow {
       bottom: initial;
       top: -60px;
       left: 10px;
     }
+  }
+}
+
+// Alliance agenda
+.agenda-06018 {
+  .inner {
+    .calculate-tiled-card-prop(width, 2, width);
+  }
+}
+
+// Conclave agenda
+.agenda-09045 {
+  .inner {
+    .calculate-tiled-card-prop(width, 7, width);
   }
 }
 

--- a/less/gameboard.less
+++ b/less/gameboard.less
@@ -296,10 +296,63 @@
   }
 }
 
-.inner {
-  .card-wrapper {
-    margin: 5px 5px 0 0;
+/**
+ * Generates the specified property based on the calculation of:
+ * property: numCards * (cardSize + cardSpacing) + additionalOffset
+ *
+ * for the various different card sizes. Example, mixing in
+ * .calculate-tiled-card-prop(min-height, 2, height, 3px) will generate CSS for:
+ * min-height: 2 * (@card-height + 5px) + 3px
+ * &.small {
+ *   min-height: 2 * (@card-sm-height + 5px) + 3px
+ * }
+ * ... etc ...
+ */
+ .calculate-tiled-card-prop(@property, @numCards, @cardMeasurement, @additionalOffset: 0px) {
+  @cardMeasurementNm: "card-@{cardMeasurement}";
+  @cardMeasurementSm: "card-sm-@{cardMeasurement}";
+  @cardMeasurementLg: "card-lg-@{cardMeasurement}";
+  @cardMeasurementXl: "card-xl-@{cardMeasurement}";
+
+
+  @{property}: @numCards * (@@cardMeasurementNm + 5px) + @additionalOffset;
+
+  &.small {
+    @{property}: @numCards * (@@cardMeasurementSm + 5px) + @additionalOffset;
   }
+
+  &.large {
+    @{property}: @numCards * (@@cardMeasurementLg + 5px) + @additionalOffset;
+  };
+
+  &.x-large {
+    @{property}: @numCards * (@@cardMeasurementXl + 5px) + @additionalOffset;
+  };
+}
+
+.inner {
+  .calculate-tiled-card-prop(max-height, 4, height);
+  overflow-y: auto;
+}
+
+.card-list {
+  .card-wrapper {
+    margin: 0 5px 5px 0;
+  }
+}
+
+.card-list-title {
+  background-color: @brand-primary;
+  color: white;
+  margin-bottom: 5px;
+  text-align: center;
+}
+
+.card-list-cards {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start;
 }
 
 .our-side {
@@ -373,8 +426,8 @@
     left: 20px;
 
     .inner {
-      min-width: @card-height * 2 + (2 * 5px);
-      min-height: @card-width * 2 + (2 * 5px);
+      .calculate-tiled-card-prop(min-height, 2, width);
+      .calculate-tiled-card-prop(min-width, 2, height, @scrollbar-width);
     }
 
     .arrow {
@@ -395,12 +448,8 @@
     top: -75px;
 
     .inner {
-      columns: 3;
-      min-height: 128px;
-
-      .card-wrapper {
-        margin: 5px 0 0 0;
-      }
+      .calculate-tiled-card-prop(min-height, 1, width);
+      .calculate-tiled-card-prop(width, 4, height);
     }
 
     .arrow {
@@ -419,10 +468,8 @@
     top: 95px;
 
     .inner {
-      min-height: @card-height;
-      width: @card-width * 5 + (5 * 5px) + @scrollbar-width;
-      max-height: @card-height * 4 + (4 * 5px);
-      overflow-y: auto;
+      .calculate-tiled-card-prop(min-height, 1, height);
+      .calculate-tiled-card-prop(width, 5, width, @scrollbar-width);
     }
 
     .arrow {
@@ -440,10 +487,8 @@
     left: 0;
 
     .inner {
-      min-height: @card-height;
-      width: @card-width * 5 + (5 * 5px) + @scrollbar-width;
-      max-height: @card-height * 4 + (4 * 5px);
-      overflow-y: auto;
+      .calculate-tiled-card-prop(min-height, 1, height);
+      .calculate-tiled-card-prop(width, 5, width, @scrollbar-width);
     }
 
     .arrow {
@@ -467,11 +512,8 @@
     bottom: 95px;
 
     .inner {
-      width: @card-width * 7 + (7 * 5px) + @scrollbar-width;
-      min-height: @card-height;
-      max-height: @card-height * 4 + (4 * 5px);
-
-      overflow-y: auto;
+      .calculate-tiled-card-prop(min-height, 1, height);
+      .calculate-tiled-card-prop(width, 7, width, @scrollbar-width);
     }
   }
 
@@ -488,9 +530,8 @@
     left: 0;
 
     .inner {
-      min-width: @card-width * 2 + (2 * 5px);
-      max-height: @card-height + 10px;
-      display: flex;
+      .calculate-tiled-card-prop(max-height, 1, height);
+      .calculate-tiled-card-prop(min-width, 2, width);
     }
 
     .arrow {
@@ -799,10 +840,4 @@ span.down-arrow {
     margin-top: 10px;
     margin-bottom: 10px;
   }
-}
-
-.group-title {
-  background-color: @brand-primary;
-  text-align: center;
-  color: white;
 }


### PR DESCRIPTION
* Scales the size of the popup based on the card size selected (previously stuck on normal sized calculations, so you'd get more wrapping if you set card size to large or extra large)
* Updated styling for grouped cards in the popup.

Normal:
![screen shot 2018-04-04 at 3 39 03 pm](https://user-images.githubusercontent.com/145077/38338894-5cba9f16-3820-11e8-9929-620ba0a1985e.png)

Select plot:
![screen shot 2018-04-04 at 3 39 19 pm](https://user-images.githubusercontent.com/145077/38338898-62109952-3820-11e8-890a-117aade248be.png)

Select Rains:
![screen shot 2018-04-04 at 3 39 37 pm](https://user-images.githubusercontent.com/145077/38338902-67a68c14-3820-11e8-8c83-4b579a624dc6.png)
