### PR TITLE
Fix client crash when attachments are marshalled

### DIFF
--- a/client/Components/GameBoard/Card.jsx
+++ b/client/Components/GameBoard/Card.jsx
@@ -27,7 +27,7 @@ function collect(connect, monitor) {
     };
 }
 
-class Card extends React.Component {
+class InnerCard extends React.Component {
     constructor() {
         super();
 
@@ -308,7 +308,7 @@ class Card extends React.Component {
 
     render() {
         if(this.props.wrapped) {
-            return this.props.connectDragSource(
+            return (
                 <div className='card-wrapper' style={ this.props.style }>
                     { this.getCard() }
                     { this.getDupes() }
@@ -320,8 +320,8 @@ class Card extends React.Component {
     }
 }
 
-Card.displayName = 'Card';
-Card.propTypes = {
+InnerCard.displayName = 'Card';
+InnerCard.propTypes = {
     card: PropTypes.shape({
         attached: PropTypes.bool,
         attachments: PropTypes.array,
@@ -366,9 +366,12 @@ Card.propTypes = {
     style: PropTypes.object,
     wrapped: PropTypes.bool
 };
-Card.defaultProps = {
+InnerCard.defaultProps = {
     orientation: 'vertical',
     wrapped: true
 };
 
-export default DragSource(ItemTypes.CARD, cardSource, collect)(Card);
+const Card = DragSource(ItemTypes.CARD, cardSource, collect)(InnerCard);
+
+export default Card;
+


### PR DESCRIPTION
Make sure the card component is using the wrapped version of itself for attachments so that they have the drag related functions

Fixes attachments crashing the client