### PR TITLE
Fix reconnecting to games when the lobby socket bounces

### DIFF
--- a/client/ReduxActions/socket.js
+++ b/client/ReduxActions/socket.js
@@ -150,13 +150,14 @@ export function connectLobby() {
                 url += ':' + server.port;
             }
 
-            if(state.games.socket) {
-                dispatch(actions.closeGameSocket());
-            }
-
             dispatch(actions.setAuthTokens(server.authToken, state.auth.refreshToken));
 
-            dispatch(actions.connectGameSocket(url, server.name));
+            if(state.games.socket && state.lobby.currentGame.id !== server.gameId) {
+                dispatch(actions.closeGameSocket());
+                dispatch(actions.connectGameSocket(url, server.name));
+            } else if(!state.games.socket) {
+                dispatch(actions.connectGameSocket(url, server.name));
+            }
         });
 
         socket.on('authfailed', () => {

--- a/server/lobby.js
+++ b/server/lobby.js
@@ -322,7 +322,7 @@ class Lobby {
 
         var game = this.findGameForUser(socket.user.username);
         if(game && game.started) {
-            this.sendHandoff(socket, game.node);
+            this.sendHandoff(socket, game.node, game.id);
         }
     }
 
@@ -340,7 +340,7 @@ class Lobby {
 
         var game = this.findGameForUser(user.username);
         if(game && game.started) {
-            this.sendHandoff(socket, game.node);
+            this.sendHandoff(socket, game.node, game.id);
         }
     }
 
@@ -469,11 +469,11 @@ class Lobby {
                 return;
             }
 
-            this.sendHandoff(socket, gameNode);
+            this.sendHandoff(socket, gameNode, game.id);
         });
     }
 
-    sendHandoff(socket, gameNode) {
+    sendHandoff(socket, gameNode, gameId) {
         let authToken = jwt.sign(socket.user.getWireSafeDetails(), this.config.secret, { expiresIn: '5m' });
 
         socket.send('handoff', {
@@ -481,7 +481,8 @@ class Lobby {
             port: gameNode.port,
             protocol: gameNode.protocol,
             name: gameNode.identity,
-            authToken: authToken
+            authToken: authToken,
+            gameId: gameId
         });
     }
 
@@ -507,7 +508,7 @@ class Lobby {
 
             if(game.started) {
                 this.router.addSpectator(game, socket.user.getDetails());
-                this.sendHandoff(socket, game.node);
+                this.sendHandoff(socket, game.node, game.id);
             } else {
                 this.sendGameState(game);
             }


### PR DESCRIPTION
send the game id with the handoff message
use this game id on the client to not hand off to a game socket that it's already connected to