### PR TITLE
Check for dupes in player.attach

### DIFF
--- a/server/game/player.js
+++ b/server/game/player.js
@@ -750,6 +750,16 @@ class Player extends Spectator {
         let originalLocation = attachment.location;
 
         attachment.owner.removeCardFromPile(attachment);
+
+        let dupeCard = this.getDuplicateInPlay(attachment);
+        if(dupeCard && dupeCard.controller === attachment.controller) {
+            dupeCard.addDuplicate(attachment);
+            if(originalLocation !== 'play area') {
+                this.game.raiseEvent('onCardEntersPlay', { card: attachment, playingType: playingType, originalLocation: originalLocation });
+            }
+            return;
+        }
+
         attachment.moveTo('play area', card);
         attachment.controller = controller;
         card.attachments.push(attachment);


### PR DESCRIPTION
Fixes a bug where Hotah's Axe through its ability could be attached in multiples to a character even though it is unique.

Fixes #1877.