### PR TITLE
Add pre-challenge action window after first player completes challenges

### DIFF
--- a/server/game/gamesteps/challengephase.js
+++ b/server/game/gamesteps/challengephase.js
@@ -9,7 +9,6 @@ class ChallengePhase extends Phase {
         super(game, 'challenge');
         this.initialise([
             new SimpleStep(this.game, () => this.beginPhase()),
-            new ActionWindow(this.game, 'Before challenge', 'challengeBegin'),
             new SimpleStep(this.game, () => this.promptForChallenge())
         ]);
     }
@@ -22,6 +21,8 @@ class ChallengePhase extends Phase {
         if(this.remainingPlayers.length === 0) {
             return true;
         }
+
+        this.game.queueStep(new ActionWindow(this.game, 'Before challenge', 'challengeBegin'));
 
         var currentPlayer = this.remainingPlayers[0];
         this.game.promptWithMenu(currentPlayer, this, {


### PR DESCRIPTION
### Currently

- Pre-challenge action window
- Player1 is prompted to initiate a challenge
- Player1 completes challenges
- Player2 is prompted for challenges

### Expected

- Pre-challenge action window
- Player1 is prompted to initiate a challenge
- Player1 completes challenges
- Pre-challenge action window
- Player2 is prompted for challenges

![rr4](https://user-images.githubusercontent.com/23409205/38395611-13684556-3934-11e8-8350-79639ff86755.png)