### PR TITLE
Fix kneeling cards in dead pile popup

### DIFF
--- a/client/Components/GameBoard/CardPile.jsx
+++ b/client/Components/GameBoard/CardPile.jsx
@@ -107,7 +107,6 @@ class CardPile extends React.Component {
             onCardMouseOut: this.props.onMouseOut,
             onCardMouseOver: this.props.onMouseOver,
             onTouchMove: this.props.onTouchMove,
-            orientation: this.props.orientation,
             size: this.props.size,
             source: this.props.source
         };

--- a/client/Components/GameBoard/CardTiledList.jsx
+++ b/client/Components/GameBoard/CardTiledList.jsx
@@ -13,7 +13,7 @@ function CardTiledList(props) {
             onMouseOut={ props.onCardMouseOut }
             onMouseOver={ props.onCardMouseOver }
             onTouchMove={ props.onTouchMove }
-            orientation={ props.orientation }
+            orientation={ card.type === 'plot' ? 'horizontal' : 'vertical' }
             size={ props.size }
             source={ props.source } />);
     });
@@ -38,7 +38,6 @@ CardTiledList.propTypes = {
     onCardMouseOut: PropTypes.func,
     onCardMouseOver: PropTypes.func,
     onTouchMove: PropTypes.func,
-    orientation: PropTypes.string,
     size: PropTypes.string,
     source: PropTypes.string,
     title: PropTypes.string


### PR DESCRIPTION
Cards in a card list should be oriented by the type of card they are -
horizontal for plot cards, vertical for everything else.

Before:
![screen shot 2018-04-06 at 2 42 38 pm](https://user-images.githubusercontent.com/145077/38445523-d15c595c-39a8-11e8-842e-939a7b83a004.png)

After:
![screen shot 2018-04-06 at 2 42 21 pm](https://user-images.githubusercontent.com/145077/38445536-d778fcb4-39a8-11e8-90c2-822365f2a693.png)
