### PR TITLE
Plots should not be displayed as "kneeled" in UI

### DIFF
--- a/client/Components/GameBoard/Card.jsx
+++ b/client/Components/GameBoard/Card.jsx
@@ -251,7 +251,7 @@ class InnerCard extends React.Component {
         let imageClass = classNames('card-image', this.sizeClass, {
             'horizontal': this.props.card.type === 'plot',
             'vertical': this.props.card.type !== 'plot',
-            'kneeled': this.props.orientation === 'kneeled' || this.props.card.kneeled || this.props.orientation === 'horizontal' && this.props.card.type !== 'plot'
+            'kneeled': this.props.card.type !== 'plot' && (this.props.orientation === 'kneeled' || this.props.card.kneeled || this.props.orientation === 'horizontal')
         });
 
         let image = <img className={ imageClass } src={ '/img/cards/' + (!this.isFacedown() ? (this.props.card.code + '.png') : 'cardback.jpg') } />;


### PR DESCRIPTION
Fixes bug introduced in #1858 

Before:
![screen shot 2018-04-06 at 3 39 59 pm](https://user-images.githubusercontent.com/145077/38447214-dd8fc5bc-39b0-11e8-884e-1271aac5043a.png)

After:
![screen shot 2018-04-06 at 3 39 46 pm](https://user-images.githubusercontent.com/145077/38447217-e18af524-39b0-11e8-8dc8-5533f0c4f067.png)
