### PR TITLE
Implement movable card windows

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,12 @@
 {
-  "presets": ["react", "env"],
-  "plugins": [ "istanbul", "react-hot-loader/babel", "transform-object-assign", "transform-object-rest-spread" ]
+  "presets": [
+    "react",
+    "env"
+  ],
+  "plugins": [
+    "istanbul",
+    "react-hot-loader/babel",
+    "transform-object-assign",
+    "transform-object-rest-spread"
+  ]
 }

--- a/client/Components/GameBoard/CardPile.jsx
+++ b/client/Components/GameBoard/CardPile.jsx
@@ -6,18 +6,20 @@ import _ from 'underscore';
 import Card from './Card';
 import CardTiledList from './CardTiledList';
 import Droppable from './Droppable';
+import MovablePanel from './MovablePanel';
 
 class CardPile extends React.Component {
-    constructor() {
-        super();
-
-        this.onCollectionClick = this.onCollectionClick.bind(this);
-        this.onTopCardClick = this.onTopCardClick.bind(this);
+    constructor(props) {
+        super(props);
 
         this.state = {
             showPopup: false,
             showMenu: false
         };
+
+        this.onCollectionClick = this.onCollectionClick.bind(this);
+        this.onTopCardClick = this.onTopCardClick.bind(this);
+        this.onCloseClick = this.onCloseClick.bind(this);
     }
 
     componentWillReceiveProps(props) {
@@ -98,7 +100,6 @@ class CardPile extends React.Component {
 
     getPopup() {
         let popup = null;
-
         let cardList = [];
 
         let listProps = {
@@ -130,13 +131,8 @@ class CardPile extends React.Component {
         let popupClass = classNames('panel', {
             'our-side': this.props.popupLocation === 'top'
         });
-        let arrowClass = classNames('arrow', 'lg', {
-            'down': this.props.popupLocation === 'top' && this.props.orientation !== 'horizontal',
-            'up': this.props.popupLocation !== 'top' && this.props.orientation !== 'horizontal',
-            'left': this.props.orientation === 'horizontal'
-        });
-        let innerClass = classNames('inner', this.props.size);
 
+        let innerClass = classNames('inner', this.props.size);
         let linkIndex = 0;
 
         let popupMenu = this.props.popupMenu ? (<div>{ _.map(this.props.popupMenu, menuItem => {
@@ -144,23 +140,17 @@ class CardPile extends React.Component {
         }) }</div>) : null;
 
         popup = (
-            <div className='popup'>
-                <div className='panel-title' onClick={ event => event.stopPropagation() }>
-                    <span className='text-center'>{ this.props.title }</span>
-                    <span className='pull-right'>
-                        <a className='close-button glyphicon glyphicon-remove' onClick={ this.onCloseClick.bind(this) } />
-                    </span>
-                </div>
+            <MovablePanel title={ this.props.title } name={ this.props.source } onCloseClick={ this.onCloseClick } side={ this.props.popupLocation }>
                 <Droppable onDragDrop={ this.props.onDragDrop } source={ this.props.source }>
                     <div className={ popupClass } onClick={ event => event.stopPropagation() }>
                         { popupMenu }
                         <div className={ innerClass }>
                             { cardList }
                         </div>
-                        <div className={ arrowClass } />
                     </div>
                 </Droppable>
-            </div>);
+            </MovablePanel>
+        );
 
         return popup;
     }
@@ -240,6 +230,7 @@ CardPile.propTypes = {
     topCard: PropTypes.object
 };
 CardPile.defaultProps = {
+    popupLocation: 'bottom',
     orientation: 'vertical'
 };
 

--- a/client/Components/GameBoard/GameBoard.jsx
+++ b/client/Components/GameBoard/GameBoard.jsx
@@ -5,8 +5,6 @@ import _ from 'underscore';
 import $ from 'jquery';
 import { toastr } from 'react-redux-toastr';
 import { bindActionCreators } from 'redux';
-import { DragDropContext } from 'react-dnd';
-import { default as TouchBackend } from 'react-dnd-touch-backend';
 import classNames from 'classnames';
 
 import PlayerStats from './PlayerStats';
@@ -444,6 +442,5 @@ function mapDispatchToProps(dispatch) {
     return boundActions;
 }
 
-const draggable = DragDropContext(TouchBackend({ enableMouseEvents: true }))(GameBoard);
-export default connect(mapStateToProps, mapDispatchToProps, null, { withRef: true })(draggable);
+export default connect(mapStateToProps, mapDispatchToProps, null, { withRef: true })(GameBoard);
 

--- a/client/Components/GameBoard/MovablePanel.jsx
+++ b/client/Components/GameBoard/MovablePanel.jsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { DragSource } from 'react-dnd';
+
+import { ItemTypes } from '../../constants';
+import PopupDefaults from './PopupDefaults';
+
+const panelSource = {
+    beginDrag(props) {
+        return {
+            name: `${props.name}-${props.side}`
+        };
+    },
+    endDrag(props, monitor) {
+        const offset = monitor.getSourceClientOffset();
+        const style = {
+            left: offset.x,
+            top: offset.y,
+            position: 'fixed'
+        };
+
+        localStorage.setItem(`${props.name}-${props.side}`, JSON.stringify(style));
+    }
+};
+
+function collect(connect, monitor) {
+    return {
+        connectDragPreview: connect.dragPreview(),
+        connectDragSource: connect.dragSource(),
+        isDragging: monitor.isDragging(),
+        dragOffset: monitor.getSourceClientOffset()
+    };
+}
+
+class MovablePanel extends React.Component {
+    constructor(props) {
+        super(props);
+
+        const key = `${props.name}-${props.side}`;
+        const savedStyle = localStorage.getItem(key);
+        const style = (savedStyle && JSON.parse(savedStyle)) || PopupDefaults[key];
+
+        this.state = {
+            position: Object.assign({}, style)
+        };
+    }
+
+    componentWillReceiveProps(props) {
+        if(props.isDragging) {
+            this.setState({
+                position: {
+                    position: 'fixed',
+                    left: props.dragOffset.x,
+                    top: props.dragOffset.y
+                }
+            });
+        }
+    }
+
+    render() {
+        let style = this.state.position;
+
+        let content = (<div className='popup' style={ style }>
+            {
+                this.props.connectDragSource(
+                    <div className='panel-title' onClick={ event => event.stopPropagation() }>
+                        <span className='text-center'>{ this.props.title }</span>
+                        <span className='pull-right'>
+                            <a className='close-button glyphicon glyphicon-remove' onClick={ this.props.onCloseClick } />
+                        </span>
+                    </div>)
+            }
+            { this.props.children }
+        </div >);
+
+        return content;
+    }
+}
+
+MovablePanel.displayName = 'MovablePanel';
+MovablePanel.propTypes = {
+    children: PropTypes.node,
+    connectDragPreview: PropTypes.func,
+    connectDragSource: PropTypes.func,
+    dragOffset: PropTypes.object,
+    isDragging: PropTypes.bool,
+    name: PropTypes.string.isRequired,
+    onCloseClick: PropTypes.func,
+    side: PropTypes.oneOf(['top', 'bottom']),
+    title: PropTypes.string
+};
+
+export default DragSource(ItemTypes.PANEL, panelSource, collect)(MovablePanel);

--- a/client/Components/GameBoard/MovablePanel.jsx
+++ b/client/Components/GameBoard/MovablePanel.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { DragSource } from 'react-dnd';
+import $ from 'jquery';
 
 import { ItemTypes } from '../../constants';
 import PopupDefaults from './PopupDefaults';
@@ -47,12 +48,24 @@ class MovablePanel extends React.Component {
 
     componentWillReceiveProps(props) {
         if(props.isDragging) {
+            let style = {
+                position: 'fixed',
+                left: Math.max(props.dragOffset.x, 0),
+                top: Math.max(props.dragOffset.y, 50)
+            };
+
+            const popup = $(this.refs.popup);
+
+            if(style.left + popup.width() > window.innerWidth) {
+                style.left = window.innerWidth - popup.width();
+            }
+
+            if(style.top + popup.height() > window.innerHeight) {
+                style.top = window.innerHeight - popup.height();
+            }
+
             this.setState({
-                position: {
-                    position: 'fixed',
-                    left: props.dragOffset.x,
-                    top: props.dragOffset.y
-                }
+                position: style
             });
         }
     }
@@ -60,7 +73,7 @@ class MovablePanel extends React.Component {
     render() {
         let style = this.state.position;
 
-        let content = (<div className='popup' style={ style }>
+        let content = (<div ref='popup' className='popup' style={ style }>
             {
                 this.props.connectDragSource(
                     <div className='panel-title' onClick={ event => event.stopPropagation() }>

--- a/client/Components/GameBoard/PlayerPlots.jsx
+++ b/client/Components/GameBoard/PlayerPlots.jsx
@@ -19,6 +19,7 @@ class PlayerPlots extends React.Component {
             orientation='horizontal'
             size={ this.props.cardSize }
             source='revealed plots'
+            popupLocation={ this.props.isMe ? 'bottom' : 'top' }
             title='Used Plots'
             topCard={ this.props.activePlot } />);
 
@@ -36,6 +37,7 @@ class PlayerPlots extends React.Component {
             orientation='horizontal'
             source='plot deck'
             title='Plots'
+            popupLocation={ this.props.isMe ? 'bottom' : 'top' }
             topCard={ { facedown: true, kneeled: true } }
             size={ this.props.cardSize } />);
 

--- a/client/Components/GameBoard/PlayerRow.jsx
+++ b/client/Components/GameBoard/PlayerRow.jsx
@@ -69,7 +69,7 @@ class PlayerRow extends React.Component {
             onMouseOut={ this.props.onMouseOut }
             onMouseOver={ this.props.onMouseOver }
             orientation='kneeled'
-            popupLocation={ this.props.isMe || this.props.spectating ? 'top' : 'bottom' }
+            popupLocation={ this.props.isMe || this.props.spectating ? 'bottom' : 'top' }
             source='out of game'
             title='Out of Game'
             size={ this.props.cardSize } />);
@@ -119,7 +119,7 @@ class PlayerRow extends React.Component {
             onMenuItemClick={ this.props.onMenuItemClick }
             onMouseOut={ this.props.onMouseOut }
             onMouseOver={ this.props.onMouseOver }
-            popupLocation={ this.props.isMe ? 'top' : 'bottom' }
+            popupLocation={ this.props.isMe ? 'bottom' : 'top' }
             source={ source }
             title={ title }
             topCard={ this.props.agenda }
@@ -177,19 +177,20 @@ class PlayerRow extends React.Component {
             onDragDrop={ this.props.onDragDrop }
             onMouseOver={ this.props.onMouseOver } onMouseOut={ this.props.onMouseOut }
             onCardClick={ this.props.isMe && !this.props.spectating ? this.props.onCardClick : null }
-            popupLocation='top' disablePopup={ this.props.spectating || !this.props.isMe }
+            popupLocation={ this.props.isMe || this.props.spectating ? 'bottom' : 'top' }
+            disablePopup={ this.props.spectating || !this.props.isMe }
             menu={ drawDeckMenu } hiddenTopCard cardCount={ this.props.numDrawCards } popupMenu={ drawDeckPopupMenu }
             onCloseClick={ this.onCloseClick.bind(this) }
             size={ this.props.cardSize } />);
         let discardPile = (<CardPile className='discard' title='Discard' source='discard pile' cards={ this.props.discardPile }
             onDragDrop={ this.props.onDragDrop }
             onMouseOver={ this.props.onMouseOver } onMouseOut={ this.props.onMouseOut } onCardClick={ this.props.onCardClick }
-            popupLocation={ this.props.isMe || this.props.spectating ? 'top' : 'bottom' }
+            popupLocation={ this.props.isMe || this.props.spectating ? 'bottom' : 'top' }
             size={ this.props.cardSize } />);
         let deadPile = (<CardPile className='dead' title='Dead' source='dead pile' cards={ this.props.deadPile }
             onDragDrop={ this.props.onDragDrop }
             onMouseOver={ this.props.onMouseOver } onMouseOut={ this.props.onMouseOut } onCardClick={ this.props.onCardClick }
-            popupLocation={ this.props.isMe || this.props.spectating ? 'top' : 'bottom' }
+            popupLocation={ this.props.isMe || this.props.spectating ? 'bottom' : 'top' }
             orientation='kneeled' size={ this.props.cardSize } />);
 
         return (

--- a/client/Components/GameBoard/PopupDefaults.js
+++ b/client/Components/GameBoard/PopupDefaults.js
@@ -1,0 +1,41 @@
+export default {
+    'plot deck-bottom': {
+        left: '90px',
+        bottom: '95px'
+    },
+    'revealed plots-bottom': {
+        left: '90px',
+        bottom: '25px'
+    },
+    'revealed plots-top': {
+        left: '95px',
+        top: '25px'
+    },
+    'draw deck-bottom': {
+        left: '0',
+        bottom: '95px'
+    },
+    'discard pile-bottom': {
+        bottom: '95px'
+    },
+    'discard pile-top': {
+        top: '95px'
+    },
+    'dead pile-bottom': {
+        bottom: '75px'
+    },
+    'dead pile-top': {
+        top: '75px'
+    },
+    'out of game-top': {
+        top: '75px',
+        left: '20px'
+    },
+    'out of game-bottom': {
+        bottom: '75px',
+        right: '0'
+    },
+    'conclave-bottom': {
+        bottom: '95px'
+    }
+};

--- a/client/constants.js
+++ b/client/constants.js
@@ -1,3 +1,4 @@
 export const ItemTypes = {
-    CARD: 'card'
+    CARD: 'card',
+    PANEL: 'panel'
 };

--- a/client/index.dev.jsx
+++ b/client/index.dev.jsx
@@ -6,6 +6,8 @@ import { navigate } from './actions';
 import 'bootstrap/dist/js/bootstrap';
 import ReduxToastr from 'react-redux-toastr';
 import { AppContainer } from 'react-hot-loader';
+import { DragDropContext } from 'react-dnd';
+import { default as TouchBackend } from 'react-dnd-touch-backend';
 
 const store = configureStore();
 
@@ -15,9 +17,11 @@ window.onpopstate = function(e) {
     store.dispatch(navigate(e.target.location.pathname));
 };
 
+const DnDContainer = DragDropContext(TouchBackend({ enableMouseEvents: true }))(AppContainer);
+
 const render = () => {
     const Application = require('./Application').default;
-    ReactDOM.render(<AppContainer>
+    ReactDOM.render(<DnDContainer>
         <Provider store={ store }>
             <div className='body'>
                 <ReduxToastr
@@ -30,7 +34,7 @@ const render = () => {
                 <Application />
             </div>
         </Provider>
-    </AppContainer>, document.getElementById('component'));
+    </DnDContainer>, document.getElementById('component'));
 };
 
 if(module.hot) {

--- a/less/gameboard.less
+++ b/less/gameboard.less
@@ -267,35 +267,6 @@
   }
 }
 
-.arrow {
-  content: '';
-  display: block;
-  width: 0;
-  height: 0;
-  position: absolute;
-  border: 8px solid transparent;
-
-  &.left {
-    border-right-color: black;
-  }
-
-  &.right {
-    border-left-color: black;
-  }
-
-  &.up {
-    border-bottom-color: black;
-  }
-
-  &.down {
-    border-top-color: black;
-  }
-
-  &.lg {
-    border-width: 12px;
-  }
-}
-
 /**
  * Generates the specified property based on the calculation of:
  * property: numCards * (cardSize + cardSpacing) + additionalOffset
@@ -355,84 +326,13 @@
   justify-content: flex-start;
 }
 
-.our-side {
-  .plot {
-    .popup {
-      bottom: -2px;
-      top: initial;
-
-      .arrow {
-        bottom: 15px;
-        top: initial;
-      }
-    }
-  }
-
-  .discard {
-    .popup {
-      bottom: 95px;
-      top: initial;
-
-      .arrow {
-        bottom: -30px;
-        top: initial;
-      }
-    }
-  }
-
-  .dead {
-    .popup {
-      bottom: 75px;
-      top: initial;
-
-      .arrow {
-        bottom: -30px;
-        top: initial;
-      }
-    }
-  }
-
-  .agenda {
-    .popup {
-      bottom: 95px;
-      top: initial;
-
-      .arrow {
-        bottom: -30px;
-        top: initial;
-      }
-    }
-  }
-
-  .additional-cards {
-    .popup {
-      bottom: 75px;
-      left: initial;
-      top: initial;
-
-      .arrow {
-        bottom: -30px;
-        top: initial;
-      }
-    }
-  }
-}
-
 .additional-cards {
   .popup {
     position: absolute;
-    bottom: initial;
-    top: 75px;
-    left: 20px;
 
     .inner {
       .calculate-tiled-card-prop(min-height, 2, width);
       .calculate-tiled-card-prop(min-width, 2, height, @scrollbar-width);
-    }
-
-    .arrow {
-      left: 0;
-      top: -60px;
     }
   }
 }
@@ -444,18 +344,10 @@
     position: absolute;
     min-height: 92px;
     min-width: 168px;
-    left: 90px;
-    top: -75px;
 
     .inner {
       .calculate-tiled-card-prop(min-height, 1, width);
       .calculate-tiled-card-prop(width, 4, height);
-    }
-
-    .arrow {
-      left: -25px;
-      top: 55px;
-      bottom: initial;
     }
   }
 }
@@ -464,18 +356,10 @@
   .popup {
     position: absolute;
     min-height: 146px;
-    bottom: initial;
-    top: 95px;
 
     .inner {
       .calculate-tiled-card-prop(min-height, 1, height);
       .calculate-tiled-card-prop(width, 5, width, @scrollbar-width);
-    }
-
-    .arrow {
-      bottom: initial;
-      top: -63px;
-      left: 10px;
     }
   }
 }
@@ -483,18 +367,10 @@
 .dead {
   .popup {
     position: absolute;
-    top: 75px;
-    left: 0;
 
     .inner {
       .calculate-tiled-card-prop(min-height, 1, height);
       .calculate-tiled-card-prop(width, 5, width, @scrollbar-width);
-    }
-
-    .arrow {
-      bottom: initial;
-      top: -63px;
-      left: 10px;
     }
   }
 }
@@ -508,32 +384,17 @@
 .draw {
   .popup {
     position: absolute;
-    left: 0;
-    bottom: 95px;
 
     .inner {
       .calculate-tiled-card-prop(min-height, 1, height);
       .calculate-tiled-card-prop(width, 7, width, @scrollbar-width);
     }
   }
-
-  .arrow {
-    bottom: -30px;
-    left: 10px;
-  }
 }
 
 .agenda {
   .popup {
     position: absolute;
-    top: 95px;
-    left: 0;
-
-    .arrow {
-      bottom: initial;
-      top: -60px;
-      left: 10px;
-    }
   }
 }
 


### PR DESCRIPTION
Allow dragging of window titles to move the windows
save the positions the windows are in in the browser
fix hot reloading
repurpose PopupLocation property to refer to the board side, rather than the popup location