### PR TITLE
Check game actions on effect targets / fix TFM Dany

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -433,14 +433,9 @@ class BaseCard {
         }
     }
 
-    allowGameAction(actionType) {
-        let currentAbilityContext = this.game.currentAbilityContext;
+    allowGameAction(actionType, context) {
+        let currentAbilityContext = context || this.game.currentAbilityContext;
         return !_.any(this.abilityRestrictions, restriction => restriction.isMatch(actionType, currentAbilityContext));
-    }
-
-    allowEffectFrom(sourceCard) {
-        let currentAbilityContext = { source: sourceCard, resolutionStage: 'effect' };
-        return !_.any(this.abilityRestrictions, restriction => restriction.isMatch('applyEffect', currentAbilityContext));
     }
 
     addAbilityRestriction(restriction) {

--- a/server/game/cardaction.js
+++ b/server/game/cardaction.js
@@ -57,7 +57,7 @@ class CardAction extends BaseAbility {
         this.handler = this.buildHandler(card, properties);
 
         if(card.getType() === 'event') {
-            this.cost.push(Costs.playEvent());
+            this.cost = this.cost.concat(Costs.playEvent());
         }
 
         if(this.max) {

--- a/server/game/cards/02.3-TKP/TheLordOfTheCrossing.js
+++ b/server/game/cards/02.3-TKP/TheLordOfTheCrossing.js
@@ -9,23 +9,19 @@ class TheLordOfTheCrossing extends AgendaCard {
 
     setupCardAbilities(ability) {
         this.persistentEffect({
-            condition: () => this.game.currentChallenge && this.game.currentChallenge.attackingPlayer === this.controller,
+            condition: () => this.isAttackingDuringChallengeNumber(1),
             match: card => this.game.currentChallenge.isAttacking(card),
-            effect: ability.effects.dynamicStrength(() => this.challengeBonus())
+            effect: ability.effects.modifyStrength(-1)
+        });
+        this.persistentEffect({
+            condition: () => this.isAttackingDuringChallengeNumber(3),
+            match: card => this.game.currentChallenge.isAttacking(card),
+            effect: ability.effects.modifyStrength(2)
         });
     }
 
-    challengeBonus() {
-        let numChallenges = this.game.currentChallenge.number;
-        if(numChallenges === 1) {
-            return -1;
-        }
-
-        if(numChallenges === 3) {
-            return 2;
-        }
-
-        return 0;
+    isAttackingDuringChallengeNumber(challengeNumber) {
+        return this.game.currentChallenge && this.game.currentChallenge.attackingPlayer === this.controller && this.game.currentChallenge.number === challengeNumber;
     }
 
     afterChallenge(event) {

--- a/server/game/cards/03-WotN/SansaStark.js
+++ b/server/game/cards/03-WotN/SansaStark.js
@@ -4,7 +4,7 @@ class SansaStark extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             match: card => card === this,
-            effect: ability.effects.dynamicStrength(() => this.calculateStrength())
+            effect: ability.effects.dynamicDecreaseStrength(() => this.calculateStrength())
         });
         this.persistentEffect({
             condition: () => this.getStrength() === 0,
@@ -16,7 +16,7 @@ class SansaStark extends DrawCard {
     calculateStrength() {
         return this.controller.deadPile.reduce((count, card) => {
             if(card.isFaction('stark')) {
-                return count - 1;
+                return count + 1;
             }
 
             return count;

--- a/server/game/cards/07-WotW/DothrakiHonorGuard.js
+++ b/server/game/cards/07-WotW/DothrakiHonorGuard.js
@@ -4,7 +4,7 @@ class DothrakiHonorGuard extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             match: this,
-            effect: ability.effects.dynamicStrength(() => -this.controller.hand.size())
+            effect: ability.effects.dynamicDecreaseStrength(() => this.controller.hand.size())
         });
     }
 }

--- a/server/game/cards/08.5-TFM/DaenerysTargaryen.js
+++ b/server/game/cards/08.5-TFM/DaenerysTargaryen.js
@@ -4,7 +4,8 @@ class DaenerysTargaryen extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             match: this,
-            effect: ability.effects.cannotDecreaseStrength(context => context.resolutionStage === 'effect')
+            //TODO: framework shouldn't be needed here but works until immunity is reworked
+            effect: ability.effects.cannotDecreaseStrength(context => ['framework', 'effect'].includes(context.resolutionStage))
         });
         this.reaction({
             when: {

--- a/server/game/cards/08.5-TFM/DaenerysTargaryen.js
+++ b/server/game/cards/08.5-TFM/DaenerysTargaryen.js
@@ -4,8 +4,7 @@ class DaenerysTargaryen extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             match: this,
-            //TODO: framework shouldn't be needed here but works until immunity is reworked
-            effect: ability.effects.cannotDecreaseStrength(context => ['framework', 'effect'].includes(context.resolutionStage))
+            effect: ability.effects.cannotDecreaseStrength(context => context.resolutionStage === 'effect')
         });
         this.reaction({
             when: {

--- a/server/game/costs.js
+++ b/server/game/costs.js
@@ -9,19 +9,6 @@ const MoveTokenFromSelfCost = require('./costs/MoveTokenFromSelfCost.js');
 
 const Costs = {
     /**
-     * Cost that aggregates a list of other costs.
-     */
-    all: function(...costs) {
-        return {
-            canPay: function(context) {
-                return _.all(costs, cost => cost.canPay(context));
-            },
-            pay: function(context) {
-                _.each(costs, cost => cost.pay(context));
-            }
-        };
-    },
-    /**
      * Cost that allows the player to choose between multiple costs. The
      * `choices` object should have string keys representing the button text
      * that will be used to prompt the player, with the values being the cost
@@ -159,12 +146,12 @@ const Costs = {
      * and place it in discard.
      */
     playEvent: function() {
-        return Costs.all(
+        return [
             Costs.payReduceableGoldCost('play'),
             Costs.expendEvent(),
             Costs.playLimited(),
             Costs.playMax()
-        );
+        ];
     },
     /**
      * Cost that will discard a gold from the card. Used mainly by cards

--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -48,6 +48,7 @@ class Effect {
         this.targetType = properties.targetType || 'card';
         this.targetLocation = properties.targetLocation || 'play area';
         this.effect = this.buildEffect(properties.effect);
+        this.gameAction = this.effect.gameAction || 'applyEffect';
         this.targets = [];
         this.context = { game: game, source: source };
         this.active = !source.facedown;
@@ -101,7 +102,7 @@ class Effect {
                 return false;
             }
 
-            if(!target.allowEffectFrom(this.source)) {
+            if(!target.allowGameAction(this.gameAction, { source: this.source, resolutionStage: 'effect' })) {
                 return false;
             }
         }

--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -48,7 +48,7 @@ class Effect {
         this.targetType = properties.targetType || 'card';
         this.targetLocation = properties.targetLocation || 'play area';
         this.effect = this.buildEffect(properties.effect);
-        this.gameAction = this.effect.gameAction || 'applyEffect';
+        this.gameAction = this.effect.gameAction || 'genericEffect';
         this.targets = [];
         this.context = { game: game, source: source };
         this.active = !source.facedown;

--- a/server/game/effect.js
+++ b/server/game/effect.js
@@ -1,7 +1,5 @@
 const _ = require('underscore');
 
-const Effects = require('./effects.js');
-
 const PlayAreaLocations = ['play area', 'active plot'];
 
 /**
@@ -31,9 +29,7 @@ const PlayAreaLocations = ['play area', 'active plot'];
  * targetLocation   - string that determines the location of cards that can be
  *                    applied by the effect. Can be 'play area' (default) or
  *                    'hand'.
- * effect           - object representing the effect to be applied. If passed an
- *                    array instead of an object, it will apply / unapply all of
- *                    the sub objects in the array instead.
+ * effect           - object representing the effect to be applied.
  * effect.apply     - function that takes a card and a context object and modifies
  *                    the card to apply the effect.
  * effect.unapply   - function that takes a card and a context object and modifies
@@ -59,9 +55,18 @@ class Effect {
         this.isStateDependent = this.isConditional || this.effect.isStateDependent;
     }
 
+    static flattenProperties(properties) {
+        if(Array.isArray(properties.effect)) {
+            let effects = _.flatten(properties.effect);
+            return effects.map(effect => Object.assign({}, properties, { effect: effect }));
+        }
+
+        return [properties];
+    }
+
     buildEffect(effect) {
         if(_.isArray(effect)) {
-            return Effects.all(effect);
+            throw new '`effect` cannot be an array';
         }
 
         return effect;

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -292,13 +292,13 @@ const Effects = {
             }
         };
     },
-    dynamicStrength: function(calculate) {
+    dynamicStrength: function(calculate, gameAction = 'increaseStrength') {
         return {
+            gameAction: gameAction,
             apply: function(card, context) {
                 context.dynamicStrength = context.dynamicStrength || {};
                 context.dynamicStrength[card.uuid] = calculate(card, context) || 0;
                 let value = context.dynamicStrength[card.uuid];
-                let gameAction = value < 0 ? 'decreaseStrength' : 'increaseStrength';
                 context.game.applyGameAction(gameAction, card, card => {
                     card.modifyStrength(value, true);
                 });
@@ -308,14 +308,12 @@ const Effects = {
                 let newStrength = calculate(card, context) || 0;
                 context.dynamicStrength[card.uuid] = newStrength;
                 let value = newStrength - currentStrength;
-                let gameAction = newStrength < 0 ? 'decreaseStrength' : 'increaseStrength';
                 context.game.applyGameAction(gameAction, card, card => {
                     card.modifyStrength(value, true);
                 });
             },
             unapply: function(card, context) {
                 let value = context.dynamicStrength[card.uuid];
-                let gameAction = value < 0 ? 'decreaseStrength' : 'increaseStrength';
                 // use same game action of apply: if they were immune to apply,
                 // we shouldn't compensate either
                 context.game.applyGameAction(gameAction, card, card => {
@@ -325,6 +323,10 @@ const Effects = {
             },
             isStateDependent: true
         };
+    },
+    dynamicDecreaseStrength: function(calculate) {
+        let negatedCalculate = (card, context) => -(calculate(card, context) || 0);
+        return Effects.dynamicStrength(negatedCalculate, 'decreaseStrength');
     },
     doesNotContributeStrength: function() {
         return {

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -126,6 +126,7 @@ const Effects = {
     modifyStrength: function(value) {
         let gameAction = value < 0 ? 'decreaseStrength' : 'increaseStrength';
         return {
+            gameAction: gameAction,
             apply: function(card, context) {
                 context.game.applyGameAction(gameAction, card, card => {
                     card.modifyStrength(value, true);

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -124,20 +124,13 @@ const Effects = {
         };
     },
     modifyStrength: function(value) {
-        let gameAction = value < 0 ? 'decreaseStrength' : 'increaseStrength';
         return {
-            gameAction: gameAction,
-            apply: function(card, context) {
-                context.game.applyGameAction(gameAction, card, card => {
-                    card.modifyStrength(value, true);
-                });
+            gameAction: value < 0 ? 'decreaseStrength' : 'increaseStrength',
+            apply: function(card) {
+                card.modifyStrength(value, true);
             },
-            unapply: function(card, context) {
-                // use same game action of apply: if they were immune to apply,
-                // we shouldn't compensate either
-                context.game.applyGameAction(gameAction, card, card => {
-                    card.modifyStrength(-value, false);
-                });
+            unapply: function(card) {
+                card.modifyStrength(-value, false);
             },
             order: value >= 0 ? 0 : 1000
         };
@@ -299,27 +292,19 @@ const Effects = {
                 context.dynamicStrength = context.dynamicStrength || {};
                 context.dynamicStrength[card.uuid] = calculate(card, context) || 0;
                 let value = context.dynamicStrength[card.uuid];
-                context.game.applyGameAction(gameAction, card, card => {
-                    card.modifyStrength(value, true);
-                });
+                card.modifyStrength(value, true);
             },
             reapply: function(card, context) {
                 let currentStrength = context.dynamicStrength[card.uuid];
                 let newStrength = calculate(card, context) || 0;
                 context.dynamicStrength[card.uuid] = newStrength;
                 let value = newStrength - currentStrength;
-                context.game.applyGameAction(gameAction, card, card => {
-                    card.modifyStrength(value, true);
-                });
+                card.modifyStrength(value, true);
             },
             unapply: function(card, context) {
                 let value = context.dynamicStrength[card.uuid];
-                // use same game action of apply: if they were immune to apply,
-                // we shouldn't compensate either
-                context.game.applyGameAction(gameAction, card, card => {
-                    card.modifyStrength(-value, false);
-                    delete context.dynamicStrength[card.uuid];
-                });
+                card.modifyStrength(-value, false);
+                delete context.dynamicStrength[card.uuid];
             },
             isStateDependent: true
         };

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -23,29 +23,6 @@ function cannotEffect(type) {
 }
 
 const Effects = {
-    all: function(effects) {
-        let stateDependentEffects = _.filter(effects, effect => effect.isStateDependent);
-        return {
-            apply: function(card, context) {
-                _.each(effects, effect => effect.apply(card, context));
-            },
-            reapply: function(card, context) {
-                _.each(stateDependentEffects, effect => {
-                    if(effect.reapply) {
-                        effect.reapply(card, context);
-                    } else {
-                        effect.unapply(card, context);
-                        effect.apply(card, context);
-                    }
-                });
-            },
-            unapply: function(card, context) {
-                _.each(effects, effect => effect.unapply(card, context));
-            },
-            isStateDependent: (stateDependentEffects.length !== 0),
-            order: _.max(_.pluck(effects, 'order'))
-        };
-    },
     setSetupGold: function(value) {
         return {
             apply: function(player) {
@@ -527,10 +504,10 @@ const Effects = {
         }
     },
     killByStrength: function(value) {
-        return Effects.all([
+        return [
             Effects.burn,
             Effects.modifyStrength(value)
-        ]);
+        ];
     },
     blank: {
         apply: function(card) {

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -221,11 +221,15 @@ class Game extends EventEmitter {
     }
 
     addEffect(source, properties) {
-        this.effectEngine.add(new Effect(this, source, properties));
+        this.addSimultaneousEffects([{ source: source, properties: properties }]);
     }
 
     addSimultaneousEffects(effectProperties) {
-        let effects = effectProperties.map(effect => new Effect(this, effect.source, effect.properties));
+        let effects = effectProperties.reduce((array, effect) => {
+            let flattenedProperties = Effect.flattenProperties(effect.properties);
+            let effects = flattenedProperties.map(props => new Effect(this, effect.source, props));
+            return array.concat(effects);
+        }, []);
         this.effectEngine.addSimultaneous(effects);
     }
 

--- a/server/game/triggeredability.js
+++ b/server/game/triggeredability.js
@@ -17,7 +17,7 @@ class TriggeredAbility extends BaseAbility {
         this.location = this.buildLocation(card, properties.location);
 
         if(card.getType() === 'event' && !properties.ignoreEventCosts) {
-            this.cost.push(Costs.playEvent());
+            this.cost = this.cost.concat(Costs.playEvent());
         }
 
         if(this.max) {

--- a/test/server/card/cardaction.spec.js
+++ b/test/server/card/cardaction.spec.js
@@ -107,8 +107,8 @@ describe('CardAction', function () {
                     this.action = new CardAction(this.gameSpy, this.cardSpy, this.properties);
                 });
 
-                it('should add the play event cost', function() {
-                    expect(this.action.cost.length).toBe(2);
+                it('should add the play event costs', function() {
+                    expect(this.action.cost.length).toBe(5);
                 });
             });
         });

--- a/test/server/cards/08.5-TFM/DaenerysTargaryen.spec.js
+++ b/test/server/cards/08.5-TFM/DaenerysTargaryen.spec.js
@@ -2,7 +2,7 @@ describe('Daenerys Targaryen (TFM)', function() {
     integration({ numOfPlayers: 1 }, function() {
         beforeEach(function() {
             const deck = this.buildDeck('targaryen', [
-                'Trading with the Pentoshi',
+                'Trading with the Pentoshi', 'Blood of the Dragon',
                 'Daenerys Targaryen (TFM)', 'Waking the Dragon', 'Winterfell Steward',
                 'Nightmares', 'A Dragon Is No Slave', 'A Dragon Is No Slave'
             ]);
@@ -20,14 +20,26 @@ describe('Daenerys Targaryen (TFM)', function() {
             this.player1.clickCard(this.steward);
 
             this.completeSetup();
+        });
 
-            this.selectFirstPlayer(this.player1);
+        describe('when a constant effect burns Daenerys Targaryen (TFM)', function() {
+            beforeEach(function() {
+                this.player1.selectPlot('Blood of the Dragon');
+                this.selectFirstPlayer(this.player1);
+            });
 
-            this.completeMarshalPhase();
+            it('should not lower her strength', function() {
+                expect(this.dany.getStrength()).toBe(3);
+            });
         });
 
         describe('when you burn a STR 1 chud', function() {
             beforeEach(function() {
+                this.player1.selectPlot('Trading with the Pentoshi');
+                this.selectFirstPlayer(this.player1);
+    
+                this.completeMarshalPhase();
+
                 this.player1.clickCard(this.waking);
                 this.player1.clickCard(this.dany);
 
@@ -40,8 +52,13 @@ describe('Daenerys Targaryen (TFM)', function() {
             });
         });
 
-        describe('when you burn Daenerys Targaryen (TFM)', function() {
+        describe('when a triggered ability burns Daenerys Targaryen (TFM)', function() {
             beforeEach(function() {
+                this.player1.selectPlot('Trading with the Pentoshi');
+                this.selectFirstPlayer(this.player1);
+    
+                this.completeMarshalPhase();
+
                 this.player1.clickCard(this.waking);
                 this.player1.clickCard(this.dany);
 

--- a/test/server/cards/08.5-TFM/DaenerysTargaryen.spec.js
+++ b/test/server/cards/08.5-TFM/DaenerysTargaryen.spec.js
@@ -37,7 +37,7 @@ describe('Daenerys Targaryen (TFM)', function() {
             beforeEach(function() {
                 this.player1.selectPlot('Trading with the Pentoshi');
                 this.selectFirstPlayer(this.player1);
-    
+
                 this.completeMarshalPhase();
 
                 this.player1.clickCard(this.waking);
@@ -56,7 +56,7 @@ describe('Daenerys Targaryen (TFM)', function() {
             beforeEach(function() {
                 this.player1.selectPlot('Trading with the Pentoshi');
                 this.selectFirstPlayer(this.player1);
-    
+
                 this.completeMarshalPhase();
 
                 this.player1.clickCard(this.waking);

--- a/test/server/cards/08.5-TFM/DaenerysTargaryen.spec.js
+++ b/test/server/cards/08.5-TFM/DaenerysTargaryen.spec.js
@@ -96,4 +96,66 @@ describe('Daenerys Targaryen (TFM)', function() {
             });
         });
     });
+
+    integration({ numOfPlayers: 1 }, function() {
+        describe('vs Lord of the Crossing', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('targaryen', [
+                    'The Lord of the Crossing',
+                    'Trading with the Pentoshi',
+                    'Daenerys Targaryen (TFM)', 'Viserion', 'Viserys Targaryen (Core)'
+                ]);
+                this.player1.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.dany = this.player1.findCardByName('Daenerys Targaryen (TFM)', 'hand');
+                this.player1.clickCard(this.dany);
+                this.player1.clickCard('Viserion', 'hand');
+                this.player1.clickCard('Viserys Targaryen', 'hand');
+
+                this.completeSetup();
+
+                this.selectFirstPlayer(this.player1);
+
+                this.completeMarshalPhase();
+            });
+
+            describe('during the first challenge', function() {
+                beforeEach(function() {
+                    this.player1.clickPrompt('Intrigue');
+                    this.player1.clickCard(this.dany);
+                    this.player1.clickPrompt('Done');
+                });
+
+                it('should not reduce her strength', function() {
+                    expect(this.dany.getStrength()).toBe(3);
+                });
+            });
+
+            describe('during the third challenge', function() {
+                beforeEach(function() {
+                    this.player1.clickPrompt('Military');
+                    this.player1.clickCard('Viserion');
+                    this.player1.clickPrompt('Done');
+                    this.skipActionWindow();
+                    this.skipActionWindow();
+
+                    this.player1.clickPrompt('Power');
+                    this.player1.clickCard('Viserys Targaryen');
+                    this.player1.clickPrompt('Done');
+                    this.skipActionWindow();
+                    this.skipActionWindow();
+
+                    this.player1.clickPrompt('Intrigue');
+                    this.player1.clickCard(this.dany);
+                    this.player1.clickPrompt('Done');
+                });
+
+                it('should increase her strength', function() {
+                    expect(this.dany.getStrength()).toBe(5);
+                });
+            });
+        });
+    });
 });

--- a/test/server/cards/08.5-TFM/DaenerysTargaryen.spec.js
+++ b/test/server/cards/08.5-TFM/DaenerysTargaryen.spec.js
@@ -158,4 +158,39 @@ describe('Daenerys Targaryen (TFM)', function() {
             });
         });
     });
+
+    integration({ numOfPlayers: 1 }, function() {
+        describe('vs Strangler', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('targaryen', [
+                    'Trading with the Pentoshi',
+                    'Daenerys Targaryen (TFM)', 'Strangler'
+                ]);
+                this.player1.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.dany = this.player1.findCardByName('Daenerys Targaryen (TFM)', 'hand');
+                let strangler = this.player1.findCardByName('Strangler', 'hand');
+                this.player1.clickCard(this.dany);
+                this.player1.clickCard(strangler);
+
+                this.completeSetup();
+                this.player1.clickCard(strangler);
+                this.player1.clickCard(this.dany);
+
+                this.selectFirstPlayer(this.player1);
+
+                this.completeMarshalPhase();
+
+                this.player1.clickPrompt('Intrigue');
+                this.player1.clickCard(this.dany);
+                this.player1.clickPrompt('Done');
+            });
+
+            it('should set her strength to 1', function() {
+                expect(this.dany.getStrength()).toBe(1);
+            });
+        });
+    });
 });

--- a/test/server/effect.spec.js
+++ b/test/server/effect.spec.js
@@ -3,8 +3,8 @@ const _ = require('underscore');
 const Effect = require('../../server/game/effect.js');
 
 function createTarget(properties = {}) {
-    let card = jasmine.createSpyObj('card', ['allowEffectFrom', 'getGameElementType']);
-    card.allowEffectFrom.and.returnValue(true);
+    let card = jasmine.createSpyObj('card', ['allowGameAction', 'getGameElementType']);
+    card.allowGameAction.and.returnValue(true);
     card.getGameElementType.and.returnValue('card');
     _.extend(card, properties);
     return card;
@@ -141,7 +141,7 @@ describe('Effect', function() {
 
             describe('when the source cannot apply an effect to the target', function() {
                 beforeEach(function() {
-                    this.matchingCard.allowEffectFrom.and.returnValue(false);
+                    this.matchingCard.allowGameAction.and.returnValue(false);
                 });
 
                 it('should reject the target', function() {


### PR DESCRIPTION
Allows specific game actions (such as `'decreaseStrength'`) be specified at the effect level, allowing the effect engine to check immunity to specific types of effects prior to targeting / applying the effect to a card.