### PR TITLE
Add an alert when a targetting prompt was cancelled

### DIFF
--- a/server/game/AbilityTarget.js
+++ b/server/game/AbilityTarget.js
@@ -32,8 +32,11 @@ class AbilityTarget {
                 result.resolve(card);
                 return true;
             },
-            onCancel: () => {
+            onCancel: (player) => {
                 result.reject();
+
+                context.game.addAlert('danger', '{0} cancels the resolution of {1} (costs were still paid)', player, context.source);
+
                 return true;
             }
         };

--- a/test/server/AbilityTarget.spec.js
+++ b/test/server/AbilityTarget.spec.js
@@ -60,7 +60,7 @@ describe('AbilityTarget', function () {
 
     describe('resolve()', function() {
         beforeEach(function() {
-            this.gameSpy = jasmine.createSpyObj('game', ['promptForSelect']);
+            this.gameSpy = jasmine.createSpyObj('game', ['promptForSelect', 'addAlert']);
             this.gameSpy.allCards = _([]);
             this.player = { player: 1 };
             this.source = { source: 1 };

--- a/test/server/card/baseability.spec.js
+++ b/test/server/card/baseability.spec.js
@@ -241,7 +241,7 @@ describe('BaseAbility', function () {
 
     describe('resolveTargets()', function() {
         beforeEach(function() {
-            this.gameSpy = jasmine.createSpyObj('game', ['promptForSelect']);
+            this.gameSpy = jasmine.createSpyObj('game', ['promptForSelect', 'addAlert']);
             this.gameSpy.allCards = _([]);
             this.player = { player: 1 };
             this.source = { source: 1 };


### PR DESCRIPTION
Currently, costs are paid and no message is shown so it can be confusing for opponents