### PR TITLE
Implement Mya Stone

### DIFF
--- a/server/game/cards/08.6-SAT/MyaStone.js
+++ b/server/game/cards/08.6-SAT/MyaStone.js
@@ -1,0 +1,35 @@
+const DrawCard = require('../../drawcard.js');
+const ApplyClaim = require('../../gamesteps/challenge/applyclaim.js');
+
+class MyaStone extends DrawCard {
+    setupCardAbilities(ability) {
+        this.interrupt({
+            when: {
+                onClaimApplied: event => (
+                    ['military', 'intrigue'].includes(event.challenge.challengeType) &&
+                    event.challenge.defendingPlayer === this.controller
+                )
+            },
+            cost: ability.costs.kneelSelf(),
+            handler: context => {
+                this.game.addMessage('{0} kneels {1} to apply {2} claim instead of {3} claim',
+                    context.player, this, 'power', context.event.challenge.challengeType);
+
+                context.replaceHandler(() => {
+                    let replacementChallenge = {
+                        challengeType: 'power',
+                        claim: context.event.challenge.winner.getClaim(),
+                        loser: context.player,
+                        winner: context.event.challenge.winner
+                    };
+
+                    this.game.queueStep(new ApplyClaim(this.game, replacementChallenge));
+                });
+            }
+        });
+    }
+}
+
+MyaStone.code = '08117';
+
+module.exports = MyaStone;


### PR DESCRIPTION
Character, Neutral, Bastard
Cost: 4
STR: 2
Icons: Power
Interruption: when the claim for a military or an intrigue challenge where you are the defending player should apply, kneel Mya Stone to apply a power claim instead.