### PR TITLE
Update test API to know about ability windows

### DIFF
--- a/test/helpers/integrationhelper.js
+++ b/test/helpers/integrationhelper.js
@@ -72,6 +72,25 @@ var customMatchers = {
                 return result;
             }
         };
+    },
+    toAllowAbilityTrigger: function(util, customEqualityMatchers) {
+        return {
+            compare: function(actual, expected) {
+                var buttons = actual.currentPrompt().buttons;
+                var result = {};
+
+                result.pass = _.any(buttons, button => util.equals(button.text, expected, customEqualityMatchers));
+
+                if(result.pass) {
+                    result.message = `Expected ${actual.name} not to have prompt button "${expected}" but it did.`;
+                } else {
+                    var buttonText = _.map(buttons, button => '[' + button.text + ']').join('\n');
+                    result.message = `Expected ${actual.name} to have prompt button "${expected}" but it had buttons:\n${buttonText}`;
+                }
+
+                return result;
+            }
+        };
     }
 };
 

--- a/test/helpers/playerinteractionwrapper.js
+++ b/test/helpers/playerinteractionwrapper.js
@@ -131,6 +131,14 @@ class PlayerInteractionWrapper {
         this.game.continue();
     }
 
+    triggerAbility(cardName) {
+        if(this.game.abilityWindowStack.length === 0) {
+            throw new Error(`Couldn't trigger ability for ${this.name}. Not in an ability window. Current prompt is:\n${this.formatPrompt()}`);
+        }
+
+        this.clickPrompt(cardName);
+    }
+
     dragCard(card, targetLocation) {
         this.game.drop(this.player.name, card.uuid, card.location, targetLocation);
         this.game.continue();

--- a/test/server/cards/01-Core/AryaStark.spec.js
+++ b/test/server/cards/01-Core/AryaStark.spec.js
@@ -26,7 +26,7 @@ describe('Arya Stark (Core)', function() {
 
             describe('when triggering her ability', function() {
                 beforeEach(function() {
-                    this.player1.clickPrompt('Arya Stark');
+                    this.player1.triggerAbility('Arya Stark');
                 });
 
                 it('should use the facedown top of deck card as a dupe', function() {
@@ -63,7 +63,7 @@ describe('Arya Stark (Core)', function() {
             });
 
             it('should not trigger her ability because she cannot be duped', function() {
-                expect(this.player2).not.toHavePromptButton('Arya Stark');
+                expect(this.player2).not.toAllowAbilityTrigger('Arya Stark');
             });
         });
     });

--- a/test/server/cards/01-Core/BenjenStark.spec.js
+++ b/test/server/cards/01-Core/BenjenStark.spec.js
@@ -32,17 +32,17 @@ describe('Benjen Stark', function() {
             });
 
             it('should allow the player to put Benjen back in the deck', function() {
-                this.player1.clickPrompt('Benjen Stark');
+                this.player1.triggerAbility('Benjen Stark');
 
                 expect(this.benjen.location).toBe('draw deck');
             });
 
             it('should not prompt twice', function() {
                 // Trigger for the one being killed.
-                this.player1.clickPrompt('Benjen Stark');
+                this.player1.triggerAbility('Benjen Stark');
 
                 // Should not prompt again for any copies of Benjen in hand
-                expect(this.player1).not.toHavePromptButton('Benjen Stark');
+                expect(this.player1).not.toAllowAbilityTrigger('Benjen Stark');
             });
         });
     });

--- a/test/server/cards/01-Core/Bodyguard.spec.js
+++ b/test/server/cards/01-Core/Bodyguard.spec.js
@@ -28,7 +28,7 @@ describe('Bodyguard', function() {
                 this.player2.selectPlot('Valar Morghulis');
                 this.selectFirstPlayer(this.player1);
 
-                this.player1.clickPrompt('Bodyguard');
+                this.player1.triggerAbility('Bodyguard');
             });
 
             it('should save the character', function() {
@@ -44,9 +44,9 @@ describe('Bodyguard', function() {
 
                 this.completeMarshalPhase();
                 this.completeChallengesPhase();
-                this.player2.clickPrompt('Varys');
+                this.player2.triggerAbility('Varys');
 
-                this.player1.clickPrompt('Bodyguard');
+                this.player1.triggerAbility('Bodyguard');
             });
 
             it('should save the character', function() {

--- a/test/server/cards/01-Core/BranStark.spec.js
+++ b/test/server/cards/01-Core/BranStark.spec.js
@@ -32,19 +32,19 @@ describe('Bran Stark (Core)', function() {
             });
 
             it('should cancel the event', function() {
-                this.player1.clickPrompt('Bran Stark');
+                this.player1.triggerAbility('Bran Stark');
 
-                expect(this.player2).toHavePromptButton('Melisandre');
+                expect(this.player2).toAllowAbilityTrigger('Melisandre');
             });
 
             it('should sacrifice bran', function() {
-                this.player1.clickPrompt('Bran Stark');
+                this.player1.triggerAbility('Bran Stark');
 
                 expect(this.bran.location).toBe('discard pile');
             });
 
             it('should still discard the event', function() {
-                this.player1.clickPrompt('Bran Stark');
+                this.player1.triggerAbility('Bran Stark');
 
                 expect(this.seenInFlames.location).toBe('discard pile');
             });

--- a/test/server/cards/01-Core/CatelynStark.spec.js
+++ b/test/server/cards/01-Core/CatelynStark.spec.js
@@ -35,7 +35,7 @@ describe('Catelyn Stark', function() {
             });
 
             it('should not prevent opponents card abilities', function() {
-                expect(this.player2).toHavePromptButton('Tyrion Lannister');
+                expect(this.player2).toAllowAbilityTrigger('Tyrion Lannister');
             });
         });
 
@@ -48,7 +48,7 @@ describe('Catelyn Stark', function() {
             });
 
             it('should prevent opponents card abilities', function() {
-                expect(this.player2).not.toHavePromptButton('Tyrion Lannister');
+                expect(this.player2).not.toAllowAbilityTrigger('Tyrion Lannister');
             });
         });
     });

--- a/test/server/cards/01-Core/EuronCrowsEye.spec.js
+++ b/test/server/cards/01-Core/EuronCrowsEye.spec.js
@@ -29,7 +29,7 @@ describe('Euron Crow\'s Eye', function() {
             });
 
             it('should not prompt', function() {
-                expect(this.player1).not.toHavePromptButton('Euron Crow\'s Eye');
+                expect(this.player1).not.toAllowAbilityTrigger('Euron Crow\'s Eye');
             });
         });
 
@@ -47,11 +47,11 @@ describe('Euron Crow\'s Eye', function() {
                 });
 
                 it('should prompt', function() {
-                    expect(this.player1).toHavePromptButton('Euron Crow\'s Eye');
+                    expect(this.player1).toAllowAbilityTrigger('Euron Crow\'s Eye');
                 });
 
                 it('should allow a location be put into play', function() {
-                    this.player1.clickPrompt('Euron Crow\'s Eye');
+                    this.player1.triggerAbility('Euron Crow\'s Eye');
                     this.player1.clickCard(this.theirArbor2);
 
                     expect(this.theirArbor2.location).toBe('play area');
@@ -69,7 +69,7 @@ describe('Euron Crow\'s Eye', function() {
                 });
 
                 it('should not prompt', function() {
-                    expect(this.player1).not.toHavePromptButton('Euron Crow\'s Eye');
+                    expect(this.player1).not.toAllowAbilityTrigger('Euron Crow\'s Eye');
                 });
             });
 
@@ -83,7 +83,7 @@ describe('Euron Crow\'s Eye', function() {
                 });
 
                 it('should not prompt', function() {
-                    expect(this.player1).not.toHavePromptButton('Euron Crow\'s Eye');
+                    expect(this.player1).not.toAllowAbilityTrigger('Euron Crow\'s Eye');
                 });
             });
         });

--- a/test/server/cards/01-Core/HeadsOnSpikes.spec.js
+++ b/test/server/cards/01-Core/HeadsOnSpikes.spec.js
@@ -95,7 +95,7 @@ describe('Heads on Spikes', function() {
                 this.completeSetup();
                 this.selectFirstPlayer(this.player1);
 
-                this.player2.clickPrompt('Missandei');
+                this.player2.triggerAbility('Missandei');
             });
 
             it('should not move Missandei from play to the dead pile', function() {

--- a/test/server/cards/01-Core/RandyllTarly.spec.js
+++ b/test/server/cards/01-Core/RandyllTarly.spec.js
@@ -38,7 +38,7 @@ describe('Randyll Tarly', function() {
                 this.player1.clickMenu(margaery, 'Give character +3 STR');
                 this.player1.clickCard(this.randyll);
 
-                this.player1.clickPrompt('Randyll Tarly');
+                this.player1.triggerAbility('Randyll Tarly');
             });
 
             it('should stand Randyll', function() {
@@ -55,7 +55,7 @@ describe('Randyll Tarly', function() {
                 this.player1.selectPlot('A Song of Summer');
 
                 // A Song of Summer takes effect immediately
-                this.player1.clickPrompt('Randyll Tarly');
+                this.player1.triggerAbility('Randyll Tarly');
             });
 
             it('should stand Randyll', function() {
@@ -100,7 +100,7 @@ describe('Randyll Tarly', function() {
             });
 
             it('should not stand Randyll', function() {
-                expect(this.player1).not.toHavePromptButton('Randyll Tarly');
+                expect(this.player1).not.toAllowAbilityTrigger('Randyll Tarly');
                 expect(this.randyll.kneeled).toBe(true);
                 expect(this.randyll.getStrength()).toBe(1);
             });
@@ -110,7 +110,7 @@ describe('Randyll Tarly', function() {
                 this.player1.clickPrompt('Done');
                 this.player2.clickPrompt('Done');
 
-                expect(this.player1).not.toHavePromptButton('Randyll Tarly');
+                expect(this.player1).not.toAllowAbilityTrigger('Randyll Tarly');
                 expect(this.randyll.kneeled).toBe(true);
                 expect(this.randyll.getStrength()).toBe(5);
             });

--- a/test/server/cards/01-Core/RisenFromTheSea.spec.js
+++ b/test/server/cards/01-Core/RisenFromTheSea.spec.js
@@ -36,7 +36,7 @@ describe('Risen from the Sea', function() {
                 this.player2.clickPrompt('Apply Claim');
 
                 this.player1.clickCard(this.character);
-                this.player1.clickPrompt('Risen from the Sea');
+                this.player1.triggerAbility('Risen from the Sea');
                 this.player1.clickCard(this.character);
             });
 
@@ -60,7 +60,7 @@ describe('Risen from the Sea', function() {
                 this.player2.clickPrompt('Apply Claim');
 
                 this.player1.clickCard(this.noAttachmentCharacter);
-                this.player1.clickPrompt('Risen from the Sea');
+                this.player1.triggerAbility('Risen from the Sea');
                 this.player1.clickCard(this.noAttachmentCharacter);
             });
 
@@ -104,7 +104,7 @@ describe('Risen from the Sea', function() {
                 beforeEach(function() {
                     this.player2.clickCard(this.strongCharacter);
 
-                    this.player1.clickPrompt('Risen from the Sea');
+                    this.player1.triggerAbility('Risen from the Sea');
                     this.player1.clickCard(this.strongCharacter);
                 });
 
@@ -121,7 +121,7 @@ describe('Risen from the Sea', function() {
                 });
 
                 it('should not prompt to save the character', function() {
-                    expect(this.player1).not.toHavePromptButton('Risen from the Sea');
+                    expect(this.player1).not.toAllowAbilityTrigger('Risen from the Sea');
                 });
 
                 it('should kill the character', function() {
@@ -135,7 +135,7 @@ describe('Risen from the Sea', function() {
                 });
 
                 it('should not prompt to save the character', function() {
-                    expect(this.player1).not.toHavePromptButton('Risen from the Sea');
+                    expect(this.player1).not.toAllowAbilityTrigger('Risen from the Sea');
                 });
 
                 it('should kill the character', function() {

--- a/test/server/cards/01-Core/TheHandsJudgment.spec.js
+++ b/test/server/cards/01-Core/TheHandsJudgment.spec.js
@@ -27,12 +27,12 @@ describe('The Hand\'s Judgment', function() {
             });
 
             it('should prompt to play Judgment', function() {
-                expect(this.player2).toHavePromptButton('The Hand\'s Judgment');
+                expect(this.player2).toAllowAbilityTrigger('The Hand\'s Judgment');
             });
 
             describe('and Judgment is used to cancel the event', function() {
                 beforeEach(function() {
-                    this.player2.clickPrompt('The Hand\'s Judgment');
+                    this.player2.triggerAbility('The Hand\'s Judgment');
                     this.player1.clickPrompt('Pass');
                 });
 
@@ -48,8 +48,8 @@ describe('The Hand\'s Judgment', function() {
 
             describe('and Judgment is cancelled by Judgment', function() {
                 beforeEach(function() {
-                    this.player2.clickPrompt('The Hand\'s Judgment');
-                    this.player1.clickPrompt('The Hand\'s Judgment');
+                    this.player2.triggerAbility('The Hand\'s Judgment');
+                    this.player1.triggerAbility('The Hand\'s Judgment');
                 });
 
                 it('should allow the effects of the original event', function() {

--- a/test/server/cards/01-Core/TheRedKeep.spec.js
+++ b/test/server/cards/01-Core/TheRedKeep.spec.js
@@ -46,7 +46,7 @@ describe('The Red Keep', function() {
             it('should not keep the strength bonus if all characters removed from the challenge', function() {
                 this.player1.clickPrompt('Pass');
                 this.player2.clickCard('Areo Hotah', 'hand');
-                this.player2.clickPrompt('Areo Hotah');
+                this.player2.triggerAbility('Areo Hotah');
                 this.player2.clickCard(this.character);
 
                 expect(this.game.currentChallenge.attackerStrength).toBe(0);

--- a/test/server/cards/01-Core/ViserysTargaryen.spec.js
+++ b/test/server/cards/01-Core/ViserysTargaryen.spec.js
@@ -38,7 +38,7 @@ describe('Viserys Targaryen', function() {
             });
 
             it('should allow the player to discard an attachment', function() {
-                this.player1.clickPrompt('Viserys Targaryen');
+                this.player1.triggerAbility('Viserys Targaryen');
                 this.player1.clickCard(this.lady);
 
                 expect(this.lady.parent).toBe(undefined);

--- a/test/server/cards/02.2-TRtW/BrothelMadame.spec.js
+++ b/test/server/cards/02.2-TRtW/BrothelMadame.spec.js
@@ -23,7 +23,7 @@ describe('Brothel Madame', function() {
             beforeEach(function() {
                 this.completeMarshalPhase();
 
-                this.player1.clickPrompt('Brothel Madame');
+                this.player1.triggerAbility('Brothel Madame');
                 this.player2.clickPrompt('No');
 
                 this.player1.clickPrompt('Done');
@@ -40,7 +40,7 @@ describe('Brothel Madame', function() {
             beforeEach(function() {
                 this.completeMarshalPhase();
 
-                this.player1.clickPrompt('Brothel Madame');
+                this.player1.triggerAbility('Brothel Madame');
                 this.player2.clickPrompt('Yes');
 
                 this.player1.clickPrompt('Done');
@@ -64,7 +64,7 @@ describe('Brothel Madame', function() {
                 this.player1.clickCard(this.character);
                 this.completeMarshalPhase();
 
-                this.player1.clickPrompt('Brothel Madame');
+                this.player1.triggerAbility('Brothel Madame');
                 this.player2.clickPrompt('No');
 
                 this.player1.clickPrompt('Intrigue');
@@ -73,7 +73,7 @@ describe('Brothel Madame', function() {
                 this.skipActionWindow();
                 this.player2.clickPrompt('Done');
                 this.skipActionWindow();
-                this.player1.clickPrompt('Paid Off');
+                this.player1.triggerAbility('Paid Off');
 
                 // Pay for Paid Off to re-stand the character
                 this.player2.clickPrompt('Yes');
@@ -98,11 +98,11 @@ describe('Brothel Madame', function() {
             describe('and the opponent pays for the first one', function() {
                 beforeEach(function() {
                     // First Madame
-                    this.player1.clickPrompt('Brothel Madame');
+                    this.player1.triggerAbility('Brothel Madame');
                     this.player2.clickPrompt('Yes');
 
                     // Second Madame
-                    this.player1.clickPrompt('Brothel Madame');
+                    this.player1.triggerAbility('Brothel Madame');
                 });
 
                 it('should not prompt the opponent to pay again', function() {
@@ -121,11 +121,11 @@ describe('Brothel Madame', function() {
             describe('and the opponent pays for the second one', function() {
                 beforeEach(function() {
                     // First Madame
-                    this.player1.clickPrompt('Brothel Madame');
+                    this.player1.triggerAbility('Brothel Madame');
                     this.player2.clickPrompt('No');
 
                     // Second Madame
-                    this.player1.clickPrompt('Brothel Madame');
+                    this.player1.triggerAbility('Brothel Madame');
                     this.player2.clickPrompt('Yes');
 
                     this.player1.clickPrompt('Done');

--- a/test/server/cards/02.2-TRtW/LadyInWaiting.spec.js
+++ b/test/server/cards/02.2-TRtW/LadyInWaiting.spec.js
@@ -83,7 +83,7 @@ describe('Lady-in-Waiting', function() {
             });
 
             it('should not allow it to be canceled', function() {
-                expect(this.player2).not.toHavePromptButton('Treachery');
+                expect(this.player2).not.toAllowAbilityTrigger('Treachery');
             });
         });
     });

--- a/test/server/cards/02.3-TKP/CroneOfVaesDothrak.spec.js
+++ b/test/server/cards/02.3-TKP/CroneOfVaesDothrak.spec.js
@@ -36,7 +36,7 @@ describe('Crone of Vaes Dothrak', function() {
                 });
 
                 it('should move the opponent character into the dead pile', function() {
-                    this.player1.clickPrompt('Crone of Vaes Dothrak');
+                    this.player1.triggerAbility('Crone of Vaes Dothrak');
                     this.player1.clickCard('Crone of Vaes Dothrak', 'play area');
 
                     expect(this.player2Object.discardPile.length).toBe(0);
@@ -59,7 +59,7 @@ describe('Crone of Vaes Dothrak', function() {
                 });
 
                 it('should move the opponent character into the discard pile', function() {
-                    expect(this.player1).not.toHavePromptButton('Crone of Vaes Dothrak');
+                    expect(this.player1).not.toAllowAbilityTrigger('Crone of Vaes Dothrak');
                     expect(this.player2Object.discardPile.length).toBe(1);
                     expect(this.player2Object.deadPile.length).toBe(0);
                 });
@@ -82,7 +82,7 @@ describe('Crone of Vaes Dothrak', function() {
                 });
 
                 it('should move the opponent character into the dead pile', function() {
-                    this.player1.clickPrompt('Crone of Vaes Dothrak');
+                    this.player1.triggerAbility('Crone of Vaes Dothrak');
                     this.player1.clickCard('Braided Warrior', 'play area');
 
                     expect(this.player2Object.discardPile.length).toBe(0);
@@ -105,7 +105,7 @@ describe('Crone of Vaes Dothrak', function() {
                 });
 
                 it('should move the opponent character into the discard pile', function() {
-                    expect(this.player1).not.toHavePromptButton('Crone of Vaes Dothrak');
+                    expect(this.player1).not.toAllowAbilityTrigger('Crone of Vaes Dothrak');
                     expect(this.player2Object.discardPile.length).toBe(1);
                     expect(this.player2Object.deadPile.length).toBe(0);
                 });

--- a/test/server/cards/02.3-TKP/SerGregorClegane.spec.js
+++ b/test/server/cards/02.3-TKP/SerGregorClegane.spec.js
@@ -50,7 +50,7 @@ describe('Ser Gregor Clegane', function() {
                 this.unopposedChallenge(this.player1, 'Military', 'Ser Gregor Clegane');
                 this.player1.clickPrompt('Apply Claim');
                 this.player2.clickCard('Hedge Knight', 'play area');
-                this.player1.clickPrompt('Ser Gregor Clegane');
+                this.player1.triggerAbility('Ser Gregor Clegane');
             });
 
             it('should put the character into the dead pile', function() {
@@ -77,7 +77,7 @@ describe('Ser Gregor Clegane', function() {
                 this.unopposedChallenge(this.player1, 'Military', 'Ser Gregor Clegane');
                 this.player1.clickPrompt('Apply Claim');
                 this.player2.clickCard('Hedge Knight', 'play area');
-                this.player1.clickPrompt('Ser Gregor Clegane');
+                this.player1.triggerAbility('Ser Gregor Clegane');
             });
 
             it('should put the character into the dead pile', function() {

--- a/test/server/cards/02.4-NMG/WraithsInTheirMidst.spec.js
+++ b/test/server/cards/02.4-NMG/WraithsInTheirMidst.spec.js
@@ -62,7 +62,7 @@ describe('WraithsInTheirMidst', function() {
 
                 this.unopposedChallenge(this.player2, 'intrigue', 'Tywin Lannister');
 
-                this.player2.clickPrompt('"The Rains of Castamere"');
+                this.player2.triggerAbility('"The Rains of Castamere"');
                 this.player2.clickCard(this.filthyAccusations);
             });
 

--- a/test/server/cards/02.5-COW/MirriMazDuur.spec.js
+++ b/test/server/cards/02.5-COW/MirriMazDuur.spec.js
@@ -45,7 +45,7 @@ describe('Mirri Maz Duur', function() {
             });
 
             it('should allow a character to be killed', function() {
-                this.player1.clickPrompt('Mirri Maz Duur');
+                this.player1.triggerAbility('Mirri Maz Duur');
                 this.player1.clickCard(this.character);
                 expect(this.character.location).toBe('dead pile');
             });
@@ -71,7 +71,7 @@ describe('Mirri Maz Duur', function() {
             });
 
             it('should consider Mirri to be attacking alone', function() {
-                expect(this.player1).toHavePromptButton('Mirri Maz Duur');
+                expect(this.player1).toAllowAbilityTrigger('Mirri Maz Duur');
             });
         });
     });

--- a/test/server/cards/02.5-COW/VengeanceForElia.spec.js
+++ b/test/server/cards/02.5-COW/VengeanceForElia.spec.js
@@ -30,7 +30,7 @@ describe('Vengeance for Elia', function() {
                 this.unopposedChallenge(this.player1, 'Military', 'Tywin Lannister');
                 this.player1.clickPrompt('Apply Claim');
 
-                this.player2.clickPrompt('Vengeance for Elia');
+                this.player2.triggerAbility('Vengeance for Elia');
             });
 
             it('should force the attacker to kill a character', function() {
@@ -45,7 +45,7 @@ describe('Vengeance for Elia', function() {
                 this.unopposedChallenge(this.player1, 'Intrigue', 'Tywin Lannister');
                 this.player1.clickPrompt('Apply Claim');
 
-                this.player2.clickPrompt('Vengeance for Elia');
+                this.player2.triggerAbility('Vengeance for Elia');
             });
 
             it('should force the attacker to discard from hand', function() {
@@ -62,7 +62,7 @@ describe('Vengeance for Elia', function() {
                 this.unopposedChallenge(this.player1, 'Power', 'Tywin Lannister');
                 this.player1.clickPrompt('Apply Claim');
 
-                this.player2.clickPrompt('Vengeance for Elia');
+                this.player2.triggerAbility('Vengeance for Elia');
             });
 
             it('should force the attacker to transfer power from themself to themself', function() {

--- a/test/server/cards/04.1-AtSK/VaryssRiddle.spec.js
+++ b/test/server/cards/04.1-AtSK/VaryssRiddle.spec.js
@@ -105,7 +105,7 @@ describe('Varys\'s Riddle', function() {
                 describe('when Calm is replaced using Rains', function() {
                     beforeEach(function() {
                         this.unopposedChallenge(this.player2, 'Intrigue', 'Ser Jaime Lannister');
-                        this.player2.clickPrompt('"The Rains of Castamere"');
+                        this.player2.triggerAbility('"The Rains of Castamere"');
                         this.player2.clickCard(this.powerBehindTheThrone);
                         this.player2.clickPrompt('Apply Claim');
                     });
@@ -130,7 +130,7 @@ describe('Varys\'s Riddle', function() {
                 this.player2.clickCard('Old Nan', 'hand');
                 this.completeSetup();
 
-                expect(this.player2).toHavePromptButton('Old Nan');
+                expect(this.player2).toAllowAbilityTrigger('Old Nan');
                 this.player2.clickPrompt('Pass');
 
                 this.selectFirstPlayer(this.player1);
@@ -138,7 +138,7 @@ describe('Varys\'s Riddle', function() {
             });
 
             it('should not trigger plot reveal interrupts / reactions', function() {
-                expect(this.player2).not.toHavePromptButton('Old Nan');
+                expect(this.player2).not.toAllowAbilityTrigger('Old Nan');
             });
         });
     });

--- a/test/server/cards/04.2-CtA/FearCutsDeeperThanSwords.spec.js
+++ b/test/server/cards/04.2-CtA/FearCutsDeeperThanSwords.spec.js
@@ -34,12 +34,12 @@ describe('Fear Cuts Deeper Than Swords', function() {
             });
 
             it('should prompt to trigger fear cuts', function() {
-                expect(this.player1).toHavePromptButton('Fear Cuts Deeper Than Swords');
+                expect(this.player1).toAllowAbilityTrigger('Fear Cuts Deeper Than Swords');
             });
 
             describe('and when fear cuts is used to cancel the ability', function() {
                 beforeEach(function() {
-                    this.player1.clickPrompt('Fear Cuts Deeper Than Swords');
+                    this.player1.triggerAbility('Fear Cuts Deeper Than Swords');
                 });
 
                 it('should cancel the plot when revealed', function() {
@@ -61,12 +61,12 @@ describe('Fear Cuts Deeper Than Swords', function() {
             });
 
             it('should prompt to trigger fear cuts', function() {
-                expect(this.player1).toHavePromptButton('Fear Cuts Deeper Than Swords');
+                expect(this.player1).toAllowAbilityTrigger('Fear Cuts Deeper Than Swords');
             });
 
             describe('and when fear cuts is used to cancel the ability', function() {
                 beforeEach(function() {
-                    this.player1.clickPrompt('Fear Cuts Deeper Than Swords');
+                    this.player1.triggerAbility('Fear Cuts Deeper Than Swords');
                 });
 
                 it('should cancel the intimidate keyword', function() {

--- a/test/server/cards/04.4-TIMC/JaqenHghar.spec.js
+++ b/test/server/cards/04.4-TIMC/JaqenHghar.spec.js
@@ -26,7 +26,7 @@ describe('Jaqen H\'ghar', function() {
 
         describe('when Jaqen enters play', function() {
             it('should allow placement of Valar Morghulis tokens', function() {
-                this.player1.clickPrompt('Jaqen H\'ghar');
+                this.player1.triggerAbility('Jaqen H\'ghar');
                 this.player1.clickCard(this.tickler);
                 this.player1.clickPrompt('Done');
 
@@ -36,7 +36,7 @@ describe('Jaqen H\'ghar', function() {
 
         describe('when Jaqen leaves play', function() {
             beforeEach(function() {
-                this.player1.clickPrompt('Jaqen H\'ghar');
+                this.player1.triggerAbility('Jaqen H\'ghar');
                 this.player1.clickCard(this.tickler);
                 this.player1.clickPrompt('Done');
 
@@ -50,7 +50,7 @@ describe('Jaqen H\'ghar', function() {
 
         describe('when Jaqen wins a challenge while attacking alone', function() {
             beforeEach(function() {
-                this.player1.clickPrompt('Jaqen H\'ghar');
+                this.player1.triggerAbility('Jaqen H\'ghar');
                 this.player1.clickCard(this.tickler);
                 this.player1.clickPrompt('Done');
 
@@ -68,14 +68,14 @@ describe('Jaqen H\'ghar', function() {
             });
 
             it('should allow him to kill a character with a Valar Morghulis token', function() {
-                this.player1.clickPrompt('Jaqen H\'ghar');
+                this.player1.triggerAbility('Jaqen H\'ghar');
                 this.player1.clickCard(this.tickler);
 
                 expect(this.tickler.location).toBe('dead pile');
             });
 
             it('should not allow him to kill a character without a Valar Morghulis token', function() {
-                this.player1.clickPrompt('Jaqen H\'ghar');
+                this.player1.triggerAbility('Jaqen H\'ghar');
                 this.player1.clickCard(this.arya);
 
                 expect(this.arya.location).toBe('play area');

--- a/test/server/cards/04.4-TIMC/ValarMorghulis.spec.js
+++ b/test/server/cards/04.4-TIMC/ValarMorghulis.spec.js
@@ -38,11 +38,11 @@ describe('Valar Morghulis', function() {
             });
 
             it('should prompt interrupts and reactions in the proper order', function() {
-                expect(this.player1).not.toHavePromptButton('Margaery Tyrell');
-                expect(this.player2).toHavePromptButton('Maester Aemon');
+                expect(this.player1).not.toAllowAbilityTrigger('Margaery Tyrell');
+                expect(this.player2).toAllowAbilityTrigger('Maester Aemon');
 
                 // Aemon saves Sam but dies
-                this.player2.clickPrompt('Maester Aemon');
+                this.player2.triggerAbility('Maester Aemon');
                 this.player2.clickCard('Samwell Tarly', 'play area');
                 expect(this.samwell.location).toBe('play area');
                 expect(this.aemon.location).toBe('dead pile');
@@ -52,7 +52,7 @@ describe('Valar Morghulis', function() {
                 expect(this.marg2.location).toBe('discard pile');
                 expect(this.rickon.location).toBe('dead pile');
 
-                expect(this.player1).toHavePromptButton('Margaery Tyrell');
+                expect(this.player1).toAllowAbilityTrigger('Margaery Tyrell');
             });
         });
 

--- a/test/server/cards/04.5-GoH/Craster.spec.js
+++ b/test/server/cards/04.5-GoH/Craster.spec.js
@@ -35,7 +35,7 @@ describe('Craster', function() {
                 this.player1.selectPlot('A Noble Cause');
                 this.selectFirstPlayer(this.player1);
 
-                this.player2.clickPrompt('Benjen Stark');
+                this.player2.triggerAbility('Benjen Stark');
                 expect(this.benjen.location).toBe('draw deck');
             });
 

--- a/test/server/cards/04.5-GoH/Harrenhal.spec.js
+++ b/test/server/cards/04.5-GoH/Harrenhal.spec.js
@@ -26,7 +26,7 @@ describe('Harrenhal (GoH)', function() {
             });
 
             it('should prompt to kill the character', function() {
-                this.player1.clickPrompt('Harrenhal');
+                this.player1.triggerAbility('Harrenhal');
 
                 expect(this.harrenhal.location).toBe('discard pile');
                 expect(this.player1Object.faction.kneeled).toBe(true);
@@ -34,9 +34,9 @@ describe('Harrenhal (GoH)', function() {
             });
 
             it('should not prompt to trigger the ability of the character that was killed', function() {
-                this.player1.clickPrompt('Harrenhal');
+                this.player1.triggerAbility('Harrenhal');
 
-                expect(this.player2).not.toHavePromptButton('Littlefinger');
+                expect(this.player2).not.toAllowAbilityTrigger('Littlefinger');
             });
         });
     });

--- a/test/server/cards/05-LoCR/CerseiLannister.spec.js
+++ b/test/server/cards/05-LoCR/CerseiLannister.spec.js
@@ -34,7 +34,7 @@ describe('Cersei Lannister (LoCR)', function() {
                 });
 
                 it('should allow Cersei to gain power', function() {
-                    this.player1.clickPrompt('Cersei Lannister');
+                    this.player1.triggerAbility('Cersei Lannister');
                     expect(this.cersei.power).toBe(1);
                 });
             });
@@ -54,9 +54,9 @@ describe('Cersei Lannister (LoCR)', function() {
                 });
 
                 it('should not prompt Cersei to gain power twice', function() {
-                    this.player1.clickPrompt('Cersei Lannister');
+                    this.player1.triggerAbility('Cersei Lannister');
 
-                    expect(this.player1).not.toHavePromptButton('Cersei Lannister');
+                    expect(this.player1).not.toAllowAbilityTrigger('Cersei Lannister');
                 });
             });
 
@@ -69,7 +69,7 @@ describe('Cersei Lannister (LoCR)', function() {
                 });
 
                 it('should allow Cersei to gain power', function() {
-                    this.player1.clickPrompt('Cersei Lannister');
+                    this.player1.triggerAbility('Cersei Lannister');
                     expect(this.cersei.power).toBe(1);
                 });
             });

--- a/test/server/cards/05-LoCR/ChellaDaughterOfCheyk.spec.js
+++ b/test/server/cards/05-LoCR/ChellaDaughterOfCheyk.spec.js
@@ -33,7 +33,7 @@ describe('Chella Daughter of Cheyk', function() {
                 this.unopposedChallenge(this.player1, 'military', this.chella);
                 this.player1.clickPrompt('Apply Claim');
                 this.player2.clickCard(this.chud);
-                this.player1.clickPrompt('Chella Daughter of Cheyk');
+                this.player1.triggerAbility('Chella Daughter of Cheyk');
 
                 expect(this.chella.tokens.ear).toBe(3);
             });

--- a/test/server/cards/05-LoCR/HighSepton.spec.js
+++ b/test/server/cards/05-LoCR/HighSepton.spec.js
@@ -36,12 +36,12 @@ describe('High Septon', function() {
                 this.player2.clickPrompt('Pass');
                 this.player2.clickPrompt('Apply Claim');
 
-                this.player2.clickPrompt('Mirri Maz Duur');
+                this.player2.triggerAbility('Mirri Maz Duur');
                 this.player2.clickCard(this.septon);
             });
 
             it('should allow it be redirected to a The Seven character', function() {
-                this.player1.clickPrompt('High Septon');
+                this.player1.triggerAbility('High Septon');
                 this.player1.clickCard(this.sevenCharacter);
 
                 expect(this.sevenCharacter.location).toBe('dead pile');
@@ -58,12 +58,12 @@ describe('High Septon', function() {
                 this.player1.clickPrompt('Done');
 
                 this.unopposedChallenge(this.player2, 'intrigue', 'Mirri Maz Duur');
-                this.player2.clickPrompt('Tears of Lys');
+                this.player2.triggerAbility('Tears of Lys');
                 this.player2.clickCard(this.nonSevenCharacter);
             });
 
             it('should not allow it be redirected', function() {
-                expect(this.player1).not.toHavePromptButton('High Septon');
+                expect(this.player1).not.toAllowAbilityTrigger('High Septon');
             });
         });
 
@@ -77,7 +77,7 @@ describe('High Septon', function() {
             });
 
             it('should not allow it be redirected', function() {
-                expect(this.player1).not.toHavePromptButton('High Septon');
+                expect(this.player1).not.toAllowAbilityTrigger('High Septon');
             });
         });
     });

--- a/test/server/cards/05-LoCR/TheRainsOfCastamere.spec.js
+++ b/test/server/cards/05-LoCR/TheRainsOfCastamere.spec.js
@@ -227,7 +227,7 @@ describe('The Rains of Castamere', function() {
             this.wardens = this.player1.findCardByName('Wardens of the West');
             this.wedding = this.player1.findCardByName('The Red Wedding');
 
-            this.player1.clickPrompt('"The Rains of Castamere"');
+            this.player1.triggerAbility('"The Rains of Castamere"');
         });
 
         it('should allow a scheme to be played', function() {
@@ -239,13 +239,13 @@ describe('The Rains of Castamere', function() {
         it('should allow reactions in the current reaction window to trigger', function() {
             this.player1.clickCard(this.wardens);
 
-            expect(this.player1).toHavePromptButton('Wardens of the West');
+            expect(this.player1).toAllowAbilityTrigger('Wardens of the West');
         });
 
         it('should not allow interrupts in the current window to trigger since the current window is for reactions only', function() {
             this.player1.clickCard(this.wedding);
 
-            expect(this.player1).not.toHavePromptButton('The Red Wedding');
+            expect(this.player1).not.toAllowAbilityTrigger('The Red Wedding');
         });
     });
 });

--- a/test/server/cards/05-LoCR/TywinLannister.spec.js
+++ b/test/server/cards/05-LoCR/TywinLannister.spec.js
@@ -43,7 +43,7 @@ describe('Tywin Lannister (LoCR)', function() {
             });
 
             it('should allow Tywin to choose to trigger', function() {
-                this.player1.clickPrompt('Tywin Lannister');
+                this.player1.triggerAbility('Tywin Lannister');
                 this.player1.clickPrompt('Hedge Knight');
                 expect(this.cersei.location).toBe('draw deck');
                 expect(this.knight.location).toBe('discard pile');
@@ -73,11 +73,11 @@ describe('Tywin Lannister (LoCR)', function() {
                 this.skipActionWindow();
 
                 // Trigger The Reader
-                this.player2.clickPrompt('The Reader - Discard 3 cards');
+                this.player2.triggerAbility('The Reader - Discard 3 cards');
             });
 
             it('should not allow Tywin to choose to trigger', function() {
-                expect(this.player1).not.toHavePromptButton('Tywin Lannister');
+                expect(this.player1).not.toAllowAbilityTrigger('Tywin Lannister');
             });
         });
 
@@ -104,7 +104,7 @@ describe('Tywin Lannister (LoCR)', function() {
             });
 
             it('should allow Tywin to choose to trigger', function() {
-                this.player1.clickPrompt('Tywin Lannister');
+                this.player1.triggerAbility('Tywin Lannister');
                 this.player1.clickPrompt('Hedge Knight');
                 expect(this.cersei.location).toBe('draw deck');
                 expect(this.knight.location).toBe('discard pile');

--- a/test/server/cards/06.1-AMAF/ThePrincesPlan.spec.js
+++ b/test/server/cards/06.1-AMAF/ThePrincesPlan.spec.js
@@ -39,11 +39,11 @@ describe('The Prince\'s Plan', function() {
             });
 
             it('should prompt to return the event back to hand', function() {
-                expect(this.player1).toHavePromptButton('The Prince\'s Plan');
+                expect(this.player1).toAllowAbilityTrigger('The Prince\'s Plan');
             });
 
             it('should allow the event to be returned to hand for 1 gold', function() {
-                this.player1.clickPrompt('The Prince\'s Plan');
+                this.player1.triggerAbility('The Prince\'s Plan');
 
                 expect(this.event.location).toBe('hand');
                 expect(this.player1Object.gold).toBe(4);

--- a/test/server/cards/06.1-AMAF/Ygritte.spec.js
+++ b/test/server/cards/06.1-AMAF/Ygritte.spec.js
@@ -23,7 +23,7 @@ describe('Ygritte', function() {
 
         it('should not be knelt by card effects', function() {
             this.player2.clickCard('Melisandre', 'hand');
-            this.player2.clickPrompt('Melisandre');
+            this.player2.triggerAbility('Melisandre');
 
             this.player2.clickCard(this.ygritte);
 

--- a/test/server/cards/06.2-GtR/TheAnnalsOfCastleBlack.spec.js
+++ b/test/server/cards/06.2-GtR/TheAnnalsOfCastleBlack.spec.js
@@ -78,11 +78,11 @@ describe('The Annals of Castle Black', function() {
             });
 
             it('should allow the event to trigger', function() {
-                expect(this.player1).toHavePromptButton('Ahead of the Tide (discard pile)');
+                expect(this.player1).toAllowAbilityTrigger('Ahead of the Tide (discard pile)');
             });
 
             it('should remove the event from the game if played', function() {
-                this.player1.clickPrompt('Ahead of the Tide (discard pile)');
+                this.player1.triggerAbility('Ahead of the Tide (discard pile)');
 
                 expect(this.interruptEventCard.location).toBe('out of game');
             });
@@ -93,7 +93,7 @@ describe('The Annals of Castle Black', function() {
                 this.completeMarshalPhase();
                 this.completeChallengesPhase();
 
-                expect(this.player1).not.toHavePromptButton('Ahead of the Tide');
+                expect(this.player1).not.toAllowAbilityTrigger('Ahead of the Tide');
             });
         });
 

--- a/test/server/cards/06.4-TRW/TheRedWedding.spec.js
+++ b/test/server/cards/06.4-TRW/TheRedWedding.spec.js
@@ -26,7 +26,7 @@ describe('The Red Wedding', function() {
 
         it('should kill an opponent Lord/Lady when winning challenge', function() {
             this.unopposedChallenge(this.player1, 'Power', this.character);
-            this.player1.clickPrompt('The Red Wedding');
+            this.player1.triggerAbility('The Red Wedding');
             this.player1.clickCard(this.opponentCharacter);
 
             expect(this.opponentCharacter.location).toBe('dead pile');
@@ -36,7 +36,7 @@ describe('The Red Wedding', function() {
             this.player1.clickPrompt('Done');
 
             this.unopposedChallenge(this.player2, 'Power', this.opponentCharacter);
-            this.player2.clickPrompt('The Red Wedding');
+            this.player2.triggerAbility('The Red Wedding');
             this.player2.clickCard(this.character);
 
             expect(this.character.location).toBe('dead pile');

--- a/test/server/cards/06.5-OR/BeggingBrother.spec.js
+++ b/test/server/cards/06.5-OR/BeggingBrother.spec.js
@@ -28,11 +28,11 @@ describe('Begging Brother', function() {
         describe('when you trigger a non-forced character ability', function() {
             beforeEach(function() {
                 this.player1.clickCard(this.tanda1);
-                this.player1.clickPrompt('Tanda Stokeworth');
+                this.player1.triggerAbility('Tanda Stokeworth');
             });
 
             it('should not prompt to trigger Begging Brother', function() {
-                expect(this.player1).not.toHavePromptButton('Begging Brother');
+                expect(this.player1).not.toAllowAbilityTrigger('Begging Brother');
             });
 
             it('should resolve as expected', function() {
@@ -47,12 +47,12 @@ describe('Begging Brother', function() {
             });
 
             it('should prompt to trigger Begging Brother', function() {
-                expect(this.player1).toHavePromptButton('Begging Brother');
+                expect(this.player1).toAllowAbilityTrigger('Begging Brother');
             });
 
             describe('and Begging Brother is used to cancel the ability', function() {
                 beforeEach(function() {
-                    this.player1.clickPrompt('Begging Brother');
+                    this.player1.triggerAbility('Begging Brother');
                 });
 
                 it('should discard a gold from Begging Brother to pay for the ability', function() {
@@ -69,16 +69,16 @@ describe('Begging Brother', function() {
             beforeEach(function() {
                 this.player1.clickPrompt('Done');
                 this.player2.clickCard(this.tanda2);
-                this.player2.clickPrompt('Tanda Stokeworth');
+                this.player2.triggerAbility('Tanda Stokeworth');
             });
 
             it('should prompt to trigger Begging Brother', function() {
-                expect(this.player1).toHavePromptButton('Begging Brother');
+                expect(this.player1).toAllowAbilityTrigger('Begging Brother');
             });
 
             describe('and Begging Brother is used to cancel the ability', function() {
                 beforeEach(function() {
-                    this.player1.clickPrompt('Begging Brother');
+                    this.player1.triggerAbility('Begging Brother');
                 });
 
                 it('should discard a gold from Begging Brother to pay for the ability', function() {

--- a/test/server/cards/07-WotW/MaesterAemon.spec.js
+++ b/test/server/cards/07-WotW/MaesterAemon.spec.js
@@ -31,7 +31,7 @@ describe('Maester Aemon (WotW)', function() {
 
         describe('when the challenge phase ends', function() {
             beforeEach(function() {
-                this.player1.clickPrompt('Maester Aemon');
+                this.player1.triggerAbility('Maester Aemon');
             });
 
             it('should prompt to apply claim for challenges not initiated against the player', function() {
@@ -53,7 +53,7 @@ describe('Maester Aemon (WotW)', function() {
 
             it('should not trigger cards that react to claim being applied for / during a challenge', function() {
                 this.player1.clickPrompt('Military');
-                expect(this.player1).not.toHavePromptButton('The Seastone Chair');
+                expect(this.player1).not.toAllowAbilityTrigger('The Seastone Chair');
             });
         });
     });

--- a/test/server/cards/08.1-TAK/NaggasRibs.spec.js
+++ b/test/server/cards/08.1-TAK/NaggasRibs.spec.js
@@ -33,7 +33,7 @@ describe('Nagga\'s Ribs', function() {
                 this.player1.clickCard('Theon Greyjoy', 'play area');
                 this.player2.clickCard('Hedge Knight', 'play area');
 
-                this.player1.clickPrompt('Nagga\'s Ribs');
+                this.player1.triggerAbility('Nagga\'s Ribs');
             });
 
             it('should move the card to the dead pile', function() {
@@ -56,7 +56,7 @@ describe('Nagga\'s Ribs', function() {
                 this.player2.clickCard('Hedge Knight', 'play area');
                 this.player2.clickCard(this.character1);
 
-                this.player1.clickPrompt('Nagga\'s Ribs');
+                this.player1.triggerAbility('Nagga\'s Ribs');
             });
 
             it('should move the dupe to the dead pile', function() {
@@ -82,21 +82,21 @@ describe('Nagga\'s Ribs', function() {
             describe('when Now My Watch Begins is triggered first', function() {
                 beforeEach(function() {
                     this.player1.clickPrompt('Pass');
-                    this.player2.clickPrompt('Now My Watch Begins');
+                    this.player2.triggerAbility('Now My Watch Begins');
                 });
 
                 it('should not prompt for Nagga\'s Ribs', function() {
-                    expect(this.player1).not.toHavePromptButton('Nagga\'s Ribs');
+                    expect(this.player1).not.toAllowAbilityTrigger('Nagga\'s Ribs');
                 });
             });
 
             describe('when Now My Watch Begins is triggered first', function() {
                 beforeEach(function() {
-                    this.player1.clickPrompt('Nagga\'s Ribs');
+                    this.player1.triggerAbility('Nagga\'s Ribs');
                 });
 
                 it('should not prompt for Now My Watch Begins', function() {
-                    expect(this.player2).not.toHavePromptButton('Now My Watch Begins');
+                    expect(this.player2).not.toAllowAbilityTrigger('Now My Watch Begins');
                 });
             });
         });

--- a/test/server/cards/08.1-TAK/TheIronBank.spec.js
+++ b/test/server/cards/08.1-TAK/TheIronBank.spec.js
@@ -28,7 +28,7 @@ describe('The Iron Bank', function() {
         describe('when the player collects income', function() {
             it('should double the gold on the Iron Bank', function() {
                 this.selectFirstPlayer(this.player1);
-                this.player1.clickPrompt('The Iron Bank');
+                this.player1.triggerAbility('The Iron Bank');
 
                 expect(this.ironBank.gold).toBe(20);
             });
@@ -37,7 +37,7 @@ describe('The Iron Bank', function() {
                 delete this.ironBank.tokens.gold;
                 this.selectFirstPlayer(this.player1);
 
-                expect(this.player1).not.toHavePromptButton('The Iron Bank');
+                expect(this.player1).not.toAllowAbilityTrigger('The Iron Bank');
             });
         });
 
@@ -50,7 +50,7 @@ describe('The Iron Bank', function() {
             });
 
             it('should not allow gold to be stolen from the card', function() {
-                this.player2.clickPrompt('A Meager Contribution');
+                this.player2.triggerAbility('A Meager Contribution');
                 // Pass on Hand's Judgment
                 this.player1.clickPrompt('Pass');
 
@@ -174,10 +174,10 @@ describe('The Iron Bank', function() {
                 this.player2.clickCard('Nightmares', 'hand');
                 this.player2.clickCard(cersei);
 
-                expect(this.player1).toHavePromptButton('The Hand\'s Judgment');
+                expect(this.player1).toAllowAbilityTrigger('The Hand\'s Judgment');
                 expect(cersei.isBlank()).toBe(false);
 
-                this.player1.clickPrompt('The Hand\'s Judgment');
+                this.player1.triggerAbility('The Hand\'s Judgment');
 
                 // Automatically take it off the Iron Bank without prompting
                 expect(this.player1).not.toHavePromptButton('1');

--- a/test/server/cards/08.5-TFM/DaenerysTargaryen.spec.js
+++ b/test/server/cards/08.5-TFM/DaenerysTargaryen.spec.js
@@ -43,7 +43,7 @@ describe('Daenerys Targaryen (TFM)', function() {
                 this.player1.clickCard(this.waking);
                 this.player1.clickCard(this.dany);
 
-                this.player1.clickPrompt('Daenerys Targaryen');
+                this.player1.triggerAbility('Daenerys Targaryen');
                 this.player1.clickCard(this.steward);
             });
 
@@ -62,7 +62,7 @@ describe('Daenerys Targaryen (TFM)', function() {
                 this.player1.clickCard(this.waking);
                 this.player1.clickCard(this.dany);
 
-                this.player1.clickPrompt('Daenerys Targaryen');
+                this.player1.triggerAbility('Daenerys Targaryen');
                 this.player1.clickCard(this.dany);
             });
 

--- a/test/server/cards/08.6-SAT/SomeoneAlwaysTells.spec.js
+++ b/test/server/cards/08.6-SAT/SomeoneAlwaysTells.spec.js
@@ -28,7 +28,7 @@ describe('Someone Always Tells', function() {
             });
 
             it('should not prompt to trigger someone always tells', function() {
-                expect(this.player1).not.toHavePromptButton('Someone Always Tells');
+                expect(this.player1).not.toAllowAbilityTrigger('Someone Always Tells');
             });
         });
 
@@ -39,14 +39,14 @@ describe('Someone Always Tells', function() {
             });
 
             it('should prompt to trigger someone always tells', function() {
-                expect(this.player1).toHavePromptButton('Someone Always Tells');
+                expect(this.player1).toAllowAbilityTrigger('Someone Always Tells');
             });
 
             describe('and when someone always tells is used to cancel', function() {
                 beforeEach(function() {
-                    this.player1.clickPrompt('Someone Always Tells');
+                    this.player1.triggerAbility('Someone Always Tells');
                 });
-    
+
                 it('should cancel the when revealed ability', function() {
                     expect(this.knight.location).toBe('play area');
                 });

--- a/test/server/cards/09-HoT/EmissaryOfTheHightower.spec.js
+++ b/test/server/cards/09-HoT/EmissaryOfTheHightower.spec.js
@@ -1,4 +1,4 @@
-describe('Hidden Thorns', function() {
+describe('Emissary of the Hightower', function() {
     integration(function() {
         beforeEach(function() {
             const deck1 = this.buildDeck('tyrell', [
@@ -32,7 +32,7 @@ describe('Hidden Thorns', function() {
 
                 // Ambush Emissary
                 this.player1.clickCard('Emissary of the Hightower', 'hand');
-                this.player1.clickPrompt('Emissary of the Hightower');
+                this.player1.triggerAbility('Emissary of the Hightower');
                 this.player1.clickCard(this.event);
 
                 // Play Growing Strong from discard
@@ -59,11 +59,11 @@ describe('Hidden Thorns', function() {
 
                 // Ambush Emissary
                 this.player1.clickCard('Emissary of the Hightower', 'hand');
-                this.player1.clickPrompt('Emissary of the Hightower');
+                this.player1.triggerAbility('Emissary of the Hightower');
                 this.player1.clickCard(this.hiddenThorns);
 
                 this.unopposedChallenge(this.player1, 'Intrigue', this.character);
-                this.player1.clickPrompt('Hidden Thorns (discard pile)');
+                this.player1.triggerAbility('Hidden Thorns (discard pile)');
 
                 this.player2.clickCard('Hedge Knight', 'hand');
                 this.player2.clickCard('Varys', 'hand');

--- a/test/server/cards/09-HoT/HiddenThorns.spec.js
+++ b/test/server/cards/09-HoT/HiddenThorns.spec.js
@@ -34,7 +34,7 @@ describe('Hidden Thorns', function() {
                 this.completeMarshalPhase();
 
                 this.unopposedChallenge(this.player1, 'Intrigue', this.character);
-                this.player1.clickPrompt('Hidden Thorns');
+                this.player1.triggerAbility('Hidden Thorns');
 
                 this.player2.clickCard(this.card1);
                 this.player2.clickCard(this.card2);
@@ -57,7 +57,7 @@ describe('Hidden Thorns', function() {
                 this.completeMarshalPhase();
 
                 this.unopposedChallenge(this.player1, 'Intrigue', this.character);
-                this.player1.clickPrompt('Hidden Thorns');
+                this.player1.triggerAbility('Hidden Thorns');
 
                 this.player2.clickCard(this.card1);
                 this.player2.clickCard(this.card2);

--- a/test/server/cards/09-HoT/MaceTyrell.spec.js
+++ b/test/server/cards/09-HoT/MaceTyrell.spec.js
@@ -31,7 +31,7 @@ describe('Mace Tyrell', function() {
 
                 expect(this.character.location).toBe('play area');
 
-                this.player1.clickPrompt('Mace Tyrell');
+                this.player1.triggerAbility('Mace Tyrell');
 
                 this.player1.clickMenu(this.mace, 'Remove character from game');
                 this.player1.clickCard(this.character);
@@ -55,7 +55,7 @@ describe('Mace Tyrell', function() {
 
                 expect(this.character.location).toBe('play area');
 
-                this.player1.clickPrompt('Mace Tyrell');
+                this.player1.triggerAbility('Mace Tyrell');
 
                 this.player1.clickMenu(this.mace, 'Remove character from game');
                 this.player1.clickCard(this.character);
@@ -83,7 +83,7 @@ describe('Mace Tyrell', function() {
 
                 expect(this.character.location).toBe('play area');
 
-                this.player1.clickPrompt('Mace Tyrell');
+                this.player1.triggerAbility('Mace Tyrell');
 
                 this.player1.clickMenu(this.mace, 'Remove character from game');
                 this.player1.clickCard(this.character);

--- a/test/server/cards/10-SoD/FalsePlans.spec.js
+++ b/test/server/cards/10-SoD/FalsePlans.spec.js
@@ -33,7 +33,7 @@ describe('False Plans', function() {
             it('should not activate', function() {
                 expect(this.player1Object.hand.length).toBe(0);
                 expect(this.player1Object.discardPile.length).toBe(1);
-                expect(this.player1).not.toHavePromptButton('False Plans');
+                expect(this.player1).not.toAllowAbilityTrigger('False Plans');
             });
         });
 
@@ -47,7 +47,7 @@ describe('False Plans', function() {
                 this.unopposedChallenge(this.player2, 'Intrigue', 'House Dayne Knight');
                 this.player2.clickPrompt('Apply Claim');
 
-                this.player1.clickPrompt('False Plans');
+                this.player1.triggerAbility('False Plans');
             });
 
             it('should discard 2 cards from the opponent', function() {
@@ -70,11 +70,11 @@ describe('False Plans', function() {
                 this.player1.clickPrompt('Apply Claim');
 
                 // Redirect the intrigue claim
-                this.player2.clickPrompt('Vengeance for Elia');
+                this.player2.triggerAbility('Vengeance for Elia');
             });
 
             it('should not prompt for False Plans', function() {
-                expect(this.player1).not.toHavePromptButton('False Plans');
+                expect(this.player1).not.toAllowAbilityTrigger('False Plans');
                 expect(this.player1Object.discardPile.length).toBe(1);
             });
         });

--- a/test/server/cards/10-SoD/Missandei.spec.js
+++ b/test/server/cards/10-SoD/Missandei.spec.js
@@ -32,7 +32,7 @@ describe('Missandei', function() {
                 this.unopposedChallenge(this.player2, 'Intrigue', this.opponentPillager);
                 this.player2.clickPrompt('Apply Claim');
 
-                this.player1.clickPrompt('Missandei');
+                this.player1.triggerAbility('Missandei');
             });
 
             it('should put her into play', function() {
@@ -51,7 +51,7 @@ describe('Missandei', function() {
                 this.player1.clickPrompt('Done');
 
                 // Pillage occurs, which would discard Missandei from deck
-                this.player1.clickPrompt('Missandei');
+                this.player1.triggerAbility('Missandei');
             });
 
             it('should put her into play', function() {

--- a/test/server/cards/10-SoD/ObellaSand.spec.js
+++ b/test/server/cards/10-SoD/ObellaSand.spec.js
@@ -37,7 +37,7 @@ describe('Obella Sand', function() {
 
                 this.player1.clickCard(this.obella1);
 
-                this.player1.clickPrompt('Obella Sand');
+                this.player1.triggerAbility('Obella Sand');
             });
 
             it('should shuffle Obella back into the deck', function() {
@@ -56,7 +56,7 @@ describe('Obella Sand', function() {
                 this.player2.clickPrompt('Apply Claim');
 
                 // This should be a prompt for Obella2, who was in hand
-                this.player1.clickPrompt('Obella Sand');
+                this.player1.triggerAbility('Obella Sand');
             });
 
             it('should shuffle Obella back into the deck', function() {

--- a/test/server/integration/AbilityLimits.spec.js
+++ b/test/server/integration/AbilityLimits.spec.js
@@ -27,7 +27,7 @@ describe('ability limits', function() {
 
                 // Manually kill a character
                 this.player1.dragCard(this.character1, 'dead pile');
-                this.player1.clickPrompt('Robb Stark');
+                this.player1.triggerAbility('Robb Stark');
 
                 this.player1.clickCard('Robb Stark', 'play area');
             });
@@ -35,7 +35,7 @@ describe('ability limits', function() {
             it('should not allow the limit to be exceeded', function() {
                 this.player1.dragCard(this.character2, 'dead pile');
 
-                expect(this.player1).not.toHavePromptButton('Robb Stark');
+                expect(this.player1).not.toAllowAbilityTrigger('Robb Stark');
             });
         });
 
@@ -71,15 +71,15 @@ describe('ability limits', function() {
 
                 // Manually kill a character
                 this.player2.dragCard(this.character1, 'dead pile');
-                this.player2.clickPrompt('Robb Stark');
+                this.player2.triggerAbility('Robb Stark');
 
-                this.player1.clickPrompt('Treachery');
+                this.player1.triggerAbility('Treachery');
             });
 
             it('should not allow the ability to be triggered again', function() {
                 this.player2.dragCard(this.character2, 'dead pile');
 
-                expect(this.player2).not.toHavePromptButton('Robb Stark');
+                expect(this.player2).not.toAllowAbilityTrigger('Robb Stark');
             });
         });
     });

--- a/test/server/integration/AbilityRequirements.spec.js
+++ b/test/server/integration/AbilityRequirements.spec.js
@@ -36,12 +36,12 @@ describe('ability requirements', function() {
                 this.skipActionWindow();
 
                 // Return the character to hand
-                this.player2.clickPrompt('Ghaston Grey');
+                this.player2.triggerAbility('Ghaston Grey');
                 this.player2.clickCard(this.character);
             });
 
             it('should prompt for the ability', function() {
-                expect(this.player2).toHavePromptButton('His Viper Eyes');
+                expect(this.player2).toAllowAbilityTrigger('His Viper Eyes');
             });
         });
     });

--- a/test/server/integration/EndOfPhaseTimings.spec.js
+++ b/test/server/integration/EndOfPhaseTimings.spec.js
@@ -31,7 +31,7 @@ describe('end of phase timings / WUA', function() {
                 // Since Nightmares will not run out until after interrupts to
                 // "when the phase ends", the player should not be able to
                 // trigger Varys.
-                expect(this.player1).not.toHavePromptButton('Varys');
+                expect(this.player1).not.toAllowAbilityTrigger('Varys');
             });
         });
 
@@ -64,7 +64,7 @@ describe('end of phase timings / WUA', function() {
                 // Ambush Venomous Blade
                 this.player2.clickCard('Venomous Blade', 'hand');
                 this.player2.clickCard(this.character);
-                this.player2.clickPrompt('Venomous Blade');
+                this.player2.triggerAbility('Venomous Blade');
                 this.player2.clickCard(this.shireen);
 
                 expect(this.shireen.tokens.poison).toBe(1);
@@ -80,7 +80,7 @@ describe('end of phase timings / WUA', function() {
                 // Nightmares wears off before the kill from Venomous Blade, so
                 // Shireen should have an opportunity to kneel someone when she
                 // dies.
-                expect(this.player1).toHavePromptButton('Shireen Baratheon');
+                expect(this.player1).toAllowAbilityTrigger('Shireen Baratheon');
             });
         });
     });

--- a/test/server/integration/ReplacementEffects.spec.js
+++ b/test/server/integration/ReplacementEffects.spec.js
@@ -32,7 +32,7 @@ describe('replacement effects', function() {
 
                 // Choose Benjen for claim
                 this.player1.clickCard(this.benjen);
-                this.player1.clickPrompt('Benjen Stark');
+                this.player1.triggerAbility('Benjen Stark');
             });
 
             it('should replace the effect', function() {
@@ -41,7 +41,7 @@ describe('replacement effects', function() {
 
             it('should still be considered to have happened', function() {
                 // Chella should gain an ear token from Benjen dying
-                this.player2.clickPrompt('Chella Daughter of Cheyk');
+                this.player2.triggerAbility('Chella Daughter of Cheyk');
 
                 expect(this.chella.tokens.ear).toBe(1);
             });
@@ -78,11 +78,11 @@ describe('replacement effects', function() {
                 this.player1.clickPrompt('Apply Claim');
 
                 // Player 1 attempts to trigger Mirri to kill the character
-                this.player1.clickPrompt('Mirri Maz Duur');
+                this.player1.triggerAbility('Mirri Maz Duur');
                 this.player1.clickCard(this.character);
 
                 // Player 2 applies the claim back to the attacker
-                this.player2.clickPrompt('Vengeance for Elia');
+                this.player2.triggerAbility('Vengeance for Elia');
             });
 
             it('should replace the original effect', function() {

--- a/test/server/integration/burneffects.spec.js
+++ b/test/server/integration/burneffects.spec.js
@@ -132,7 +132,7 @@ describe('burn effects', function() {
                     // 4 base = 4 remaining when Dracarys'ed
                     expect(this.quentyn.getStrength()).toBe(4);
 
-                    this.player1.clickPrompt('Quentyn Martell');
+                    this.player1.triggerAbility('Quentyn Martell');
                 });
 
                 it('should not allow a 4 STR character to be killed', function() {
@@ -165,7 +165,7 @@ describe('burn effects', function() {
                     // 4 base + 1 Song of Summer - 1 Blood of Dragon = 4 remaining when Dracarys'ed
                     expect(this.quentyn.getStrength()).toBe(4);
 
-                    this.player1.clickPrompt('Quentyn Martell');
+                    this.player1.triggerAbility('Quentyn Martell');
                 });
 
                 it('should not allow a 4 STR character to be killed', function() {
@@ -205,7 +205,7 @@ describe('burn effects', function() {
                     // 4 base + 1 Song of Summer - 2 Astapor = 3 remaining when Dracarys'ed
                     expect(this.quentyn.getStrength()).toBe(3);
 
-                    this.player1.clickPrompt('Quentyn Martell');
+                    this.player1.triggerAbility('Quentyn Martell');
                 });
 
                 it('should not allow a 3 STR character to be killed', function() {
@@ -245,7 +245,7 @@ describe('burn effects', function() {
                     // 4 base + 1 Song of Summer - 4 Dracarys! = 1 remaining when Astapor'ed
                     expect(this.quentyn.getStrength()).toBe(1);
 
-                    this.player1.clickPrompt('Quentyn Martell');
+                    this.player1.triggerAbility('Quentyn Martell');
                 });
 
                 it('should not allow a 1 STR character to be killed', function() {

--- a/test/server/integration/challengesphase.spec.js
+++ b/test/server/integration/challengesphase.spec.js
@@ -30,7 +30,7 @@ describe('challenges phase', function() {
 
                 this.player1.clickCard(stealthTarget);
 
-                expect(this.player1).toHavePromptButton('Tyrion Lannister');
+                expect(this.player1).toAllowAbilityTrigger('Tyrion Lannister');
                 expect(stealthTarget.stealth).toBe(true);
             });
         });
@@ -69,7 +69,7 @@ describe('challenges phase', function() {
             });
 
             it('should not trigger any win reactions for the defender', function() {
-                expect(this.player2).not.toHavePromptButton('The Shadow Tower');
+                expect(this.player2).not.toAllowAbilityTrigger('The Shadow Tower');
             });
 
             it('should complete the challenge', function() {
@@ -122,29 +122,29 @@ describe('challenges phase', function() {
             it('should prompt for challenge initiated, attackers declared, and stealth simultaneously', function() {
                 this.initiateChallenge();
 
-                expect(this.player1).toHavePromptButton('Tyrion Lannister');
-                expect(this.player1).toHavePromptButton('Dornish Paramour');
-                expect(this.player1).toHavePromptButton('Marya Seaworth - Kneel Hedge Knight');
-                expect(this.player1).toHavePromptButton('Marya Seaworth - Kneel Lannisport Merchant');
+                expect(this.player1).toAllowAbilityTrigger('Tyrion Lannister');
+                expect(this.player1).toAllowAbilityTrigger('Dornish Paramour');
+                expect(this.player1).toAllowAbilityTrigger('Marya Seaworth - Kneel Hedge Knight');
+                expect(this.player1).toAllowAbilityTrigger('Marya Seaworth - Kneel Lannisport Merchant');
                 expect(this.player1.currentPrompt().buttons.length).toBe(5);
             });
 
             it('should reactions in the same window to generate gold needed to pay costs', function() {
                 this.player1Object.gold = 0;
                 this.initiateChallenge();
-                expect(this.player1).not.toHavePromptButton('Marya Seaworth - Kneel Hedge Knight');
-                expect(this.player1).not.toHavePromptButton('Marya Seaworth - Kneel Lannisport Merchant');
+                expect(this.player1).not.toAllowAbilityTrigger('Marya Seaworth - Kneel Hedge Knight');
+                expect(this.player1).not.toAllowAbilityTrigger('Marya Seaworth - Kneel Lannisport Merchant');
 
-                this.player1.clickPrompt('Tyrion Lannister');
+                this.player1.triggerAbility('Tyrion Lannister');
 
-                expect(this.player1).toHavePromptButton('Marya Seaworth - Kneel Hedge Knight');
-                expect(this.player1).toHavePromptButton('Marya Seaworth - Kneel Lannisport Merchant');
+                expect(this.player1).toAllowAbilityTrigger('Marya Seaworth - Kneel Hedge Knight');
+                expect(this.player1).toAllowAbilityTrigger('Marya Seaworth - Kneel Lannisport Merchant');
             });
 
             it('should allow multiple reactions from the same card to be triggered', function() {
                 this.initiateChallenge();
-                this.player1.clickPrompt('Marya Seaworth - Kneel Hedge Knight');
-                this.player1.clickPrompt('Marya Seaworth - Kneel Lannisport Merchant');
+                this.player1.triggerAbility('Marya Seaworth - Kneel Hedge Knight');
+                this.player1.triggerAbility('Marya Seaworth - Kneel Lannisport Merchant');
 
                 expect(this.knight.kneeled).toBe(true);
                 expect(this.merchant.kneeled).toBe(true);

--- a/test/server/integration/effects.spec.js
+++ b/test/server/integration/effects.spec.js
@@ -101,7 +101,7 @@ describe('effects', function() {
 
                 this.skipActionWindow();
 
-                this.player2.clickPrompt('Tyene Sand');
+                this.player2.triggerAbility('Tyene Sand');
                 this.player2.clickCard(this.character);
 
                 expect(this.character.tokens['poison']).toBeTruthy();
@@ -110,7 +110,7 @@ describe('effects', function() {
 
                 this.player2.clickPrompt('Done');
 
-                this.player1.clickPrompt('Winter Festival');
+                this.player1.triggerAbility('Winter Festival');
             });
 
             it('should apply when/until effects before at the end of phase effects', function() {

--- a/test/server/integration/eventmaximums.spec.js
+++ b/test/server/integration/eventmaximums.spec.js
@@ -1,5 +1,3 @@
-const _ = require('underscore');
-
 describe('event maximums', function() {
     integration(function() {
         beforeEach(function() {
@@ -18,30 +16,24 @@ describe('event maximums', function() {
         });
 
         it('should not allow an event with a max to be prompted past the max', function() {
-            this.player1.clickPrompt('A Meager Contribution');
+            this.player1.triggerAbility('A Meager Contribution');
 
-            expect(this.player1).not.toHavePromptButton('A Meager Contribution');
-        });
-
-        it('should only show one copy of the event in the prompt', function() {
-            let prompt = this.player1.currentPrompt();
-            let copies = _.filter(prompt.buttons, button => button.text === 'A Meager Contribution');
-            expect(_.size(copies)).toBe(1);
+            expect(this.player1).not.toAllowAbilityTrigger('A Meager Contribution');
         });
 
         it('should allow other players to play the event even if it reaches a maximum with another player', function() {
-            this.player1.clickPrompt('A Meager Contribution');
+            this.player1.triggerAbility('A Meager Contribution');
 
             // Complete marshaling
             this.player2.clickPrompt('Done');
 
-            expect(this.player2).toHavePromptButton('A Meager Contribution');
+            expect(this.player2).toAllowAbilityTrigger('A Meager Contribution');
         });
 
         describe('when the maximum period has passed', function() {
             beforeEach(function() {
                 // Play the card Round 1
-                this.player1.clickPrompt('A Meager Contribution');
+                this.player1.triggerAbility('A Meager Contribution');
                 this.player2.clickPrompt('Done');
                 this.player2.clickPrompt('Pass');
                 this.player1.clickPrompt('Done');
@@ -52,7 +44,7 @@ describe('event maximums', function() {
             });
 
             it('should allow the card to be prompted again', function() {
-                expect(this.player1).toHavePromptButton('A Meager Contribution');
+                expect(this.player1).toAllowAbilityTrigger('A Meager Contribution');
             });
         });
     });

--- a/test/server/integration/factionchange.spec.js
+++ b/test/server/integration/factionchange.spec.js
@@ -98,7 +98,7 @@ describe('faction change', function() {
             });
 
             it('should count as that affiliation having been killed', function() {
-                expect(this.player1).toHavePromptButton('Robb Stark');
+                expect(this.player1).toAllowAbilityTrigger('Robb Stark');
             });
         });
     });

--- a/test/server/integration/leavingplay.spec.js
+++ b/test/server/integration/leavingplay.spec.js
@@ -82,13 +82,13 @@ describe('leaving play', function() {
             });
 
             it('should prompt to use the interrupt and not have the card leave play immediately', function() {
-                expect(this.player1).toHavePromptButton('Improved Fortifications');
+                expect(this.player1).toAllowAbilityTrigger('Improved Fortifications');
                 expect(this.location.location).toBe('play area');
                 expect(this.player1Object.cardsInPlay).toContain(this.location);
             });
 
             it('should stop the card from leaving play once the ability is triggered', function() {
-                this.player1.clickPrompt('Improved Fortifications');
+                this.player1.triggerAbility('Improved Fortifications');
                 expect(this.location.location).toBe('play area');
                 expect(this.player1Object.cardsInPlay).toContain(this.location);
                 expect(this.attachment.location).toBe('discard pile');
@@ -119,7 +119,7 @@ describe('leaving play', function() {
                 this.selectPlotOrder(this.player1);
 
                 this.player1.clickCard(this.character);
-                this.player1.clickPrompt('Melisandre');
+                this.player1.triggerAbility('Melisandre');
                 this.player1.clickCard(this.chud1);
 
                 this.player1.dragCard(this.character, 'hand');
@@ -127,7 +127,7 @@ describe('leaving play', function() {
             });
 
             it('should reset after leaving play', function() {
-                expect(this.player1).toHavePromptButton('Melisandre');
+                expect(this.player1).toAllowAbilityTrigger('Melisandre');
             });
         });
     });

--- a/test/server/integration/marshalphase.spec.js
+++ b/test/server/integration/marshalphase.spec.js
@@ -37,7 +37,7 @@ describe('marshal phase', function() {
                 this.kingsroad.controller.moveCard(this.kingsroad, 'draw deck');
                 this.player1.clickCard(this.arya);
 
-                this.player1.clickPrompt('Arya Stark');
+                this.player1.triggerAbility('Arya Stark');
 
                 expect(this.arya.dupes.length).toBe(1);
             });

--- a/test/server/integration/nestedabilitysequences.spec.js
+++ b/test/server/integration/nestedabilitysequences.spec.js
@@ -55,47 +55,47 @@ describe('nested ability sequences', function() {
             });
 
             it('should prompt with all available reactions', function() {
-                expect(this.player1).toHavePromptButton('Robb Stark');
-                expect(this.player1).toHavePromptButton('Arya Stark');
-                expect(this.player1).toHavePromptButton('Catelyn Stark');
+                expect(this.player1).toAllowAbilityTrigger('Robb Stark');
+                expect(this.player1).toAllowAbilityTrigger('Arya Stark');
+                expect(this.player1).toAllowAbilityTrigger('Catelyn Stark');
             });
 
             describe('when an ability triggers a new ability window', function() {
                 beforeEach(function() {
                     // Arya Stark sacrifices herself, prompt to trigger
-                    this.player1.clickPrompt('Arya Stark');
+                    this.player1.triggerAbility('Arya Stark');
                 });
 
                 it('should prompt again with eligible cards', function() {
-                    expect(this.player1).toHavePromptButton('Robb Stark');
-                    expect(this.player1).toHavePromptButton('Catelyn Stark');
-                    expect(this.player1).not.toHavePromptButton('Arya Stark');
+                    expect(this.player1).toAllowAbilityTrigger('Robb Stark');
+                    expect(this.player1).toAllowAbilityTrigger('Catelyn Stark');
+                    expect(this.player1).not.toAllowAbilityTrigger('Arya Stark');
                 });
 
                 it('should resolve the current trigger before continuing', function() {
-                    this.player1.clickPrompt('Catelyn Stark');
+                    this.player1.triggerAbility('Catelyn Stark');
 
                     expect(this.cat.power).toBe(1);
-                    expect(this.player1).toHavePromptButton('Robb Stark');
-                    expect(this.player1).not.toHavePromptButton('Catelyn Stark');
-                    expect(this.player1).not.toHavePromptButton('Arya Stark');
+                    expect(this.player1).toAllowAbilityTrigger('Robb Stark');
+                    expect(this.player1).not.toAllowAbilityTrigger('Catelyn Stark');
+                    expect(this.player1).not.toAllowAbilityTrigger('Arya Stark');
                 });
 
                 it('should continue with the previous reaction window once the current trigger is resolved', function() {
-                    this.player1.clickPrompt('Catelyn Stark');
+                    this.player1.triggerAbility('Catelyn Stark');
                     this.player1.clickPrompt('Pass');
 
                     expect(this.player1).toHavePrompt('Select a character');
                     this.player1.clickPrompt('Done');
 
-                    expect(this.player1).toHavePromptButton('Robb Stark');
-                    expect(this.player1).toHavePromptButton('Catelyn Stark');
-                    expect(this.player1).not.toHavePromptButton('Arya Stark');
+                    expect(this.player1).toAllowAbilityTrigger('Robb Stark');
+                    expect(this.player1).toAllowAbilityTrigger('Catelyn Stark');
+                    expect(this.player1).not.toAllowAbilityTrigger('Arya Stark');
                 });
 
                 it('should not allow abilities to trigger past their limit upon rewinding', function() {
                     // Gain power for Catelyn from Arya sacrifice (1)
-                    this.player1.clickPrompt('Catelyn Stark');
+                    this.player1.triggerAbility('Catelyn Stark');
                     this.player1.clickPrompt('Pass');
 
                     // Kill the other steward using Arya
@@ -103,18 +103,18 @@ describe('nested ability sequences', function() {
                     this.player1.clickCard(this.steward1);
 
                     // Gain power for Catelyn from Steward #2 kill (2)
-                    this.player1.clickPrompt('Catelyn Stark');
+                    this.player1.triggerAbility('Catelyn Stark');
                     this.player1.clickPrompt('Pass');
 
                     // Even though Catelyn original was able to trigger from the
                     // killing of Steward #1, she has reached her ability limit and
                     // is no longer eligible.
                     expect(this.cat.power).toBe(2);
-                    expect(this.player1).not.toHavePromptButton('Catelyn Stark');
+                    expect(this.player1).not.toAllowAbilityTrigger('Catelyn Stark');
 
                     // Robb Stark is still eligible though.
-                    expect(this.player1).toHavePromptButton('Robb Stark');
-                    expect(this.player1).not.toHavePromptButton('Arya Stark');
+                    expect(this.player1).toAllowAbilityTrigger('Robb Stark');
+                    expect(this.player1).not.toAllowAbilityTrigger('Arya Stark');
                 });
             });
         });
@@ -155,12 +155,12 @@ describe('nested ability sequences', function() {
                 this.skipActionWindow();
 
                 // Activate Blackfish to draw a card.
-                this.player1.clickPrompt('The Blackfish');
+                this.player1.triggerAbility('The Blackfish');
             });
 
             it('should prompt for the drawn card when eligible', function() {
                 expect(this.eventCard.location).toBe('hand');
-                expect(this.player1).toHavePromptButton('Put to the Torch');
+                expect(this.player1).toAllowAbilityTrigger('Put to the Torch');
             });
         });
     });

--- a/test/server/integration/playingevents.spec.js
+++ b/test/server/integration/playingevents.spec.js
@@ -40,9 +40,9 @@ describe('playing events', function() {
             });
 
             it('should count as having played the event', function() {
-                expect(this.player1).toHavePromptButton('Melisandre');
+                expect(this.player1).toAllowAbilityTrigger('Melisandre');
 
-                this.player1.clickPrompt('Melisandre');
+                this.player1.triggerAbility('Melisandre');
                 this.player1.clickCard(this.knight);
 
                 expect(this.knight.kneeled).toBe(true);
@@ -52,7 +52,7 @@ describe('playing events', function() {
         describe('when cancelling the effects of an event', function() {
             beforeEach(function() {
                 this.player1.clickCard('Seen In Flames');
-                this.player2.clickPrompt('The Hand\'s Judgment');
+                this.player2.triggerAbility('The Hand\'s Judgment');
 
                 // Pass on Tower of the Sun
                 this.player2.clickPrompt('Pass');
@@ -61,13 +61,13 @@ describe('playing events', function() {
             it('should not prompt to cancel the event again', function() {
                 // The second copy of Hand's Judgment should not prompt for the
                 // already cancelled event.
-                expect(this.player2).not.toHavePromptButton('The Hand\'s Judgment');
+                expect(this.player2).not.toAllowAbilityTrigger('The Hand\'s Judgment');
             });
 
             it('should still count as having played the event', function() {
-                expect(this.player1).toHavePromptButton('Melisandre');
+                expect(this.player1).toAllowAbilityTrigger('Melisandre');
 
-                this.player1.clickPrompt('Melisandre');
+                this.player1.triggerAbility('Melisandre');
                 this.player1.clickCard(this.knight);
 
                 expect(this.knight.kneeled).toBe(true);
@@ -88,11 +88,11 @@ describe('playing events', function() {
 
                 this.skipActionWindow();
 
-                this.player2.clickPrompt('The Prince\'s Plan');
+                this.player2.triggerAbility('The Prince\'s Plan');
             });
 
             it('should not count as playing an event', function() {
-                expect(this.player2).not.toHavePromptButton('Tower of the Sun');
+                expect(this.player2).not.toAllowAbilityTrigger('Tower of the Sun');
             });
         });
 
@@ -104,7 +104,7 @@ describe('playing events', function() {
                 this.game.killCharacter(character, { allowSave: true });
                 this.game.continue();
 
-                this.player1.clickPrompt('Risen from the Sea');
+                this.player1.triggerAbility('Risen from the Sea');
                 this.player1.clickCard(character);
 
                 // Pass on Hand's Judgment to allow the save
@@ -112,7 +112,7 @@ describe('playing events', function() {
             });
 
             it('should count as playing an event', function() {
-                expect(this.player2).toHavePromptButton('Tower of the Sun');
+                expect(this.player2).toAllowAbilityTrigger('Tower of the Sun');
             });
         });
     });

--- a/test/server/integration/setup.spec.js
+++ b/test/server/integration/setup.spec.js
@@ -211,9 +211,9 @@ describe('setup phase', function() {
                 this.completeMarshalPhase();
                 this.completeChallengesPhase();
 
-                this.player1.clickPrompt('The Wall');
+                this.player1.triggerAbility('The Wall');
 
-                expect(this.player1).not.toHavePromptButton('The Wall');
+                expect(this.player1).not.toAllowAbilityTrigger('The Wall');
             });
         });
 

--- a/test/server/integration/takecontrol.spec.js
+++ b/test/server/integration/takecontrol.spec.js
@@ -164,7 +164,7 @@ describe('take control', function() {
                 this.player1.clickPrompt('Apply Claim');
 
                 // Use Euron to take control of the opponent Kingsroad.
-                this.player1.clickPrompt('Euron Crow\'s Eye');
+                this.player1.triggerAbility('Euron Crow\'s Eye');
                 this.player1.clickCard(this.kingsroad);
 
                 expect(this.kingsroad.controller).toBe(this.player1Object);
@@ -244,7 +244,7 @@ describe('take control', function() {
                     this.player1.clickPrompt('Apply Claim');
 
                     // Use Euron to take control of the opponent Wall.
-                    this.player1.clickPrompt('Euron Crow\'s Eye');
+                    this.player1.triggerAbility('Euron Crow\'s Eye');
                     this.player1.clickCard(this.wall);
 
                     expect(this.player1Object.cardsInPlay.map(card => card.uuid)).toContain(this.wall.uuid);
@@ -357,7 +357,7 @@ describe('take control', function() {
                 this.player1.clickPrompt('Apply Claim');
 
                 // Use Euron to take control of the opponent Iron Mines.
-                this.player1.clickPrompt('Euron Crow\'s Eye');
+                this.player1.triggerAbility('Euron Crow\'s Eye');
                 this.player1.clickCard(this.mines);
             });
 
@@ -380,7 +380,7 @@ describe('take control', function() {
 
                 this.player1.clickCard(knight);
 
-                this.player1.clickPrompt('Iron Mines');
+                this.player1.triggerAbility('Iron Mines');
                 expect(this.player1).toHavePrompt('Select a character');
                 this.player1.clickCard(knight);
 
@@ -403,8 +403,8 @@ describe('take control', function() {
 
                 this.player2.clickCard('Hedge Knight', 'play area');
 
-                expect(this.player1).not.toHavePromptButton('Iron Mines');
-                expect(this.player2).not.toHavePromptButton('Iron Mines');
+                expect(this.player1).not.toAllowAbilityTrigger('Iron Mines');
+                expect(this.player2).not.toAllowAbilityTrigger('Iron Mines');
             });
         });
 
@@ -700,7 +700,7 @@ describe('take control', function() {
                 this.completeMarshalPhase();
                 this.completeChallengesPhase();
 
-                this.player1.clickPrompt('Varys');
+                this.player1.triggerAbility('Varys');
             });
 
             it('should place the character in the proper owner\'s pile', function() {


### PR DESCRIPTION
Previously tests simply clicked on prompt buttons directly to trigger
interrupt and reaction abilities. This was inflexible in terms of
changing how the UI works. Now, tests specify they want to trigger the
ability and the test framework takes care of the rest.