### PR TITLE
Add standalone, pre-made decks

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ npm install
 npm run build-vendor-dev
 mkdir server/logs
 node server/scripts/fetchdata.js
+node server/scripts/importstandalonedecks.js
 node .
 node server/gamenode
 ```

--- a/client/Components/Games/PendingGame.jsx
+++ b/client/Components/Games/PendingGame.jsx
@@ -89,7 +89,7 @@ class PendingGame extends React.Component {
     selectDeck(deck) {
         $('#decks-modal').modal('hide');
 
-        this.props.socket.emit('selectdeck', this.props.currentGame.id, deck);
+        this.props.socket.emit('selectdeck', this.props.currentGame.id, deck._id);
     }
 
     getNumberOfPlayers(props) {

--- a/client/Components/Games/PendingGame.jsx
+++ b/client/Components/Games/PendingGame.jsx
@@ -37,6 +37,7 @@ class PendingGame extends React.Component {
 
     componentDidMount() {
         this.props.loadDecks();
+        this.props.loadStandaloneDecks();
     }
 
     componentWillReceiveProps(props) {
@@ -242,7 +243,8 @@ class PendingGame extends React.Component {
                     decks={ this.props.decks }
                     id='decks-modal'
                     loading={ this.props.loading }
-                    onDeckSelected={ this.selectDeck.bind(this) } />
+                    onDeckSelected={ this.selectDeck.bind(this) }
+                    standaloneDecks={ this.props.standaloneDecks } />
             </div >);
     }
 }
@@ -256,10 +258,12 @@ PendingGame.propTypes = {
     gameSocketClose: PropTypes.func,
     host: PropTypes.string,
     loadDecks: PropTypes.func,
+    loadStandaloneDecks: PropTypes.func,
     loading: PropTypes.bool,
     navigate: PropTypes.func,
     sendSocketMessage: PropTypes.func,
     socket: PropTypes.object,
+    standaloneDecks: PropTypes.array,
     startGame: PropTypes.func,
     user: PropTypes.object,
     zoomCard: PropTypes.func
@@ -274,6 +278,7 @@ function mapStateToProps(state) {
         host: state.games.gameHost,
         loading: state.api.loading,
         socket: state.lobby.socket,
+        standaloneDecks: state.cards.standaloneDecks,
         user: state.account.user
     };
 }

--- a/client/Components/Games/SelectDeckModal.jsx
+++ b/client/Components/Games/SelectDeckModal.jsx
@@ -14,7 +14,17 @@ class SelectDeckModal extends React.Component {
         } else if(this.props.apiError) {
             decks = <AlertPanel type='error' message={ this.props.apiError } />;
         } else {
-            decks = <DeckList className='deck-list-popup' decks={ this.props.decks } onSelectDeck={ this.props.onDeckSelected } />;
+            decks = (
+                <div>
+                    <DeckList className='deck-list-popup' decks={ this.props.decks } onSelectDeck={ this.props.onDeckSelected } />
+                    { this.props.standaloneDecks && this.props.standaloneDecks.length !== 0 && (
+                        <div>
+                            <h3 className='deck-list-header'>Or choose a standalone deck:</h3>
+                            <DeckList className='deck-list-popup' decks={ this.props.standaloneDecks } onSelectDeck={ this.props.onDeckSelected } />
+                        </div>)
+                    }
+                </div>
+            );
         }
 
         return (
@@ -30,7 +40,8 @@ SelectDeckModal.propTypes = {
     decks: PropTypes.array,
     id: PropTypes.string,
     loading: PropTypes.bool,
-    onDeckSelected: PropTypes.func
+    onDeckSelected: PropTypes.func,
+    standaloneDecks: PropTypes.array
 };
 
 export default SelectDeckModal;

--- a/client/ReduxActions/cards.js
+++ b/client/ReduxActions/cards.js
@@ -37,3 +37,13 @@ export function loadRestrictedList() {
         APIParams: { url: '/api/restricted-list', cache: false }
     };
 }
+
+export function loadStandaloneDecks() {
+    return {
+        types: ['REQUEST_STANDALONE_DECKS', 'RECEIVE_STANDALONE_DECKS'],
+        shouldCallAPI: (state) => {
+            return !state.cards.standaloneDecks;
+        },
+        APIParams: { url: '/api/standalone-decks', cache: false }
+    };
+}

--- a/client/reducers/cards.js
+++ b/client/reducers/cards.js
@@ -109,6 +109,14 @@ export default function(state = {}, action) {
             processDecks(newState.decks, newState);
 
             return newState;
+        case 'RECEIVE_STANDALONE_DECKS':
+            newState = Object.assign({}, state, {
+                standaloneDecks: action.response.decks
+            });
+
+            processDecks(newState.standaloneDecks, newState);
+
+            return newState;
         case 'ZOOM_CARD':
             return Object.assign({}, state, {
                 zoomCard: action.card

--- a/less/common.less
+++ b/less/common.less
@@ -24,6 +24,10 @@
   background-color: #999999;
 }
 
+.deck-list-header {
+  margin: 0.5em 0;
+}
+
 .panel {
   background-color: rgba(0, 0, 0, 0.65);
 }

--- a/server/api/decks.js
+++ b/server/api/decks.js
@@ -72,4 +72,14 @@ module.exports.init = function(server) {
         await deckService.delete(id);
         res.send({ success: true, message: 'Deck deleted successfully', deckId: id });
     }));
+
+    server.get('/api/standalone-decks', function(req, res, next) {
+        deckService.getStandaloneDecks()
+            .then(decks => {
+                res.send({ success: true, decks: decks });
+            })
+            .catch(err => {
+                next(err);
+            });
+    });
 };

--- a/server/lobby.js
+++ b/server/lobby.js
@@ -559,10 +559,6 @@ class Lobby {
     }
 
     onSelectDeck(socket, gameId, deckId) {
-        if(_.isObject(deckId)) {
-            deckId = deckId._id;
-        }
-
         var game = this.games[gameId];
         if(!game) {
             return;

--- a/server/scripts/importstandalonedecks.js
+++ b/server/scripts/importstandalonedecks.js
@@ -1,0 +1,65 @@
+/*eslint no-console:0 */
+
+const fs = require('fs');
+const path = require('path');
+const monk = require('monk');
+
+const CardService = require('../services/CardService');
+const DeckService = require('../services/DeckService');
+
+class ImportStandaloneDecks {
+    constructor() {
+        this.db = monk('mongodb://127.0.0.1:27017/throneteki');
+        this.cardService = new CardService(this.db);
+        this.deckService = new DeckService(this.db);
+    }
+
+    async import() {
+        try {
+            this.cards = await this.cardService.getAllCards();
+
+            for(let deck of this.loadDecks()) {
+                let existingDeck = await this.deckService.getByStandaloneId(deck.id);
+                if(!existingDeck) {
+                    let formattedDeck = this.formatDeck(deck);
+                    console.log('Importing', formattedDeck.name);
+                    await this.deckService.createStandalone(formattedDeck);
+                }
+            }
+            console.log('Done importing standalone decks');
+        } catch(err) {
+            console.error('Could not finish import', err);
+        } finally {
+            this.db.close();
+        }
+    }
+
+    loadDecks() {
+        let data = fs.readFileSync(path.join(__dirname, '../../throneteki-json-data/standalone-decks.json'));
+        return JSON.parse(data);
+    }
+
+    formatDeck(deck) {
+        let drawCards = deck.cards.filter(card => ['attachment', 'character', 'event', 'location'].includes(this.cards[card.code].type));
+        let plotCards = deck.cards.filter(card => this.cards[card.code].type === 'plot');
+        let formattedDeck = {
+            standaloneDeckId: deck.id,
+            bannerCards: [],
+            name: deck.name,
+            faction: { value: deck.faction },
+            drawCards: drawCards.map(card => ({ count: card.count, card: { code: card.code }})),
+            plotCards: plotCards.map(card => ({ count: card.count, card: { code: card.code }})),
+            rookeryCards: [],
+            lastUpdated: new Date(deck.releaseDate)
+        };
+
+        if(deck.agenda) {
+            formattedDeck.agenda = { code: deck.agenda };
+        }
+
+        return formattedDeck;
+    }
+}
+
+let importer = new ImportStandaloneDecks();
+importer.import();

--- a/server/services/DeckService.js
+++ b/server/services/DeckService.js
@@ -13,8 +13,20 @@ class DeckService {
             });
     }
 
+    getByStandaloneId(id) {
+        return this.decks.findOne({ standaloneDeckId: id })
+            .catch(err => {
+                logger.error('Unable to fetch standalone deck', err);
+                throw new Error('Unable to fetch standalone deck ' + id);
+            });
+    }
+
     findByUserName(userName) {
         return this.decks.find({ username: userName }, { sort: { lastUpdated: -1 } });
+    }
+
+    getStandaloneDecks() {
+        return this.decks.find({ standaloneDeckId: { $exists: true } }, { sort: { lastUpdated: -1 } });
     }
 
     create(deck) {
@@ -28,6 +40,22 @@ class DeckService {
             agenda: deck.agenda,
             rookeryCards: deck.rookeryCards || [],
             lastUpdated: new Date()
+        };
+
+        return this.decks.insert(properties);
+    }
+
+    createStandalone(deck) {
+        let properties = {
+            name: deck.name,
+            plotCards: deck.plotCards,
+            bannerCards: deck.bannerCards,
+            drawCards: deck.drawCards,
+            faction: deck.faction,
+            agenda: deck.agenda,
+            rookeryCards: deck.rookeryCards || [],
+            lastUpdated: deck.lastUpdated,
+            standaloneDeckId: deck.standaloneDeckId
         };
 
         return this.decks.insert(properties);


### PR DESCRIPTION
Adds the ability for people to play with the standalone decks such as the 2016 and 2017 World Championship decks, and the upcoming individual House Intro decks. This should make things a bit more friendly for new users, allowing them to immediately start playing without having to create or upload a deck of their own.

Need to make sure submodules are updated and run `node server/scripts/importstandalonedecks.js` to import the decks.

New user:
![screen shot 2018-04-20 at 12 07 11 pm](https://user-images.githubusercontent.com/145077/39070265-8c701802-4497-11e8-98e5-6149072221f1.png)

User with a few decks:
![screen shot 2018-04-20 at 12 07 38 pm](https://user-images.githubusercontent.com/145077/39070267-8f43c2fe-4497-11e8-88ca-9c619792a3a4.png)

User with a lot of decks:
![screen shot 2018-04-20 at 12 06 18 pm](https://user-images.githubusercontent.com/145077/39070261-89e8f4f0-4497-11e8-9765-db2de117d8cb.png)

