### PR TITLE
Fix "loses all" effects

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -49,6 +49,7 @@ class BaseCard {
         this.keywords = new ReferenceCountedSetProperty();
         this.traits = new ReferenceCountedSetProperty();
         this.blanks = new ReferenceCountedSetProperty();
+        this.losesAllAspects = new ReferenceCountedSetProperty();
 
         this.tokens = {};
         this.plotModifierValues = {
@@ -286,6 +287,10 @@ class BaseCard {
     }
 
     hasKeyword(keyword) {
+        if(this.losesAllAspects.contains('keywords')) {
+            return false;
+        }
+
         return this.keywords.contains(keyword);
     }
 
@@ -298,11 +303,19 @@ class BaseCard {
     }
 
     hasTrait(trait) {
+        if(this.losesAllAspects.contains('traits')) {
+            return false;
+        }
+
         return !this.isFullBlank() && this.traits.contains(trait);
     }
 
     isFaction(faction) {
         let normalizedFaction = faction.toLowerCase();
+
+        if(this.losesAllAspects.contains('factions')) {
+            return normalizedFaction === 'neutral';
+        }
 
         if(normalizedFaction === 'neutral') {
             return !!this.factions[normalizedFaction] && _.size(this.factions) === 1;
@@ -470,6 +483,10 @@ class BaseCard {
     }
 
     getTraits() {
+        if(this.losesAllAspects.contains('traits')) {
+            return [];
+        }
+
         return this.traits.getValues();
     }
 

--- a/server/game/cards/05-LoCR/SweetDonnelHill.js
+++ b/server/game/cards/05-LoCR/SweetDonnelHill.js
@@ -6,7 +6,7 @@ class SweetDonnelHill extends DrawCard {
             condition: () => this.game.currentChallenge && this.game.currentChallenge.isDefending(this),
             match: (card) => this.game.currentChallenge.isAttacking(card) && card.getType() === 'character',
             targetController: 'any',
-            effect: ability.effects.removeAllKeywords()
+            effect: ability.effects.losesAllKeywords()
         });
     }
 }

--- a/server/game/cards/08.5-TFM/IAmNoOne.js
+++ b/server/game/cards/08.5-TFM/IAmNoOne.js
@@ -1,5 +1,4 @@
 const DrawCard = require('../../drawcard.js');
-const _ = require('underscore');
 
 class IAmNoOne extends DrawCard {
     setupCardAbilities(ability) {
@@ -10,17 +9,15 @@ class IAmNoOne extends DrawCard {
                                        card.getPrintedCost() <= 3 && card.controller === this.controller
             },
             handler: context => {
-                let effectArr = _.flatten([
-                    context.target.getFactions().map(faction => ability.effects.removeFaction(faction)),
-                    context.target.getTraits().map(trait => ability.effects.removeTrait(trait)),
-                    ability.effects.addKeyword('stealth'),
-                    ability.effects.addKeyword('insight'),
-                    ability.effects.doesNotKneelAsAttacker()
-                ]);
-
                 this.untilEndOfPhase(() => ({
                     match: context.target,
-                    effect: effectArr
+                    effect: [
+                        ability.effects.losesAllFactions(),
+                        ability.effects.losesAllTraits(),
+                        ability.effects.addKeyword('stealth'),
+                        ability.effects.addKeyword('insight'),
+                        ability.effects.doesNotKneelAsAttacker()
+                    ]
                 }));
 
                 this.game.addMessage('{0} plays {1} and chooses {2} as its target',

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -68,6 +68,7 @@ class DrawCard extends BaseCard {
         clone.dupes = this.dupes.map(dupe => dupe.createSnapshot());
         clone.factions = Object.assign({}, this.factions);
         clone.icons = this.icons.clone();
+        clone.losesAllAspects = this.losesAllAspects.clone();
         clone.keywords = this.keywords.clone();
         clone.kneeled = this.kneeled;
         clone.parent = this.parent;

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -22,6 +22,19 @@ function cannotEffect(type) {
     };
 }
 
+function losesAllAspectEffect(aspect) {
+    return function() {
+        return {
+            apply: function(card) {
+                card.losesAllAspects.add(aspect);
+            },
+            unapply: function(card) {
+                card.losesAllAspects.remove(aspect);
+            }
+        };
+    };
+}
+
 const Effects = {
     setSetupGold: function(value) {
         return {
@@ -431,18 +444,9 @@ const Effects = {
             }
         };
     },
-    removeAllKeywords: function() {
-        return [
-            this.removeKeyword('Ambush'),
-            this.removeKeyword('Insight'),
-            this.removeKeyword('Intimidate'),
-            this.removeKeyword('Pillage'),
-            this.removeKeyword('Renown'),
-            this.removeKeyword('Stealth'),
-            this.removeKeyword('Terminal'),
-            this.removeKeyword('Limited')
-        ];
-    },
+    losesAllFactions: losesAllAspectEffect('factions'),
+    losesAllKeywords: losesAllAspectEffect('keywords'),
+    losesAllTraits: losesAllAspectEffect('traits'),
     addTrait: function(trait) {
         return {
             apply: function(card) {

--- a/test/server/effects/LosesAll.spec.js
+++ b/test/server/effects/LosesAll.spec.js
@@ -1,0 +1,55 @@
+describe('"Loses all" related effects', function() {
+    integration(function() {
+        describe('Losing all traits via I Am No One', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('stark', [
+                    'A Noble Cause',
+                    'I Am No One', 'Hedge Knight', 'Knighted'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.knight = this.player1.findCardByName('Hedge Knight');
+
+                this.player1.clickCard(this.knight);
+
+                this.completeSetup();
+
+                this.selectFirstPlayer(this.player1);
+            });
+
+            it('should remove all existing traits from the character', function() {
+                this.player1.clickCard('I Am No One', 'hand');
+                this.player1.clickCard(this.knight);
+
+                expect(this.knight.hasTrait('Knight')).toBe(false);
+            });
+
+            it('should remove any traits that has multiple instances', function() {
+                // Knight the character to give it an additional instance of the
+                // trait
+                this.player1.clickCard('Knighted', 'hand');
+                this.player1.clickCard(this.knight);
+
+                this.player1.clickCard('I Am No One', 'hand');
+                this.player1.clickCard(this.knight);
+
+                expect(this.knight.hasTrait('Knight')).toBe(false);
+            });
+
+            it('should prevent any traits from being gained while in effect', function() {
+                // Clear any existing traits
+                this.player1.clickCard('I Am No One', 'hand');
+                this.player1.clickCard(this.knight);
+
+                // Attempt to re-Knight the character
+                this.player1.clickCard('Knighted', 'hand');
+                this.player1.clickCard(this.knight);
+
+                expect(this.knight.hasTrait('Knight')).toBe(false);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Per a new ruling, a card that "loses all" of something, such as
keywords, faction affiliation, or traits, loses all instances of that
thing instead losing one instance of each.

http://www.cardgamedb.com/forums/index.php?/topic/39647-ruling-i-am-no-one/?p=328947.