### PR TITLE
Only raise onCardStrengthChanged if strength is not set

### DIFF
--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -171,22 +171,28 @@ class DrawCard extends BaseCard {
         }
 
         this.strengthModifier += amount;
-        this.game.raiseEvent('onCardStrengthChanged', {
-            card: this,
-            amount: amount,
-            applying: applying
-        });
+
+        if(!this.strengthSet) {
+            this.game.raiseEvent('onCardStrengthChanged', {
+                card: this,
+                amount: amount,
+                applying: applying
+            });
+        }
     }
 
     modifyStrengthMultiplier(amount, applying = true) {
         let strengthBefore = this.getStrength();
 
         this.strengthMultiplier *= amount;
-        this.game.raiseEvent('onCardStrengthChanged', {
-            card: this,
-            amount: this.getStrength() - strengthBefore,
-            applying: applying
-        });
+
+        if(!this.strengthSet) {
+            this.game.raiseEvent('onCardStrengthChanged', {
+                card: this,
+                amount: this.getStrength() - strengthBefore,
+                applying: applying
+            });
+        }
     }
 
     getPrintedStrength() {


### PR DESCRIPTION
Previously, Randyll Tarly with Strangler could stand after modifying his strength through for example Wardens of the South. This PR fixes that by only raising the event if the character's strength is not set.