### PR TITLE
Convert ability timer to use redux

### DIFF
--- a/client/Components/GameBoard/AbilityTimer.jsx
+++ b/client/Components/GameBoard/AbilityTimer.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class AbilityTimer extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.tick = this.tick.bind(this);
+
+        this.state = {
+            remaining: props.limit
+        };
+    }
+
+    componentWillMount() {
+        this.setState({
+            request: requestAnimationFrame(this.tick)
+        });
+    }
+
+    componentWillUnmount() {
+        cancelAnimationFrame(this.state.request);
+    }
+
+    tick() {
+        // Subtract an offset factor to ensure timer reaches 0 before the
+        // component is unmounted.
+        const timeOffset = 0.25;
+        let now = new Date();
+        let elapsed = (now - this.props.startTime) / 1000;
+        let remaining = (this.props.limit - elapsed) - timeOffset;
+
+        if(remaining < 0) {
+            remaining = 0;
+        }
+
+        this.setState({
+            remaining: remaining,
+            request: requestAnimationFrame(this.tick)
+        });
+    }
+
+    render() {
+        let remainingPercent = ((this.state.remaining / this.props.limit) * 100).toFixed() + '%';
+        return (
+            <div>
+                <span>Auto passing in { this.state.remaining.toFixed() }...</span>
+                <div className='progress'>
+                    <div className='progress-bar progress-bar-success' role='progressbar' style={ { width: remainingPercent } } />
+                </div>
+            </div>);
+    }
+}
+
+AbilityTimer.propTypes = {
+    limit: PropTypes.number,
+    startTime: PropTypes.instanceOf(Date)
+};
+
+export default AbilityTimer;

--- a/client/Components/GameBoard/ActivePlayerPrompt.jsx
+++ b/client/Components/GameBoard/ActivePlayerPrompt.jsx
@@ -7,40 +7,6 @@ import AbilityTimer from './AbilityTimer';
 import CardNameLookup from './CardNameLookup';
 
 class ActivePlayerPrompt extends React.Component {
-    componentWillUpdate(newProps) {
-        if(_.difference(newProps.buttons, this.props.buttons).length === 0) {
-            return;
-        }
-
-        if(newProps.user.settings.windowTimer === 0) {
-            return;
-        }
-
-        if(_.any(newProps.buttons, button => {
-            return button.timer;
-        })) {
-            if(newProps.timerStartTime) {
-                return;
-            }
-
-            this.props.startAbilityTimer(newProps.user.settings.windowTimer);
-        }
-    }
-
-    buttonsAreEqual(oldButtons, newButtons) {
-        if(!oldButtons || !newButtons || oldButtons.length !== newButtons.length) {
-            return false;
-        }
-
-        for(let i = 0; i < oldButtons.length; ++i) {
-            if(!_.isEqual(oldButtons[i], newButtons[i])) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
     onButtonClick(event, command, arg, method) {
         event.preventDefault();
 
@@ -171,7 +137,6 @@ ActivePlayerPrompt.propTypes = {
     phase: PropTypes.string,
     promptTitle: PropTypes.string,
     socket: PropTypes.object,
-    startAbilityTimer: PropTypes.func,
     stopAbilityTimer: PropTypes.func,
     timerLimit: PropTypes.number,
     timerStartTime: PropTypes.instanceOf(Date),

--- a/client/Components/GameBoard/GameBoard.jsx
+++ b/client/Components/GameBoard/GameBoard.jsx
@@ -269,10 +269,6 @@ export class GameBoard extends React.Component {
         this.props.sendGameMessage('toggleKeywordSetting', option, value);
     }
 
-    onTimerExpired() {
-        this.props.sendGameMessage('menuButton', null, 'pass');
-    }
-
     onSettingsClick() {
         $('#settings-modal').modal('show');
     }
@@ -372,8 +368,11 @@ export class GameBoard extends React.Component {
                                         onMouseOver={ this.onMouseOver }
                                         onMouseOut={ this.onMouseOut }
                                         user={ this.props.user }
-                                        onTimerExpired={ this.onTimerExpired.bind(this) }
-                                        phase={ thisPlayer.phase } />
+                                        phase={ thisPlayer.phase }
+                                        timerLimit={ this.props.timerLimit }
+                                        timerStartTime={ this.props.timerStartTime }
+                                        startAbilityTimer={ this.props.startAbilityTimer }
+                                        stopAbilityTimer={ this.props.stopAbilityTimer } />
                                 </div>
                             </div>
                             <div className='play-area'>
@@ -461,6 +460,10 @@ GameBoard.propTypes = {
     sendGameMessage: PropTypes.func,
     setContextMenu: PropTypes.func,
     socket: PropTypes.object,
+    startAbilityTimer: PropTypes.func,
+    stopAbilityTimer: PropTypes.func,
+    timerLimit: PropTypes.number,
+    timerStartTime: PropTypes.instanceOf(Date),
     user: PropTypes.object,
     zoomCard: PropTypes.func
 };
@@ -471,6 +474,8 @@ function mapStateToProps(state) {
         cards: state.cards.cards,
         currentGame: state.lobby.currentGame,
         socket: state.lobby.socket,
+        timerLimit: state.prompt.timerLimit,
+        timerStartTime: state.prompt.timerStartTime,
         user: state.account.user
     };
 }

--- a/client/Components/GameBoard/GameBoard.jsx
+++ b/client/Components/GameBoard/GameBoard.jsx
@@ -371,7 +371,6 @@ export class GameBoard extends React.Component {
                                         phase={ thisPlayer.phase }
                                         timerLimit={ this.props.timerLimit }
                                         timerStartTime={ this.props.timerStartTime }
-                                        startAbilityTimer={ this.props.startAbilityTimer }
                                         stopAbilityTimer={ this.props.stopAbilityTimer } />
                                 </div>
                             </div>
@@ -460,7 +459,6 @@ GameBoard.propTypes = {
     sendGameMessage: PropTypes.func,
     setContextMenu: PropTypes.func,
     socket: PropTypes.object,
-    startAbilityTimer: PropTypes.func,
     stopAbilityTimer: PropTypes.func,
     timerLimit: PropTypes.number,
     timerStartTime: PropTypes.instanceOf(Date),

--- a/client/Components/GameBoard/GameBoard.jsx
+++ b/client/Components/GameBoard/GameBoard.jsx
@@ -195,6 +195,7 @@ export class GameBoard extends React.Component {
     }
 
     onCardClick(card) {
+        this.props.stopAbilityTimer();
         this.props.sendGameMessage('cardClicked', card.uuid);
     }
 
@@ -254,6 +255,7 @@ export class GameBoard extends React.Component {
     }
 
     onMenuItemClick(card, menuItem) {
+        this.props.stopAbilityTimer();
         this.props.sendGameMessage('menuItemClick', card.uuid, menuItem);
     }
 

--- a/client/ReduxActions/prompt.js
+++ b/client/ReduxActions/prompt.js
@@ -1,0 +1,31 @@
+import { sendGameMessage } from './socket';
+
+export function startAbilityTimer(timeLimit) {
+    return dispatch => {
+        let started = new Date();
+
+        let handle = setTimeout(() => {
+            dispatch(expireAbilityTimer());
+        }, timeLimit * 1000);
+
+        dispatch({
+            type: 'START_ABILITY_TIMER',
+            startTime: started,
+            limit: timeLimit,
+            handle: handle
+        });
+    };
+}
+
+export function stopAbilityTimer() {
+    return {
+        type: 'STOP_ABILITY_TIMER'
+    };
+}
+
+export function expireAbilityTimer() {
+    return dispatch => {
+        dispatch(stopAbilityTimer());
+        dispatch(sendGameMessage('menuButton', null, 'pass'));
+    };
+}

--- a/client/actions.js
+++ b/client/actions.js
@@ -8,3 +8,4 @@ export * from './ReduxActions/deck';
 export * from './ReduxActions/admin';
 export * from './ReduxActions/user';
 export * from './ReduxActions/account';
+export * from './ReduxActions/prompt';

--- a/client/reducers/index.js
+++ b/client/reducers/index.js
@@ -9,10 +9,11 @@ import admin from './admin';
 import user from './user';
 import account from './account';
 import lobby from './lobby';
+import prompt from './prompt';
 import {reducer as toastrReducer} from 'react-redux-toastr';
 
 const rootReducer = combineReducers({
-    navigation, auth, cards, games, news, toastr: toastrReducer, api, admin, user, account, lobby
+    navigation, auth, cards, games, news, toastr: toastrReducer, api, admin, user, account, lobby, prompt
 });
 
 export default rootReducer;

--- a/client/reducers/prompt.js
+++ b/client/reducers/prompt.js
@@ -1,0 +1,22 @@
+export default function(state = {}, action) {
+    switch(action.type) {
+        case 'START_ABILITY_TIMER':
+            return Object.assign({}, state, {
+                timerStartTime: action.startTime,
+                timerLimit: action.limit,
+                timerHandle: action.handle
+            });
+        case 'STOP_ABILITY_TIMER':
+            if(state.timerHandle) {
+                clearTimeout(state.timerHandle);
+            }
+
+            return Object.assign({}, state, {
+                timerStartTime: null,
+                timerLimit: null,
+                timerHandle: null
+            });
+    }
+
+    return state;
+}


### PR DESCRIPTION
Converts the ability timer on prompts to store state in redux, in order to allow cancellation of the timer where cards are clicked or menu items triggered.

Prep work for converting ability window prompts to use clicking cards to trigger their abilities instead of menu buttons.