### PR TITLE
Click cards to trigger interrupt / reaction abilities

### DIFF
--- a/client/Components/GameBoard/ActivePlayerPrompt.jsx
+++ b/client/Components/GameBoard/ActivePlayerPrompt.jsx
@@ -22,7 +22,7 @@ class ActivePlayerPrompt extends React.Component {
 
         this.props.stopAbilityTimer();
 
-        if(button.method) {
+        if(button.method || button.arg) {
             this.props.onButtonClick(button.command, button.arg, button.method);
         }
     }

--- a/client/Components/GameBoard/Card.jsx
+++ b/client/Components/GameBoard/Card.jsx
@@ -66,6 +66,12 @@ class InnerCard extends React.Component {
     }
 
     isAllowedMenuSource() {
+        // Explicitly disable menus on agendas when they're selectable during a
+        // card select prompt.
+        if(this.props.source === 'agenda' && this.props.card.selectable) {
+            return false;
+        }
+
         return this.props.source === 'play area' || this.props.source === 'agenda' || this.props.source === 'revealed plots';
     }
 

--- a/client/Components/GameBoard/CardPile.jsx
+++ b/client/Components/GameBoard/CardPile.jsx
@@ -77,7 +77,7 @@ class CardPile extends React.Component {
             return;
         }
 
-        if(this.props.disablePopup) {
+        if(this.props.disablePopup || this.isTopCardSelectable) {
             if(this.props.onCardClick) {
                 this.props.onCardClick(this.props.topCard);
             }
@@ -86,6 +86,14 @@ class CardPile extends React.Component {
         }
 
         this.setState({ showPopup: !this.state.showPopup });
+    }
+
+    get isTopCardSelectable() {
+        if(!this.props.topCard) {
+            return false;
+        }
+
+        return this.props.topCard.selectable && (!this.props.cards || this.props.cards.every(card => card.unselectable));
     }
 
     onCardClick(card) {

--- a/client/ReduxActions/game.js
+++ b/client/ReduxActions/game.js
@@ -29,7 +29,8 @@ export function receiveGameState(game, username) {
 
         if(user && previousGameState) {
             if(hasTimer(game, user.username) && !hasTimer(previousGameState, user.username) && user.settings.windowTimer !== 0) {
-                dispatch(actions.startAbilityTimer(user.settings.windowTimer));
+                let timerProps = game.players[user.username].buttons.find(button => button.timer);
+                dispatch(actions.startAbilityTimer(user.settings.windowTimer, timerProps));
             } else if(!hasTimer(game, user.username) && hasTimer(previousGameState, user.username)) {
                 dispatch(actions.stopAbilityTimer());
             }

--- a/client/ReduxActions/prompt.js
+++ b/client/ReduxActions/prompt.js
@@ -1,11 +1,11 @@
 import { sendGameMessage } from './socket';
 
-export function startAbilityTimer(timeLimit) {
+export function startAbilityTimer(timeLimit, timerProps) {
     return dispatch => {
         let started = new Date();
 
         let handle = setTimeout(() => {
-            dispatch(expireAbilityTimer());
+            dispatch(expireAbilityTimer(timerProps));
         }, timeLimit * 1000);
 
         dispatch({
@@ -23,9 +23,9 @@ export function stopAbilityTimer() {
     };
 }
 
-export function expireAbilityTimer() {
+export function expireAbilityTimer(timerProps) {
     return dispatch => {
         dispatch(stopAbilityTimer());
-        dispatch(sendGameMessage('menuButton', null, 'pass'));
+        dispatch(sendGameMessage('menuButton', timerProps.arg, timerProps.method));
     };
 }

--- a/server/game/forcedtriggeredability.js
+++ b/server/game/forcedtriggeredability.js
@@ -32,10 +32,6 @@ class ForcedTriggeredAbility extends TriggeredAbility {
         return true;
     }
 
-    getChoices() {
-        return [{ text: 'default', choice: 'default' }];
-    }
-
     executeHandler(context) {
         this.handler(context);
     }

--- a/server/game/gamesteps/AbilityChoicePrompt.js
+++ b/server/game/gamesteps/AbilityChoicePrompt.js
@@ -1,0 +1,42 @@
+const BaseStep = require('./basestep');
+
+class AbilityChoicePrompt extends BaseStep {
+    constructor(game, context, choices) {
+        super(game);
+        this.context = context;
+        this.choices = choices;
+    }
+
+    continue() {
+        let buttons = this.choices.map(choice => {
+            return { text: choice.text, arg: choice.text, method: 'chooseAbilityChoice' };
+        });
+
+        buttons.push({ text: 'Done', method: 'skipResolution' });
+
+        this.game.promptWithMenu(this.context.player, this, {
+            activePrompt: {
+                menuTitle: `Choose ability for ${this.context.source.name}`,
+                buttons: buttons
+            },
+            source: this.card
+        });
+    }
+
+    chooseAbilityChoice(player, choiceText) {
+        let choice = this.choices.find(choice => choice.text === choiceText);
+
+        if(choice) {
+            choice.handler(this.context);
+        }
+
+        return true;
+    }
+
+    skipResolution() {
+        this.game.addAlert('{0} cancels the resolution of {1} (costs were still paid)', this.context.player, this.context.source);
+        return true;
+    }
+}
+
+module.exports = AbilityChoicePrompt;

--- a/server/game/gamesteps/BaseAbilityWindow.js
+++ b/server/game/gamesteps/BaseAbilityWindow.js
@@ -31,20 +31,13 @@ class BaseAbilityWindow extends BaseStep {
             return;
         }
 
-        let abilityGroupId = uuid.v1();
-
-        for(let choiceText of ability.getChoices(context)) {
-            this.abilityChoices.push({
-                id: uuid.v1(),
-                abilityGroupId: abilityGroupId,
-                player: context.player,
-                ability: ability,
-                card: ability.card,
-                text: choiceText.text,
-                choice: choiceText.choice,
-                context: context
-            });
-        }
+        this.abilityChoices.push({
+            id: uuid.v1(),
+            player: context.player,
+            ability: ability,
+            card: ability.card,
+            context: context
+        });
     }
 
     hasResolvedAbility(ability, event) {

--- a/server/game/gamesteps/TriggeredAbilityWindow.js
+++ b/server/game/gamesteps/TriggeredAbilityWindow.js
@@ -49,10 +49,18 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
             additionalControls: this.getAdditionalPromptControls(),
             doneButtonText: 'Pass',
             onSelect: (player, card) => this.chooseCardToTrigger(player, card),
-            onCancel: player => this.pass(player),
-            onMenuCommand: (player, cardId) => {
-                let card = cardsForPlayer.find(c => c.uuid === cardId);
-                this.chooseCardToTrigger(player, card);
+            onCancel: () => this.pass(),
+            onMenuCommand: (player, arg) => {
+                if(arg === 'pass') {
+                    this.pass();
+                } else if(arg === 'passAndPauseForRound') {
+                    player.disableTimerForRound();
+                    this.pass();
+                } else {
+                    let card = cardsForPlayer.find(c => c.uuid === arg);
+                    this.chooseCardToTrigger(player, card);
+                }
+
                 return true;
             }
         });
@@ -66,9 +74,9 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
         });
 
         if(this.cancelTimer.isEnabled(player)) {
-            buttons.push({ timer: true, method: 'pass', id: uuid.v1() });
+            buttons.push({ timer: true, arg: 'pass', id: uuid.v1() });
             buttons.push({ text: 'I need more time', timerCancel: true });
-            buttons.push({ text: 'Don\'t ask again until end of round', timerCancel: true, method: 'pass', arg: 'pauseRound' });
+            buttons.push({ text: 'Don\'t ask again until end of round', timerCancel: true, arg: 'passAndPauseForRound' });
         }
 
         return buttons;
@@ -131,11 +139,7 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
         this.players = this.rotatedPlayerOrder(choice.player);
     }
 
-    pass(player, arg) {
-        if(arg === 'pauseRound') {
-            player.disableTimerForRound();
-        }
-
+    pass() {
         this.players.shift();
         return true;
     }

--- a/server/game/gamesteps/TriggeredAbilityWindow.js
+++ b/server/game/gamesteps/TriggeredAbilityWindow.js
@@ -73,9 +73,10 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
 
     getAbilityButtonText(abilityChoice) {
         let title = abilityChoice.card.name;
+        let additionalTitle = abilityChoice.ability.getTitle(abilityChoice.context);
 
-        if(abilityChoice.text !== 'default') {
-            title += ' - ' + abilityChoice.text;
+        if(additionalTitle) {
+            title += ' - ' + additionalTitle;
         }
 
         if(!abilityChoice.ability.location.includes(abilityChoice.card.location)) {
@@ -122,7 +123,6 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
             return false;
         }
 
-        choice.context.choice = choice.choice;
         this.resolveAbility(choice.ability, choice.context);
 
         // Always rotate player order without filtering, in case an ability is

--- a/server/game/gamesteps/selectcardprompt.js
+++ b/server/game/gamesteps/selectcardprompt.js
@@ -12,6 +12,7 @@ const CardSelector = require('../CardSelector.js');
  * multiSelect        - boolean that ensures that the selected cards are sent as
  *                      an array, even if the numCards limit is 1.
  * additionalButtons  - array of additional buttons for the prompt.
+ * additionalControls - array of additional controls for the prompt.
  * activePromptTitle  - the title that should be used in the prompt for the
  *                      choosing player.
  * waitingPromptTitle - the title that should be used in the prompt for the
@@ -101,8 +102,9 @@ class SelectCardPrompt extends UiPrompt {
             selectOrder: this.properties.ordered,
             menuTitle: this.properties.activePromptTitle || this.selector.defaultActivePromptTitle(),
             buttons: this.properties.additionalButtons.concat([
-                { text: 'Done', arg: 'done' }
+                { text: this.properties.doneButtonText || 'Done', arg: 'done' }
             ]),
+            controls: this.properties.additionalControls,
             promptTitle: this.properties.source ? this.properties.source.name : undefined
         };
     }

--- a/server/game/playerpromptstate.js
+++ b/server/game/playerpromptstate.js
@@ -26,7 +26,11 @@ class PlayerPromptState {
     }
 
     clearSelectableCards() {
-        _.each(this.selectableCards, card => card.getType() !== 'plot' && card.hideFacedownTarget());
+        for(let card of this.selectableCards) {
+            if(['attachment', 'character', 'event', 'location'].includes(card.getType())) {
+                card.hideFacedownTarget();
+            }
+        }
         this.selectableCards = [];
     }
 

--- a/test/helpers/integrationhelper.js
+++ b/test/helpers/integrationhelper.js
@@ -76,16 +76,21 @@ var customMatchers = {
     toAllowAbilityTrigger: function(util, customEqualityMatchers) {
         return {
             compare: function(actual, expected) {
-                var buttons = actual.currentPrompt().buttons;
-                var result = {};
+                let result = {};
+                if(typeof expected !== 'string') {
+                    expected = expected.name;
+                }
 
-                result.pass = _.any(buttons, button => util.equals(button.text, expected, customEqualityMatchers));
+                let selectableCardNames = actual.player.getSelectableCards().map(card => card.name);
+                let isPromptingAbility = actual.game.abilityWindowStack.length !== 0;
+                let includesCard = selectableCardNames.some(cardName => util.equals(cardName, expected, customEqualityMatchers));
+
+                result.pass = isPromptingAbility && includesCard;
 
                 if(result.pass) {
-                    result.message = `Expected ${actual.name} not to have prompt button "${expected}" but it did.`;
+                    result.message = `Expected ${actual.name} not to be allowed to trigger ${expected} but it is.`;
                 } else {
-                    var buttonText = _.map(buttons, button => '[' + button.text + ']').join('\n');
-                    result.message = `Expected ${actual.name} to have prompt button "${expected}" but it had buttons:\n${buttonText}`;
+                    result.message = `Expected ${actual.name} to be allowed to trigger ${expected} but it isn't.`;
                 }
 
                 return result;

--- a/test/server/card/cardreaction.spec.js
+++ b/test/server/card/cardreaction.spec.js
@@ -1,9 +1,10 @@
 const CardReaction = require('../../../server/game/cardreaction.js');
 const Event = require('../../../server/game/event.js');
+const AbilityChoicePrompt = require('../../../server/game/gamesteps/AbilityChoicePrompt');
 
 describe('CardReaction', function () {
     beforeEach(function () {
-        this.gameSpy = jasmine.createSpyObj('game', ['on', 'popAbilityContext', 'pushAbilityContext', 'removeListener', 'registerAbility']);
+        this.gameSpy = jasmine.createSpyObj('game', ['on', 'popAbilityContext', 'pushAbilityContext', 'queueStep', 'removeListener', 'registerAbility']);
         this.cardSpy = jasmine.createSpyObj('card', ['getPrintedType', 'getType', 'isAnyBlank']);
         this.cardSpy.location = 'play area';
         this.limitSpy = jasmine.createSpyObj('limit', ['increment', 'isAtMax', 'registerEvents', 'unregisterEvents']);
@@ -243,31 +244,12 @@ describe('CardReaction', function () {
                     },
                     handler: jasmine.createSpy('handler')
                 };
-                this.context.choice = 'default';
+                this.reaction = this.createReaction();
+                this.reaction.executeHandler(this.context);
             });
 
-            describe('when the choice is default', function () {
-                beforeEach(function() {
-                    this.reaction = this.createReaction();
-                    this.context.choice = 'default';
-                    this.reaction.executeHandler(this.context);
-                });
-
-                it('should call the handler', function() {
-                    expect(this.properties.handler).toHaveBeenCalled();
-                });
-            });
-
-            describe('when the choice is unconfigured', function() {
-                beforeEach(function() {
-                    this.reaction = this.createReaction();
-                    this.context.choice = 'Win the game';
-                    this.reaction.executeHandler(this.context);
-                });
-
-                it('should not call the handler', function() {
-                    expect(this.properties.handler).not.toHaveBeenCalled();
-                });
+            it('should call the handler', function() {
+                expect(this.properties.handler).toHaveBeenCalled();
             });
         });
 
@@ -283,35 +265,12 @@ describe('CardReaction', function () {
                         'Baz': jasmine.createSpy('handler3')
                     }
                 };
-                this.context.choice = 'Baz';
+                this.reaction = this.createReaction();
+                this.reaction.executeHandler(this.context);
             });
 
-            describe('when the choice is an existing choice', function () {
-                beforeEach(function() {
-                    this.reaction = this.createReaction();
-                    this.context.choice = 'Baz';
-                    this.reaction.executeHandler(this.context);
-                });
-
-                it('should call the appropriate handler', function() {
-                    expect(this.properties.choices['Foo']).not.toHaveBeenCalled();
-                    expect(this.properties.choices['Bar']).not.toHaveBeenCalled();
-                    expect(this.properties.choices['Baz']).toHaveBeenCalled();
-                });
-            });
-
-            describe('when the choice is unconfigured', function() {
-                beforeEach(function() {
-                    this.reaction = this.createReaction();
-                    this.context.choice = 'Win the game';
-                    this.reaction.executeHandler(this.context);
-                });
-
-                it('should not call any of the handler', function() {
-                    expect(this.properties.choices['Foo']).not.toHaveBeenCalled();
-                    expect(this.properties.choices['Bar']).not.toHaveBeenCalled();
-                    expect(this.properties.choices['Baz']).not.toHaveBeenCalled();
-                });
+            it('should call queue the ability choice prompt', function() {
+                expect(this.gameSpy.queueStep).toHaveBeenCalledWith(jasmine.any(AbilityChoicePrompt));
             });
         });
     });

--- a/test/server/cards/05-LoCR/TywinLannister.spec.js
+++ b/test/server/cards/05-LoCR/TywinLannister.spec.js
@@ -73,7 +73,8 @@ describe('Tywin Lannister (LoCR)', function() {
                 this.skipActionWindow();
 
                 // Trigger The Reader
-                this.player2.triggerAbility('The Reader - Discard 3 cards');
+                this.player2.triggerAbility('The Reader');
+                this.player2.clickPrompt('Discard 3 cards');
             });
 
             it('should not allow Tywin to choose to trigger', function() {

--- a/test/server/cards/06.2-GtR/TheAnnalsOfCastleBlack.spec.js
+++ b/test/server/cards/06.2-GtR/TheAnnalsOfCastleBlack.spec.js
@@ -78,11 +78,11 @@ describe('The Annals of Castle Black', function() {
             });
 
             it('should allow the event to trigger', function() {
-                expect(this.player1).toAllowAbilityTrigger('Ahead of the Tide (discard pile)');
+                expect(this.player1).toAllowAbilityTrigger('Ahead of the Tide');
             });
 
             it('should remove the event from the game if played', function() {
-                this.player1.triggerAbility('Ahead of the Tide (discard pile)');
+                this.player1.triggerAbility('Ahead of the Tide');
 
                 expect(this.interruptEventCard.location).toBe('out of game');
             });

--- a/test/server/cards/09-HoT/EmissaryOfTheHightower.spec.js
+++ b/test/server/cards/09-HoT/EmissaryOfTheHightower.spec.js
@@ -63,7 +63,8 @@ describe('Emissary of the Hightower', function() {
                 this.player1.clickCard(this.hiddenThorns);
 
                 this.unopposedChallenge(this.player1, 'Intrigue', this.character);
-                this.player1.triggerAbility('Hidden Thorns (discard pile)');
+
+                this.player1.triggerAbility('Hidden Thorns');
 
                 this.player2.clickCard('Hedge Knight', 'hand');
                 this.player2.clickCard('Varys', 'hand');

--- a/test/server/cards/10-SoD/Missandei.spec.js
+++ b/test/server/cards/10-SoD/Missandei.spec.js
@@ -43,7 +43,6 @@ describe('Missandei', function() {
 
         describe('when Missandei is discarded from deck', function() {
             beforeEach(function() {
-                // this.player1.dragCard(this.missandei, 'draw deck');
                 this.unopposedChallenge(this.player2, 'Military', this.opponentPillager);
                 this.player2.clickPrompt('Apply Claim');
 

--- a/test/server/gamesteps/BaseAbilityWindow.spec.js
+++ b/test/server/gamesteps/BaseAbilityWindow.spec.js
@@ -7,7 +7,7 @@ describe('BaseAbilityWindow', function() {
         this.eventSpy = jasmine.createSpyObj('event', ['emitTo', 'getConcurrentEvents']);
         this.eventSpy.getConcurrentEvents.and.returnValue([this.eventSpy]);
 
-        this.abilitySpy = jasmine.createSpyObj('ability', ['createContext', 'getChoices', 'isTriggeredByEvent', 'meetsRequirements']);
+        this.abilitySpy = jasmine.createSpyObj('ability', ['createContext', 'isTriggeredByEvent', 'meetsRequirements']);
 
         this.window = new BaseAbilityWindow(this.gameSpy, {
             event: this.eventSpy,
@@ -68,10 +68,6 @@ describe('BaseAbilityWindow', function() {
             this.context = { context: 1, player: this.player };
             this.abilitySpy.card = this.card;
             this.abilitySpy.createContext.and.returnValue(this.context);
-            this.abilitySpy.getChoices.and.returnValue([
-                { choice: 'choice1', text: 'Choice 1' },
-                { choice: 'choice2', text: 'Choice 2' }
-            ]);
             this.abilitySpy.meetsRequirements.and.returnValue(true);
         });
 
@@ -85,34 +81,13 @@ describe('BaseAbilityWindow', function() {
                 expect(this.abilitySpy.createContext).toHaveBeenCalledTimes(1);
             });
 
-            it('should register each choice', function() {
+            it('should register the ability', function() {
                 expect(this.window.abilityChoices).toContain(jasmine.objectContaining({
                     ability: this.abilitySpy,
                     card: this.card,
-                    choice: 'choice1',
                     context: this.context,
-                    player: this.player,
-                    text: 'Choice 1'
+                    player: this.player
                 }));
-
-                expect(this.window.abilityChoices).toContain(jasmine.objectContaining({
-                    ability: this.abilitySpy,
-                    card: this.card,
-                    choice: 'choice2',
-                    context: this.context,
-                    player: this.player,
-                    text: 'Choice 2'
-                }));
-            });
-
-            it('should register each choice with a unique ID', function() {
-                let [choice1, choice2] = this.window.abilityChoices;
-                expect(choice1.id).not.toEqual(choice2.id);
-            });
-
-            it('should register each choice with the same group ID', function() {
-                let [choice1, choice2] = this.window.abilityChoices;
-                expect(choice1.abilityGroupId).toEqual(choice2.abilityGroupId);
             });
         });
 

--- a/test/server/gamesteps/TriggeredAbilityWindow.spec.js
+++ b/test/server/gamesteps/TriggeredAbilityWindow.spec.js
@@ -8,7 +8,7 @@ describe('TriggeredAbilityWindow', function() {
         this.player1Spy.noTimer = true;
         this.player2Spy.noTimer = true;
 
-        this.gameSpy = jasmine.createSpyObj('game', ['getPlayersInFirstPlayerOrder', 'promptWithMenu', 'resolveAbility']);
+        this.gameSpy = jasmine.createSpyObj('game', ['getPlayersInFirstPlayerOrder', 'promptForSelect', 'resolveAbility']);
         this.gameSpy.getPlayersInFirstPlayerOrder.and.returnValue([this.player1Spy, this.player2Spy]);
 
         this.eventSpy = jasmine.createSpyObj('event', ['emitTo', 'getConcurrentEvents', 'getPrimaryEvent']);
@@ -66,7 +66,7 @@ describe('TriggeredAbilityWindow', function() {
             });
 
             it('should not prompt', function() {
-                expect(this.gameSpy.promptWithMenu).not.toHaveBeenCalled();
+                expect(this.gameSpy.promptForSelect).not.toHaveBeenCalled();
             });
 
             it('should complete the prompt', function() {
@@ -81,7 +81,7 @@ describe('TriggeredAbilityWindow', function() {
             });
 
             it('should not prompt', function() {
-                expect(this.gameSpy.promptWithMenu).not.toHaveBeenCalled();
+                expect(this.gameSpy.promptForSelect).not.toHaveBeenCalled();
             });
 
             it('should complete the prompt', function() {
@@ -104,82 +104,11 @@ describe('TriggeredAbilityWindow', function() {
                 });
 
                 it('should prompt the first player', function() {
-                    expect(this.gameSpy.promptWithMenu).toHaveBeenCalledWith(this.player1Spy, this.window, jasmine.objectContaining({
-                        activePrompt: jasmine.objectContaining({
-                            menuTitle: jasmine.any(String),
-                            buttons: [
-                                jasmine.objectContaining({ text: 'The Card', arg: jasmine.any(String), method: 'chooseCardToTrigger' }),
-                                jasmine.objectContaining({ text: 'The Card 2', arg: jasmine.any(String), method: 'chooseCardToTrigger' }),
-                                jasmine.objectContaining({ text: 'Pass', method: 'pass' })
-                            ]
-                        })
-                    }));
+                    expect(this.gameSpy.promptForSelect).toHaveBeenCalledWith(this.player1Spy, jasmine.any(Object));
                 });
 
                 it('should continue to prompt', function() {
                     expect(this.result).toBe(false);
-                });
-            });
-
-            describe('and the ability has a maximum', function() {
-                beforeEach(function() {
-                    this.ability1Spy.hasMax.and.returnValue(true);
-                    this.ability2Spy.hasMax.and.returnValue(true);
-                });
-
-                describe('and another ability from a card with that title has not been registered', function() {
-                    it('should display buttons as normal', function() {
-                        this.window.continue();
-                        expect(this.gameSpy.promptWithMenu).toHaveBeenCalledWith(this.player1Spy, this.window, jasmine.objectContaining({
-                            activePrompt: jasmine.objectContaining({
-                                menuTitle: jasmine.any(String),
-                                buttons: [
-                                    jasmine.objectContaining({ text: 'The Card', arg: jasmine.any(String), method: 'chooseCardToTrigger' }),
-                                    jasmine.objectContaining({ text: 'The Card 2', arg: jasmine.any(String), method: 'chooseCardToTrigger' }),
-                                    jasmine.objectContaining({ text: 'Pass', method: 'pass' })
-                                ]
-                            })
-                        }));
-                    });
-                });
-
-                describe('and another ability from a card with that title has been registered', function() {
-                    beforeEach(function() {
-                        this.abilityCard2.name = 'The Card';
-                        this.window.continue();
-                    });
-
-                    it('should only display the first copy', function() {
-                        expect(this.gameSpy.promptWithMenu).toHaveBeenCalledWith(this.player1Spy, this.window, jasmine.objectContaining({
-                            activePrompt: jasmine.objectContaining({
-                                menuTitle: jasmine.any(String),
-                                buttons: [
-                                    jasmine.objectContaining({ text: 'The Card', arg: jasmine.any(String), method: 'chooseCardToTrigger' }),
-                                    jasmine.objectContaining({ text: 'Pass', method: 'pass' })
-                                ]
-                            })
-                        }));
-                    });
-                });
-            });
-
-            describe('and all abilities for the current player are not eligible', function() {
-                beforeEach(function() {
-                    this.ability1Spy.meetsRequirements.and.returnValue(false);
-                    this.ability2Spy.meetsRequirements.and.returnValue(false);
-                    this.window.continue();
-                });
-
-                it('should prompt the next player', function() {
-                    expect(this.gameSpy.promptWithMenu).toHaveBeenCalledWith(this.player2Spy, this.window, jasmine.objectContaining({
-                        activePrompt: jasmine.objectContaining({
-                            menuTitle: jasmine.any(String),
-                            buttons: [
-                                jasmine.objectContaining({ text: 'Their Card', arg: jasmine.any(String), method: 'chooseCardToTrigger' }),
-                                jasmine.objectContaining({ text: 'Pass', method: 'pass' })
-                            ]
-                        })
-                    }));
                 });
             });
         });

--- a/test/server/gamesteps/TriggeredAbilityWindow.spec.js
+++ b/test/server/gamesteps/TriggeredAbilityWindow.spec.js
@@ -40,15 +40,15 @@ describe('TriggeredAbilityWindow', function() {
         }
 
         this.context1 = { context: 1, player: this.player1Spy, event: this.eventSpy };
-        this.abilityCard1 = createCard({ card: 1, name: 'The Card', controller: this.player1Spy });
+        this.abilityCard1 = createCard({ uuid: '111', name: 'The Card', controller: this.player1Spy });
         this.ability1Spy = createAbility(this.abilityCard1, this.context1);
 
         this.context2 = { context: 2, player: this.player1Spy, event: this.eventSpy };
-        this.abilityCard2 = createCard({ card: 2, name: 'The Card 2', controller: this.player1Spy });
+        this.abilityCard2 = createCard({ uuid: '222', name: 'The Card 2', controller: this.player1Spy });
         this.ability2Spy = createAbility(this.abilityCard2, this.context2);
 
         this.context3 = { context: 3, player: this.player2Spy, event: this.eventSpy };
-        this.abilityCard3 = createCard({ card: 3, name: 'Their Card', controller: this.player2Spy });
+        this.abilityCard3 = createCard({ uuid: '333', name: 'Their Card', controller: this.player2Spy });
         this.ability3Spy = createAbility(this.abilityCard3, this.context3);
     });
 
@@ -108,8 +108,8 @@ describe('TriggeredAbilityWindow', function() {
                         activePrompt: jasmine.objectContaining({
                             menuTitle: jasmine.any(String),
                             buttons: [
-                                jasmine.objectContaining({ text: 'The Card', arg: jasmine.any(String), method: 'chooseAbility' }),
-                                jasmine.objectContaining({ text: 'The Card 2', arg: jasmine.any(String), method: 'chooseAbility' }),
+                                jasmine.objectContaining({ text: 'The Card', arg: jasmine.any(String), method: 'chooseCardToTrigger' }),
+                                jasmine.objectContaining({ text: 'The Card 2', arg: jasmine.any(String), method: 'chooseCardToTrigger' }),
                                 jasmine.objectContaining({ text: 'Pass', method: 'pass' })
                             ]
                         })
@@ -134,8 +134,8 @@ describe('TriggeredAbilityWindow', function() {
                             activePrompt: jasmine.objectContaining({
                                 menuTitle: jasmine.any(String),
                                 buttons: [
-                                    jasmine.objectContaining({ text: 'The Card', arg: jasmine.any(String), method: 'chooseAbility' }),
-                                    jasmine.objectContaining({ text: 'The Card 2', arg: jasmine.any(String), method: 'chooseAbility' }),
+                                    jasmine.objectContaining({ text: 'The Card', arg: jasmine.any(String), method: 'chooseCardToTrigger' }),
+                                    jasmine.objectContaining({ text: 'The Card 2', arg: jasmine.any(String), method: 'chooseCardToTrigger' }),
                                     jasmine.objectContaining({ text: 'Pass', method: 'pass' })
                                 ]
                             })
@@ -154,7 +154,7 @@ describe('TriggeredAbilityWindow', function() {
                             activePrompt: jasmine.objectContaining({
                                 menuTitle: jasmine.any(String),
                                 buttons: [
-                                    jasmine.objectContaining({ text: 'The Card', arg: jasmine.any(String), method: 'chooseAbility' }),
+                                    jasmine.objectContaining({ text: 'The Card', arg: jasmine.any(String), method: 'chooseCardToTrigger' }),
                                     jasmine.objectContaining({ text: 'Pass', method: 'pass' })
                                 ]
                             })
@@ -175,7 +175,7 @@ describe('TriggeredAbilityWindow', function() {
                         activePrompt: jasmine.objectContaining({
                             menuTitle: jasmine.any(String),
                             buttons: [
-                                jasmine.objectContaining({ text: 'Their Card', arg: jasmine.any(String), method: 'chooseAbility' }),
+                                jasmine.objectContaining({ text: 'Their Card', arg: jasmine.any(String), method: 'chooseCardToTrigger' }),
                                 jasmine.objectContaining({ text: 'Pass', method: 'pass' })
                             ]
                         })
@@ -205,8 +205,8 @@ describe('TriggeredAbilityWindow', function() {
         describe('when the player select a choice they do not own', function() {
             beforeEach(function() {
                 // Choosing a player 2 ability
-                let choice = this.window.abilityChoices[2].id;
-                this.window.chooseAbility(this.player1Spy, choice);
+                let choice = this.window.abilityChoices[2];
+                this.window.chooseAbility(choice);
             });
 
             it('should not resolve an ability', function() {
@@ -216,8 +216,8 @@ describe('TriggeredAbilityWindow', function() {
 
         describe('when the player selects a valid choice', function() {
             beforeEach(function() {
-                let choice = this.window.abilityChoices[1].id;
-                this.window.chooseAbility(this.player1Spy, choice);
+                let choice = this.window.abilityChoices[1];
+                this.window.chooseAbility(choice);
             });
 
             it('should resolve the ability', function() {

--- a/test/server/gamesteps/TriggeredAbilityWindow.spec.js
+++ b/test/server/gamesteps/TriggeredAbilityWindow.spec.js
@@ -30,11 +30,10 @@ describe('TriggeredAbilityWindow', function() {
             return cardSpy;
         }
 
-        function createAbility(card, context, choices = [{ choice: 'default', text: 'default' }]) {
-            let ability = jasmine.createSpyObj('ability', ['createContext', 'getChoices', 'hasMax', 'meetsRequirements']);
+        function createAbility(card, context) {
+            let ability = jasmine.createSpyObj('ability', ['createContext', 'getTitle', 'hasMax', 'meetsRequirements']);
             ability.card = card;
             ability.createContext.and.returnValue(context);
-            ability.getChoices.and.returnValue(choices);
             ability.location = ['play area'];
             ability.meetsRequirements.and.returnValue(true);
             return ability;
@@ -42,10 +41,7 @@ describe('TriggeredAbilityWindow', function() {
 
         this.context1 = { context: 1, player: this.player1Spy, event: this.eventSpy };
         this.abilityCard1 = createCard({ card: 1, name: 'The Card', controller: this.player1Spy });
-        this.ability1Spy = createAbility(this.abilityCard1, this.context1, [
-            { choice: 'choice1', text: 'My Choice 1' },
-            { choice: 'choice2', text: 'My Choice 2' }
-        ]);
+        this.ability1Spy = createAbility(this.abilityCard1, this.context1);
 
         this.context2 = { context: 2, player: this.player1Spy, event: this.eventSpy };
         this.abilityCard2 = createCard({ card: 2, name: 'The Card 2', controller: this.player1Spy });
@@ -112,8 +108,7 @@ describe('TriggeredAbilityWindow', function() {
                         activePrompt: jasmine.objectContaining({
                             menuTitle: jasmine.any(String),
                             buttons: [
-                                jasmine.objectContaining({ text: 'The Card - My Choice 1', arg: jasmine.any(String), method: 'chooseAbility' }),
-                                jasmine.objectContaining({ text: 'The Card - My Choice 2', arg: jasmine.any(String), method: 'chooseAbility' }),
+                                jasmine.objectContaining({ text: 'The Card', arg: jasmine.any(String), method: 'chooseAbility' }),
                                 jasmine.objectContaining({ text: 'The Card 2', arg: jasmine.any(String), method: 'chooseAbility' }),
                                 jasmine.objectContaining({ text: 'Pass', method: 'pass' })
                             ]
@@ -128,7 +123,6 @@ describe('TriggeredAbilityWindow', function() {
 
             describe('and the ability has a maximum', function() {
                 beforeEach(function() {
-                    this.ability1Spy.getChoices.and.returnValue([{ choice: 'default', text: 'default' }]);
                     this.ability1Spy.hasMax.and.returnValue(true);
                     this.ability2Spy.hasMax.and.returnValue(true);
                 });
@@ -211,7 +205,7 @@ describe('TriggeredAbilityWindow', function() {
         describe('when the player select a choice they do not own', function() {
             beforeEach(function() {
                 // Choosing a player 2 ability
-                let choice = this.window.abilityChoices[3].id;
+                let choice = this.window.abilityChoices[2].id;
                 this.window.chooseAbility(this.player1Spy, choice);
             });
 
@@ -226,12 +220,8 @@ describe('TriggeredAbilityWindow', function() {
                 this.window.chooseAbility(this.player1Spy, choice);
             });
 
-            it('should update the ability context with the choice made', function() {
-                expect(this.context1.choice).toBe('choice2');
-            });
-
             it('should resolve the ability', function() {
-                expect(this.window.resolveAbility).toHaveBeenCalledWith(this.ability1Spy, this.context1);
+                expect(this.window.resolveAbility).toHaveBeenCalledWith(this.ability2Spy, this.context2);
             });
 
             it('should rotate the order of players to allow the next player pick next', function() {

--- a/test/server/integration/challengesphase.spec.js
+++ b/test/server/integration/challengesphase.spec.js
@@ -124,27 +124,27 @@ describe('challenges phase', function() {
 
                 expect(this.player1).toAllowAbilityTrigger('Tyrion Lannister');
                 expect(this.player1).toAllowAbilityTrigger('Dornish Paramour');
-                expect(this.player1).toAllowAbilityTrigger('Marya Seaworth - Kneel Hedge Knight');
-                expect(this.player1).toAllowAbilityTrigger('Marya Seaworth - Kneel Lannisport Merchant');
-                expect(this.player1.currentPrompt().buttons.length).toBe(5);
+                expect(this.player1).toAllowAbilityTrigger('Marya Seaworth');
+                expect(this.player1.currentPrompt().buttons.length).toBe(4);
             });
 
             it('should reactions in the same window to generate gold needed to pay costs', function() {
                 this.player1Object.gold = 0;
                 this.initiateChallenge();
-                expect(this.player1).not.toAllowAbilityTrigger('Marya Seaworth - Kneel Hedge Knight');
-                expect(this.player1).not.toAllowAbilityTrigger('Marya Seaworth - Kneel Lannisport Merchant');
+                expect(this.player1).not.toAllowAbilityTrigger('Marya Seaworth');
 
                 this.player1.triggerAbility('Tyrion Lannister');
 
-                expect(this.player1).toAllowAbilityTrigger('Marya Seaworth - Kneel Hedge Knight');
-                expect(this.player1).toAllowAbilityTrigger('Marya Seaworth - Kneel Lannisport Merchant');
+                expect(this.player1).toAllowAbilityTrigger('Marya Seaworth');
             });
 
             it('should allow multiple reactions from the same card to be triggered', function() {
                 this.initiateChallenge();
-                this.player1.triggerAbility('Marya Seaworth - Kneel Hedge Knight');
-                this.player1.triggerAbility('Marya Seaworth - Kneel Lannisport Merchant');
+
+                this.player1.triggerAbility('Marya Seaworth');
+                this.player1.clickCard(this.knight);
+                this.player1.triggerAbility('Marya Seaworth');
+                this.player1.clickCard(this.merchant);
 
                 expect(this.knight.kneeled).toBe(true);
                 expect(this.merchant.kneeled).toBe(true);

--- a/test/server/integration/challengesphase.spec.js
+++ b/test/server/integration/challengesphase.spec.js
@@ -125,7 +125,6 @@ describe('challenges phase', function() {
                 expect(this.player1).toAllowAbilityTrigger('Tyrion Lannister');
                 expect(this.player1).toAllowAbilityTrigger('Dornish Paramour');
                 expect(this.player1).toAllowAbilityTrigger('Marya Seaworth');
-                expect(this.player1.currentPrompt().buttons.length).toBe(4);
             });
 
             it('should reactions in the same window to generate gold needed to pay costs', function() {


### PR DESCRIPTION
* When prompted for an interrupt or reaction window, players now click on the card they want to trigger directly instead of clicking menu buttons.
* If the same card can trigger on multiple simultaneous events (e.g. Marya Seaworth when multiple characters are bypassed from stealth), the player is then prompted to click on the card associated with the event.
* If the card has multiple choices (e.g. LoCR Tyrion), the choice is presented in a button menu after the card is chosen.
* Action abilities continue to be triggered through card-level menus during the appropriate action window.
* When revealed and forced interrupt / reaction order continues to be chosen by button prompts for now.

I highly recommend pulling this locally to try it out rather than reviewing solely based on code changes.