### PR TITLE
Clear ability resolution when leaving playable area

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -390,6 +390,7 @@ class BaseCard {
                 reaction.registerEvents();
             } else if(reaction.isEventListeningLocation(originalLocation) && !reaction.isEventListeningLocation(targetLocation)) {
                 reaction.unregisterEvents();
+                this.game.clearAbilityResolution(reaction);
             }
         });
 

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -796,6 +796,12 @@ class Game extends EventEmitter {
         window.registerAbility(ability, event);
     }
 
+    clearAbilityResolution(ability) {
+        for(let window of this.abilityWindowStack) {
+            window.clearAbilityResolution(ability);
+        }
+    }
+
     raiseEvent(eventName, params, handler) {
         if(!handler) {
             handler = () => true;

--- a/server/game/gamesteps/BaseAbilityWindow.js
+++ b/server/game/gamesteps/BaseAbilityWindow.js
@@ -59,6 +59,10 @@ class BaseAbilityWindow extends BaseStep {
     markAbilityAsResolved(ability, event) {
         this.resolvedAbilities.push({ ability: ability, event: event });
     }
+
+    clearAbilityResolution(ability) {
+        this.resolvedAbilities = this.resolvedAbilities.filter(resolvedAbility => resolvedAbility.ability !== ability);
+    }
 }
 
 module.exports = BaseAbilityWindow;

--- a/test/server/integration/AbilityRequirements.spec.js
+++ b/test/server/integration/AbilityRequirements.spec.js
@@ -44,5 +44,58 @@ describe('ability requirements', function() {
                 expect(this.player2).toAllowAbilityTrigger('His Viper Eyes');
             });
         });
+
+        describe('when an ability leaves a playable area and re-enters a playable area', function() {
+            beforeEach(function() {
+                const deck1 = this.buildDeck('lannister', [
+                    'A Noble Cause',
+                    'Cersei Lannister (Core)', 'Lannisport', 'Maester at the Rock', 'Without His Beard'
+                ]);
+                const deck2 = this.buildDeck('martell', [
+                    'A Noble Cause',
+                    'Ghaston Grey', 'Ghaston Grey', 'Ghaston Grey',
+                    'His Viper Eyes', 'His Viper Eyes', 'His Viper Eyes',
+                    'Doran Martell (Core)', 'Doran Martell (Core)', 'Doran Martell (Core)',
+                    'Areo Hotah (Core)', 'Areo Hotah (Core)', 'Areo Hotah (Core)'
+                ]);
+                this.player1.selectDeck(deck1);
+                this.player2.selectDeck(deck2);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.player1.clickCard('Maester at the Rock', 'hand');
+                this.player1.clickCard('Lannisport', 'hand');
+
+                this.completeSetup();
+
+                this.selectFirstPlayer(this.player1);
+
+                this.player1.clickCard('Cersei Lannister', 'hand');
+
+                this.completeMarshalPhase();
+
+                this.player1.clickPrompt('Intrigue');
+                this.player1.clickCard('Cersei Lannister', 'play area');
+                this.player1.clickPrompt('Done');
+
+                this.skipActionWindow();
+
+                this.player2.clickPrompt('Done');
+
+                this.skipActionWindow();
+
+                this.player1.triggerAbility('Without His Beard');
+                this.player1.clickPrompt('3');
+                this.player1.triggerAbility('Maester at the Rock');
+                this.player1.triggerAbility('Lannisport');
+
+                let event = this.player1.findCardByName('Without His Beard');
+                expect(event.location).toBe('hand');
+            });
+
+            it('should prompt for the ability', function() {
+                expect(this.player1).toAllowAbilityTrigger('Without His Beard');
+            });
+        });
     });
 });


### PR DESCRIPTION
If a card whose ability would trigger for a specific triggering
condition leaves the playable area and re-enters the playable area while
that triggering condition is still active, the player should be able to
trigger that ability again.

For example, if you have an event in hand whose condition has been met,
play that event, then return that event back to hand through a nested
sequence (Maester at Rock to put the event on the draw deck, Lannisport
to re-draw the event), you should then be able to play that same event
again.