### PR TITLE
Don't raise onTargetsChosen after cancellation

### DIFF
--- a/server/game/AbilityTarget.js
+++ b/server/game/AbilityTarget.js
@@ -32,11 +32,8 @@ class AbilityTarget {
                 result.resolve(card);
                 return true;
             },
-            onCancel: (player) => {
+            onCancel: () => {
                 result.reject();
-
-                context.game.addAlert('danger', '{0} cancels the resolution of {1} (costs were still paid)', player, context.source);
-
                 return true;
             }
         };

--- a/server/game/gamesteps/abilityresolver.js
+++ b/server/game/gamesteps/abilityresolver.js
@@ -128,9 +128,14 @@ class AbilityResolver extends BaseStep {
             return;
         }
 
-        this.cancelled = _.any(this.targetResults, result => result.resolved && !result.value);
+        let cancelledTargeting = this.targetResults.some(result => result.resolved && !result.value);
+        if(cancelledTargeting) {
+            this.cancelled = true;
+            this.game.addAlert('danger', '{0} cancels the resolution of {1} (costs were still paid)', this.context.player, this.context.source);
+            return;
+        }
 
-        if(!_.all(this.targetResults, result => result.resolved)) {
+        if(!this.targetResults.every(result => result.resolved)) {
             return false;
         }
 

--- a/test/server/cards/05-LoCR/HighSepton.spec.js
+++ b/test/server/cards/05-LoCR/HighSepton.spec.js
@@ -49,6 +49,27 @@ describe('High Septon', function() {
             });
         });
 
+        describe('when target resolution is cancelled', function() {
+            beforeEach(function() {
+                this.selectFirstPlayer(this.player2);
+
+                this.completeMarshalPhase();
+
+                this.unopposedChallenge(this.player2, 'intrigue', 'Mirri Maz Duur');
+                this.player2.clickPrompt('Pass');
+                this.player2.clickPrompt('Apply Claim');
+
+                this.player2.triggerAbility('Mirri Maz Duur');
+            });
+
+            it('should not crash', function() {
+                expect(() => {
+                    // Cancel targeting for Mirri
+                    this.player2.clickPrompt('Done');
+                }).not.toThrow();
+            });
+        });
+
         describe('vs a non-targeting ability', function() {
             beforeEach(function() {
                 this.selectFirstPlayer(this.player2);

--- a/test/server/gamesteps/abilityresolver.spec.js
+++ b/test/server/gamesteps/abilityresolver.spec.js
@@ -2,7 +2,7 @@ const AbilityResolver = require('../../../server/game/gamesteps/abilityresolver.
 
 describe('AbilityResolver', function() {
     beforeEach(function() {
-        this.game = jasmine.createSpyObj('game', ['markActionAsTaken', 'popAbilityContext', 'pushAbilityContext', 'raiseEvent', 'reportError']);
+        this.game = jasmine.createSpyObj('game', ['addAlert', 'markActionAsTaken', 'popAbilityContext', 'pushAbilityContext', 'raiseEvent', 'reportError']);
         this.game.raiseEvent.and.callFake((name, params, handler) => {
             if(handler) {
                 handler(params);
@@ -13,6 +13,7 @@ describe('AbilityResolver', function() {
         });
         this.ability = jasmine.createSpyObj('ability', ['incrementLimit', 'isAction', 'isCardAbility', 'isForcedAbility', 'isPlayableEventAbility', 'needsChooseOpponent', 'resolveCosts', 'payCosts', 'resolveTargets', 'executeHandler']);
         this.ability.isCardAbility.and.returnValue(true);
+        this.ability.resolveTargets.and.returnValue([]);
         this.player = jasmine.createSpyObj('player', ['moveCard']);
         this.source = jasmine.createSpyObj('source', ['createSnapshot', 'getType']);
         this.source.owner = this.player;
@@ -257,6 +258,10 @@ describe('AbilityResolver', function() {
 
                     it('should not execute the handler', function() {
                         expect(this.ability.executeHandler).not.toHaveBeenCalled();
+                    });
+
+                    it('should add an alert', function() {
+                        expect(this.game.addAlert).toHaveBeenCalled();
                     });
                 });
             });


### PR DESCRIPTION
The onTargetsChosen event was being raised in situations where the
player had cancelled target selection during an ability. This caused
crashes in the High Septon, which expects that the list of targets are
actual card objects.

Fixes THRONETEKI-23D