### PR TITLE
Fix timing for At Prince Doran's Behest

### DIFF
--- a/server/game/AtomicEvent.js
+++ b/server/game/AtomicEvent.js
@@ -2,6 +2,7 @@ class AtomicEvent {
     constructor() {
         this.cancelled = false;
         this.childEvents = [];
+        this.attachedEvents = [];
     }
 
     addChildEvent(event) {
@@ -65,6 +66,10 @@ class AtomicEvent {
 
     getPrimaryEvent() {
         return this.childEvents[0];
+    }
+
+    toString() {
+        return `atomic(${this.childEvents.map(e => e.toString()).join(' + ')})`;
     }
 }
 

--- a/server/game/SimultaneousEvents.js
+++ b/server/game/SimultaneousEvents.js
@@ -1,0 +1,57 @@
+class SimultaneousEvents {
+    constructor() {
+        this.childEvents = [];
+    }
+
+    addChildEvent(event) {
+        this.childEvents.push(event);
+    }
+
+    emitTo(emitter, suffix) {
+        for(let event of this.childEvents) {
+            event.emitTo(emitter, suffix);
+        }
+    }
+
+    get cancelled() {
+        return this.childEvents.every(event => event.cancelled);
+    }
+
+    cancel() {
+        for(let event of this.childEvents) {
+            event.cancel();
+        }
+
+        if(this.parent) {
+            this.parent.onChildCancelled(this);
+        }
+    }
+
+    executeHandler() {
+        for(let event of this.childEvents) {
+            event.executeHandler();
+        }
+    }
+
+    executePostHandler() {
+        for(let event of this.childEvents) {
+            event.executePostHandler();
+        }
+    }
+
+    getConcurrentEvents() {
+        return this.childEvents.reduce((concurrentEvents, event) => {
+            return concurrentEvents.concat(event.getConcurrentEvents());
+        }, []);
+    }
+
+    getPrimaryEvent() {
+        return this.childEvents[0];
+    }
+
+    toString() {
+        return `simultaneous(${this.childEvents.map(e => e.toString()).join(', ')})`;
+    }
+}
+
+module.exports = SimultaneousEvents;

--- a/server/game/cards/02.5-COW/PullingTheStrings.js
+++ b/server/game/cards/02.5-COW/PullingTheStrings.js
@@ -29,7 +29,7 @@ class PullingTheStrings extends PlotCard {
 
         this.game.addMessage('{0} uses {1} to initiate the when resolved effect of {2}', player, this, card);
         card.controller = player;
-        this.game.raiseEvent('onPlotsWhenRevealed', { plots: [card] });
+        this.game.raiseEvent('onPlotWhenRevealed', { plot: card });
         this.game.queueSimpleStep(() => {
             card.controller = card.owner;
             card.moveTo('revealed plots');

--- a/server/game/cards/02.5-COW/PullingTheStrings.js
+++ b/server/game/cards/02.5-COW/PullingTheStrings.js
@@ -3,10 +3,12 @@ const PlotCard = require('../../plotcard.js');
 class PullingTheStrings extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
-            handler: () => {
+            handler: context => {
                 if(this.resolving) {
                     return;
                 }
+
+                this.context = context;
 
                 this.game.promptForSelect(this.controller, {
                     cardCondition: card => this.cardCondition(card),
@@ -24,15 +26,19 @@ class PullingTheStrings extends PlotCard {
     }
 
     onCardSelected(player, card) {
-        card.moveTo('active plot');
         this.resolving = true;
 
-        this.game.addMessage('{0} uses {1} to initiate the when resolved effect of {2}', player, this, card);
+        this.game.addMessage('{0} uses {1} to initiate the When Revealed ability of {2}', player, this, card);
         card.controller = player;
-        this.game.raiseEvent('onPlotWhenRevealed', { plot: card });
+
+        let whenRevealed = card.getWhenRevealedAbility();
+        if(whenRevealed) {
+            // Attach the current When Revealed event to the new context
+            let context = whenRevealed.createContext(this.context.event);
+            this.game.resolveAbility(whenRevealed, context);
+        }
         this.game.queueSimpleStep(() => {
             card.controller = card.owner;
-            card.moveTo('revealed plots');
 
             this.resolving = false;
         });

--- a/server/game/cards/04.1-AtSK/VaryssRiddle.js
+++ b/server/game/cards/04.1-AtSK/VaryssRiddle.js
@@ -44,7 +44,7 @@ class VaryssRiddle extends PlotCard {
         plot.controller = this.controller;
         this.resolving = true;
 
-        this.game.raiseEvent('onPlotsWhenRevealed', { plots: [plot] });
+        this.game.raiseEvent('onPlotWhenRevealed', { plot: plot });
         this.game.queueSimpleStep(() => {
             this.resolving = false;
             plot.controller = plot.owner;

--- a/server/game/cards/04.1-AtSK/VaryssRiddle.js
+++ b/server/game/cards/04.1-AtSK/VaryssRiddle.js
@@ -3,13 +3,15 @@ const PlotCard = require('../../plotcard.js');
 class VaryssRiddle extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
-            handler: () => {
+            handler: context => {
                 let opponents = this.game.getOpponents(this.controller);
                 this.nonRiddlePlots = opponents.map(opponent => opponent.activePlot).filter(plot => !plot.hasTrait('Riddle'));
 
                 if(this.resolving || this.nonRiddlePlots.length === 0) {
                     return;
                 }
+
+                this.context = context;
 
                 if(this.nonRiddlePlots.length === 1) {
                     this.resolveWhenRevealed(this.nonRiddlePlots[0]);
@@ -44,7 +46,12 @@ class VaryssRiddle extends PlotCard {
         plot.controller = this.controller;
         this.resolving = true;
 
-        this.game.raiseEvent('onPlotWhenRevealed', { plot: plot });
+        let whenRevealed = plot.getWhenRevealedAbility();
+        if(whenRevealed) {
+            // Attach the current When Revealed event to the new context
+            let context = whenRevealed.createContext(this.context.event);
+            this.game.resolveAbility(whenRevealed, context);
+        }
         this.game.queueSimpleStep(() => {
             this.resolving = false;
             plot.controller = plot.owner;

--- a/server/game/cards/04.6-TC/TyrionsChain.js
+++ b/server/game/cards/04.6-TC/TyrionsChain.js
@@ -50,7 +50,7 @@ class TyrionsChain extends DrawCard {
 
         this.game.addMessage('{0} uses {1} to initiate the When Revealed ability of {2}', this.controller, this, warPlot);
         warPlot.controller = this.controller;
-        this.game.raiseEvent('onPlotsWhenRevealed', { plots: [warPlot] });
+        this.game.raiseEvent('onPlotWhenRevealed', { plot: warPlot });
         this.game.queueSimpleStep(() => {
             warPlot.controller = warPlot.owner;
             this.resolving = false;

--- a/server/game/cards/04.6-TC/TyrionsChain.js
+++ b/server/game/cards/04.6-TC/TyrionsChain.js
@@ -12,12 +12,14 @@ class TyrionsChain extends DrawCard {
                 )
             },
             max: ability.limit.perPhase(1),
-            handler: () => {
+            handler: context => {
                 let warPlots = this.getRevealedWarPlots();
 
                 let buttons = _.map(warPlots, card => ({
                     method: 'selectWarPlot', card: card
                 }));
+
+                this.context = context;
 
                 this.game.promptWithMenu(this.controller, this, {
                     activePrompt: {
@@ -50,7 +52,13 @@ class TyrionsChain extends DrawCard {
 
         this.game.addMessage('{0} uses {1} to initiate the When Revealed ability of {2}', this.controller, this, warPlot);
         warPlot.controller = this.controller;
-        this.game.raiseEvent('onPlotWhenRevealed', { plot: warPlot });
+
+        let whenRevealed = warPlot.getWhenRevealedAbility();
+        if(whenRevealed) {
+            // Attach the current When Revealed event to the new context
+            let context = whenRevealed.createContext(this.context.event);
+            this.game.resolveAbility(whenRevealed, context);
+        }
         this.game.queueSimpleStep(() => {
             warPlot.controller = warPlot.owner;
             this.resolving = false;

--- a/server/game/cards/10-SoD/AtPrinceDoransBehest.js
+++ b/server/game/cards/10-SoD/AtPrinceDoransBehest.js
@@ -1,9 +1,6 @@
 const RevealPlots = require('../../gamesteps/revealplots.js');
 const PlotCard = require('../../plotcard.js');
 
-//TODO: This currently nests the resolution of the When Revealed of the fetched plot within the resolution
-//of this plot. Instead, if a new When Revealed is fetched, it should resolve simultaneously with any other
-//unresolved When Revealed abilities, allowing the first player to (again) choose the order.
 class AtPrinceDoransBehest extends PlotCard {
     setupCardAbilities() {
         this.whenRevealed({
@@ -19,7 +16,7 @@ class AtPrinceDoransBehest extends PlotCard {
                 context.player.selectedPlot = context.target;
                 context.player.removeActivePlot();
                 context.player.flipPlotFaceup();
-                this.game.queueStep(new RevealPlots(this.game, [context.target]));
+                this.game.queueStep(new RevealPlots(this.game, [context.target], context.event));
             }
         });
     }

--- a/server/game/event.js
+++ b/server/game/event.js
@@ -7,6 +7,7 @@ class Event {
         this.handler = handler;
         this.postHandler = postHandler;
         this.childEvents = [];
+        this.attachedEvents = [];
 
         _.extend(this, params);
         this.params = [this].concat([params]);
@@ -70,6 +71,23 @@ class Event {
 
     getPrimaryEvent() {
         return this;
+    }
+
+    thenAttachEvent(event) {
+        this.attachedEvents.push(event);
+        this.addChildEvent(event);
+    }
+
+    clearAttachedEvents() {
+        this.attachedEvents = [];
+    }
+
+    toString() {
+        if(this.childEvents.length !== 0) {
+            return `${this.name} + children(${this.childEvents.map(e => e.toString()).join(', ')})`;
+        }
+
+        return this.name;
     }
 }
 

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -840,6 +840,10 @@ class Game extends EventEmitter {
         this.queueStep(new EventWindow(this, event, () => this.postEventCalculations()));
     }
 
+    resolveEvent(event) {
+        this.queueStep(new EventWindow(this, event, () => this.postEventCalculations()));
+    }
+
     /**
      * Function that executes after the handler for each Event has executed. In
      * terms of overall engine it is useful for things that require regular

--- a/server/game/gamesteps/ForcedTriggeredAbilityWindow.js
+++ b/server/game/gamesteps/ForcedTriggeredAbilityWindow.js
@@ -3,6 +3,11 @@ const TriggeredAbilityWindowTitles = require('./TriggeredAbilityWindowTitles');
 
 class ForcedTriggeredAbilityWindow extends BaseAbilityWindow {
     continue() {
+        if(this.hasAttachedEvents()) {
+            this.openWindowForAttachedEvents();
+            return false;
+        }
+
         this.gatherChoices();
 
         if(this.abilityChoices.length === 1) {

--- a/server/game/gamesteps/TriggeredAbilityWindow.js
+++ b/server/game/gamesteps/TriggeredAbilityWindow.js
@@ -20,6 +20,11 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
     }
 
     continue() {
+        if(this.hasAttachedEvents()) {
+            this.openWindowForAttachedEvents();
+            return false;
+        }
+
         this.gatherChoices();
 
         this.players = this.filterChoicelessPlayers(this.players || this.game.getPlayersInFirstPlayerOrder());

--- a/server/game/gamesteps/eventwindow.js
+++ b/server/game/gamesteps/eventwindow.js
@@ -67,7 +67,7 @@ class EventWindow extends BaseStep {
             return;
         }
 
-        if(this.event.name === 'onPlotsWhenRevealed') {
+        if(this.event.getConcurrentEvents().some(event => event.name === 'onPlotRevealed')) {
             this.openAbilityWindow('whenrevealed');
         }
     }

--- a/server/game/plotcard.js
+++ b/server/game/plotcard.js
@@ -24,6 +24,10 @@ class PlotCard extends BaseCard {
         this.abilities.reactions.push(reaction);
     }
 
+    getWhenRevealedAbility() {
+        return this.abilities.reactions.find(ability => ability instanceof CardWhenRevealed);
+    }
+
     getInitiative() {
         var baseValue = this.canProvidePlotModifier['initiative'] ? this.getPrintedInitiative() : 0;
         return baseValue + this.initiativeModifier;

--- a/server/game/plotcard.js
+++ b/server/game/plotcard.js
@@ -17,7 +17,7 @@ class PlotCard extends BaseCard {
     whenRevealed(properties) {
         let whenClause = {
             when: {
-                onPlotsWhenRevealed: event => event.plots.includes(this)
+                onPlotRevealed: event => event.plot === this
             }
         };
         let reaction = new CardWhenRevealed(this.game, this, _.extend(whenClause, properties));

--- a/test/server/cards/04.2-CtA/SummerHarvest.spec.js
+++ b/test/server/cards/04.2-CtA/SummerHarvest.spec.js
@@ -26,22 +26,6 @@ describe('SummerHarvest', function() {
             it('should calculate the gold amount properly', function() {
                 expect(this.summerHarvest.getIncome()).toBe(7);
             });
-
-            describe('when playing it again after going through all plots', function() {
-                beforeEach(function() {
-                    this.completeMarshalPhase();
-                    this.completeChallengesPhase();
-
-                    // Move Summer Harvest back to the plot deck so it's eligible to be picked again.
-                    this.summerHarvest.controller.moveCard(this.summerHarvest, 'plot deck');
-
-                    this.selectFirstPlayer(this.player1);
-                });
-
-                it('should still properly calculate the gold amount properly', function() {
-                    expect(this.summerHarvest.getIncome()).toBe(7);
-                });
-            });
         });
 
         describe('when played against Varys\'s Riddle', function() {

--- a/test/server/cards/10-SoD/AtPrinceDoransBehest.spec.js
+++ b/test/server/cards/10-SoD/AtPrinceDoransBehest.spec.js
@@ -99,4 +99,72 @@ describe('At Prince Doran\'s Behest', function() {
             });
         });
     });
+
+    describe('vs Varys\'s Riddle', function() {
+        integration(function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('martell', [
+                    'At Prince Doran\'s Behest', 'Varys\'s Riddle', 'Valar Morghulis', 'Marched to the Wall'
+                ]);
+
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+                this.completeSetup();
+
+                this.player1.selectPlot('At Prince Doran\'s Behest');
+                this.player2.selectPlot('Varys\'s Riddle');
+                this.selectFirstPlayer(this.player2);
+            });
+
+            describe('after revealing a new plot via Riddle', function() {
+                beforeEach(function() {
+                    // Resolve Varys's Riddle first to copy Behest
+                    this.selectPlotOrder(this.player2);
+                    this.player2.clickCard('Valar Morghulis', 'plot deck');
+                });
+
+                it('should prompt first player for plot order', function() {
+                    expect(this.player2).toHavePrompt('Choose when revealed order');
+                    expect(this.player2).toHavePromptButton('player1 - At Prince Doran\'s Behest');
+                    expect(this.player2).toHavePromptButton('player2 - Valar Morghulis');
+                });
+            });
+
+            describe('repeated Behest vs Riddle', function() {
+                beforeEach(function() {
+                    // Resolve Varys's Riddle first to copy player 1's Behest
+                    this.selectPlotOrder(this.player2);
+
+                    // Reveal player 2's Behest
+                    this.player2.clickCard('At Prince Doran\'s Behest', 'plot deck');
+
+                    // Resolve player 1's Behest
+                    this.selectPlotOrder(this.player1);
+
+                    // Reveal player 1's Riddle
+                    this.player1.clickCard('Varys\'s Riddle', 'plot deck');
+
+                    // Resolve player 1's Riddle to copy player 2's Behest
+                    this.selectPlotOrder(this.player1);
+
+                    // Reveal a normal plot for player 1
+                    this.player1.clickCard('Valar Morghulis', 'plot deck');
+
+                    // Resolve player 2's Behest
+                    this.selectPlotOrder(this.player2);
+
+                    // Reveal a normal plot for player 2
+                    this.player2.clickCard('Valar Morghulis', 'plot deck');
+                });
+
+                it('should prompt first player for plot order', function() {
+                    expect(this.player2).toHavePrompt('Choose when revealed order');
+                    expect(this.player2).toHavePromptButton('player1 - Valar Morghulis');
+                    expect(this.player2).toHavePromptButton('player2 - Valar Morghulis');
+                });
+            });
+        });
+    });
 });

--- a/test/server/cards/10-SoD/AtPrinceDoransBehest.spec.js
+++ b/test/server/cards/10-SoD/AtPrinceDoransBehest.spec.js
@@ -1,0 +1,102 @@
+describe('At Prince Doran\'s Behest', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck1 = this.buildDeck('martell', [
+                'At Prince Doran\'s Behest', 'Valar Morghulis',
+                'Desert Scavenger', 'Caswell\'s Keep'
+            ]);
+            const deck2 = this.buildDeck('stark', [
+                'Marched to the Wall', 'A Noble Cause',
+                'Old Nan', 'Old Nan', 'Old Nan', 'Old Nan', 'Old Nan',
+                'Old Nan', 'Old Nan', 'Old Nan', 'Old Nan', 'Old Nan'
+            ]);
+
+            this.player1.selectDeck(deck1);
+            this.player2.selectDeck(deck2);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.character = this.player1.findCardByName('Desert Scavenger', 'hand');
+
+            this.player1.clickCard(this.character);
+        });
+
+        describe('when Behest is resolved first', function() {
+            beforeEach(function() {
+                this.completeSetup();
+
+                this.player1.selectPlot('At Prince Doran\'s Behest');
+                this.player2.selectPlot('Marched to the Wall');
+                this.selectFirstPlayer(this.player2);
+
+                // Resolve Behest first
+                this.selectPlotOrder(this.player1);
+
+                this.player1.clickCard('Valar Morghulis', 'plot deck');
+            });
+
+            it('should allow the first player to choose order', function() {
+                expect(this.player2).toHavePrompt('Choose when revealed order');
+                expect(this.player2).toHavePromptButton('player1 - Valar Morghulis');
+                expect(this.player2).toHavePromptButton('player2 - Marched to the Wall');
+            });
+
+            it('should not automatically resolve the selected plot', function() {
+                expect(this.character.location).toBe('play area');
+            });
+        });
+
+        describe('when interrupts are available for plot reveals', function() {
+            beforeEach(function() {
+                this.player2.clickCard('Old Nan', 'hand');
+                this.completeSetup();
+
+                this.player1.selectPlot('At Prince Doran\'s Behest');
+                this.player2.selectPlot('Marched to the Wall');
+
+                // Don't use Old Nan to modify the initial plots
+                this.player2.clickPrompt('Pass');
+
+                this.selectFirstPlayer(this.player2);
+
+                // Resolve Behest first
+                this.selectPlotOrder(this.player1);
+
+                this.player1.clickCard('Valar Morghulis', 'plot deck');
+            });
+
+            it('should prompt for those interrupts', function() {
+                expect(this.player2).toAllowAbilityTrigger('Old Nan');
+            });
+        });
+
+        describe('when reactions are available for plot reveals', function() {
+            beforeEach(function() {
+                this.player1.clickCard('Caswell\'s Keep', 'hand');
+                this.completeSetup();
+
+                this.player1.selectPlot('At Prince Doran\'s Behest');
+                this.player2.selectPlot('Marched to the Wall');
+
+                this.selectFirstPlayer(this.player2);
+
+                // Resolve Behest first
+                this.selectPlotOrder(this.player1);
+
+                this.player1.clickCard('Valar Morghulis', 'plot deck');
+
+                // Resolve new set of plots
+                this.selectPlotOrder(this.player1);
+
+                // Trigger Caswell's Keep for the first plot
+                this.player1.triggerAbility('Caswell\'s Keep');
+                this.player1.clickPrompt('player2');
+                this.player1.clickPrompt('Old Nan');
+            });
+
+            it('should trigger a reaction for the second plot revealed', function() {
+                expect(this.player1).toAllowAbilityTrigger('Caswell\'s Keep');
+            });
+        });
+    });
+});

--- a/test/server/gamesteps/ForcedTriggeredAbilityWindow.spec.js
+++ b/test/server/gamesteps/ForcedTriggeredAbilityWindow.spec.js
@@ -11,6 +11,7 @@ describe('ForcedTriggeredAbilityWindow', function() {
         this.gameSpy.getFirstPlayer.and.returnValue(this.player1Spy);
 
         this.eventSpy = jasmine.createSpyObj('event', ['emitTo', 'getConcurrentEvents', 'getPrimaryEvent']);
+        this.eventSpy.attachedEvents = [];
         this.eventSpy.getConcurrentEvents.and.returnValue([this.eventSpy]);
         this.eventSpy.getPrimaryEvent.and.returnValue(this.eventSpy);
 

--- a/test/server/gamesteps/TriggeredAbilityWindow.spec.js
+++ b/test/server/gamesteps/TriggeredAbilityWindow.spec.js
@@ -12,6 +12,7 @@ describe('TriggeredAbilityWindow', function() {
         this.gameSpy.getPlayersInFirstPlayerOrder.and.returnValue([this.player1Spy, this.player2Spy]);
 
         this.eventSpy = jasmine.createSpyObj('event', ['emitTo', 'getConcurrentEvents', 'getPrimaryEvent']);
+        this.eventSpy.attachedEvents = [];
         this.eventSpy.getConcurrentEvents.and.returnValue([this.eventSpy]);
         this.eventSpy.getPrimaryEvent.and.returnValue(this.eventSpy);
 

--- a/test/server/gamesteps/eventwindow.spec.js
+++ b/test/server/gamesteps/eventwindow.spec.js
@@ -3,7 +3,8 @@ const EventWindow = require('../../../server/game/gamesteps/eventwindow.js');
 describe('EventWindow', function() {
     beforeEach(function() {
         this.gameSpy = jasmine.createSpyObj('game', ['openAbilityWindow', 'saveWithDupe']);
-        this.eventSpy = jasmine.createSpyObj('event', ['allowAutomaticSave', 'cancel', 'emitTo', 'executeHandler', 'executePostHandler', 'getConcurrentEvents']);
+        this.eventSpy = jasmine.createSpyObj('event', ['allowAutomaticSave', 'cancel', 'clearAttachedEvents', 'emitTo', 'executeHandler', 'executePostHandler', 'getConcurrentEvents']);
+        this.eventSpy.attachedEvents = [];
         this.eventSpy.getConcurrentEvents.and.returnValue([]);
         this.eventWindow = new EventWindow(this.gameSpy, this.eventSpy);
     });
@@ -30,8 +31,9 @@ describe('EventWindow', function() {
 
         describe('when a concurrent event can be saved', function() {
             beforeEach(function() {
-                this.concurrentEventSpy = jasmine.createSpyObj('concurrentEvent', ['allowAutomaticSave', 'cancel']);
+                this.concurrentEventSpy = jasmine.createSpyObj('concurrentEvent', ['allowAutomaticSave', 'cancel', 'clearAttachedEvents']);
                 this.concurrentEventSpy.allowAutomaticSave.and.returnValue(true);
+                this.concurrentEventSpy.attachedEvents = [];
                 this.concurrentEventSpy.card = { card: 1 };
                 this.eventSpy.card = { card: 2 };
                 this.eventSpy.getConcurrentEvents.and.returnValue([this.eventSpy, this.concurrentEventSpy]);


### PR DESCRIPTION
* Ensures that first player gets to choose plot order after a new plot has been revealed by Behest
* Adds the capability to have a separate interrupt window with combined reactions, allowing proper interrupt / reaction timing after a new plot has been revealed by Behest.
* Fixes timing on ability copiers like Varys's Riddle to resolve the copied ability in the context of their own "When Revealed" event (necessary w/ Behest, otherwise it generates a nested sequence)

Fixes #1864 