### PR TITLE
Fix ability triggers for multiple non-target events

### DIFF
--- a/server/game/gamesteps/TriggeredAbilityWindow.js
+++ b/server/game/gamesteps/TriggeredAbilityWindow.js
@@ -109,12 +109,12 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
             return false;
         }
 
-        if(choices.length === 1) {
+        let availableTargets = choices.map(choice => choice.context.event.card || choice.context.event.target).filter(card => !!card);
+
+        if(choices.length === 1 || availableTargets.length <= 1) {
             this.chooseAbility(choices[0]);
             return true;
         }
-
-        let availableTargets = choices.map(choice => choice.context.event.card || choice.context.event.target);
 
         this.game.promptForSelect(player, {
             activePromptTitle: `Choose target for ${card.name}`,


### PR DESCRIPTION
If the same card can trigger its ability for multiple simultaneous
events, but those events don't have an associated card or target to
choose from, then it should automatically resolve the ability against
the first available event. This fixes Caswell's Keep's response to
multiple plots being revealed by At Prince Doran's Behest.

This fix may not be universal, and we should examine other cases as more
simultaneous resolution of events is added to the engine.