### PR TITLE
Allow abilities of immune cards to be triggered

### DIFF
--- a/server/game/CardSelector.js
+++ b/server/game/CardSelector.js
@@ -10,6 +10,7 @@ const defaultProperties = {
     numCards: 1,
     cardCondition: () => true,
     cardType: ['attachment', 'character', 'event', 'location'],
+    isCardEffect: true,
     gameAction: 'target',
     multiSelect: false,
     singleController: false,

--- a/server/game/CardSelectors/BaseCardSelector.js
+++ b/server/game/CardSelectors/BaseCardSelector.js
@@ -20,6 +20,9 @@ class BaseCardSelector {
      * @param {boolean} properties.revealTargets
      * indicates that all selectable facedown cards are flipped faceup for
      * the selecting player.
+     * @param {boolean} properties.isCardEffect
+     * indicates whether the selector is part of a card effect and thus should
+     * check for card immunity
      */
     constructor(properties) {
         this.cardCondition = properties.cardCondition;
@@ -27,6 +30,7 @@ class BaseCardSelector {
         this.gameAction = properties.gameAction;
         this.singleController = properties.singleController;
         this.revealTargets = properties.revealTargets;
+        this.isCardEffect = properties.isCardEffect;
 
         if(!Array.isArray(properties.cardType)) {
             this.cardType = [properties.cardType];
@@ -48,9 +52,12 @@ class BaseCardSelector {
         return (
             this.cardType.includes(card.getType()) &&
             this.cardCondition(card, context) &&
-            card.allowGameAction('target', context) &&
-            card.allowGameAction(this.gameAction)
+            this.isAllowedForGameAction(card, context)
         );
+    }
+
+    isAllowedForGameAction(card, context) {
+        return !this.isCardEffect || card.allowGameAction('target', context) && card.allowGameAction(this.gameAction);
     }
 
     /**

--- a/server/game/gamesteps/TriggeredAbilityWindow.js
+++ b/server/game/gamesteps/TriggeredAbilityWindow.js
@@ -48,6 +48,7 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
 
         this.game.promptForSelect(player, {
             activePromptTitle: TriggeredAbilityWindowTitles.getTitle(this.abilityType, this.event.getPrimaryEvent()),
+            isCardEffect: false,
             cardCondition: card => cardsForPlayer.includes(card),
             cardType: ['agenda', 'attachment', 'character', 'event', 'location', 'plot'],
             additionalButtons: this.getButtons(player, unclickableCards),
@@ -118,6 +119,7 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
 
         this.game.promptForSelect(player, {
             activePromptTitle: `Choose target for ${card.name}`,
+            isCardEffect: false,
             cardCondition: card => availableTargets.includes(card),
             onSelect: (player, selectedCard) => {
                 let choice = choices.find(choice => choice.context.event.card === selectedCard || choice.context.event.target === selectedCard);

--- a/test/server/integration/immunity.spec.js
+++ b/test/server/integration/immunity.spec.js
@@ -48,5 +48,38 @@ describe('immunity', function() {
                 expect(this.chamber.location).toBe('play area');
             });
         });
+
+        describe('triggering the ability of a card that has immunity', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('lannister', [
+                    'Sneak Attack',
+                    'Pleasure Barge', 'Pleasure Barge', 'Pleasure Barge',
+                    'Pleasure Barge', 'Pleasure Barge', 'Pleasure Barge',
+                    'Pleasure Barge', 'Pleasure Barge', 'Pleasure Barge',
+                    'Pleasure Barge', 'Pleasure Barge', 'Pleasure Barge'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.pleasureBarge = this.player1.findCardByName('Pleasure Barge', 'hand');
+
+                this.completeSetup();
+
+                this.selectFirstPlayer(this.player1);
+            });
+
+            describe('when a card is immune to all card effects can trigger an ability', function() {
+                beforeEach(function() {
+                    // Marshal Pleasure Barge
+                    this.player1.clickCard(this.pleasureBarge);
+                });
+
+                it('should allow the ability to be triggered', function() {
+                    expect(this.player1).toAllowAbilityTrigger(this.pleasureBarge);
+                });
+            });
+        });
     });
 });


### PR DESCRIPTION
Fixes an issue where Pleasure Barge could not be triggered after
marshalling it because the ability trigger prompt thought Pleasure Barge
was immune.