### PR TITLE
Ensure plot revealed by Behest triggers

### DIFF
--- a/server/game/gamesteps/ForcedTriggeredAbilityWindow.js
+++ b/server/game/gamesteps/ForcedTriggeredAbilityWindow.js
@@ -13,7 +13,7 @@ class ForcedTriggeredAbilityWindow extends BaseAbilityWindow {
         if(this.abilityChoices.length === 1) {
             let abilityChoice = this.abilityChoices[0];
             this.resolveAbility(abilityChoice.ability, abilityChoice.context);
-            return true;
+            return false;
         }
 
         if(this.abilityChoices.length > 1) {

--- a/test/server/cards/10-SoD/AtPrinceDoransBehest.spec.js
+++ b/test/server/cards/10-SoD/AtPrinceDoransBehest.spec.js
@@ -46,6 +46,22 @@ describe('At Prince Doran\'s Behest', function() {
             });
         });
 
+        describe('when resolution order does not need to be chosen', function() {
+            beforeEach(function() {
+                this.completeSetup();
+
+                this.player1.selectPlot('At Prince Doran\'s Behest');
+                this.player2.selectPlot('A Noble Cause');
+                this.selectFirstPlayer(this.player2);
+
+                this.player1.clickCard('Valar Morghulis', 'plot deck');
+            });
+
+            it('should automatically resolve the selected plot', function() {
+                expect(this.character.location).toBe('dead pile');
+            });
+        });
+
         describe('when interrupts are available for plot reveals', function() {
             beforeEach(function() {
                 this.player2.clickCard('Old Nan', 'hand');

--- a/test/server/gamesteps/ForcedTriggeredAbilityWindow.spec.js
+++ b/test/server/gamesteps/ForcedTriggeredAbilityWindow.spec.js
@@ -84,8 +84,14 @@ describe('ForcedTriggeredAbilityWindow', function() {
                 expect(this.gameSpy.promptWithMenu).not.toHaveBeenCalled();
             });
 
-            it('should complete the prompt', function() {
-                expect(this.result).toBe(true);
+            it('should not complete the prompt', function() {
+                // The execution of the forced ability may raise additional
+                // abilities in the same window. Thus, the prompt should be kept
+                // open until there are 0 abilities left in the window.
+                // e.g. At Prince Doran's Behest could be the only 'When Revealed'
+                // ability, but itself could reveal another 'When Revealed'
+                // ability in the same window.
+                expect(this.result).toBe(false);
             });
         });
 


### PR DESCRIPTION
When At Prince Doran's Behest was revealed as the only plot with a 'when
revealed' ability, the ability window was closing immediately after
executing Behest. This lead to the plot revealed by Behest not
executing, because the window it would be executed in was already
closed.

Now, the 'when revealed' ability window will stay open until it has done
one final cycle and verified there are no more abilities needing to be
executed.