### PR TITLE
Add warning for actions during marshal phase

### DIFF
--- a/server/game/game.js
+++ b/server/game/game.js
@@ -756,7 +756,7 @@ class Game extends EventEmitter {
     markActionAsTaken(context) {
         if(this.currentActionWindow) {
             this.currentActionWindow.markActionAsTaken();
-        } else if(this.currentPhase !== 'marshal') {
+        } else if(this.currentPhase !== 'marshal' || this.hasOpenInterruptOrReactionWindow()) {
             this.addAlert('danger', '{0} uses {1} outside of an action window', context.player, context.source);
         }
     }
@@ -800,6 +800,10 @@ class Game extends EventEmitter {
         for(let window of this.abilityWindowStack) {
             window.clearAbilityResolution(ability);
         }
+    }
+
+    hasOpenInterruptOrReactionWindow() {
+        return this.abilityWindowStack.length !== 0;
     }
 
     raiseEvent(eventName, params, handler) {

--- a/test/helpers/integrationhelper.js
+++ b/test/helpers/integrationhelper.js
@@ -82,7 +82,7 @@ var customMatchers = {
                 }
 
                 let selectableCardNames = actual.player.getSelectableCards().map(card => card.name);
-                let isPromptingAbility = actual.game.abilityWindowStack.length !== 0;
+                let isPromptingAbility = actual.game.hasOpenInterruptOrReactionWindow();
                 let includesCard = selectableCardNames.some(cardName => util.equals(cardName, expected, customEqualityMatchers));
 
                 result.pass = isPromptingAbility && includesCard;

--- a/test/helpers/playerinteractionwrapper.js
+++ b/test/helpers/playerinteractionwrapper.js
@@ -136,7 +136,7 @@ class PlayerInteractionWrapper {
     }
 
     triggerAbility(cardOrCardName) {
-        if(this.game.abilityWindowStack.length === 0) {
+        if(!this.game.hasOpenInterruptOrReactionWindow()) {
             throw new Error(`Couldn't trigger ability for ${this.name}. Not in an ability window. Current prompt is:\n${this.formatPrompt()}`);
         }
 


### PR DESCRIPTION
Previously, triggering an action ability outside of an action window
would print a warning in chat except during the marshal phase. Because
the marshal phase was excluded, actions could be used without warning
even when they were outside the normal marshal phase window. For
example, actions used while another ability was being resolved or
while a player was being prompted for interrupts / reactions did not
properly give the warning.

Fixes #1966 