### PR TITLE
Fix rookery validation when selecting a deck

### DIFF
--- a/server/lobby.js
+++ b/server/lobby.js
@@ -579,6 +579,10 @@ class Lobby {
                     draw.card = draw.card.custom ? draw.card : cards[draw.card.code];
                 });
 
+                for(let cardQuantity of deck.rookeryCards) {
+                    cardQuantity.card = cardQuantity.card.custom ? cardQuantity.card : cards[cardQuantity.card.code];
+                }
+
                 if(deck.agenda) {
                     deck.agenda = cards[deck.agenda.code];
                 }


### PR DESCRIPTION
The server side validation was marking decks with rookery cards as
invalid even though client-side they were fine. This was because the
card data for the rookery cards was incomplete on the server.