### PR TITLE
Add plain text formatting for game chat

### DIFF
--- a/server/game/PlainTextGameChatFormatter.js
+++ b/server/game/PlainTextGameChatFormatter.js
@@ -1,0 +1,65 @@
+const moment = require('moment');
+
+const HeaderDivider = '='.repeat(20);
+
+class PlainTextGameChatFormatter {
+    constructor(gameChat) {
+        this.gameChat = gameChat;
+    }
+
+    get messages() {
+        return this.gameChat.messages;
+    }
+
+    format() {
+        return this.messages.map(messageProps => this.formatMessage(messageProps)).join('\n');
+    }
+
+    formatMessage(messageProps) {
+        return `${moment(messageProps.date).format('YYYY-MM-DD HH:mm:ss')} ${this.formatMessageFragment(messageProps.message)}`;
+    }
+
+    formatMessageFragment(messageProps) {
+        let result = '';
+        for(const [key, fragment] of Object.entries(messageProps)) {
+            if(fragment === null || fragment === undefined) {
+                continue;
+            }
+
+            if(key === 'alert') {
+                let message = this.formatMessageFragment(fragment.message);
+
+                switch(fragment.type) {
+                    case 'endofround':
+                    case 'phasestart':
+                    case 'startofround':
+                        result += `${HeaderDivider} ${message} ${HeaderDivider}`;
+                        break;
+                    case 'success':
+                    case 'info':
+                    case 'danger':
+                    case 'warning':
+                        result += `${fragment.type.toUpperCase()} ${message}`;
+                        break;
+                    default:
+                        result += message;
+                        break;
+                }
+            } else if(fragment.message) {
+                result += this.formatMessageFragment(fragment.message);
+            } else if(fragment.argType === 'card') {
+                result += fragment.label;
+            } else if(fragment.name && fragment.argType === 'player') {
+                result += `${fragment.name}:`;
+            } else if(fragment.argType === 'nonAvatarPlayer') {
+                result += fragment.name;
+            } else {
+                result += fragment.toString();
+            }
+        }
+
+        return result;
+    }
+}
+
+module.exports = PlainTextGameChatFormatter;

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -31,6 +31,7 @@ const SimultaneousEvents = require('./SimultaneousEvents');
 const ChooseGoldSourceAmounts = require('./gamesteps/ChooseGoldSourceAmounts.js');
 const DropCommand = require('./ServerCommands/DropCommand');
 const CardVisibility = require('./CardVisibility');
+const PlainTextGameChatFormatter = require('./PlainTextGameChatFormatter');
 
 class Game extends EventEmitter {
     constructor(details, options = {}) {
@@ -103,6 +104,11 @@ class Game extends EventEmitter {
 
     get messages() {
         return this.gameChat.messages;
+    }
+
+    getPlainTextLog() {
+        let formatter = new PlainTextGameChatFormatter(this.gameChat);
+        return formatter.format();
     }
 
     hasActivePlayer(playerName) {

--- a/test/server/game/PlainTextGameChatFormatter.spec.js
+++ b/test/server/game/PlainTextGameChatFormatter.spec.js
@@ -1,0 +1,50 @@
+const PlainTextGameChatFormatter = require('../../../server/game/PlainTextGameChatFormatter');
+const GameChat = require('../../../server/game/gamechat.js');
+const BaseCard = require('../../../server/game/basecard');
+const Spectator = require('../../../server/game/spectator');
+
+describe('PlainTextGameChatFormatter', function() {
+    beforeEach(function() {
+        this.chat = new GameChat();
+        this.formatter = new PlainTextGameChatFormatter(this.chat);
+    });
+
+    describe('format()', function() {
+        it('works for plain text messages', function() {
+            this.chat.addMessage('Hello world');
+            expect(this.formatter.format()).toMatch(/Hello world$/);
+        });
+
+        it('works for chat messages', function() {
+            this.chat.addChatMessage('{0} {1}', { name: 'Player 1' }, 'good game!');
+            expect(this.formatter.format()).toMatch(/Player 1: good game!$/);
+        });
+
+        it('works for status alerts', function() {
+            this.chat.addAlert('danger', 'Will Robinson');
+            expect(this.formatter.format()).toMatch(/DANGER Will Robinson$/);
+        });
+
+        it('works for heading alerts', function() {
+            this.chat.addAlert('endofround', 'End of round 1');
+            expect(this.formatter.format()).toMatch(/==================== End of round 1 ====================$/);
+        });
+
+        it('works for embedded cards', function() {
+            let card = new BaseCard({}, { name: 'The Pounce That Was Promised' });
+            this.chat.addMessage('Player 1 plays {0} from their hand', card);
+            expect(this.formatter.format()).toMatch(/Player 1 plays The Pounce That Was Promised from their hand$/);
+        });
+
+        it('works for embedded players', function() {
+            let player = new Spectator(1, { username: 'Player 1' });
+            this.chat.addMessage('{0} plays The Pounce That Was Promised from their hand', player);
+            expect(this.formatter.format()).toMatch(/Player 1 plays The Pounce That Was Promised from their hand$/);
+        });
+
+        it('works for embedded arrays', function() {
+            this.chat.addMessage('The character {0}', ['kneels', 'cries', 'dies']);
+            expect(this.formatter.format()).toMatch(/The character kneels, cries, and dies$/);
+        });
+    });
+});


### PR DESCRIPTION
Returns in the following format:
```
2019-01-11 21:03:07 ==================== setup phase ====================
2019-01-11 21:03:07 test1 announces they are playing as House Martell with Fealty
2019-01-11 21:03:08 test1 has connected to the game server
2019-01-11 21:03:15 test1: Hey, there!
2019-01-11 21:03:30 test1 has kept their hand
2019-01-11 21:03:37 test2: Good luck, have fun.
2019-01-11 21:03:38 test1 has finished setup
2019-01-11 21:03:40 test2 has kept their hand
2019-01-11 21:03:45 test2 has finished setup
2019-01-11 21:03:45 test1 sets up The Roseroad, Shandystone, Desert Scavenger, and Obara Sand
2019-01-11 21:03:45 ==================== plot phase ====================
2019-01-11 21:03:59 test1 has selected a plot
2019-01-11 21:03:59 test1 won initiative
2019-01-11 21:04:07 test1 has selected test1 to be the first player
2019-01-11 21:04:07 ==================== draw phase ====================
2019-01-11 21:04:07 test1 draws 3 cards
2019-01-11 21:04:07 ==================== marshal phase ====================
2019-01-11 21:04:07 test1 collects 7 gold
2019-01-11 21:04:11 test1 marshals Blood Orange Grove costing 0 gold
2019-01-11 21:04:20 DANGER test1 kneels Blood Orange Grove
2019-01-11 21:04:28 test1 marshals Hellholt costing 2 gold
2019-01-11 21:04:31 test1 uses Blood Orange Grove to reduce the cost of the next martell card by 1
2019-01-11 21:04:33 test1 uses Desert Scavenger to reduce the cost of the next martell character by 1
2019-01-11 21:04:36 test1 marshals Shadow City Bastard costing 0 gold
2019-01-11 21:05:16 test1 marshals Palace Spearman costing 4 gold
2019-01-11 21:05:20 test1 has finished marshalling
```