### PR TITLE
Prevent immunity from card's own effects

### DIFF
--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -641,13 +641,17 @@ const Effects = {
         };
     },
     immuneTo: function(cardCondition) {
-        let restriction = new ImmunityRestriction(cardCondition);
         return {
-            apply: function(card) {
+            apply: function(card, context) {
+                let restriction = new ImmunityRestriction(cardCondition, context.source);
+                context.immuneTo = context.immuneTo || {};
+                context.immuneTo[card.uuid] = restriction;
                 card.addAbilityRestriction(restriction);
             },
-            unapply: function(card) {
+            unapply: function(card, context) {
+                let restriction = context.immuneTo[card.uuid];
                 card.removeAbilityRestriction(restriction);
+                delete context.immuneTo[card.uuid];
             }
         };
     },

--- a/server/game/immunityrestriction.js
+++ b/server/game/immunityrestriction.js
@@ -1,12 +1,14 @@
 class ImmunityRestriction {
-    constructor(cardCondition) {
+    constructor(cardCondition, immunitySource) {
         this.cardCondition = cardCondition;
+        this.immunitySource = immunitySource;
     }
 
     isMatch(type, abilityContext) {
         return (
             abilityContext.resolutionStage === 'effect' &&
             abilityContext.source &&
+            abilityContext.source !== this.immunitySource &&
             this.cardCondition(abilityContext.source, abilityContext)
         );
     }

--- a/test/server/cards/02.1-TtB/PleasureBarge.spec.js
+++ b/test/server/cards/02.1-TtB/PleasureBarge.spec.js
@@ -1,0 +1,65 @@
+describe('Pleasure Barge', function() {
+    integration(function() {
+        describe('gold modifier', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('Tyrell', [
+                    'A Noble Cause',
+                    'Pleasure Barge'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.player1.clickCard('Pleasure Barge', 'hand');
+
+                this.completeSetup();
+
+                this.selectFirstPlayer(this.player1);
+            });
+
+            it('reduces gold properly', function() {
+                // 5 gold from plot - 1 gold from Pleasure Barge
+                expect(this.player1Object.gold).toBe(4);
+            });
+        });
+
+        describe('immunity vs card effects', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('Tyrell', [
+                    'A Noble Cause', 'Political Disaster',
+                    'Pleasure Barge', 'The Roseroad', 'Highgarden'
+                ]);
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.pleasureBarge = this.player2.findCardByName('Pleasure Barge', 'hand');
+
+                this.player2.clickCard(this.pleasureBarge);
+                this.player2.clickCard('The Roseroad', 'hand');
+                this.player2.clickCard('Highgarden', 'hand');
+
+                this.completeSetup();
+
+                this.player1.selectPlot('Political Disaster');
+                this.player2.selectPlot('A Noble Cause');
+
+                this.selectFirstPlayer(this.player2);
+
+                // Select locations for Political Disaster
+                this.player2.clickCard('The Roseroad', 'play area');
+                this.player2.clickCard('Highgarden', 'play area');
+                this.player2.clickPrompt('Done');
+            });
+
+            it('is not affected by card effects', function() {
+                // Pleasure Barge is immune to all card effects, which means that
+                // even though it wasn't chosen to be kept for Political Disaster,
+                // it should not be discarded from play.
+                expect(this.pleasureBarge.location).toBe('play area');
+            });
+        });
+    });
+});


### PR DESCRIPTION
For cards that have blanket immunity from card effects, such as Pleasure
Barge, that immunity should not cancel itself out, nor should it cancel
other properties of the card such as income modifiers or traits.