### PR TITLE
Allow Rickon Stark to cancel any "search" ability

### DIFF
--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -598,6 +598,11 @@ class BaseCard {
         }
     }
 
+    hasText(text) {
+        let cardText = this.cardData.text.toLowerCase();
+        return cardText.includes(text.toLowerCase());
+    }
+
     get gold() {
         return this.tokens['gold'] || 0;
     }

--- a/server/game/cards/03-WotN/RickonStark.js
+++ b/server/game/cards/03-WotN/RickonStark.js
@@ -5,7 +5,7 @@ class RickonStark extends DrawCard {
         this.interrupt({
             canCancel: true,
             when: {
-                onBeforeDeckSearch: () => true
+                onCardAbilityInitiated: event => event.source.hasText('search')
             },
             cost: ability.costs.sacrificeSelf(),
             handler: context => {

--- a/test/server/cards/03-WotN/RickonStark.spec.js
+++ b/test/server/cards/03-WotN/RickonStark.spec.js
@@ -1,0 +1,99 @@
+describe('Rickon Stark', function() {
+    integration(function() {
+        describe('when a normal search would be triggered', function() {
+            beforeEach(function() {
+                const deck = this.buildDeck('stark', [
+                    'A Noble Cause', 'Here to Serve',
+                    'Rickon Stark'
+                ]);
+
+                this.player1.selectDeck(deck);
+                this.player2.selectDeck(deck);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.rickon = this.player1.findCardByName('Rickon Stark', 'hand');
+
+                this.player1.clickCard(this.rickon);
+
+                this.completeSetup();
+            });
+
+            describe('and the search is for the opponent', function() {
+                beforeEach(function() {
+                    this.player1.selectPlot('A Noble Cause');
+                    this.player2.selectPlot('Here to Serve');
+                    this.selectFirstPlayer(this.player1);
+                });
+
+                it('allows Rickon to cancel', function() {
+                    expect(this.player1).toAllowAbilityTrigger(this.rickon);
+                });
+            });
+
+            describe('and the search is for the current player', function() {
+                beforeEach(function() {
+                    this.player1.selectPlot('Here to Serve');
+                    this.player2.selectPlot('A Noble Cause');
+                    this.selectFirstPlayer(this.player1);
+                });
+
+                it('allows Rickon to cancel', function() {
+                    expect(this.player1).toAllowAbilityTrigger(this.rickon);
+                });
+            });
+        });
+
+        describe('when an ability has search under a choice or Then', function() {
+            beforeEach(function() {
+                const deck1 = this.buildDeck('stark', [
+                    'A Noble Cause',
+                    'Rickon Stark'
+                ]);
+                const deck2 = this.buildDeck('greyjoy', [
+                    'Sea of Blood',
+                    'A Noble Cause',
+                    'Balon Greyjoy (Core)'
+                ]);
+
+                this.player1.selectDeck(deck1);
+                this.player2.selectDeck(deck2);
+                this.startGame();
+                this.keepStartingHands();
+
+                this.rickon = this.player1.findCardByName('Rickon Stark', 'hand');
+                this.seaOfBlood = this.player2.findCardByName('Sea of Blood', 'agenda');
+                this.opponentCharacter = this.player2.findCardByName('Balon Greyjoy', 'hand');
+
+                this.player1.clickCard(this.rickon);
+                this.player2.clickCard(this.opponentCharacter);
+
+                this.completeSetup();
+
+                this.selectFirstPlayer(this.player2);
+                this.completeMarshalPhase();
+
+                this.player2.clickPrompt('Military');
+                this.player2.clickCard(this.opponentCharacter);
+                this.player2.clickPrompt('Done');
+                this.skipActionWindow();
+                this.player1.clickPrompt('Done');
+                this.skipActionWindow();
+
+                this.player2.triggerAbility('Sea of Blood');
+            });
+
+            it('allows Rickon to cancel the ability', function() {
+                expect(this.player1).toAllowAbilityTrigger(this.rickon);
+            });
+
+            it('cancels the full ability before the choice / Then', function() {
+                this.player1.triggerAbility(this.rickon);
+
+                // Ensure costs were paid but the pre-then effect didn't resolve
+                expect(this.player2Object.faction.kneeled).toBe(true);
+                expect(this.seaOfBlood.hasToken('blood')).toBe(false);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Previously, Rickon Stark was implemented to cancel searches directly.
However, per the card text, Rickon should cancel the effects of any
ability that has the word "search" in it. This includes cards where the
search is in a "Then" clause (Heir to the Iron Throne, Sea of Blood),
cards where the search is a choice (Dragonbinder), or even Rickon
himself.

Fixes #2295 