### PR TITLE
fix Randyll Tarly (19-JS)

### DIFF
--- a/server/game/GameActions/RevealTopCards.js
+++ b/server/game/GameActions/RevealTopCards.js
@@ -8,7 +8,7 @@ class RevealTopCards extends GameAction {
     message({ amount = 1, player, context }) {
         player = player || context.player;
         const cards = player.drawDeck.slice(0, amount);
-        return RevealCards.message({ player, context: { ...context, revealed: cards } });
+        return RevealCards.message({ player, cards, context: { ...context, revealed: cards } });
     }
 
     canChangeGameState({ amount = 1, player, context }) {


### PR DESCRIPTION
- add missing param to RevealCards.message path

More context:
- Randyll Tarly (19-JS) produces a server error when his second ability (reveal top card) is used. This is because he includes {gameAction} in a top-level 'message' property that calls RevealTopCards.message(). That, in turn, calls RevealCards.message(), but without the key 'cards' param. Since that param is immediately used for a Map function, the resulting error halts execution.
- This fix simply explicitly adds the cards param to the RevealCards.message() call to avoid a Map call on an undefined variable.
- Why doesn't this affect a bunch of other cards that reveal? Because they don't use this path - they either don't reference {gameAction} in their message (which is what prompts the RevealTopCards.message() to fire) or include it further down in their execution, usually after a .then() and a few more things have happened (as opposed to Randyll who has the message with {gameAction} at the top level).

p.s. Shout out to Malkavski for being such a dedicated Tyrell fan