### PR TITLE
fixing card codes of redesignes

### DIFF
--- a/server/game/cards/17.2-R2/AegonTargaryen.js
+++ b/server/game/cards/17.2-R2/AegonTargaryen.js
@@ -30,6 +30,6 @@ class AegonTargaryen extends DrawCard {
     }
 }
 
-AegonTargaryen.code = '17171';
+AegonTargaryen.code = '17172';
 
 export default AegonTargaryen;

--- a/server/game/cards/17.2-R2/DaenerysTargaryen.js
+++ b/server/game/cards/17.2-R2/DaenerysTargaryen.js
@@ -37,6 +37,6 @@ class DaenerysTargaryen extends DrawCard {
     }
 }
 
-DaenerysTargaryen.code = '17170';
+DaenerysTargaryen.code = '17171';
 
 export default DaenerysTargaryen;

--- a/server/game/cards/17.2-R2/GreatRanging.js
+++ b/server/game/cards/17.2-R2/GreatRanging.js
@@ -22,6 +22,6 @@ class GreatRanging extends DrawCard {
     }
 }
 
-GreatRanging.code = '17173';
+GreatRanging.code = '17170';
 
 export default GreatRanging;

--- a/server/game/cards/17.2-R2/Queensguard.js
+++ b/server/game/cards/17.2-R2/Queensguard.js
@@ -22,6 +22,6 @@ class Queensguard extends DrawCard {
     }
 }
 
-Queensguard.code = '17172';
+Queensguard.code = '17173';
 
 export default Queensguard;

--- a/server/game/cards/17.2-R2/RandyllTarly.js
+++ b/server/game/cards/17.2-R2/RandyllTarly.js
@@ -70,6 +70,6 @@ class RandyllTarly extends DrawCard {
     }
 }
 
-RandyllTarly.code = '17175';
+RandyllTarly.code = '17174';
 
 export default RandyllTarly;


### PR DESCRIPTION
when i was adding placeholder codes for the cards, i put NW behind Targ, and accidentally put Randyll on the same code as Oldtown. This should fix it